### PR TITLE
Fix link to CHANGELOG.md in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@ Feel free to edit, complete or extend this list while the PR is open.
 ### Checklist
 <!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
 
-- [ ] Update [CHANGELOG.md](/CHANGELOG.md)
+- [ ] Update [CHANGELOG.md](../blob/main/CHANGELOG.md)
 - [ ] Update [constellation-docs](https://github.com/edgelesssys/constellation-docs)
     - [ ] Link PR in docs
 - [ ] Link to Milestone


### PR DESCRIPTION
### Proposed change(s)
Fix link to CHANGELOG.md in PR template (it 404s currently, click below to test ;))

Correct link: [CHANGELOG.md](../blob/main/CHANGELOG.md)

I am not sure we can automatically link to the correct branch, though.

- [ ] Update [CHANGELOG.md](/CHANGELOG.md)
- [ ] Update [constellation-docs](https://github.com/edgelesssys/constellation-docs)
    - [ ] Link PR in docs
- [ ] Link to Milestone
