### PR TITLE
Add GCP ServiceAccount to E2E test

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -14,6 +14,9 @@ inputs:
   cloudProvider:
     description: "Either 'gcp' or 'azure'."
     required: true
+  gcpClusterServiceAccountKey:
+    description: "Service account to use inside the created Constellation cluster on GCP."
+    required: false
   machineType:
     description: "Machine type of VM to spawn."
     required: true
@@ -124,6 +127,14 @@ runs:
         cdbg deploy
       shell: bash
       if: ${{ inputs.isDebugImage == 'true' }}
+
+    - name: Create serviceAccountKey.json
+      if: ${{ inputs.cloudProvider == 'gcp' }}
+      shell: bash
+      run: |
+        echo "$GCP_CLUSTER_SERVICE_ACCOUNT_KEY" > serviceAccountKey.json
+      env:
+        GCP_CLUSTER_SERVICE_ACCOUNT_KEY: ${{ inputs.gcpClusterServiceAccountKey }}
 
     - name: Constellation init
       run: |

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -27,6 +27,9 @@ inputs:
   gcp_service_account_json:
     description: "Service account with permissions to create Constellation on GCP."
     required: false
+  gcpClusterServiceAccountKey:
+    description: "Service account to use inside the created Constellation cluster on GCP."
+    required: false
   azure_credentials:
     description: "Credentials authorized to create Constellation on Azure."
     required: false
@@ -90,6 +93,7 @@ runs:
       uses: ./.github/actions/constellation_create
       with:
         cloudProvider: ${{ inputs.cloudProvider }}
+        gcpClusterServiceAccountKey: ${{ inputs.gcpClusterServiceAccountKey }}
         autoscale: ${{ inputs.autoscale }}
         workerNodesCount: ${{ inputs.workerNodesCount }}
         controlNodesCount: ${{ inputs.controlNodesCount }}

--- a/.github/workflows/e2e-test-gcp-weekly.yml
+++ b/.github/workflows/e2e-test-gcp-weekly.yml
@@ -28,6 +28,7 @@ jobs:
           cloudProvider: "gcp"
           machineType: "n2d-standard-2"
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           sonobuoyTestSuiteCmd: '--plugin e2e --plugin-env e2e.E2E_FOCUS="\[Conformance\]" --plugin-env e2e.E2E_SKIP="for service with type clusterIP|HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol" --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-plugin.yaml --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-master-plugin.yaml'
           kubernetesVersion: ${{ matrix.version }}
           msTeamsWebhook: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}

--- a/.github/workflows/e2e-test-gcp.yml
+++ b/.github/workflows/e2e-test-gcp.yml
@@ -23,6 +23,7 @@ jobs:
           cloudProvider: "gcp"
           machineType: "n2d-standard-2"
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           # TODO: Remove E2E_SKIP once AB#2174 is resolved
           sonobuoyTestSuiteCmd: '--plugin e2e --plugin-env e2e.E2E_FOCUS="\[Conformance\]" --plugin-env e2e.E2E_SKIP="for service with type clusterIP|HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol" --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-plugin.yaml --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-master-plugin.yaml'
           msTeamsWebhook: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
@@ -55,6 +56,7 @@ jobs:
           cloudProvider: "gcp"
           machineType: "n2d-standard-2"
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           sonobuoyTestSuiteCmd: "--mode quick"
           kubernetesVersion: ${{ matrix.version }}
           msTeamsWebhook: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -65,6 +65,7 @@ jobs:
           cloudProvider: ${{ github.event.inputs.cloudProvider }}
           machineType: ${{ github.event.inputs.machineType }}
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           azure_credentials: ${{ secrets.AZURE_E2E_CREDENTIALS }}
           sonobuoyTestSuiteCmd: ${{ github.event.inputs.sonobuoyTestSuiteCmd }}
           kubernetesVersion: ${{ github.event.inputs.kubernetesVersion }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Created another ServiceAccount to use with constallation init
(constellation-e2e-cluster-acc in our GCP project)
- Added the JSON key as a Secret in this repo
- Use it in E2E tests


<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Check PR & running test in old repository (the new repo is still missing the required secrets to run correctly)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](/CHANGELOG.md)
- [ ] Update [constellation-docs](https://github.com/edgelesssys/constellation-docs)
    - [ ] Link PR in docs
- [ ] Link to Milestone
