### PR TITLE
Disable golangci-lint cache

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -37,3 +37,7 @@ jobs:
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc
+        with:
+          skip-pkg-cache: true
+          skip-build-cache: true
+          args: --timeout=15m


### PR DESCRIPTION
Not sure if we want to merge this, but cache linter runs are spitting out long logs with many "error" annotations when using the cache: https://github.com/edgelesssys/constellation/actions/runs/2943609250

Turns out this is a known issue that "cannot be fixed" from the golangci team since it comes from GitHub's `@action/cache` internal package which does not overwriting existing files.
https://github.com/golangci/golangci-lint-action/issues/244

The issues go away when disabling the cache (which is the suggested workaround). However, without the cache linting times are significantly higher (with cache: 1-2 minutes, without: ~5 minutes).

So not entirely sure if it makes sense to fix it this way. I don't even know for sure if it impacts the linting process itself if files are not overwritten. I don't think it does, but not for sure. 

Still, likely it's just better to be safe and take the longer action run. We got other actions running for longer anyway.