### PR TITLE
AB#2352 node operator: retry updating pendingNode deadline on conflict

### DIFF
--- a/operators/constellation-node-operator/controllers/pendingnode_controller_env_test.go
+++ b/operators/constellation-node-operator/controllers/pendingnode_controller_env_test.go
@@ -87,9 +87,11 @@ var _ = Describe("PendingNode controller", func() {
 			By("setting the CSP node state to terminated")
 			fakes.nodeStateGetter.setNodeState(updatev1alpha1.NodeStateTerminated)
 			// trigger reconciliation before regular check interval to speed up test by changing the spec
-			Expect(k8sClient.Get(ctx, pendingNodeLookupKey, pendingNode)).Should(Succeed())
-			pendingNode.Spec.Deadline = &metav1.Time{Time: fakes.clock.Now().Add(time.Second)}
-			Expect(k8sClient.Update(ctx, pendingNode)).Should(Succeed())
+			Eventually(func() error {
+				Expect(k8sClient.Get(ctx, pendingNodeLookupKey, pendingNode)).Should(Succeed())
+				pendingNode.Spec.Deadline = &metav1.Time{Time: fakes.clock.Now().Add(time.Second)}
+				return k8sClient.Update(ctx, pendingNode)
+			}, timeout, interval).Should(Succeed())
 
 			By("checking if the pending node resource is deleted")
 			Eventually(func() error {


### PR DESCRIPTION
Signed-off-by: Malte Poll <mp@edgeless.systems>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- retry updating pendingNode deadline on conflict

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

