### PR TITLE
Use absolute link to CHANGELOG.md in template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@ Feel free to edit, complete or extend this list while the PR is open.
 ### Checklist
 <!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
 
-- [ ] Update [CHANGELOG.md](../blob/main/CHANGELOG.md)
+- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
 - [ ] Update [constellation-docs](https://github.com/edgelesssys/constellation-docs)
     - [ ] Link PR in docs
 - [ ] Link to Milestone


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use absolute link to CHANGELOG.md instead of a relative one

### Related issue
- I already adjusted this in https://github.com/edgelesssys/constellation/pull/4 which fixed it for the PR view, but it's still broken for the preview plane or other potential places this could be linked to.

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->
