### PR TITLE
Run binary builds in parallel

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -14,25 +14,30 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  build-binaries:
+  build-bootstrapper:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Build the bootstrapper
-        id: build-bootstrapper
         uses: ./.github/actions/build_bootstrapper
-      
+
+  build-debugd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Build debugd
-        id: build-debugd
         uses: ./.github/actions/build_debugd
-      
+
+  build-disk-mapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Build disk-mapper
-        id: build-disk-mapper
         uses: ./.github/actions/build_disk_mapper
 
+  build-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
       - name: Build CLI
-        id: build-cli
         uses: ./.github/actions/build_cli


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Speed up the build-binaries workflow by running multiple jobs instead of one sequential job

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- This cuts down the action runtime to ~7 minutes from the previous 12-13 minutes

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](../blob/main/CHANGELOG.md)
- [ ] Update [constellation-docs](https://github.com/edgelesssys/constellation-docs)
    - [ ] Link PR in docs
- [ ] Link to Milestone
