### PR TITLE
Fork node maintenance operator and deploy it on all supported k8s versions

### DIFF
--- a/bootstrapper/internal/kubernetes/kubernetes.go
+++ b/bootstrapper/internal/kubernetes/kubernetes.go
@@ -200,11 +200,8 @@ func (k *KubeWrapper) InitCluster(
 		return nil, fmt.Errorf("failed to setup verification service: %w", err)
 	}
 
-	// TODO: enable operator deployment on kubernetes 1.24 once https://github.com/medik8s/node-maintenance-operator/issues/49 is fixed
-	if k8sVersion != versions.V1_24 {
-		if err := k.setupOperators(ctx); err != nil {
-			return nil, fmt.Errorf("setting up operators: %w", err)
-		}
+	if err := k.setupOperators(ctx); err != nil {
+		return nil, fmt.Errorf("setting up operators: %w", err)
 	}
 
 	if k.cloudProvider == "gcp" {

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -30,15 +30,17 @@ func IsSupportedK8sVersion(version string) bool {
 const (
 	// Constellation images.
 	// These images are built in a way that they support all versions currently listed in VersionConfigs.
-	JoinImage                           = "ghcr.io/edgelesssys/constellation/join-service:v0.0.1"
-	AccessManagerImage                  = "ghcr.io/edgelesssys/constellation/access-manager:v0.0.1"
-	KmsImage                            = "ghcr.io/edgelesssys/constellation/kmsserver:v0.0.1"
-	VerificationImage                   = "ghcr.io/edgelesssys/constellation/verification-service:v0.0.1"
-	GcpGuestImage                       = "ghcr.io/edgelesssys/gcp-guest-agent:20220713.00"
-	NodeOperatorCatalogImage            = "ghcr.io/edgelesssys/constellation/node-operator-catalog"
-	NodeOperatorVersion                 = "v0.0.1"
-	NodeMaintenanceOperatorCatalogImage = "quay.io/medik8s/node-maintenance-operator-catalog"
-	NodeMaintenanceOperatorVersion      = "v0.13.0"
+	JoinImage                = "ghcr.io/edgelesssys/constellation/join-service:v0.0.1"
+	AccessManagerImage       = "ghcr.io/edgelesssys/constellation/access-manager:v0.0.1"
+	KmsImage                 = "ghcr.io/edgelesssys/constellation/kmsserver:v0.0.1"
+	VerificationImage        = "ghcr.io/edgelesssys/constellation/verification-service:v0.0.1"
+	GcpGuestImage            = "ghcr.io/edgelesssys/gcp-guest-agent:20220713.00"
+	NodeOperatorCatalogImage = "ghcr.io/edgelesssys/constellation/node-operator-catalog"
+	NodeOperatorVersion      = "v0.0.1"
+	// TODO: switch node maintenance operator catalog back to upstream quay.io/medik8s/node-maintenance-operator-catalog
+	// once https://github.com/medik8s/node-maintenance-operator/issues/49 is resolved.
+	NodeMaintenanceOperatorCatalogImage = "ghcr.io/edgelesssys/constellation/node-maintenance-operator-catalog"
+	NodeMaintenanceOperatorVersion      = "v0.13.1-alpha1"
 
 	// currently supported versions.
 	V1_22  ValidK8sVersion = "1.22"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use forked version of Node Maintenance Operator with support for kubernetes >= 1.24
- Deploy operators on all supported k8s versions

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->
