### PR TITLE
Ensure no uid values end up in resource delete cmd

### DIFF
--- a/.github/actions/e2e_cleanup/action.yml
+++ b/.github/actions/e2e_cleanup/action.yml
@@ -3,8 +3,8 @@ description: "Clean up existing resource in the e2e-test resource group on Azure
 runs:
   using: "composite"
   steps:
-  - name: cleanup
-    shell: bash --noprofile --norc -e {0}
-    run: |
-      resources="$(az resource list --resource-group "e2e-test" | grep id | awk -F \" '{print $4}')"
-      for id in $resources; do az resource delete --resource-group "e2e-test" --ids "$id" --verbose; done
+    - name: cleanup
+      shell: bash --noprofile --norc -e {0}
+      run: |
+        resources="$(az resource list --resource-group "e2e-test" | grep \"id\" | awk -F \" '{print $4}')"
+        for id in $resources; do az resource delete --resource-group "e2e-test" --ids "$id" --verbose; done


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- The original grep also matches on the uid fields. That is why uids are given to the resource delete cmd, which consequently fails. [Example](https://github.com/edgelesssys/constellation/runs/8114507754?check_suite_focus=true#step:3:6369)

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->
