### PR TITLE
Group attestation OIDs by CSP

### DIFF
--- a/internal/attestation/azure/snp/issuer.go
+++ b/internal/attestation/azure/snp/issuer.go
@@ -44,7 +44,7 @@ func GetIdKeyDigest(open vtpm.TPMOpenFunc) ([]byte, error) {
 
 // Issuer for Azure TPM attestation.
 type Issuer struct {
-	oid.Azure
+	oid.AzureSNP
 	*vtpm.Issuer
 }
 

--- a/internal/attestation/azure/snp/validator.go
+++ b/internal/attestation/azure/snp/validator.go
@@ -24,7 +24,7 @@ const arkPEM = "-----BEGIN CERTIFICATE-----\nMIIGYzCCBBKgAwIBAgIDAQAAMEYGCSqGSIb
 
 // Validator for Azure confidential VM attestation.
 type Validator struct {
-	oid.Azure
+	oid.AzureSNP
 	*vtpm.Validator
 }
 

--- a/internal/oid/oid.go
+++ b/internal/oid/oid.go
@@ -1,3 +1,20 @@
+/*
+Package oid defines OIDs for different CSPs. Currently this is used in attested TLS to distinguish the attestation documents.
+OIDs beginning with 1.3.9900 are reserved and can be used without registration.
+
+* The 1.3.9900.1 branch is reserved for placeholder values and testing.
+
+* The 1.3.9900.2 branch is reserved for AWS.
+
+* The 1.3.9900.3 branch is reserved for GCP.
+
+* The 1.3.9900.4 branch is reserved for Azure.
+
+* The 1.3.9900.5 branch is reserved for QEMU.
+
+Deprecated OIDs should never be reused for different purposes.
+Instead, new OIDs should be added in the appropriate branch at the next available index.
+*/
 package oid
 
 import (
@@ -9,15 +26,12 @@ type Getter interface {
 	OID() asn1.ObjectIdentifier
 }
 
-// Here we define OIDs for different CSPs. Currently this is used in attested TLS to distinguish the attestation documents.
-// OIDs beginning with 1.3.9900 are reserved and can be used without registration.
-
 // Dummy OID for testing.
 type Dummy struct{}
 
 // OID returns the struct's object identifier.
 func (Dummy) OID() asn1.ObjectIdentifier {
-	return asn1.ObjectIdentifier{1, 3, 9900, 1}
+	return asn1.ObjectIdentifier{1, 3, 9900, 1, 1}
 }
 
 // AWS holds the AWS OID.
@@ -25,7 +39,7 @@ type AWS struct{}
 
 // OID returns the struct's object identifier.
 func (AWS) OID() asn1.ObjectIdentifier {
-	return asn1.ObjectIdentifier{1, 3, 9900, 2}
+	return asn1.ObjectIdentifier{1, 3, 9900, 2, 1}
 }
 
 // GCP holds the GCP OID.
@@ -33,23 +47,23 @@ type GCP struct{}
 
 // OID returns the struct's object identifier.
 func (GCP) OID() asn1.ObjectIdentifier {
-	return asn1.ObjectIdentifier{1, 3, 9900, 3}
+	return asn1.ObjectIdentifier{1, 3, 9900, 3, 1}
 }
 
-// Azure holds the Azure OID.
-type Azure struct{}
+// AzureSNP holds the OID for Azure SNP CVMs.
+type AzureSNP struct{}
 
 // OID returns the struct's object identifier.
-func (Azure) OID() asn1.ObjectIdentifier {
-	return asn1.ObjectIdentifier{1, 3, 9900, 4}
+func (AzureSNP) OID() asn1.ObjectIdentifier {
+	return asn1.ObjectIdentifier{1, 3, 9900, 4, 1}
 }
 
-// Azure holds the Azure TrustedLaunch OID.
+// Azure holds the OID for Azure TrustedLaunch VMs.
 type AzureTrustedLaunch struct{}
 
 // OID returns the struct's object identifier.
 func (AzureTrustedLaunch) OID() asn1.ObjectIdentifier {
-	return asn1.ObjectIdentifier{1, 3, 9900, 5}
+	return asn1.ObjectIdentifier{1, 3, 9900, 4, 2}
 }
 
 // QEMU holds the QEMU OID.
@@ -57,5 +71,5 @@ type QEMU struct{}
 
 // OID returns the struct's object identifier.
 func (QEMU) OID() asn1.ObjectIdentifier {
-	return asn1.ObjectIdentifier{1, 3, 9900, 6}
+	return asn1.ObjectIdentifier{1, 3, 9900, 5, 1}
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Group OIDs by CSP
  - Each CSP has its own unique branch
  - A CSP's branch can have any number of attestation provider CSPs

Example:

Azure has the branch `1.3.9900.4`.
The Azure SNP OID is `1.3.9900.4.1`, and the trusted launch OID is `1.3.9900.4.2`.
A potential future TDX OID could be `1.3.9900.4.3`.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [constellation-docs](https://github.com/edgelesssys/constellation-docs)
    - [ ] Link PR in docs
- [ ] Link to Milestone
