### PR TITLE
clidocgen: Support nested commands properly

### DIFF
--- a/hack/clidocgen/main.go
+++ b/hack/clidocgen/main.go
@@ -31,13 +31,8 @@ func main() {
 		name := c.Name()
 		fullName, level := determineFullNameAndLevel(c)
 
-		// Used for indentation based on the level of a command.
-		var nestingSpaces string
-		for i := 0; i < level; i++ {
-			nestingSpaces += "  "
-		}
-
-		fmt.Fprintf(cmdList, "%s* [%v](#constellation-%v): %v\n", nestingSpaces, name, fullName, c.Short)
+		// First two arguments are used to create indentation for nested commands (2 spaces per level).
+		fmt.Fprintf(cmdList, "%*s* [%v](#constellation-%v): %v\n", 2*level, "", name, fullName, c.Short)
 		if err := doc.GenMarkdown(c, body); err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Properly support nested commands in the generated CLI reference output

![image](https://user-images.githubusercontent.com/26608194/188180282-237fb4db-70cb-4b2d-9790-8832a297dd85.png)


<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- In theory it might be better to just track full name & level in `allSubCommands`, but that would involve using some custom struct to keep track of the level and full name (I guess?). So for simplicity and since it's just a hack script ran by the CI traversing backwards again after collecting all commands seems easier for now, especially since Cobra already implements plenty of commands for dealing with parent commands (but not for children).

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [constellation-docs](https://github.com/edgelesssys/constellation-docs)
    - [ ] Link PR in docs
- [ ] Link to Milestone
