### PR TITLE
Document instanceType in first-steps.md

### DIFF
--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -59,7 +59,7 @@ The following steps will guide you through the process of creating a cluster and
 
     For CVMs, any VM type with a minimum of 4 vCPUs from the [DCasv5 & DCadsv5](https://docs.microsoft.com/en-us/azure/virtual-machines/dcasv5-dcadsv5-series) or [ECasv5 & ECadsv5](https://docs.microsoft.com/en-us/azure/virtual-machines/ecasv5-ecadsv5-series) families is supported.
 
-    If you decide to use trusted launch VMs instead, set **confidentialVM** to false. Afterward, you can use any VMs with a minimum of 4 vCPUs from the [Dav4 & Dasv4](https://docs.microsoft.com/en-us/azure/virtual-machines/dav4-dasv4-series) or [Eav4 & Easv4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) families.
+    If you decide to use [trusted launch VMs](../workflows/trusted-launch.md) instead, set **confidentialVM** to false. Afterward, you can use any VMs with a minimum of 4 vCPUs from the [Dav4 & Dasv4](https://docs.microsoft.com/en-us/azure/virtual-machines/dav4-dasv4-series) or [Eav4 & Easv4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) families.
 
     Run `constellation config instance-types` to get the list of all supported options.
 
@@ -85,7 +85,7 @@ The following steps will guide you through the process of creating a cluster and
 
       For CVMs, any type with a minimum of 4 vCPUs from the [DCasv5 & DCadsv5](https://docs.microsoft.com/en-us/azure/virtual-machines/dcasv5-dcadsv5-series) or [ECasv5 & ECadsv5](https://docs.microsoft.com/en-us/azure/virtual-machines/ecasv5-ecadsv5-series) families is supported. It defaults to `Standard_DC4as_v5` (4 vCPUs, 16 GB RAM).
 
-      If you decide to use trusted launch VMs instead, set **confidentialVM** to false. Afterward, you can use any VMs with a minimum of 4 vCPUs from the [Dav4 & Dasv4](https://docs.microsoft.com/en-us/azure/virtual-machines/dav4-dasv4-series) or [Eav4 & Easv4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) families.
+      If you decide to use [trusted launch VMs](../workflows/trusted-launch.md) instead, set **confidentialVM** to false. Afterward, you can use any VMs with a minimum of 4 vCPUs from the [Dav4 & Dasv4](https://docs.microsoft.com/en-us/azure/virtual-machines/dav4-dasv4-series) or [Eav4 & Easv4](https://docs.microsoft.com/en-us/azure/virtual-machines/eav4-easv4-series) families.
 
       Run `constellation config instance-types` to get the list of all supported options.
 


### PR DESCRIPTION
### Proposed change(s)
- Document instanceType in first-steps.md for the documentation

I marked this PR as a draft for now until #48 is merged so I can drop a link to the trusted launch caveats later.

Not 100% if we want to keep all this information in first-steps.md since most values we talk about here are values which **must** be set by the user since we have no good defaults for them whereas the instance type does have a default, but in my opinion the instance type is an important choice for the customer so I don't think it's too wrong here.

Originally I was planning to hide it all in "Reference -> Configuration file", but I think we planned to remove this anyway so this seemed like the best place to fit it in there without creating another article in some section (which we had before, but was removed?).

Also, related to the same issue, not sure how to integrate this with the Azure CLI flow. The default works here and we advertise it as a quick start, but the information about supported instances is hidden behind the "Azure (Portal)" tab in this case. 

Feedback appreciated.
