### PR TITLE
Remove note to instance types specifically

### DIFF
--- a/cli/internal/cmd/configgenerate.go
+++ b/cli/internal/cmd/configgenerate.go
@@ -63,8 +63,6 @@ func configGenerate(cmd *cobra.Command, fileHandler file.Handler, provider cloud
 	}
 	cmd.Println("Config file written to", flags.file)
 	cmd.Println("Please fill in your CSP specific configuration before proceeding.")
-	cmd.Println("You can find the list of supported virtual machine types by executing:")
-	cmd.Println("\tconstellation config instance-types")
 	cmd.Println("Fore more information refer to our documentation:")
 	cmd.Println("\thttps://constellation-docs.edgeless.systems/constellation/getting-started/first-steps#create-a-cluster")
 


### PR DESCRIPTION
Along with #61, some stuff seems to have gone wrong when rebasing / dealing with merge conflicts and this was reintroduced despite the intention to remove this. 