### PR TITLE
e2e: Write service account key path for GCP

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -72,7 +72,8 @@ runs:
           "(.provider | select(. | has(\"gcp\")).gcp.project) = \"constellation-331613\" |
             (.provider | select(. | has(\"gcp\")).gcp.region) = \"europe-west3\" |
             (.provider | select(. | has(\"gcp\")).gcp.zone) = \"europe-west3-b\" |
-            (.provider | select(. | has(\"gcp\")).gcp.enforcedMeasurements) = [11,12]" \
+            (.provider | select(. | has(\"gcp\")).gcp.enforcedMeasurements) = [11,12]" |
+            (.provider | select(. | has(\"gcp\")).gcp.serviceAccountKeyPath) = \"serviceAccountKey.json\" \
           constellation-conf.yaml
 
         if [ ${{ inputs.kubernetesVersion != '' }} = true ]; then


### PR DESCRIPTION
Signed-off-by: Malte Poll <mp@edgeless.systems>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Write service account key path for GCP

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- is no longer a default field so it has to be set by the e2e test: https://github.com/edgelesssys/constellation/blob/a1e73881535f287d74a50f827b6862b4f94d2090/internal/config/config.go#L285
