### PR TITLE
Only run link checker when docs have changed

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -3,8 +3,14 @@ name: Links
 on:
   push:
     branches:
-    - main
+      - main
+    paths:
+      - "**.md"
+      - "**.html"
   pull_request:
+    paths:
+      - "**.md"
+      - "**.html"
 
 jobs:
   linkChecker:


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Only run link checker when docs/ has been changed (it only checks for *.md and *.html anyway)
