### PR TITLE
AB#2394 Change KMS to be deployed as DaemonSet

### DIFF
--- a/bootstrapper/internal/kubernetes/k8sapi/resources/kms.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/resources/kms.go
@@ -26,7 +26,7 @@ type kmsDeployment struct {
 	Service            k8s.Service
 	ClusterRole        rbac.ClusterRole
 	ClusterRoleBinding rbac.ClusterRoleBinding
-	Deployment         apps.Deployment
+	Deployment         apps.DaemonSet
 	MasterSecret       k8s.Secret
 }
 
@@ -117,19 +117,21 @@ func NewKMSDeployment(csp string, config KMSConfig) *kmsDeployment {
 				},
 			},
 		},
-		Deployment: apps.Deployment{
+		Deployment: apps.DaemonSet{
 			TypeMeta: meta.TypeMeta{
 				APIVersion: "apps/v1",
-				Kind:       "Deployment",
+				Kind:       "DaemonSet",
 			},
 			ObjectMeta: meta.ObjectMeta{
 				Labels: map[string]string{
-					"k8s-app": "kms",
+					"k8s-app":                       "kms",
+					"component":                     "kms",
+					"kubernetes.io/cluster-service": "true",
 				},
 				Name:      "kms",
 				Namespace: kmsNamespace,
 			},
-			Spec: apps.DeploymentSpec{
+			Spec: apps.DaemonSetSpec{
 				Selector: &meta.LabelSelector{
 					MatchLabels: map[string]string{
 						"k8s-app": "kms",


### PR DESCRIPTION

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
The KMS was deployed as a standard Kubernetes Deployment. This means it was not automatically deployed on all control-plane nodes or autoscaled if a new control-plane node joined the cluster

This PR updates the Deployment to be a daemonset, which deploys the KMS on all control-plane nodes.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](/docs)
- [ ] Link to Milestone
