### PR TITLE
cli: azure scale set poller: check for power state of every instance

### DIFF
--- a/cli/internal/azure/client/api.go
+++ b/cli/internal/azure/client/api.go
@@ -51,6 +51,12 @@ type scaleSetsAPI interface {
 		*runtime.Poller[armcomputev2.VirtualMachineScaleSetsClientCreateOrUpdateResponse], error)
 }
 
+type virtualMachineScaleSetVMsAPI interface {
+	GetInstanceView(ctx context.Context, resourceGroupName string, vmScaleSetName string, instanceID string,
+		options *armcomputev2.VirtualMachineScaleSetVMsClientGetInstanceViewOptions,
+	) (armcomputev2.VirtualMachineScaleSetVMsClientGetInstanceViewResponse, error)
+}
+
 type publicIPAddressesAPI interface {
 	NewListVirtualMachineScaleSetVMPublicIPAddressesPager(
 		resourceGroupName string, virtualMachineScaleSetName string,

--- a/cli/internal/azure/client/client.go
+++ b/cli/internal/azure/client/client.go
@@ -37,6 +37,7 @@ type Client struct {
 	networkSecurityGroupsAPI
 	resourceAPI
 	scaleSetsAPI
+	virtualMachineScaleSetVMsAPI
 	publicIPAddressesAPI
 	networkInterfacesAPI
 	loadBalancersAPI
@@ -91,6 +92,10 @@ func NewFromDefault(subscriptionID, tenantID string) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	virtualMachineScaleSetVMsAPI, err := armcomputev2.NewVirtualMachineScaleSetVMsClient(subscriptionID, cred, nil)
+	if err != nil {
+		return nil, err
+	}
 	publicIPAddressesAPI, err := armnetwork.NewPublicIPAddressesClient(subscriptionID, cred, nil)
 	if err != nil {
 		return nil, err
@@ -119,22 +124,23 @@ func NewFromDefault(subscriptionID, tenantID string) (*Client, error) {
 	roleAssignmentsAPI.Authorizer = managementAuthorizer
 
 	return &Client{
-		networksAPI:              netAPI,
-		networkSecurityGroupsAPI: netSecGrpAPI,
-		resourceAPI:              resourceAPI,
-		scaleSetsAPI:             scaleSetAPI,
-		publicIPAddressesAPI:     publicIPAddressesAPI,
-		networkInterfacesAPI:     networkInterfacesAPI,
-		loadBalancersAPI:         loadBalancersAPI,
-		applicationsAPI:          applicationsAPI,
-		servicePrincipalsAPI:     servicePrincipalsAPI,
-		roleAssignmentsAPI:       roleAssignmentsAPI,
-		applicationInsightsAPI:   applicationInsightsAPI,
-		subscriptionID:           subscriptionID,
-		tenantID:                 tenantID,
-		workers:                  cloudtypes.Instances{},
-		controlPlanes:            cloudtypes.Instances{},
-		pollFrequency:            time.Second * 5,
+		networksAPI:                  netAPI,
+		networkSecurityGroupsAPI:     netSecGrpAPI,
+		resourceAPI:                  resourceAPI,
+		scaleSetsAPI:                 scaleSetAPI,
+		virtualMachineScaleSetVMsAPI: virtualMachineScaleSetVMsAPI,
+		publicIPAddressesAPI:         publicIPAddressesAPI,
+		networkInterfacesAPI:         networkInterfacesAPI,
+		loadBalancersAPI:             loadBalancersAPI,
+		applicationsAPI:              applicationsAPI,
+		servicePrincipalsAPI:         servicePrincipalsAPI,
+		roleAssignmentsAPI:           roleAssignmentsAPI,
+		applicationInsightsAPI:       applicationInsightsAPI,
+		subscriptionID:               subscriptionID,
+		tenantID:                     tenantID,
+		workers:                      cloudtypes.Instances{},
+		controlPlanes:                cloudtypes.Instances{},
+		pollFrequency:                time.Second * 5,
 	}, nil
 }
 

--- a/cli/internal/azure/client/compute_test.go
+++ b/cli/internal/azure/client/compute_test.go
@@ -30,8 +30,8 @@ func TestCreateInstances(t *testing.T) {
 			publicIPAddressesAPI: stubPublicIPAddressesAPI{},
 			networkInterfacesAPI: stubNetworkInterfacesAPI{},
 			scaleSetsAPI: stubScaleSetsAPI{
-				stubResponse: armcomputev2.VirtualMachineScaleSetsClientCreateOrUpdateResponse{
-					VirtualMachineScaleSet: armcomputev2.VirtualMachineScaleSet{Identity: &armcomputev2.VirtualMachineScaleSetIdentity{PrincipalID: to.Ptr("principal-id")}},
+				getResponse: armcomputev2.VirtualMachineScaleSet{
+					Identity: &armcomputev2.VirtualMachineScaleSetIdentity{PrincipalID: to.Ptr("principal-id")}, SKU: &armcomputev2.SKU{Capacity: to.Ptr[int64](0)},
 				},
 			},
 			createInstancesInput: CreateInstancesInput{


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: azure scale set poller: check for power state of every instance

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

The poller did not wait long enough resulting in a race for the instance IPs. Checking if every VM is starting / started is slower but ensures the VM resource is fully created.

```
An error occurred: GET https://management.azure.com/subscriptions/***/resourceGroups/e2e-test-847057e2/providers/Microsoft.Compute/virtualMachineScaleSets/constellation-scale-set-workers-BcsvI/virtualMachines/0/networkInterfaces/constellation-scale-set-workers-BcsvI/ipconfigurations/constellation-scale-set-workers-BcsvI/publicipaddresses
--------------------------------------------------------------------------------
RESPONSE 404: 404 Not Found
ERROR CODE: NotFound
--------------------------------------------------------------------------------
***
  "error": ***
    "code": "NotFound",
    "message": "Resource /subscriptions/***/resourceGroups/e2e-test-847057e2/providers/Microsoft.Compute/virtualMachineScaleSets/constellation-scale-set-workers-BcsvI not found.",
    "details": []
  ***
***
--------------------------------------------------------------------------------
```

Debug logging showing how the poller behaves for both scalesets:

```
./constellation create azure -c 3 -w 1 --name malte -y
Configured image does not look like a released production image. Double check image before deploying to production.
Polling
status: {0xc00060fbd0 0xc00060fbf0 0xc00060fbe0 <nil> <nil>} ProvisioningState/creating
Polling
Polling
status: {0xc000a05330 0xc000a05350 0xc000a05340 <nil> <nil>} ProvisioningState/creating
status: {0xc00060fca0 0xc00060fc90 0xc00060fcb0 <nil> <nil>} ProvisioningState/creating
Polling
status: {0xc000c0c3a0 0xc000c0c3c0 0xc000c0c3b0 <nil> <nil>} ProvisioningState/creating
Polling
status: {0xc000c0c440 0xc000c0c460 0xc000c0c450 <nil> <nil>} ProvisioningState/creating
Polling
status: {0xc000c0c910 0xc000c0c900 0xc000c0c8f0 <nil> <nil>} ProvisioningState/creating
Polling
status: {0xc000b54140 0xc000b54160 0xc000b54150 <nil> <nil>} ProvisioningState/creating
Polling
status: {0xc000a05810 0xc000a05830 0xc000a05820 <nil> <nil>} ProvisioningState/creating
Polling
status: {0xc000c0d460 0xc000c0d450 0xc000c0d440 <nil> <nil>} ProvisioningState/creating
status: {0xc000c0d4a0 0xc000c0d4c0 0xc000c0d4b0 <nil> <nil>} PowerState/starting
Polling
status: {0xc000c0d960 0xc000c0d980 0xc000c0d970 <nil> <nil>} ProvisioningState/creating
Polling
status: {0xc000c0de00 0xc000c0de20 0xc000c0de10 <nil> <nil>} ProvisioningState/creating
Polling
status: {0xc000b54cc0 0xc000b54cf0 0xc000b54ce0 <nil> <nil>} ProvisioningState/creating
status: {0xc000b54d70 0xc000b54da0 0xc000b54d90 <nil> <nil>} PowerState/running
status: {0xc000b55180 0xc000b551a0 0xc000b55190 <nil> <nil>} ProvisioningState/creating
status: {0xc000b551f0 0xc000b55210 0xc000b55200 <nil> <nil>} PowerState/running
status: {0xc000c0dfb0 0xc000c0dfd0 0xc000c0dfc0 <nil> <nil>} ProvisioningState/creating
status: {0xc000b98010 0xc000b98050 0xc000b98020 <nil> <nil>} PowerState/running
Your Constellation cluster was created successfully.
```

