### PR TITLE
e2e test: wait for specified amount of nodes to join the cluster and become ready

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -164,7 +164,7 @@ runs:
 
     - name: Wait for nodes to join and become ready
       run: |
-        echo "::group::wait for nodes"
+        echo "::group::Wait for nodes"
         NODES_COUNT=$((${{ inputs.controlNodesCount }} + ${{ inputs.workerNodesCount }}))
         JOINWAIT=0
         until [ "$(kubectl get nodes -o json | jq '.items | length')" == "${NODES_COUNT}" ] || [ $JOINWAIT -gt $JOINTIMEOUT ];


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- wait for specified amount of nodes to join the cluster and become ready

### Successful run

https://github.com/edgelesssys/constellation/runs/8223913572?check_suite_focus=true

```
wait for nodes
1/10 nodes have joined.. waiting..
1/10 nodes have joined.. waiting..
2/10 nodes have joined.. waiting..
node/e2e-test-control-plane-udcoi-brmx condition met
node/e2e-test-control-plane-udcoi-kk7v condition met
node/e2e-test-control-plane-udcoi-wnl8 condition met
node/e2e-test-control-plane-udcoi-zss5 condition met
node/e2e-test-worker-udcoi-3t96 condition met
node/e2e-test-worker-udcoi-9xx9 condition met
node/e2e-test-worker-udcoi-kpfq condition met
node/e2e-test-worker-udcoi-n272 condition met
node/e2e-test-worker-udcoi-prqj condition met
node/e2e-test-worker-udcoi-q27s condition met
```

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
