### PR TITLE
Lower CoreDNS reschedule timeout to 10s

### DIFF
--- a/bootstrapper/internal/kubernetes/k8sapi/util.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/util.go
@@ -264,12 +264,19 @@ func (k *KubernetesUtil) deployCiliumGCP(ctx context.Context, helmClient *action
 		return err
 	}
 
+	timeoutS := int64(10)
 	// allow coredns to run on uninitialized nodes (required by cloud-controller-manager)
 	tolerations := []corev1.Toleration{
 		{
 			Key:    "node.cloudprovider.kubernetes.io/uninitialized",
 			Value:  "true",
-			Effect: "NoSchedule",
+			Effect: corev1.TaintEffectNoSchedule,
+		},
+		{
+			Key:               "node.kubernetes.io/unreachable",
+			Operator:          corev1.TolerationOpExists,
+			Effect:            corev1.TaintEffectNoExecute,
+			TolerationSeconds: &timeoutS,
 		},
 	}
 	if err = kubectl.AddTolerationsToDeployment(ctx, tolerations, "coredns", "kube-system"); err != nil {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- lower CoreDNS reschedule timeout to 10s
  - This fixes DNS being unavailable in the cluster for 5 minutes if the initial control-plane is rebooted/shutdown
- GCP image: `projects/constellation-331613/global/images/constellation-ref-disk-mapper`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
