### PR TITLE
Sync Azure/GCP tab choice

### DIFF
--- a/docs/docs/architecture/attestation.md
+++ b/docs/docs/architecture/attestation.md
@@ -124,7 +124,7 @@ Constellation allows to specify in the [config](../reference/config.md) which me
 Enforcing non-reproducible measurements controlled by the cloud provider means that changes in these values require manual updates to the cluster's config.
 By default, Constellation only enforces measurements that are stable values produced by the infrastructure or by Constellation directly.
 
-<tabs>
+<tabs groupId="csp">
 <tabItem value="azure" label="Azure" default>
 
 Constellation leverages the [vTPM](https://docs.microsoft.com/en-us/azure/virtual-machines/trusted-launch#vtpm) feature of Azure CVMs for runtime measurements.
@@ -233,5 +233,5 @@ flowchart LR
   B[CLI]-- "contains" -->D["Public Key"]
   A[Edgeless]-- "signs" -->E["Runtime measurements"]
   D["Public Key"]-- "verifies" -->E["Runtime measurements"]
-  E["Runtime measurements"]-- "verify" -->F["Constellation cluster"] 
+  E["Runtime measurements"]-- "verify" -->F["Constellation cluster"]
 ```

--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -6,7 +6,7 @@ The following steps will guide you through the process of creating a cluster and
 
 1. Create the configuration file for your selected cloud provider.
 
-    <tabs>
+    <tabs groupId="csp">
     <tabItem value="azure" label="Azure" default>
 
     ```bash
@@ -27,8 +27,8 @@ The following steps will guide you through the process of creating a cluster and
 
 2.  Fill in your cloud provider specific information:
 
-    <tabs>
-    <tabItem value="azure-cli" label="Azure (CLI)" default>
+    <tabs groupId="csp">
+    <tabItem value="azure" label="Azure (CLI)" default>
 
     For a quick start it's recommended to use our `az` script to automatically create all required resources:
 
@@ -114,7 +114,7 @@ The following steps will guide you through the process of creating a cluster and
         Set the configuration value to the secret value.
 
     </tabItem>
-    <tabItem value="gcp-cli" label="GCP (CLI)">
+    <tabItem value="gcp" label="GCP (CLI)">
 
     For a quick start it's recommended to use our `gcloud` script to automatically create all required resources:
 

--- a/docs/docs/getting-started/install.md
+++ b/docs/docs/getting-started/install.md
@@ -62,7 +62,7 @@ Don't use the testing methods for setting up a production-grade Constellation cl
 
 :::
 
-<tabs>
+<tabs groupId="csp">
 <tabItem value="azure" label="Azure" default>
 
 **Testing**
@@ -116,7 +116,7 @@ For production clusters, use one of the following options on a trusted machine:
 
 ### Authorization
 
-<tabs>
+<tabs groupId="csp">
 <tabItem value="azure" label="Azure" default>
 
 Your user account needs the following permissions to set up a Constellation cluster:

--- a/docs/docs/workflows/create.md
+++ b/docs/docs/workflows/create.md
@@ -25,7 +25,7 @@ You can find the currently supported machine types for your cloud environment in
 
 Constellation can generate a configuration file for your cloud provider:
 
-<tabs>
+<tabs groupId="csp">
 <tabItem value="azure" label="Azure" default>
 
 ```bash

--- a/docs/docs/workflows/recovery.md
+++ b/docs/docs/workflows/recovery.md
@@ -28,7 +28,7 @@ Constellation provides logging information on the boot process and status via [c
 In the following, you'll find detailed descriptions for identifying clusters stuck in recovery for each cloud environment.
 Once you've identified that your cluster is in an unhealthy state you can use the [recovery](recovery.md#recover-your-cluster) command of the Constellation CLI to restore it.
 
-<tabs>
+<tabs groupId="csp">
 <tabItem value="azure" label="Azure" default>
 
 In the Azure cloud portal find the cluster's resource group `<cluster-name>-<suffix>`

--- a/docs/docs/workflows/scale.md
+++ b/docs/docs/workflows/scale.md
@@ -8,7 +8,7 @@ Constellation provides all features of a Kubernetes cluster including scaling an
 
 Alternatively, you can choose to manually scale your cluster:
 
-<tabs>
+<tabs groupId="csp">
 <tabItem value="azure" label="Azure" default>
 
 1. Find your Constellation resource group.
@@ -34,7 +34,7 @@ Control-plane nodes can **only be scaled manually and only scaled up**!
 
 To increase the number of control-plane nodes, follow these steps:
 
-<tabs>
+<tabs groupId="csp">
 
 <tabItem value="azure" label="Azure" default>
 

--- a/docs/docs/workflows/storage.md
+++ b/docs/docs/workflows/storage.md
@@ -22,7 +22,7 @@ For more details see [encrypted persistent storage](../architecture/encrypted-st
 
 Constellation can use the following drivers which offer node level encryption and optional integrity protection.
 
-<tabs>
+<tabs groupId="csp">
 <tabItem value="azure" label="Azure" default>
 
 1. [Azure Disk Storage](https://github.com/edgelesssys/constellation-azuredisk-csi-driver)
@@ -48,7 +48,7 @@ Note that in case the options above aren't a suitable solution for you, Constell
 
 The following installation guide gives a brief overview of using CSI-based confidential cloud storage for persistent volumes in Constellation.
 
-<tabs>
+<tabs groupId="csp">
 <tabItem value="azure" label="Azure" default>
 
 1. Install the CSI driver:
@@ -184,7 +184,7 @@ By default, integrity protection is disabled for performance reasons. If you wan
 ### Set the default storage class
 The examples above are defined to be automatically set as the default storage class. The default storage class is responsible for all persistent volume claims that don't explicitly request `storageClassName`. In case you need to change the default, follow the steps below:
 
-<tabs>
+<tabs groupId="csp">
 <tabItem value="azure" label="Azure" default>
 
   1. List the storage classes in your cluster:

--- a/docs/docs/workflows/troubleshooting.md
+++ b/docs/docs/workflows/troubleshooting.md
@@ -8,7 +8,7 @@ To provide information during early stages of the node's boot process, Constella
 
 You can view these information in the follow places:
 
-<tabs>
+<tabs groupId="csp">
 <tabItem value="azure" label="Azure" default>
 
 1. In your Azure subscription find the Constellation resource group.


### PR DESCRIPTION
### Proposed change(s)
- Sync Azure/GCP tab choice (e.g.: If you select GCP, all other tabs will switch to GCP and the choice persists across different pages of the documentation (Docusaurus stores it in localStorage of the browser)

Only issue I see here is that it does not work 100% well with the first-steps tabs where we have Azure (CLI), Azure (Portal), GCP (CLI) and GCP (Portal). Here I assigned the CLI ones to be syncing, however you could jump from Azure (Portal) <-> GCP (Portal) or Azure (CLI) to GCP (Portal) and it would not sync due to different IDs.

Not sure how to solve this. Having another tab group for CLI/Portal below Azure/GCP would work, but looks a bit ugly imo without changing CSS. 

I don't know, any ideas appreciated.