### PR TITLE
CI: Fix automatic trigger of CLI reference update

### DIFF
--- a/.github/workflows/update-cli-reference.yml
+++ b/.github/workflows/update-cli-reference.yml
@@ -22,11 +22,8 @@ jobs:
           go-version: 1.18
 
       - name: Generate reference docs
-        run: |
-          cd hack/clidocgen
-          go build .
-          ./clidocgen > content.md
-          cat header.md content.md > ../../cli.md
+        run: go run . | cat header.md - > ../../cli.md
+        working-directory: hack/clidocgen
 
       - name: Get commit sha
         run: |


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Trigger CI CLI reference update on changes to `cli/cmd/**`, not `docs/docs/reference/cli.md` (which does trigger the action only _after_ the action has run once)
- Remove remaining references to old docs repo
- Auto-format the YAML