### PR TITLE
Remove clone3 workaround

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,13 +1,5 @@
 FROM fedora@sha256:36af84ba69e21c9ef86a0424a090674c433b2b80c2462e57503886f1d823abe8 as build
 
-# This workaround is necessary since glibc in versions >= 2.34 are incompatible with docker versions <= 20.10.9.
-# Since the host ubuntu is running docker 20.10.7, this incompatibility becomes a problem.
-# The workaround binary is a small go program that adds a missing seccomp filter to all programs invoked through the
-# container's shell. More explanations can be found in the clone3-workaround repo and the blogpost linked in the repo.
-ADD https://github.com/AkihiroSuda/clone3-workaround/releases/download/v1.0.0/clone3-workaround.x86_64 /clone3-workaround
-RUN chmod 100 /clone3-workaround
-SHELL ["/clone3-workaround", "/bin/sh", "-c"]
-
 RUN dnf -y update && \
     dnf -y install @development-tools pkg-config iproute iputils wget git jq openssl-devel cryptsetup-libs cryptsetup-devel && \
     dnf clean all


### PR DESCRIPTION
### Proposed change(s)
- Remove clone3 workaround from Dockerfile

From what I can tell, this was introduced to fix E2E tests since we used a private runner before with some older version of Docker (why?). Since #52 however, we switched to using GitHub-hosted runners using `ubuntu-latest`, which has [Docker 20.10.17](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#tools) and thus does not appear to have the same issue: https://github.com/edgelesssys/constellation/runs/8269877141?check_suite_focus=true

Therefore, let's remove this workaround. Anything/anyone still reliant on this workaround should just update their Docker. AFAIK our CoreOS builder is still self-hosted, but never had this issue.