### PR TITLE
konnectivity strict node routing

### DIFF
--- a/bootstrapper/internal/kubernetes/cloud_provider.go
+++ b/bootstrapper/internal/kubernetes/cloud_provider.go
@@ -25,6 +25,8 @@ type ProviderMetadata interface {
 	Self(ctx context.Context) (metadata.InstanceMetadata, error)
 	// GetSubnetworkCIDR retrieves the subnetwork CIDR for the current instance.
 	GetSubnetworkCIDR(ctx context.Context) (string, error)
+	// GetNodenetworkCIDR retrieves the node network CIDR for the current instance.
+	GetNodenetworkCIDR(ctx context.Context) (string, error)
 	// SupportsLoadBalancer returns true if the cloud provider supports load balancers.
 	SupportsLoadBalancer() bool
 	// GetLoadBalancerEndpoint retrieves the load balancer endpoint.
@@ -97,6 +99,9 @@ type stubProviderMetadata struct {
 	GetSubnetworkCIDRErr  error
 	GetSubnetworkCIDRResp string
 
+	GetNodenetworkCIDRErr  error
+	GetNodenetworkCIDRResp string
+
 	ListErr  error
 	ListResp []metadata.InstanceMetadata
 
@@ -119,6 +124,10 @@ func (m *stubProviderMetadata) GetLoadBalancerEndpoint(ctx context.Context) (str
 
 func (m *stubProviderMetadata) GetSubnetworkCIDR(ctx context.Context) (string, error) {
 	return m.GetSubnetworkCIDRResp, m.GetSubnetworkCIDRErr
+}
+
+func (m *stubProviderMetadata) GetNodenetworkCIDR(ctx context.Context) (string, error) {
+	return m.GetNodenetworkCIDRResp, m.GetNodenetworkCIDRErr
 }
 
 func (m *stubProviderMetadata) List(ctx context.Context) ([]metadata.InstanceMetadata, error) {

--- a/bootstrapper/internal/kubernetes/k8sapi/kubeadm_config.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/kubeadm_config.go
@@ -73,7 +73,7 @@ func (c *CoreOSConfiguration) InitConfiguration(externalCloudProvider bool, k8sV
 						"audit-log-maxsize":   "100",                                    // CIS benchmark - Default value of Rancher
 						"profiling":           "false",                                  // CIS benchmark
 						// Disabled konnectivity until agents have stable connections
-						// "egress-selector-config-file": "/etc/kubernetes/egress-selector-configuration.yaml",
+						"egress-selector-config-file": "/etc/kubernetes/egress-selector-configuration.yaml",
 						"kubelet-certificate-authority": filepath.Join(
 							kubeconstants.KubernetesDir,
 							kubeconstants.DefaultCertificateDir,

--- a/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
@@ -114,9 +114,12 @@ func NewKonnectivityAgents(konnectivityServerAddress string) *konnectivityAgents
 									"--sync-forever=true",
 									// Ensure stable connection to the konnectivity server.
 									"--keepalive-time=20s",
-									"--sync-interval=1s",     // GKE: 5s
-									"--sync-interval-cap=3s", // GKE: 30s
-									"--probe-interval=1s",    // GKE: 5s
+									// "--sync-interval=1s",     // GKE: 5s
+									// "--sync-interval-cap=3s", // GKE: 30s
+									// "--probe-interval=1s",    // GKE: 5s
+									"--sync-interval=5s",      // GKE: 5s
+									"--sync-interval-cap=30s", // GKE: 30s
+									"--probe-interval=5s",     // GKE: 5s
 									"--v=3",
 								},
 								Env: []corev1.EnvVar{
@@ -332,8 +335,8 @@ func NewKonnectivityServerStaticPod(nodeCIDR, csp string) *konnectivityServerSta
 	}
 	// Add strict routing via setting "--node-cidr=10.9.0.0/16" as argument.
 	if csp != "gcp" {
-		yaml.StaticPod.Spec.Containers[0].Args = append(yaml.StaticPod.Spec.Containers[0].Args, "--node-cidr="+nodeCIDR)
-		yaml.StaticPod.Spec.Containers[0].Args = append(yaml.StaticPod.Spec.Containers[0].Args, "--proxy-strategies=destHost,default")
+		// yaml.StaticPod.Spec.Containers[0].Args = append(yaml.StaticPod.Spec.Containers[0].Args, "--node-cidr="+nodeCIDR)
+		yaml.StaticPod.Spec.Containers[0].Args = append(yaml.StaticPod.Spec.Containers[0].Args, "--proxy-strategies=default")
 	} else {
 		yaml.StaticPod.Spec.Containers[0].Args = append(yaml.StaticPod.Spec.Containers[0].Args, "--proxy-strategies=default")
 	}

--- a/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
@@ -253,7 +253,6 @@ func NewKonnectivityServerStaticPod(nodeCIDR, csp string) *konnectivityServerSta
 							"--agent-service-account=konnectivity-agent",
 							"--kubeconfig=/etc/kubernetes/konnectivity-server.conf",
 							"--authentication-audience=system:konnectivity-server",
-							"--proxy-strategies=destHost,default",
 						},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
@@ -334,6 +333,9 @@ func NewKonnectivityServerStaticPod(nodeCIDR, csp string) *konnectivityServerSta
 	// Add strict routing via setting "--node-cidr=10.9.0.0/16" as argument.
 	if csp != "gcp" {
 		yaml.StaticPod.Spec.Containers[0].Args = append(yaml.StaticPod.Spec.Containers[0].Args, "--node-cidr="+nodeCIDR)
+		yaml.StaticPod.Spec.Containers[0].Args = append(yaml.StaticPod.Spec.Containers[0].Args, "--proxy-strategies=destHost,default")
+	} else {
+		yaml.StaticPod.Spec.Containers[0].Args = append(yaml.StaticPod.Spec.Containers[0].Args, "--proxy-strategies=default")
 	}
 	return yaml
 }

--- a/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
@@ -107,7 +107,7 @@ func NewKonnectivityAgents(konnectivityServerAddress string) *konnectivityAgents
 									"--admin-server-port=8133",
 									"--health-server-port=8134",
 									"--service-account-token-path=/var/run/secrets/tokens/konnectivity-agent-token",
-									"--agent-identifiers=host=$(HOST_IP)",
+									"--agent-identifiers=host=$(HOST_IP)&default-route=true",
 									// we will be able to avoid constant polling when either one is done:
 									// https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/358
 									// https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/273
@@ -213,7 +213,7 @@ func NewKonnectivityAgents(konnectivityServerAddress string) *konnectivityAgents
 	}
 }
 
-func NewKonnectivityServerStaticPod() *konnectivityServerStaticPod {
+func NewKonnectivityServerStaticPod(nodeCIDR string) *konnectivityServerStaticPod {
 	udsHostPathType := corev1.HostPathDirectoryOrCreate
 	return &konnectivityServerStaticPod{
 		StaticPod: corev1.Pod{
@@ -253,7 +253,9 @@ func NewKonnectivityServerStaticPod() *konnectivityServerStaticPod {
 							"--agent-service-account=konnectivity-agent",
 							"--kubeconfig=/etc/kubernetes/konnectivity-server.conf",
 							"--authentication-audience=system:konnectivity-server",
-							"--proxy-strategies=destHost,default",
+							// "--proxy-strategies=destHost,default",
+							"--proxy-strategies=destHost,defaultRoute",
+							"--node-cidr=" + nodeCIDR, //"--node-cidr=10.9.0.0/16",
 						},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{

--- a/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
@@ -113,10 +113,9 @@ func NewKonnectivityAgents(konnectivityServerAddress string) *konnectivityAgents
 									// https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/273
 									"--sync-forever=true",
 									// Ensure stable connection to the konnectivity server.
-									"--keepalive-time=60s",
-									"--sync-interval=1s",
-									"--sync-interval-cap=3s",
-									"--probe-interval=1s",
+									"--sync-interval=1s",     // GKE: 5s
+									"--sync-interval-cap=3s", // GKE: 30s
+									"--probe-interval=1s",    // GKE: 5s
 									"--v=3",
 								},
 								Env: []corev1.EnvVar{
@@ -253,9 +252,8 @@ func NewKonnectivityServerStaticPod(nodeCIDR string) *konnectivityServerStaticPo
 							"--agent-service-account=konnectivity-agent",
 							"--kubeconfig=/etc/kubernetes/konnectivity-server.conf",
 							"--authentication-audience=system:konnectivity-server",
-							// "--proxy-strategies=destHost,default",
-							"--proxy-strategies=destHost,defaultRoute",
-							"--node-cidr=" + nodeCIDR, //"--node-cidr=10.9.0.0/16",
+							"--proxy-strategies=destHost,default",
+							"--node-cidr=" + nodeCIDR, //--node-cidr=10.9.0.0/16,
 						},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{

--- a/bootstrapper/internal/kubernetes/k8sapi/util.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/util.go
@@ -131,7 +131,7 @@ func (k *KubernetesUtil) InstallComponents(ctx context.Context, version versions
 }
 
 func (k *KubernetesUtil) InitCluster(
-	ctx context.Context, initConfig []byte, nodeName string, ips []net.IP, controlPlaneEndpoint string, log *logger.Logger,
+	ctx context.Context, initConfig []byte, nodeName string, ips []net.IP, controlPlaneEndpoint string, nodeCIDR string, log *logger.Logger,
 ) error {
 	// TODO: audit policy should be user input
 	auditPolicy, err := resources.NewDefaultAuditPolicy().Marshal()
@@ -182,7 +182,7 @@ func (k *KubernetesUtil) InitCluster(
 	}
 
 	log.Infof("Preparing node for Konnectivity")
-	if err := k.prepareControlPlaneForKonnectivity(ctx, controlPlaneEndpoint); err != nil {
+	if err := k.prepareControlPlaneForKonnectivity(ctx, controlPlaneEndpoint, nodeCIDR); err != nil {
 		return fmt.Errorf("setup konnectivity: %w", err)
 	}
 
@@ -201,7 +201,7 @@ func (k *KubernetesUtil) InitCluster(
 	return nil
 }
 
-func (k *KubernetesUtil) prepareControlPlaneForKonnectivity(ctx context.Context, loadBalancerEndpoint string) error {
+func (k *KubernetesUtil) prepareControlPlaneForKonnectivity(ctx context.Context, loadBalancerEndpoint, nodeCIDR string) error {
 	if !strings.Contains(loadBalancerEndpoint, ":") {
 		loadBalancerEndpoint = net.JoinHostPort(loadBalancerEndpoint, strconv.Itoa(constants.KubernetesPort))
 	}
@@ -210,7 +210,7 @@ func (k *KubernetesUtil) prepareControlPlaneForKonnectivity(ctx context.Context,
 		return fmt.Errorf("creating static pods directory: %w", err)
 	}
 
-	konnectivityServerYaml, err := resources.NewKonnectivityServerStaticPod().Marshal()
+	konnectivityServerYaml, err := resources.NewKonnectivityServerStaticPod(nodeCIDR).Marshal()
 	if err != nil {
 		return fmt.Errorf("generating konnectivity server static pod: %w", err)
 	}
@@ -514,7 +514,7 @@ func (k *KubernetesUtil) SetupNodeOperator(ctx context.Context, kubectl Client, 
 }
 
 // JoinCluster joins existing Kubernetes cluster using kubeadm join.
-func (k *KubernetesUtil) JoinCluster(ctx context.Context, joinConfig []byte, peerRole role.Role, controlPlaneEndpoint string, log *logger.Logger) error {
+func (k *KubernetesUtil) JoinCluster(ctx context.Context, joinConfig []byte, peerRole role.Role, controlPlaneEndpoint string, nodeCIDR string, log *logger.Logger) error {
 	// TODO: audit policy should be user input
 	auditPolicy, err := resources.NewDefaultAuditPolicy().Marshal()
 	if err != nil {
@@ -535,7 +535,7 @@ func (k *KubernetesUtil) JoinCluster(ctx context.Context, joinConfig []byte, pee
 
 	if peerRole == role.ControlPlane {
 		log.Infof("Prep Init Kubernetes cluster")
-		if err := k.prepareControlPlaneForKonnectivity(ctx, controlPlaneEndpoint); err != nil {
+		if err := k.prepareControlPlaneForKonnectivity(ctx, controlPlaneEndpoint, nodeCIDR); err != nil {
 			return fmt.Errorf("setup konnectivity: %w", err)
 		}
 	}

--- a/bootstrapper/internal/kubernetes/k8sutil.go
+++ b/bootstrapper/internal/kubernetes/k8sutil.go
@@ -19,8 +19,8 @@ import (
 
 type clusterUtil interface {
 	InstallComponents(ctx context.Context, version versions.ValidK8sVersion) error
-	InitCluster(ctx context.Context, initConfig []byte, nodeName string, ips []net.IP, controlPlaneEndpoint string, nodeCIDR string, log *logger.Logger) error
-	JoinCluster(ctx context.Context, joinConfig []byte, peerRole role.Role, controlPlaneEndpoint string, nodeCIDR string, log *logger.Logger) error
+	InitCluster(ctx context.Context, initConfig []byte, nodeName string, ips []net.IP, controlPlaneEndpoint string, nodeCIDR string, csp string, log *logger.Logger) error
+	JoinCluster(ctx context.Context, joinConfig []byte, peerRole role.Role, controlPlaneEndpoint string, nodeCIDR string, csp string, log *logger.Logger) error
 	SetupHelmDeployments(ctx context.Context, client k8sapi.Client, helmDeployments []byte, in k8sapi.SetupPodNetworkInput, log *logger.Logger) error
 	SetupAccessManager(kubectl k8sapi.Client, sshUsers kubernetes.Marshaler) error
 	SetupAutoscaling(kubectl k8sapi.Client, clusterAutoscalerConfiguration kubernetes.Marshaler, secrets kubernetes.Marshaler) error

--- a/bootstrapper/internal/kubernetes/k8sutil.go
+++ b/bootstrapper/internal/kubernetes/k8sutil.go
@@ -19,8 +19,8 @@ import (
 
 type clusterUtil interface {
 	InstallComponents(ctx context.Context, version versions.ValidK8sVersion) error
-	InitCluster(ctx context.Context, initConfig []byte, nodeName string, ips []net.IP, controlPlaneEndpoint string, log *logger.Logger) error
-	JoinCluster(ctx context.Context, joinConfig []byte, peerRole role.Role, controlPlaneEndpoint string, log *logger.Logger) error
+	InitCluster(ctx context.Context, initConfig []byte, nodeName string, ips []net.IP, controlPlaneEndpoint string, nodeCIDR string, log *logger.Logger) error
+	JoinCluster(ctx context.Context, joinConfig []byte, peerRole role.Role, controlPlaneEndpoint string, nodeCIDR string, log *logger.Logger) error
 	SetupHelmDeployments(ctx context.Context, client k8sapi.Client, helmDeployments []byte, in k8sapi.SetupPodNetworkInput, log *logger.Logger) error
 	SetupAccessManager(kubectl k8sapi.Client, sshUsers kubernetes.Marshaler) error
 	SetupAutoscaling(kubectl k8sapi.Client, clusterAutoscalerConfiguration kubernetes.Marshaler, secrets kubernetes.Marshaler) error

--- a/bootstrapper/internal/kubernetes/kubernetes.go
+++ b/bootstrapper/internal/kubernetes/kubernetes.go
@@ -160,7 +160,7 @@ func (k *KubeWrapper) InitCluster(
 		return nil, fmt.Errorf("encoding kubeadm init configuration as YAML: %w", err)
 	}
 	log.Infof("Initializing Kubernetes cluster")
-	if err := k.clusterUtil.InitCluster(ctx, initConfigYAML, nodeName, validIPs, controlPlaneEndpoint, nodeCIDR, log); err != nil {
+	if err := k.clusterUtil.InitCluster(ctx, initConfigYAML, nodeName, validIPs, controlPlaneEndpoint, nodeCIDR, k.cloudProvider, log); err != nil {
 		return nil, fmt.Errorf("kubeadm init: %w", err)
 	}
 	kubeConfig, err := k.GetKubeconfig()
@@ -315,7 +315,7 @@ func (k *KubeWrapper) JoinCluster(ctx context.Context, args *kubeadm.BootstrapTo
 		return fmt.Errorf("encoding kubeadm join configuration as YAML: %w", err)
 	}
 	log.With(zap.String("apiServerEndpoint", args.APIServerEndpoint)).Infof("Joining Kubernetes cluster")
-	if err := k.clusterUtil.JoinCluster(ctx, joinConfigYAML, peerRole, loadbalancerEndpoint, nodeCIDR, log); err != nil {
+	if err := k.clusterUtil.JoinCluster(ctx, joinConfigYAML, peerRole, loadbalancerEndpoint, nodeCIDR, k.cloudProvider, log); err != nil {
 		return fmt.Errorf("joining cluster: %v; %w ", string(joinConfigYAML), err)
 	}
 

--- a/bootstrapper/internal/kubernetes/kubernetes_test.go
+++ b/bootstrapper/internal/kubernetes/kubernetes_test.go
@@ -557,7 +557,7 @@ func (s *stubClusterUtil) InstallComponents(ctx context.Context, version version
 	return s.installComponentsErr
 }
 
-func (s *stubClusterUtil) InitCluster(ctx context.Context, initConfig []byte, nodeName string, ips []net.IP, controlPlaneEndpoint string, nodeCIDR string, log *logger.Logger) error {
+func (s *stubClusterUtil) InitCluster(ctx context.Context, initConfig []byte, nodeName string, ips []net.IP, controlPlaneEndpoint string, nodeCIDR string, csp string, log *logger.Logger) error {
 	s.initConfigs = append(s.initConfigs, initConfig)
 	return s.initClusterErr
 }
@@ -610,7 +610,7 @@ func (s *stubClusterUtil) SetupNodeOperator(ctx context.Context, kubectl k8sapi.
 	return s.setupNodeOperatorErr
 }
 
-func (s *stubClusterUtil) JoinCluster(ctx context.Context, joinConfig []byte, peerRole role.Role, controlPlaneEndpoint string, nodeCIDR string, log *logger.Logger) error {
+func (s *stubClusterUtil) JoinCluster(ctx context.Context, joinConfig []byte, peerRole role.Role, controlPlaneEndpoint string, nodeCIDR string, csp string, log *logger.Logger) error {
 	s.joinConfigs = append(s.joinConfigs, joinConfig)
 	return s.joinClusterErr
 }

--- a/bootstrapper/internal/kubernetes/kubernetes_test.go
+++ b/bootstrapper/internal/kubernetes/kubernetes_test.go
@@ -557,7 +557,7 @@ func (s *stubClusterUtil) InstallComponents(ctx context.Context, version version
 	return s.installComponentsErr
 }
 
-func (s *stubClusterUtil) InitCluster(ctx context.Context, initConfig []byte, nodeName string, ips []net.IP, controlPlaneEndpoint string, log *logger.Logger) error {
+func (s *stubClusterUtil) InitCluster(ctx context.Context, initConfig []byte, nodeName string, ips []net.IP, controlPlaneEndpoint string, nodeCIDR string, log *logger.Logger) error {
 	s.initConfigs = append(s.initConfigs, initConfig)
 	return s.initClusterErr
 }
@@ -610,7 +610,7 @@ func (s *stubClusterUtil) SetupNodeOperator(ctx context.Context, kubectl k8sapi.
 	return s.setupNodeOperatorErr
 }
 
-func (s *stubClusterUtil) JoinCluster(ctx context.Context, joinConfig []byte, peerRole role.Role, controlPlaneEndpoint string, log *logger.Logger) error {
+func (s *stubClusterUtil) JoinCluster(ctx context.Context, joinConfig []byte, peerRole role.Role, controlPlaneEndpoint string, nodeCIDR string, log *logger.Logger) error {
 	s.joinConfigs = append(s.joinConfigs, joinConfig)
 	return s.joinClusterErr
 }

--- a/cli/internal/gcp/client/loadbalancer.go
+++ b/cli/internal/gcp/client/loadbalancer.go
@@ -172,10 +172,12 @@ func (c *Client) createBackendService(ctx context.Context, lb *loadBalancer) err
 			LoadBalancingScheme: proto.String(computepb.BackendService_LoadBalancingScheme_name[int32(computepb.BackendService_EXTERNAL)]),
 			HealthChecks:        []string{c.resourceURI(scopeGlobal, "healthChecks", lb.name)},
 			PortName:            proto.String(lb.backendPortName),
+			TimeoutSec:          proto.Int32(240),
 			Backends: []*computepb.Backend{
 				{
-					BalancingMode: proto.String(computepb.Backend_BalancingMode_name[int32(computepb.Backend_UTILIZATION)]),
-					Group:         proto.String(c.resourceURI(scopeZone, "instanceGroups", c.controlPlaneInstanceGroup)),
+					BalancingMode:  proto.String(computepb.Backend_BalancingMode_name[int32(computepb.Backend_UTILIZATION)]),
+					MaxUtilization: proto.Float32(0.8),
+					Group:          proto.String(c.resourceURI(scopeZone, "instanceGroups", c.controlPlaneInstanceGroup)),
 				},
 			},
 		},

--- a/internal/cloud/azure/metadata.go
+++ b/internal/cloud/azure/metadata.go
@@ -154,6 +154,24 @@ func (m *Metadata) GetNetworkSecurityGroupName(ctx context.Context) (string, err
 	return *nsg.Name, nil
 }
 
+// GetNodenetworkCIDR retrieves the subnetwork CIDR from cloud provider metadata.
+func (m *Metadata) GetNodenetworkCIDR(ctx context.Context) (string, error) {
+	resourceGroup, err := m.imdsAPI.ResourceGroup(ctx)
+	if err != nil {
+		return "", err
+	}
+	virtualNetwork, err := m.getVirtualNetwork(ctx, resourceGroup)
+	if err != nil {
+		return "", err
+	}
+	if virtualNetwork == nil || virtualNetwork.Properties == nil || len(virtualNetwork.Properties.Subnets) == 0 ||
+		virtualNetwork.Properties.Subnets[0].Properties == nil || virtualNetwork.Properties.Subnets[0].Properties.AddressPrefix == nil {
+		return "", fmt.Errorf("could not retrieve subnetwork CIDR from virtual network %v", virtualNetwork)
+	}
+
+	return *virtualNetwork.Properties.Subnets[0].Properties.AddressPrefix, nil
+}
+
 // GetSubnetworkCIDR retrieves the subnetwork CIDR from cloud provider metadata.
 func (m *Metadata) GetSubnetworkCIDR(ctx context.Context) (string, error) {
 	resourceGroup, err := m.imdsAPI.ResourceGroup(ctx)

--- a/internal/cloud/gcp/metadata.go
+++ b/internal/cloud/gcp/metadata.go
@@ -30,8 +30,10 @@ type API interface {
 	RetrieveZone() (string, error)
 	// RetrieveInstanceName retrieves the instance name of the current instance.
 	RetrieveInstanceName() (string, error)
-	// RetrieveSubnetworkAliasCIDR retrieves the subnetwork CIDR of the current instance.
+	// RetrieveSubnetworkAliasCIDR retrieves the subnetwork alias CIDR of the current instance.
 	RetrieveSubnetworkAliasCIDR(ctx context.Context, project, zone, instanceName string) (string, error)
+	// RetrieveSubnetworkCIDR retrieves the subnetwork CIDR of the current instance.
+	RetrieveSubnetworkCIDR(ctx context.Context, project, zone, instanceName string) (string, error)
 	// RetrieveLoadBalancerEndpoint retrieves the load balancer endpoint of the current instance.
 	RetrieveLoadBalancerEndpoint(ctx context.Context, project string) (string, error)
 	// SetInstanceMetadata sets metadata key: value of the instance specified by project, zone and instanceName.
@@ -110,6 +112,23 @@ func (m *Metadata) GetSubnetworkCIDR(ctx context.Context) (string, error) {
 		return "", err
 	}
 	return m.api.RetrieveSubnetworkAliasCIDR(ctx, project, zone, instanceName)
+}
+
+// GetNodenetworkCIDR returns the subnetwork CIDR of the current instance.
+func (m *Metadata) GetNodenetworkCIDR(ctx context.Context) (string, error) {
+	project, err := m.api.RetrieveProjectID()
+	if err != nil {
+		return "", err
+	}
+	zone, err := m.api.RetrieveZone()
+	if err != nil {
+		return "", err
+	}
+	instanceName, err := m.api.RetrieveInstanceName()
+	if err != nil {
+		return "", err
+	}
+	return m.api.RetrieveSubnetworkCIDR(ctx, project, zone, instanceName)
 }
 
 // SupportsLoadBalancer returns true if the cloud provider supports load balancers.

--- a/internal/cloud/gcp/metadata_test.go
+++ b/internal/cloud/gcp/metadata_test.go
@@ -246,6 +246,7 @@ type stubGCPClient struct {
 	retrieveInstanceMetadaValues map[string]string
 	retrieveInstanceMetadataErr  error
 	retrieveSubnetworkAliasErr   error
+	retrieveSubnetworkErr        error
 	projectID                    string
 	zone                         string
 	instanceName                 string
@@ -322,4 +323,8 @@ func (s *stubGCPClient) UnsetInstanceMetadata(ctx context.Context, project, zone
 
 func (s *stubGCPClient) RetrieveSubnetworkAliasCIDR(ctx context.Context, project, zone, instanceName string) (string, error) {
 	return "", s.retrieveSubnetworkAliasErr
+}
+
+func (s *stubGCPClient) RetrieveSubnetworkCIDR(ctx context.Context, project, zone, instanceName string) (string, error) {
+	return "", s.retrieveSubnetworkErr
 }

--- a/internal/cloud/qemu/metadata.go
+++ b/internal/cloud/qemu/metadata.go
@@ -83,9 +83,14 @@ func (m Metadata) UID(ctx context.Context) (string, error) {
 	return "", nil
 }
 
-// GetSubnetworkCIDR retrieves the subnetwork CIDR from cloud provider metadata.
+// GetSubnetworkCIDR retrieves the pod subnetwork CIDR from cloud provider metadata.
 func (m Metadata) GetSubnetworkCIDR(ctx context.Context) (string, error) {
 	return "10.244.0.0/16", nil
+}
+
+// GetNodenetworkCIDR retrieves the node subnetwork CIDR from cloud provider metadata.
+func (m Metadata) GetNodenetworkCIDR(ctx context.Context) (string, error) {
+	return "0.0.0.0/0", nil
 }
 
 func (m Metadata) retrieveMetadata(ctx context.Context, uri string) ([]byte, error) {

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -45,8 +45,8 @@ const (
 	// These images are built in a way that they support all versions currently listed in VersionConfigs.
 	KonnectivityAgentImage = "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.32"
 	// TODO: switch back to official image once cilium node2node encryption is enabled.
-	// KonnectivityServerImage = "registry.k8s.io/kas-network-proxy/proxy-server:v0.0.32".
-	KonnectivityServerImage  = "ghcr.io/3u13r/constellation-konnectivity-server:v0.0.33-edgeless@sha256:75a46a3d6cca859e301059ba62324cf986826122ec315a753dd7389d3fe09473"
+	// KonnectivityServerImage = "registry.k8s.io/kas-network-proxy/proxy-server:v0.0.32"
+	KonnectivityServerImage  = "ghcr.io/3u13r/constellation-konnectivity-server:latest@sha256:a737d2c50f5a2612ffccf2c47349bcccf60fb6e79dfa9af5a50352ae9bc24753"
 	JoinImage                = "ghcr.io/edgelesssys/constellation/join-service:v2.0.0"
 	AccessManagerImage       = "ghcr.io/edgelesssys/constellation/access-manager:v2.0.0"
 	KmsImage                 = "ghcr.io/edgelesssys/constellation/kmsserver:v2.0.0"

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -43,8 +43,10 @@ func IsPreviewK8sVersion(version ValidK8sVersion) bool {
 const (
 	// Constellation images.
 	// These images are built in a way that they support all versions currently listed in VersionConfigs.
-	KonnectivityAgentImage   = "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.32"
-	KonnectivityServerImage  = "registry.k8s.io/kas-network-proxy/proxy-server:v0.0.32"
+	KonnectivityAgentImage = "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.32"
+	// TODO: switch back to official image once cilium node2node encryption is enabled.
+	// KonnectivityServerImage  = "registry.k8s.io/kas-network-proxy/proxy-server:v0.0.32".
+	KonnectivityServerImage  = "ghcr.io/3u13r/constellation-konnectivity-server:v0.0.33-edgeless@sha256:bf5748999b20576c7c97f25d2762408d705df5ae20640494bcb4cac5d648b583"
 	JoinImage                = "ghcr.io/edgelesssys/constellation/join-service:v2.0.0"
 	AccessManagerImage       = "ghcr.io/edgelesssys/constellation/access-manager:v2.0.0"
 	KmsImage                 = "ghcr.io/edgelesssys/constellation/kmsserver:v2.0.0"

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -45,8 +45,8 @@ const (
 	// These images are built in a way that they support all versions currently listed in VersionConfigs.
 	KonnectivityAgentImage = "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.32"
 	// TODO: switch back to official image once cilium node2node encryption is enabled.
-	// KonnectivityServerImage  = "registry.k8s.io/kas-network-proxy/proxy-server:v0.0.32".
-	KonnectivityServerImage  = "ghcr.io/3u13r/constellation-konnectivity-server:v0.0.33-edgeless@sha256:bf5748999b20576c7c97f25d2762408d705df5ae20640494bcb4cac5d648b583"
+	// KonnectivityServerImage = "registry.k8s.io/kas-network-proxy/proxy-server:v0.0.32".
+	KonnectivityServerImage  = "ghcr.io/3u13r/constellation-konnectivity-server:v0.0.33-edgeless"
 	JoinImage                = "ghcr.io/edgelesssys/constellation/join-service:v2.0.0"
 	AccessManagerImage       = "ghcr.io/edgelesssys/constellation/access-manager:v2.0.0"
 	KmsImage                 = "ghcr.io/edgelesssys/constellation/kmsserver:v2.0.0"

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -46,7 +46,7 @@ const (
 	KonnectivityAgentImage = "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent:v0.0.32"
 	// TODO: switch back to official image once cilium node2node encryption is enabled.
 	// KonnectivityServerImage = "registry.k8s.io/kas-network-proxy/proxy-server:v0.0.32".
-	KonnectivityServerImage  = "ghcr.io/3u13r/constellation-konnectivity-server:v0.0.33-edgeless"
+	KonnectivityServerImage  = "ghcr.io/3u13r/constellation-konnectivity-server:v0.0.33-edgeless@sha256:75a46a3d6cca859e301059ba62324cf986826122ec315a753dd7389d3fe09473"
 	JoinImage                = "ghcr.io/edgelesssys/constellation/join-service:v2.0.0"
 	AccessManagerImage       = "ghcr.io/edgelesssys/constellation/access-manager:v2.0.0"
 	KmsImage                 = "ghcr.io/edgelesssys/constellation/kmsserver:v2.0.0"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use fork of konnectivity server to only stricty route api server to node traffic
- Our konnectivity now doesn't do a lookup on the requested endpoint, since nodes don't have a DNS name



<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [x] Test e2e on Azure (3 control-plane nodes)
- [ ] Test e2e on GCP (3 control-plane nodes)
