### PR TITLE
license messages

### DIFF
--- a/internal/license/checker_enterprise.go
+++ b/internal/license/checker_enterprise.go
@@ -62,6 +62,9 @@ func (c *Checker) CheckLicense(ctx context.Context, provider cloudprovider.Provi
 	if err != nil {
 		printer("Unable to contact license server.\n")
 		printer("Please keep your vCPU quota in mind.\n")
+	} else if licenseID == CommunityLicense {
+		printer("You can use Constellation to create services for internal consumption.\n")
+		printer("For details, see https://docs.edgeless.systems/constellation/overview/license\n")
 	} else {
 		printer("Please keep your vCPU quota (%d) in mind.\n", quotaResp.Quota)
 	}


### PR DESCRIPTION
1. Don't print "license not found" if there's another error
2. ~(not changed yet:)~ Community license ~still prints~printed "Please keep your vCPU quota (8) in mind.". Should ~we~
    * ~let the lic server reply with a high number~
    * ~print nothing for community license~
    * print something about internal use