### PR TITLE
Remove obsolete tpmPath to OpenTPM

### DIFF
--- a/internal/attestation/vtpm/vtpm.go
+++ b/internal/attestation/vtpm/vtpm.go
@@ -12,17 +12,12 @@ import (
 	"github.com/google/go-tpm/tpm2"
 )
 
-const (
-	// tpmPath is the path to the vTPM.
-	tpmPath = "/dev/tpmrm0"
-)
-
 // TPMOpenFunc opens a TPM device.
 type TPMOpenFunc func() (io.ReadWriteCloser, error)
 
 // OpenVTPM opens the vTPM at `TPMPath`.
 func OpenVTPM() (io.ReadWriteCloser, error) {
-	return tpm2.OpenTPM(tpmPath)
+	return tpm2.OpenTPM()
 }
 
 type nopTPM struct{}


### PR DESCRIPTION
### Proposed change(s)
- Remove tpmPath to OpenTPM

This currently breaks building the CLI on Windows, but it's also completely unnecessary. OpenTPM already tries /dev/tpmrm0 first by default, so we can just remove this and in theory add CLI support for Windows (even if we don't plan on creating an official Windows CLI release yet).

