### PR TITLE
fix waiting on gcp load balancer

### DIFF
--- a/internal/grpc/retry/retry.go
+++ b/internal/grpc/retry/retry.go
@@ -41,6 +41,11 @@ func ServiceIsUnavailable(err error) bool {
 		return true
 	}
 
+	// retry if GCP proxy LB isn't fully available yet
+	if strings.HasPrefix(statusErr.Message(), `connection error: desc = "transport: authentication handshake failed: read tcp`) {
+		return true
+	}
+
 	// ideally we would check the error type directly, but grpc only provides a string
 	return !strings.HasPrefix(statusErr.Message(), `connection error: desc = "transport: authentication handshake failed`)
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- quick fix for when the GCP load balancer is not ready. 

This error is only needed for production images, since when using debugd the first time we wait on the load balancers (i.e. when uploading the bootstrapper via cdbg) we ignore every error. Since all load balancers are created at the same time, they are all ready when `constellation init` is executed. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
