### PR TITLE
fix e2e latest debug image selection

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -97,8 +97,7 @@ runs:
           gcp)
             if [ "${{ inputs.coreosImage == 'debug-latest' }}" = true ]
             then
-              GCP_LATEST_FAMILY=$(gcloud compute images list --project constellation-images --filter="family ~ constellation-debug-v\d+-\d+-\d+" --format="value(family)" | sort --version-sort | tail -n 1)
-              GCP_IMAGE_NAME=$(gcloud compute images list --project constellation-images --filter="name ~ constellation-\d{10} AND family:${GCP_LATEST_FAMILY}" --sort-by=creationTimestamp --format="table(name)" | tail -n 1)
+              GCP_IMAGE_NAME=$(gcloud compute images list --project constellation-images --filter="name ~ constellation-\d{10} AND family~constellation-debug-v\d+-\d+-\d+" --sort-by=creationTimestamp --format="table(name)" | tail -n 1)
               GCP_IMAGE="projects/constellation-images/global/images/${GCP_IMAGE_NAME}"
             else
               GCP_IMAGE=${{ inputs.coreosImage }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- select debug image with latest timestamp on GCP disregarding the image family

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
