### PR TITLE
docs: fix command in trusted launch workflow and add fetch-measurements

### DIFF
--- a/cli/internal/cmd/configfetchmeasurements.go
+++ b/cli/internal/cmd/configfetchmeasurements.go
@@ -57,7 +57,7 @@ func configFetchMeasurements(cmd *cobra.Command, fileHandler file.Handler, clien
 	}
 
 	if conf.IsDebugImage() {
-		cmd.Println("Configured image does not look like a released production image. Double check image before deploying to production.")
+		cmd.Println("Configured image doesn't look like a released production image. Double check image before deploying to production.")
 	}
 
 	if err := flags.updateURLs(conf); err != nil {

--- a/docs/docs/workflows/trusted-launch.md
+++ b/docs/docs/workflows/trusted-launch.md
@@ -1,6 +1,6 @@
 # Use Azure trusted launch VMs
 
-Constellation also supports [trusted launch VMs](https://docs.microsoft.com/en-us/azure/virtual-machines/trusted-launch) on Microsoft Azure. Trusted launch VMs don't offer the same level of security as CVMs, but are available in more regions and in larger quantities. The main difference between trusted launch VMs and normal VMs is that the former offer vTPM-based remote attestation. When used with trusted launch VMs, Constellation relies on vTPM-based remote attestation to verify nodes.
+Constellation also supports [trusted launch VMs](https://docs.microsoft.com/en-us/azure/virtual-machines/trusted-launch) on Microsoft Azure. Trusted launch VMs don't offer the same level of security as Confidential VMs, but are available in more regions and in larger quantities. The main difference between trusted launch VMs and normal VMs is that the former offer vTPM-based remote attestation. When used with trusted launch VMs, Constellation relies on vTPM-based remote attestation to verify nodes.
 
 :::caution
 
@@ -20,7 +20,7 @@ After you've downloaded the image, create a resource group `constellation-images
 You can use a script to do this:
 
 ```bash
-wget https://github.com/edgelesssys/constellation/blob/main/hack/importAzure.sh
+wget https://raw.githubusercontent.com/edgelesssys/constellation/main/hack/importAzure.sh
 chmod +x importAzure.sh
 AZURE_IMAGE_VERSION=2.0.0 AZURE_RESOURCE_GROUP_NAME=constellation-images AZURE_IMAGE_FILE=./2.0.0 ./importAzure.sh
 ```
@@ -31,6 +31,14 @@ The script creates the following resources:
 3. The actual image with the provided version. In this case `2.0.0`
 
 Once the import is completed, use the `ID` of the image version in your `constellation-conf.yaml` for the `image` field. Set `confidentialVM` to `false`.
+
+Fetch the image measurements:
+
+```bash
+IMAGE_VERSION=2.0.0
+URL=https://public-edgeless-constellation.s3.us-east-2.amazonaws.com//CommunityGalleries/ConstellationCVM-b3782fa0-0df7-4f2f-963e-fc7fc42663df/Images/constellation/Versions/$IMAGE_VERSION/measurements.yaml
+constellation config fetch-measurements -u$URL -s$URL.sig
+```
 
 :::info
 

--- a/docs/versioned_docs/version-2.0/workflows/trusted-launch.md
+++ b/docs/versioned_docs/version-2.0/workflows/trusted-launch.md
@@ -1,6 +1,6 @@
 # Use Azure trusted launch VMs
 
-Constellation also supports [trusted launch VMs](https://docs.microsoft.com/en-us/azure/virtual-machines/trusted-launch) on Microsoft Azure. Trusted launch VMs don't offer the same level of security as CVMs, but are available in more regions and in larger quantities. The main difference between trusted launch VMs and normal VMs is that the former offer vTPM-based remote attestation. When used with trusted launch VMs, Constellation relies on vTPM-based remote attestation to verify nodes.
+Constellation also supports [trusted launch VMs](https://docs.microsoft.com/en-us/azure/virtual-machines/trusted-launch) on Microsoft Azure. Trusted launch VMs don't offer the same level of security as Confidential VMs, but are available in more regions and in larger quantities. The main difference between trusted launch VMs and normal VMs is that the former offer vTPM-based remote attestation. When used with trusted launch VMs, Constellation relies on vTPM-based remote attestation to verify nodes.
 
 :::caution
 
@@ -20,7 +20,7 @@ After you've downloaded the image, create a resource group `constellation-images
 You can use a script to do this:
 
 ```bash
-wget https://github.com/edgelesssys/constellation/blob/main/hack/importAzure.sh
+wget https://raw.githubusercontent.com/edgelesssys/constellation/main/hack/importAzure.sh
 chmod +x importAzure.sh
 AZURE_IMAGE_VERSION=2.0.0 AZURE_RESOURCE_GROUP_NAME=constellation-images AZURE_IMAGE_FILE=./2.0.0 ./importAzure.sh
 ```
@@ -31,6 +31,14 @@ The script creates the following resources:
 3. The actual image with the provided version. In this case `2.0.0`
 
 Once the import is completed, use the `ID` of the image version in your `constellation-conf.yaml` for the `image` field. Set `confidentialVM` to `false`.
+
+Fetch the image measurements:
+
+```bash
+IMAGE_VERSION=2.0.0
+URL=https://public-edgeless-constellation.s3.us-east-2.amazonaws.com//CommunityGalleries/ConstellationCVM-b3782fa0-0df7-4f2f-963e-fc7fc42663df/Images/constellation/Versions/$IMAGE_VERSION/measurements.yaml
+constellation config fetch-measurements -u$URL -s$URL.sig
+```
 
 :::info
 

--- a/hack/importAzure.sh
+++ b/hack/importAzure.sh
@@ -44,6 +44,7 @@ AZURE_IMAGE_NAME="${AZURE_IMAGE_NAME:-upload-target}"
 AZURE_IMAGE_OFFER="${AZURE_IMAGE_OFFER:-constellation}"
 AZURE_IMAGE_DEFINITION="${AZURE_IMAGE_DEFINITION:-constellation}"
 AZURE_SKU="${AZURE_SKU:-constellation-coreos}"
+AZURE_SECURITY_TYPE="${AZURE_SECURITY_TYPE:-TrustedLaunch}"
 
 if [[ -z "${AZURE_RESOURCE_GROUP_NAME}" ]]; then
   echo "Please provide a value for AZURE_RESOURCE_GROUP_NAME."
@@ -67,6 +68,7 @@ echo "AZURE_IMAGE_DEFINITION=${AZURE_IMAGE_DEFINITION}"
 echo "AZURE_IMAGE_VERSION=${AZURE_IMAGE_VERSION}"
 echo "AZURE_PUBLISHER=${AZURE_PUBLISHER}"
 echo "AZURE_SKU=${AZURE_SKU}"
+echo "AZURE_SECURITY_TYPE=${AZURE_SECURITY_TYPE}"
 echo ""
 
 read -p "Continue (y/n)?" choice
@@ -101,7 +103,7 @@ az image create -g ${AZURE_RESOURCE_GROUP_NAME} -l ${AZURE_REGION} -n ${AZURE_IM
 echo "Creating Azure Shared Image Gallery."
 az sig create -l ${AZURE_REGION} --gallery-name ${AZURE_GALLERY_NAME} --resource-group ${AZURE_RESOURCE_GROUP_NAME}
 echo "Creating Image Definition."
-az sig image-definition create --resource-group ${AZURE_RESOURCE_GROUP_NAME} -l ${AZURE_REGION} --gallery-name ${AZURE_GALLERY_NAME} --gallery-image-definition ${AZURE_IMAGE_DEFINITION} --publisher ${AZURE_PUBLISHER} --offer ${AZURE_IMAGE_OFFER} --sku ${AZURE_SKU} --os-type Linux --os-state generalized --hyper-v-generation V2 --features SecurityType=ConfidentialVmSupported
+az sig image-definition create --resource-group ${AZURE_RESOURCE_GROUP_NAME} -l ${AZURE_REGION} --gallery-name ${AZURE_GALLERY_NAME} --gallery-image-definition ${AZURE_IMAGE_DEFINITION} --publisher ${AZURE_PUBLISHER} --offer ${AZURE_IMAGE_OFFER} --sku ${AZURE_SKU} --os-type Linux --os-state generalized --hyper-v-generation V2 --features SecurityType=${AZURE_SECURITY_TYPE}
 echo "Retrieving temporary image ID."
 AZURE_IMAGE_ID=$(az image list --query "[?name == '${AZURE_IMAGE_NAME}' && resourceGroup == '${AZURE_RESOURCE_GROUP_NAME^^}'] | [0].id" --output json | jq -r)
 


### PR DESCRIPTION
TrustedLaunchAndConfidentialVmSupported fails on my machine (latest az cli):
```
(InvalidParameter) The value 'TrustedLaunchAndConfidentialVmSupported' for feature 'SecurityType' is invalid. Allowed characters are English alphanumerical characters with spaces and commas. The length of the value cannot exceed 100 characters.
Code: InvalidParameter
Message: The value 'TrustedLaunchAndConfidentialVmSupported' for feature 'SecurityType' is invalid. Allowed characters are English alphanumerical characters with spaces and commas. The length of the value cannot exceed 100 characters.
Target: galleryImage.properties.features
```
Instead I made it configurable via env var.