### PR TITLE
Fix dirty build tag for CLI releases != linux/amd64

### DIFF
--- a/.github/actions/build_cli/action.yml
+++ b/.github/actions/build_cli/action.yml
@@ -71,6 +71,7 @@ runs:
       run: |
         curl -sLO https://github.com/sigstore/rekor/releases/download/v0.9.0/rekor-cli-linux-amd64
         sudo install rekor-cli-linux-amd64 /usr/local/bin/rekor-cli
+        rm rekor-cli-linux-amd64
       shell: bash
       working-directory: build
       if: ${{ inputs.cosignPublicKey != '' && inputs.cosignPrivateKey != '' && inputs.cosignPassword != '' }}

--- a/.github/actions/build_cli/action.yml
+++ b/.github/actions/build_cli/action.yml
@@ -66,12 +66,15 @@ runs:
     - name: Install Cosign
       uses: sigstore/cosign-installer@48866aa521d8bf870604709cd43ec2f602d03ff2
       if: ${{ inputs.cosignPublicKey != '' && inputs.cosignPrivateKey != '' && inputs.cosignPassword != '' }}
+
     - name: Install Rekor
       run: |
         curl -sLO https://github.com/sigstore/rekor/releases/download/v0.9.0/rekor-cli-linux-amd64
         sudo install rekor-cli-linux-amd64 /usr/local/bin/rekor-cli
       shell: bash
+      working-directory: build
       if: ${{ inputs.cosignPublicKey != '' && inputs.cosignPrivateKey != '' && inputs.cosignPassword != '' }}
+
     - name: Sign CLI
       run: |
         SIGN_TARGET=constellation-${{ inputs.targetOS }}-${{ inputs.targetArch }}

--- a/.github/actions/constellation_measure/action.yml
+++ b/.github/actions/constellation_measure/action.yml
@@ -73,6 +73,7 @@ runs:
       run: |
         curl -sLO https://github.com/sigstore/rekor/releases/download/v0.9.0/rekor-cli-linux-amd64
         sudo install rekor-cli-linux-amd64 /usr/local/bin/rekor-cli
+        rm rekor-cli-linux-amd64
       shell: bash
       if: ${{ inputs.cosignPublicKey != '' && inputs.cosignPrivateKey != '' && inputs.cosignPassword != '' }}
     - name: Sign measurements


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
In our v2.0.0 CLI release, all binaries except the Linux amd64 are tagged with `GitTreeState: dirty` when executing `constellation version`. Presumably, this seems to be the case due to Rekor being downloaded to the constellation root directory, which is not excluded from our git and thus taints the state. Therefore, let's specify it explicitly that we want to download to the build directory and also clean up the binary after we copied it.

It's a bit hard to test before we push another release, but testing it by running the action in act and copying the binaries out of the container seems to work and gives a clean state to the other binaries with this PR.
