### PR TITLE
increase control plane count during e2e tests

### DIFF
--- a/.github/workflows/e2e-test-azure-weekly.yml
+++ b/.github/workflows/e2e-test-azure-weekly.yml
@@ -41,7 +41,7 @@ jobs:
         uses: ./.github/actions/e2e_test
         with:
           workerNodesCount: "2"
-          controlNodesCount: "1"
+          controlNodesCount: "3"
           cloudProvider: "azure"
           sonobuoyTestSuiteCmd: '--plugin e2e --plugin-env e2e.E2E_FOCUS="\[Conformance\]" --plugin-env e2e.E2E_SKIP="for service with type clusterIP|HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol" --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-plugin.yaml --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-master-plugin.yaml'
           kubernetesVersion: ${{ matrix.version }}

--- a/.github/workflows/e2e-test-azure.yml
+++ b/.github/workflows/e2e-test-azure.yml
@@ -36,7 +36,7 @@ jobs:
         uses: ./.github/actions/e2e_test
         with:
           workerNodesCount: "2"
-          controlNodesCount: "1"
+          controlNodesCount: "3"
           cloudProvider: "azure"
           azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
           azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
@@ -108,7 +108,7 @@ jobs:
         uses: ./.github/actions/e2e_test
         with:
           workerNodesCount: "2"
-          controlNodesCount: "1"
+          controlNodesCount: "3"
           cloudProvider: "azure"
           azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
           azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}

--- a/.github/workflows/e2e-test-gcp-weekly.yml
+++ b/.github/workflows/e2e-test-gcp-weekly.yml
@@ -27,7 +27,7 @@ jobs:
         uses: ./.github/actions/e2e_test
         with:
           workerNodesCount: "2"
-          controlNodesCount: "1"
+          controlNodesCount: "3"
           cloudProvider: "gcp"
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}

--- a/.github/workflows/e2e-test-gcp.yml
+++ b/.github/workflows/e2e-test-gcp.yml
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/actions/e2e_test
         with:
           workerNodesCount: "2"
-          controlNodesCount: "1"
+          controlNodesCount: "3"
           cloudProvider: "gcp"
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
@@ -69,7 +69,7 @@ jobs:
         uses: ./.github/actions/e2e_test
         with:
           workerNodesCount: "2"
-          controlNodesCount: "1"
+          controlNodesCount: "3"
           cloudProvider: "gcp"
           machineType: "n2d-standard-4"
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}

--- a/.github/workflows/e2e-test-manual-macos.yml
+++ b/.github/workflows/e2e-test-manual-macos.yml
@@ -9,7 +9,7 @@ on:
         required: true
       controlNodesCount:
         description: "Number of control-plane nodes to spawn."
-        default: "1"
+        default: "3"
         required: true
       cloudProvider:
         description: "Which cloud provider to use."

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -9,7 +9,7 @@ on:
         required: true
       controlNodesCount:
         description: "Number of control-plane nodes to spawn."
-        default: "1"
+        default: "3"
         required: true
       cloudProvider:
         description: "Which cloud provider to use."


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Before the e2e test didn't catch the konnectivity problems, increasing control control plane count to avoid regression as soon as the feature is re-implemented as well as test HA kubernetes

There are some cloud costs attached to this PR, mainly due to the "e2e Test Azure" and "e2e Test GCP" which run the whole sonobuoy suite every night (during the work week) on our default K8s version. For better cost control/overview, we could put the e2e test in their own project (at least on gcp). 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Link to Milestone
