### PR TITLE
AB#2262 Automatic recovery

### DIFF
--- a/cli/internal/azure/loadbalancer.go
+++ b/cli/internal/azure/loadbalancer.go
@@ -98,8 +98,9 @@ func (l LoadBalancer) Azure() armnetwork.LoadBalancer {
 				{
 					Name: to.Ptr(recoveryHealthProbeName),
 					Properties: &armnetwork.ProbePropertiesFormat{
-						Protocol: to.Ptr(armnetwork.ProbeProtocolTCP),
-						Port:     to.Ptr[int32](constants.RecoveryPort),
+						Protocol:          to.Ptr(armnetwork.ProbeProtocolTCP),
+						Port:              to.Ptr[int32](constants.RecoveryPort),
+						IntervalInSeconds: to.Ptr[int32](5),
 					},
 				},
 			},

--- a/docs/docs/workflows/recovery.md
+++ b/docs/docs/workflows/recovery.md
@@ -51,7 +51,7 @@ If that fails, because the control plane is unhealthy, you will see log messages
 {"level":"ERROR","ts":"2022-09-08T09:57:23Z","logger":"rejoinClient","caller":"rejoinclient/client.go:110","msg":"Failed to rejoin on all endpoints"}
 ```
 
-This means that you have to recover the node manually. For this, you need its IP address, which can be obtained from the *Overview* page under *Private IP address*.
+This means that you have to recover the node manually.
 
 </tabItem>
 <tabItem value="gcp" label="GCP">
@@ -88,33 +88,26 @@ If that fails, because the control plane is unhealthy, you will see log messages
 {"level":"ERROR","ts":"2022-09-08T10:22:13Z","logger":"rejoinClient","caller":"rejoinclient/client.go:110","msg":"Failed to rejoin on all endpoints"}
 ```
 
-This means that you have to recover the node manually. For this, you need its IP address, which can be obtained from the *"VM Instance" -> "network interfaces"* page under *"Primary internal IP address."*
+This means that you have to recover the node manually.
 
 </tabItem>
 </tabs>
 
 ## Recover your cluster
 
-The following process needs to be repeated until a [member quorum for etcd](https://etcd.io/docs/v3.5/faq/#what-is-failure-tolerance) is established.
-For example, assume you have 5 control-plane nodes in your cluster and 4 of them have been rebooted due to a maintenance downtime in the cloud environment.
-You have to run through the following process for 2 of these nodes and recover them manually to recover the quorum.
-From there, your cluster will auto heal the remaining 2 control-plane nodes and the rest of your cluster.
+Recovering a cluster requires the following parameters:
 
-Recovering a node requires the following parameters:
-
-* The node's IP address
+* The `constellation-id.json` file in your working directory or the cluster's load balancer IP address
 * Access to the master secret of the cluster
 
-See the [Identify unhealthy clusters](#identify-unhealthy-clusters) description of how to obtain the node's IP address.
-Note that the recovery command needs to connect to the recovering nodes.
-Nodes only have private IP addresses in the VPC of the cluster, hence, the command needs to be issued from within the VPC network of the cluster.
-The easiest approach is to set up a jump host connected to the VPC network and perform the recovery from there.
+A cluster can be recovered like this:
 
-Given these prerequisites a node can be recovered like this:
-
-```
-$ constellation recover -e 34.107.89.208 --master-secret constellation-mastersecret.json
+```bash
+$ constellation recover --master-secret constellation-mastersecret.json
 Pushed recovery key.
+Pushed recovery key.
+Pushed recovery key.
+Recovered 3 control-plane nodes.
 ```
 
 In the serial console output of the node you'll see a similar output to the following:

--- a/internal/grpc/retry/retry_test.go
+++ b/internal/grpc/retry/retry_test.go
@@ -29,10 +29,18 @@ func TestServiceIsUnavailable(t *testing.T) {
 			err: status.Error(codes.Internal, "error"),
 		},
 		"unavailable error with authentication handshake failure": {
-			err: status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed`),
+			err: status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: bad certificate"`),
 		},
 		"normal unavailable error": {
 			err:             status.Error(codes.Unavailable, "error"),
+			wantUnavailable: true,
+		},
+		"handshake EOF error": {
+			err:             status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: EOF"`),
+			wantUnavailable: true,
+		},
+		"handshake read tcp error": {
+			err:             status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: read tcp error"`),
 			wantUnavailable: true,
 		},
 		"wrapped error": {
@@ -48,6 +56,47 @@ func TestServiceIsUnavailable(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 			assert.Equal(tc.wantUnavailable, ServiceIsUnavailable(tc.err))
+		})
+	}
+}
+
+func TestLoadbalancerIsNotReady(t *testing.T) {
+	testCases := map[string]struct {
+		err          error
+		wantNotReady bool
+	}{
+		"nil": {},
+		"not status error": {
+			err: errors.New("error"),
+		},
+		"not unavailable": {
+			err: status.Error(codes.Internal, "error"),
+		},
+		"unavailable error with authentication handshake failure": {
+			err: status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: bad certificate"`),
+		},
+		"handshake EOF error": {
+			err: status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: EOF"`),
+		},
+		"handshake read tcp error": {
+			err:          status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: read tcp error"`),
+			wantNotReady: true,
+		},
+		"normal unavailable error": {
+			err: status.Error(codes.Unavailable, "error"),
+		},
+		"wrapped error": {
+			err: fmt.Errorf("some wrapping: %w", status.Error(codes.Unavailable, "error")),
+		},
+		"code unknown": {
+			err: status.Error(codes.Unknown, "unknown"),
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			assert.Equal(tc.wantNotReady, LoadbalancerIsNotReady(tc.err))
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Update the `constellation recover` command to be fully automatic
  - Endpoint is read from file if not explicitly set using the `--endpoint`/`-e` flag
  - Recover call is repeated until the recovery loadbalancer no longer has any "healthy" backends

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- The actual changeset is rather small: We simply wrap the recover call in a for loop that terminates after a non-retriable error is encountered
- Azure's LB healthprobe frequency was increased to 5 seconds (the maximum)
  - This is needed because otherwise the LB is slow to realise a node was successfully recovered
    - This is no problem on GCP since the default probe frequency is 1 second
- A "service unavailable" error is retried once, this is to avoid aborting the recovery in case the LB routes our request to a node we just recovered
  - For GCP we set a small retry interval of 5 seconds, since that is enough for the LB to remove the node from its backends
  - On Azure we require a larger interval to avoid this issue, this slows down recovery slightly and therefore it is only set if the CSP is Azure

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Link to Milestone
