### PR TITLE
AB#2198: CI/E2E for macOS 

### DIFF
--- a/.github/actions/azure_login/action.yml
+++ b/.github/actions/azure_login/action.yml
@@ -2,30 +2,14 @@ name: Azure login
 description: "Login to Azure & configure az CLI."
 inputs:
   azure_credentials:
-    description: 'Credentials authorized to create Constellation on Azure.'
+    description: "Credentials authorized to create Constellation on Azure."
     required: true
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-  - name: Install az CLI
-    run: |
-      echo "::group::Install build dependencies"
-      sudo apt-get update
-      sudo apt-get install ca-certificates curl apt-transport-https lsb-release gnupg -y
-      curl -sL https://packages.microsoft.com/keys/microsoft.asc |
-        gpg --dearmor |
-        sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
-      AZ_REPO=$(lsb_release -cs)
-      echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" |
-          sudo tee /etc/apt/sources.list.d/azure-cli.list
-      sudo apt-get update
-      sudo apt-get install azure-cli -y
-      az help
-      echo "::endgroup::"
-    shell: bash
-  # As described at:
-  # https://github.com/Azure/login#configure-deployment-credentials
-  - name: Login to Azure
-    uses: azure/login@24848bc889cfc0a8313c2b3e378ac0d625b9bc16
-    with:
-      creds: ${{ inputs.azure_credentials }}
+    # As described at:
+    # https://github.com/Azure/login#configure-deployment-credentials
+    - name: Login to Azure
+      uses: azure/login@24848bc889cfc0a8313c2b3e378ac0d625b9bc16
+      with:
+        creds: ${{ inputs.azure_credentials }}

--- a/.github/actions/build_bootstrapper/action.yml
+++ b/.github/actions/build_bootstrapper/action.yml
@@ -7,19 +7,10 @@ inputs:
     default: "./bootstrapper"
     required: true
 
+# Linux runner only (Docker required)
 runs:
   using: "composite"
   steps:
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
-
-    - name: Install Dependencies
-      shell: bash
-      run: |
-        echo "::group::Install build dependencies"
-        sudo apt-get update && sudo apt-get -y install cmake make
-        echo "::endgroup::"
-
     - name: Build the bootstrapper
       shell: bash
       run: |

--- a/.github/actions/build_cdbg/action.yml
+++ b/.github/actions/build_cdbg/action.yml
@@ -1,0 +1,14 @@
+name: Build cdbg
+description: Build the Constellation cdbg binary
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build cdbg
+      shell: bash
+      run: |
+        echo "::group::Build cdbg"
+        mkdir -p build && cd build
+        cmake ..
+        make cdbg
+        echo "::endgroup::"

--- a/.github/actions/build_cdbg/action.yml
+++ b/.github/actions/build_cdbg/action.yml
@@ -1,6 +1,16 @@
 name: Build cdbg
 description: Build the Constellation cdbg binary
 
+inputs:
+  targetOS:
+    description: "Build CLI for this OS. [linux, darwin]"
+    required: true
+    default: "linux"
+  targetArch:
+    description: "Build CLI for this architecture. [amd64, arm64]"
+    required: true
+    default: "amd64"
+
 runs:
   using: "composite"
   steps:
@@ -10,5 +20,5 @@ runs:
         echo "::group::Build cdbg"
         mkdir -p build && cd build
         cmake ..
-        make cdbg
+        GOOS=${{ inputs.targetOS }} GOARCH=${{ inputs.targetArch }} make cdbg
         echo "::endgroup::"

--- a/.github/actions/build_cli/action.yml
+++ b/.github/actions/build_cli/action.yml
@@ -63,7 +63,7 @@ runs:
 
     - name: Install Rekor
       run: |
-        curl -sLO https://github.com/sigstore/rekor/releases/download/v0.9.0/rekor-cli-linux-amd64
+        curl -sLO https://github.com/sigstore/rekor/releases/download/v0.12.0/rekor-cli-linux-amd64
         sudo install rekor-cli-linux-amd64 /usr/local/bin/rekor-cli
         rm rekor-cli-linux-amd64
       shell: bash

--- a/.github/actions/build_cli/action.yml
+++ b/.github/actions/build_cli/action.yml
@@ -31,26 +31,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Install build dependencies
-      run: |
-        echo "::group::Install build dependencies"
-        sudo apt-get update
-        sudo apt-get install \
-          build-essential cmake \
-          -y
-        echo "::endgroup::"
-      shell: bash
-
     # https://github.blog/2022-04-12-git-security-vulnerability-announced/
     - name: Mark repository safe
       run: |
         git config --global --add safe.directory /__w/constellation/constellation
       shell: bash
-
-    - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
-      with:
-        go-version: "1.19.1"
 
     - name: Build CLI
       run: |

--- a/.github/actions/build_cli/action.yml
+++ b/.github/actions/build_cli/action.yml
@@ -48,7 +48,7 @@ runs:
         else
           cmake ..
         fi
-        GOOS=${{ inputs.targetOS }} GOARCH=${{ inputs.targetArch }} make -j`nproc` cli
+        GOOS=${{ inputs.targetOS }} GOARCH=${{ inputs.targetArch }} make cli
         cp constellation constellation-${{ inputs.targetOS }}-${{ inputs.targetArch }}
         echo "$(pwd)" >> $GITHUB_PATH
         export PATH="$PATH:$(pwd)"
@@ -63,9 +63,11 @@ runs:
 
     - name: Install Rekor
       run: |
-        curl -sLO https://github.com/sigstore/rekor/releases/download/v0.12.0/rekor-cli-linux-amd64
-        sudo install rekor-cli-linux-amd64 /usr/local/bin/rekor-cli
-        rm rekor-cli-linux-amd64
+        HOSTOS="$(go env GOOS)"
+        HOSTARCH="$(go env GOARCH)"
+        curl -sLO https://github.com/sigstore/rekor/releases/download/v0.12.0/rekor-cli-${HOSTOS}-${HOSTARCH}
+        sudo install rekor-cli-${HOSTOS}-${HOSTARCH} /usr/local/bin/rekor-cli
+        rm rekor-cli-${HOSTOS}-${HOSTARCH}
       shell: bash
       working-directory: build
       if: ${{ inputs.cosignPublicKey != '' && inputs.cosignPrivateKey != '' && inputs.cosignPassword != '' }}

--- a/.github/actions/build_debugd/action.yml
+++ b/.github/actions/build_debugd/action.yml
@@ -7,22 +7,10 @@ inputs:
     default: "./debugd"
     required: true
 
+# Linux runner only
 runs:
   using: "composite"
   steps:
-    - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
-      with:
-        go-version: "1.19.1"
-
-    - name: Install Dependencies
-      shell: bash
-      run: |
-        echo "::group::Install build dependencies"
-        sudo apt-get update
-        sudo apt-get -y install cmake make
-        echo "::endgroup::"
-
     - name: Build debugd
       shell: bash
       run: |

--- a/.github/actions/build_debugd/action.yml
+++ b/.github/actions/build_debugd/action.yml
@@ -20,7 +20,6 @@ runs:
         cmake ..
         export GOCACHE=${homedir}/.cache/go-build
         export GOPATH=${homedir}/go
-        export GOPRIVATE=github.com/edgelesssys
         export GOMODCACHE=${homedir}/.cache/go-mod
         make debugd
         mv -n debugd "${{ inputs.outputPath }}"

--- a/.github/actions/build_debugd/action.yml
+++ b/.github/actions/build_debugd/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: "./debugd"
     required: true
 
-# Linux runner only
+# Linux runner only (homedir trick does not work on macOS, required for private runner)
 runs:
   using: "composite"
   steps:
@@ -22,6 +22,6 @@ runs:
         export GOPATH=${homedir}/go
         export GOPRIVATE=github.com/edgelesssys
         export GOMODCACHE=${homedir}/.cache/go-mod
-        make debugd cdbg
+        make debugd
         mv -n debugd "${{ inputs.outputPath }}"
         echo "::endgroup::"

--- a/.github/actions/build_disk_mapper/action.yml
+++ b/.github/actions/build_disk_mapper/action.yml
@@ -3,23 +3,14 @@ description: Build the Constellation disk-mapper binary
 
 inputs:
   outputPath:
-    description: 'Output path of the binary'
-    default: './disk-mapper'
+    description: "Output path of the binary"
+    default: "./disk-mapper"
     required: true
 
+# Linux runner only (Docker required)
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
-
-    - name: Install Dependencies
-      shell: bash
-      run: |
-        echo "::group::Install build dependencies"
-        sudo apt-get update && sudo apt-get -y install cmake make
-        echo "::endgroup::" 
-    
     - name: Build the disk-mapper
       shell: bash
       run: |

--- a/.github/actions/build_micro_service/action.yml
+++ b/.github/actions/build_micro_service/action.yml
@@ -2,23 +2,23 @@ name: Build micro service
 description: Build and upload a container image for a Constellation micro-service
 inputs:
   name:
-    description: 'Name of the micro-service'
+    description: "Name of the micro-service"
     required: true
   projectVersion:
-    description: 'Version of the micro-service'
-    default: '0.0.0'
+    description: "Version of the micro-service"
+    default: "0.0.0"
     required: false
   dockerfile:
-    description: 'Path to the services Dockerfile'
+    description: "Path to the services Dockerfile"
     required: true
   pushTag:
-    description: 'Use this image tag'
+    description: "Use this image tag"
     required: false
   githubToken:
-    description: 'GitHub authorization token'
+    description: "GitHub authorization token"
     required: true
 
-
+# Linux runner only (Docker required)
 runs:
   using: "composite"
   steps:
@@ -37,11 +37,6 @@ runs:
           type=raw,value=${{ inputs.pushTag }},enable=${{ '' != inputs.pushTag }}
           type=raw,value=${{ steps.pseudo-version.outputs.pseudoVersion }},enable=${{ '' != steps.pseudo-version.outputs.pseudoVersion }}
           type=ref,event=branch
-
-    - name: Set up Docker Buildx
-      id: docker-setup
-      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
-
     - name: Log in to the Container registry
       id: docker-login
       uses: docker/login-action@dd4fa0671be5250ee6f50aedf4cb05514abda2c7

--- a/.github/actions/build_operator/action.yml
+++ b/.github/actions/build_operator/action.yml
@@ -2,19 +2,19 @@ name: Build operator
 description: Build and upload a container image for a Constellation operator
 inputs:
   name:
-    description: 'Name of the operator'
+    description: "Name of the operator"
     required: true
   sourceDir:
-    description: 'Path to the operators source directory'
+    description: "Path to the operators source directory"
     required: true
   pushTag:
-    description: 'Use this image tag'
+    description: "Use this image tag"
     required: false
   githubToken:
-    description: 'GitHub authorization token'
+    description: "GitHub authorization token"
     required: true
 
-
+# Linux runner only (Docker required)
 runs:
   using: "composite"
   steps:
@@ -26,10 +26,6 @@ runs:
       uses: ./.github/actions/install_operator_sdk
       with:
         version: v1.22.2
-
-    - name: Set up Docker Buildx
-      id: docker-setup
-      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
 
     - name: Log in to the Container registry
       id: docker-login
@@ -50,7 +46,6 @@ runs:
           type=raw,value=${{ inputs.pushTag }},enable=${{ '' != inputs.pushTag }}
           type=raw,value=${{ steps.pseudo-version.outputs.pseudoVersion }},enable=${{ '' != steps.pseudo-version.outputs.pseudoVersion }}
           type=ref,event=branch
-
 
     - name: Build and push container image
       uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -43,15 +43,6 @@ runs:
         curl -sLO https://dl.k8s.io/release/v1.23.0/bin/linux/amd64/kubectl
         install kubectl /usr/local/bin
       shell: bash
-    - name: Install yq jq
-      run: |
-        echo "::group::Install dependencies"
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CC86BB64
-        sudo add-apt-repository ppa:rmescandon/yq
-        sudo apt update
-        sudo apt install yq jq -y
-        echo "::endgroup::"
-      shell: bash
 
     - name: Constellation config generate
       run: |

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -40,7 +40,9 @@ runs:
   steps:
     - name: Install kubectl
       run: |
-        curl -sLO https://dl.k8s.io/release/v1.23.0/bin/linux/amd64/kubectl
+        HOSTOS="$(go env GOOS)"
+        HOSTARCH="$(go env GOARCH)"
+        curl -sLO https://dl.k8s.io/release/v1.23.0/bin/{$HOSTOS}/{$HOSTARCH}/kubectl
         install kubectl /usr/local/bin
       shell: bash
 

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -141,6 +141,7 @@ runs:
     - name: Cdbg deploy
       run: |
         echo "::group::cdbg deploy"
+        chmod +x $GITHUB_WORKSPACE/build/cdbg
         cdbg deploy --bootstrapper $GITHUB_WORKSPACE/build/bootstrapper
         echo "::endgroup::"
       shell: bash

--- a/.github/actions/constellation_measure/action.yml
+++ b/.github/actions/constellation_measure/action.yml
@@ -71,7 +71,7 @@ runs:
       if: ${{ inputs.cosignPublicKey != '' && inputs.cosignPrivateKey != '' && inputs.cosignPassword != '' }}
     - name: Install Rekor
       run: |
-        curl -sLO https://github.com/sigstore/rekor/releases/download/v0.9.0/rekor-cli-linux-amd64
+        curl -sLO https://github.com/sigstore/rekor/releases/download/v0.12.0/rekor-cli-linux-amd64
         sudo install rekor-cli-linux-amd64 /usr/local/bin/rekor-cli
         rm rekor-cli-linux-amd64
       shell: bash

--- a/.github/actions/constellation_measure/action.yml
+++ b/.github/actions/constellation_measure/action.yml
@@ -95,13 +95,6 @@ runs:
         COSIGN_PASSWORD: ${{ inputs.cosignPassword }}
       if: ${{ inputs.cosignPublicKey != '' && inputs.cosignPrivateKey != '' && inputs.cosignPassword != '' }}
 
-    - name: Install AWS CLI
-      run: |
-        echo "::group::Install AWS CLI"
-        sudo apt-get update && sudo apt-get -y install awscli
-        echo "::endgroup::"
-      shell: bash
-      if: ${{ inputs.awsAccessKeyID != '' && inputs.awsSecretAccessKey != '' && inputs.awsDefaultRegion != '' && inputs.awsBucketName != '' }}
     - name: Upload to S3
       run: |
         IMAGE=$(yq e ".provider.${CSP}.image" constellation-conf.yaml)

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -46,22 +46,47 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Determine build target
+      id: determine-build-target
+      shell: bash
+      run: |
+        echo "::set-output name=hostOS::$(go env GOOS)"
+        echo "::set-output name=hostArch::$(go env GOARCH)"
+
     - name: Build CLI
       uses: ./.github/actions/build_cli
+      with:
+        targetOS: ${{ steps.determine-build-target.outputs.hostOS }}
+        targetArch: ${{ steps.determine-build-target.outputs.hostArch }}
+
+    # macOS runners don't have Docker preinstalled, so they cannot build the bootstrapper.
+    # But we can use a Linux runner to build it and store/retrieve it from the action cache.
+    - name: Download the bootstrapper from cache
+      id: download-bootstrapper-cache
+      if: inputs.isDebugImage == 'true' && runner.os == 'macOS'
+      uses: actions/cache@v3
+      with:
+        key: bootstrapper-${{ github.sha }}
+        path: "build/bootstrapper"
+
     - name: Build the bootstrapper
       id: build-bootstrapper
       uses: ./.github/actions/build_bootstrapper
-      if: ${{ inputs.isDebugImage == 'true' }}
-    - name: Build debugd
-      id: build-debugd
-      uses: ./.github/actions/build_debugd
-      if: ${{ inputs.isDebugImage == 'true' }}
+      if: inputs.isDebugImage == 'true' && runner.os != 'macOS'
+
+    - name: Build cdbg
+      id: build-cdbg
+      uses: ./.github/actions/build_cdbg
+      if: inputs.isDebugImage == 'true'
+      with:
+        targetOS: ${{ steps.determine-build-target.outputs.hostOS }}
+        targetArch: ${{ steps.determine-build-target.outputs.hostArch }}
 
     - name: Login to GCP
       uses: ./.github/actions/gcp_login
       with:
         gcp_service_account_json: ${{ inputs.gcp_service_account_json }}
-      if: ${{ inputs.cloudProvider == 'gcp' }}
+      if: inputs.cloudProvider == 'gcp'
 
     - name: Create cluster
       uses: ./.github/actions/constellation_create

--- a/.github/actions/gcp_login/action.yml
+++ b/.github/actions/gcp_login/action.yml
@@ -2,19 +2,14 @@ name: GCP login
 description: "Login to GCP & configure gcloud CLI."
 inputs:
   gcp_service_account_json:
-    description: 'Service account with permissions to create Constellation on GCP.'
+    description: "Service account with permissions to create Constellation on GCP."
     required: true
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-  # As described at:
-  # https://github.com/google-github-actions/setup-gcloud#service-account-key-json
-  - name: Authorize GCP access
-    uses: google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955
-    with:
-      credentials_json: ${{ inputs.gcp_service_account_json }}
-  - name: Set up Cloud SDK
-    uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb
-  - name: Verify logged in
-    run: gcloud info
-    shell: bash
+    # As described at:
+    # https://github.com/google-github-actions/setup-gcloud#service-account-key-json
+    - name: Authorize GCP access
+      uses: google-github-actions/auth@ceee102ec2387dd9e844e01b530ccd4ec87ce955
+      with:
+        credentials_json: ${{ inputs.gcp_service_account_json }}

--- a/.github/actions/generate_measurements/action.yml
+++ b/.github/actions/generate_measurements/action.yml
@@ -72,9 +72,9 @@ runs:
       id: build-bootstrapper
       uses: ./.github/actions/build_bootstrapper
       if: ${{ inputs.isDebugImage == 'true' }}
-    - name: Build debugd
-      id: build-debugd
-      uses: ./.github/actions/build_debugd
+    - name: Build cdbg
+      id: build-cdbg
+      uses: ./.github/actions/build_cdbg
       if: ${{ inputs.isDebugImage == 'true' }}
 
     - name: Login to GCP

--- a/.github/actions/install_operator_sdk/action.yml
+++ b/.github/actions/install_operator_sdk/action.yml
@@ -6,28 +6,19 @@ inputs:
     description: "Version of the operator-sdk to install"
     required: true
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
-
-  - name: Install curl gpg
-    shell: bash
-    run: |
-      echo "::group::Install dependencies"
-      sudo apt update
-      sudo apt install curl gpg -y
-      echo "::endgroup::"
-
-  - name: Install operator-sdk
-    shell: bash
-    run: |
-      export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
-      export OS=$(uname | awk '{print tolower($0)}')
-      export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/${{ inputs.version }}
-      curl -sLO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
-      gpg --keyserver keyserver.ubuntu.com --recv-keys 052996E2A20B5C7E
-      curl -sLO ${OPERATOR_SDK_DL_URL}/checksums.txt
-      curl -sLO ${OPERATOR_SDK_DL_URL}/checksums.txt.asc
-      gpg -u "Operator SDK (release) <cncf-operator-sdk@cncf.io>" --verify checksums.txt.asc
-      grep operator-sdk_${OS}_${ARCH} checksums.txt | sha256sum -c -
-      chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
-      rm checksums.txt checksums.txt.asc
+    - name: Install operator-sdk
+      shell: bash
+      run: |
+        export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
+        export OS=$(uname | awk '{print tolower($0)}')
+        export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/${{ inputs.version }}
+        curl -sLO ${OPERATOR_SDK_DL_URL}/operator-sdk_${OS}_${ARCH}
+        gpg --keyserver keyserver.ubuntu.com --recv-keys 052996E2A20B5C7E
+        curl -sLO ${OPERATOR_SDK_DL_URL}/checksums.txt
+        curl -sLO ${OPERATOR_SDK_DL_URL}/checksums.txt.asc
+        gpg -u "Operator SDK (release) <cncf-operator-sdk@cncf.io>" --verify checksums.txt.asc
+        grep operator-sdk_${OS}_${ARCH} checksums.txt | sha256sum -c -
+        chmod +x operator-sdk_${OS}_${ARCH} && sudo mv operator-sdk_${OS}_${ARCH} /usr/local/bin/operator-sdk
+        rm checksums.txt checksums.txt.asc

--- a/.github/actions/pseudo_version/action.yml
+++ b/.github/actions/pseudo_version/action.yml
@@ -33,7 +33,6 @@ runs:
         homedir="$(getent passwd $(id -u) | cut -d ":" -f 6)"
         export GOCACHE=${homedir}/.cache/go-build
         export GOPATH=${homedir}/go
-        export GOPRIVATE=github.com/edgelesssys
         export GOMODCACHE=${homedir}/.cache/go-mod
         pseudoVersion=$(go run .)
         semanticVersion=$(go run . -semantic-version)

--- a/.github/actions/pseudo_version/action.yml
+++ b/.github/actions/pseudo_version/action.yml
@@ -18,14 +18,10 @@ outputs:
     description: "Branch name"
     value: ${{ steps.pseudo-version.outputs.branchName }}
 
+# Linux runner only (homedir trick does not work on macOS, required for private runner)
 runs:
   using: "composite"
   steps:
-    - name: Install Go
-      uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
-      with:
-        go-version: "1.19.1"
-
     - name: get pseudo version
       id: pseudo-version
       run: |

--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -1,0 +1,57 @@
+name: Setup Linux build environment
+description: "Setup a Linux Build environment (for self-hosted runners)"
+runs:
+  using: "composite"
+  steps:
+    - name: Setup custom apt repositories (azure-cli & yq)
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install ca-certificates curl apt-transport-https lsb-release gnupg -y
+        curl -sL https://packages.microsoft.com/keys/microsoft.asc |
+          gpg --dearmor |
+          sudo tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null
+        AZ_REPO=$(lsb_release -cs)
+        echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" |
+            sudo tee /etc/apt/sources.list.d/azure-cli.list
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys CC86BB64
+        sudo add-apt-repository ppa:rmescandon/yq
+
+    - name: Update apt repository information
+      shell: bash
+      run: |
+        sudo apt-get update
+
+    - name: Install build-essential & CMake
+      shell: bash
+      run: |
+        sudo apt-get install \
+          build-essential cmake \
+          -y
+
+    - name: Install curl gpg
+      shell: bash
+      run: |
+        sudo apt-get install curl gpg -y
+
+    - name: Install yq jq
+      run: |
+        sudo apt-get install yq jq -y
+      shell: bash
+
+    - name: Install AWS CLI
+      run: |
+        sudo apt-get -y install awscli
+      shell: bash
+
+    - name: Install az CLI
+      run: |
+        sudo apt-get install azure-cli -y
+      shell: bash
+
+    - name: Set up gcloud CLI
+      uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb
+
+    - name: Set up Docker Buildx
+      id: docker-setup
+      uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9

--- a/.github/actions/sonobuoy/action.yml
+++ b/.github/actions/sonobuoy/action.yml
@@ -13,8 +13,10 @@ runs:
   steps:
     - name: Install sonobuoy
       run: |
-        curl -sLO https://github.com/vmware-tanzu/sonobuoy/releases/download/v${{ inputs.sonobuoyVersion }}/sonobuoy_${{ inputs.sonobuoyVersion }}_linux_amd64.tar.gz
-        tar -xzf sonobuoy_${{ inputs.sonobuoyVersion }}_linux_amd64.tar.gz
+        HOSTOS="$(go env GOOS)"
+        HOSTARCH="$(go env GOARCH)"
+        curl -sLO https://github.com/vmware-tanzu/sonobuoy/releases/download/v${{ inputs.sonobuoyVersion }}/sonobuoy_${{ inputs.sonobuoyVersion }}_${HOSTOS}_${HOSTARCH}.tar.gz
+        tar -xzf sonobuoy_${{ inputs.sonobuoyVersion }}_${HOSTOS}_${HOSTARCH}.tar.gz
         install sonobuoy /usr/local/bin
       shell: bash
     - name: Sonobuoy version

--- a/.github/actions/sonobuoy/action.yml
+++ b/.github/actions/sonobuoy/action.yml
@@ -3,7 +3,7 @@ description: "Executed the e2e test framework sonobuoy."
 inputs:
   sonobuoyVersion:
     description: "Version of sonobuoy test CLI to use."
-    default: "0.56.4"
+    default: "0.56.10"
     required: true
   sonobuoyTestSuiteCmd:
     description: "Which tests should be run?"

--- a/.github/docs/release.md
+++ b/.github/docs/release.md
@@ -41,10 +41,12 @@ This checklist will prepare `v1.3.0` from `v1.2.0`. Adjust your version numbers 
         gh workflow run build-coreos.yml --ref release/v1.3 -F debug=false -F coreOSConfigBranch=release/v1.3 -F imageVersion=v1.3.0
         ```
     8. Update [default images in config](/internal/config/images_enterprise.go)
-    9. Run [E2E tests](/.github/workflows/e2e-test-manual.yml) to confirm stability.
+    9. Run manual E2E tests using [Linux](/.github/workflows/e2e-test-manual.yml) and [macOS](/.github/workflows/e2e-test-manual-macos.yml) to confirm functionality and stability.
         ```sh
         gh workflow run e2e-test-manual.yml --ref release/v1.3 -F workerNodesCount=2 -F controlNodesCount=1 -F autoscale=false -F cloudProvider=azure -F machineType=Standard_DC4as_v5 -F sonobuoyTestSuiteCmd="--mode quick" -F kubernetesVersion=1.23 -F coreosImage=/CommunityGalleries/ConstellationCVM-b3782fa0-0df7-4f2f-963e-fc7fc42663df/Images/constellation/Versions/1.3.0 -F isDebugImage=false
+        gh workflow run e2e-test-manual-macos.yml --ref release/v1.3 -F workerNodesCount=2 -F controlNodesCount=1 -F autoscale=false -F cloudProvider=azure -F machineType=Standard_DC4as_v5 -F sonobuoyTestSuiteCmd="--mode quick" -F kubernetesVersion=1.23 -F coreosImage=/CommunityGalleries/ConstellationCVM-b3782fa0-0df7-4f2f-963e-fc7fc42663df/Images/constellation/Versions/1.3.0 -F isDebugImage=false
         gh workflow run e2e-test-manual.yml --ref release/v1.3 -F workerNodesCount=2 -F controlNodesCount=1 -F autoscale=false -F cloudProvider=gcp -F machineType=n2d-standard-4 -F sonobuoyTestSuiteCmd="--mode quick" -F kubernetesVersion=1.23 -F coreosImage=projects/constellation-images/global/images/constellation-v1-3-0 -F isDebugImage=false
+        gh workflow run e2e-test-manual-macos.yml --ref release/v1.3 -F workerNodesCount=2 -F controlNodesCount=1 -F autoscale=false -F cloudProvider=gcp -F machineType=n2d-standard-4 -F sonobuoyTestSuiteCmd="--mode quick" -F kubernetesVersion=1.23 -F coreosImage=projects/constellation-images/global/images/constellation-v1-3-0 -F isDebugImage=false
         ```
     10. [Generate measurements](/.github/workflows/generate-measurements.yml) for the images on each CSP.
         ```sh

--- a/.github/templates/micro-service-image.yml.template
+++ b/.github/templates/micro-service-image.yml.template
@@ -32,9 +32,6 @@ jobs:
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
-      - name: Set up Docker Buildx
-        id: docker-setup
-        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9
 
       - name: Log in to the Container registry
         id: docker-login

--- a/.github/workflows/build-access-manager-image.yml
+++ b/.github/workflows/build-access-manager-image.yml
@@ -23,6 +23,11 @@ jobs:
         id: checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Build and upload access-manager container image
         id: build-and-upload
         uses: ./.github/actions/build_micro_service

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -46,6 +46,20 @@ jobs:
       - name: Build debugd
         uses: ./.github/actions/build_debugd
 
+  build-cdbg:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
+      - name: Check out repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Build cdbg
+        uses: ./.github/actions/build_cdbg
+
   build-disk-mapper:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -57,8 +57,29 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - name: Build cdbg
+      - name: Build cdbg (Linux, amd64)
         uses: ./.github/actions/build_cdbg
+        with:
+          targetOS: "linux"
+          targetArch: "amd64"
+
+      - name: Build cdbg (Linux, arm64)
+        uses: ./.github/actions/build_cdbg
+        with:
+          targetOS: "linux"
+          targetArch: "arm64"
+
+      - name: Build cdbg (macOS, amd64)
+        uses: ./.github/actions/build_cdbg
+        with:
+          targetOS: "linux"
+          targetArch: "arm64"
+
+      - name: Build cdbg (macOS, arm64)
+        uses: ./.github/actions/build_cdbg
+        with:
+          targetOS: "linux"
+          targetArch: "arm64"
 
   build-disk-mapper:
     runs-on: ubuntu-latest
@@ -74,7 +95,7 @@ jobs:
       - name: Build disk-mapper
         uses: ./.github/actions/build_disk_mapper
 
-  build-cli-linux-amd64:
+  build-cli:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go environment
@@ -85,58 +106,25 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - name: Build CLI
+      - name: Build CLI (Linux, amd64)
         uses: ./.github/actions/build_cli
         with:
           targetOS: linux
           targetArch: amd64
 
-  build-cli-linux-arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Go environment
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
-        with:
-          go-version: "1.19.1"
-
-      - name: Check out repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-
-      - name: Build CLI
+      - name: Build CLI (Linux, arm64)
         uses: ./.github/actions/build_cli
         with:
           targetOS: linux
           targetArch: arm64
 
-  build-cli-darwin-amd64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Go environment
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
-        with:
-          go-version: "1.19.1"
-
-      - name: Check out repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-
-      - name: Build CLI
+      - name: Build CLI (macOS, amd64)
         uses: ./.github/actions/build_cli
         with:
           targetOS: darwin
           targetArch: amd64
 
-  build-cli-darwin-arm64:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Setup Go environment
-        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
-        with:
-          go-version: "1.19.1"
-
-      - name: Check out repository
-        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-
-      - name: Build CLI
+      - name: Build CLI (macOS, arm64)
         uses: ./.github/actions/build_cli
         with:
           targetOS: darwin

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build disk-mapper
         uses: ./.github/actions/build_disk_mapper
 
-  build-cli:
+  build-cli-linux-amd64:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go environment
@@ -73,3 +73,57 @@ jobs:
 
       - name: Build CLI
         uses: ./.github/actions/build_cli
+        with:
+          targetOS: linux
+          targetArch: amd64
+
+  build-cli-linux-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
+      - name: Check out repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Build CLI
+        uses: ./.github/actions/build_cli
+        with:
+          targetOS: linux
+          targetArch: arm64
+
+  build-cli-darwin-amd64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
+      - name: Check out repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Build CLI
+        uses: ./.github/actions/build_cli
+        with:
+          targetOS: darwin
+          targetArch: amd64
+
+  build-cli-darwin-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
+      - name: Check out repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Build CLI
+        uses: ./.github/actions/build_cli
+        with:
+          targetOS: darwin
+          targetArch: arm64

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -21,27 +21,55 @@ jobs:
   build-bootstrapper:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
+      - name: Check out repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
       - name: Build the bootstrapper
         uses: ./.github/actions/build_bootstrapper
 
   build-debugd:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
+      - name: Check out repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
       - name: Build debugd
         uses: ./.github/actions/build_debugd
 
   build-disk-mapper:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
+      - name: Check out repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
       - name: Build disk-mapper
         uses: ./.github/actions/build_disk_mapper
 
   build-cli:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
+      - name: Check out repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
       - name: Build CLI
         uses: ./.github/actions/build_cli

--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -38,9 +38,7 @@ jobs:
             type=semver,pattern=v{{version}},value=${{ matrix.version }}
             type=semver,pattern=v{{major}}.{{minor}},value=${{ matrix.version }}
             type=semver,pattern=v{{major}},value=${{ matrix.version }}
-      - name: Set up Docker Buildx
-        id: docker-setup
-        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
+
       - name: Log in to the Container registry
         id: docker-login
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b

--- a/.github/workflows/build-constellation-node-operator.yml
+++ b/.github/workflows/build-constellation-node-operator.yml
@@ -19,6 +19,11 @@ jobs:
         id: checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Build and upload constellation-node-operator container image
         uses: ./.github/actions/build_operator
         with:

--- a/.github/workflows/build-coreos.yml
+++ b/.github/workflows/build-coreos.yml
@@ -31,6 +31,15 @@ jobs:
           submodules: recursive
           token: ${{ secrets.CI_GITHUB_REPOSITORY }}
 
+      - name: Install build packages
+        id: install-packages
+        uses: ./.github/actions/setup_linux
+
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Build bootstrapper
         if: ${{ inputs.debug == false }}
         uses: ./.github/actions/build_bootstrapper
@@ -59,10 +68,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Azure CLI
+      - name: Install AzCopy
         shell: bash
         run: |
-          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
           wget -q https://aka.ms/downloadazcopy-v10-linux -O azcopy.tar.gz
           tar --strip-components 1 -xf azcopy.tar.gz
           rm azcopy.tar.gz

--- a/.github/workflows/build-gcp-guest-agent.yml
+++ b/.github/workflows/build-gcp-guest-agent.yml
@@ -41,9 +41,7 @@ jobs:
             latest=${{ matrix.latest || false }}
           tags: |
             type=raw,value=${{ matrix.version }}
-      - name: Set up Docker Buildx
-        id: docker-setup
-        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
+
       - name: Log in to the Container registry
         id: docker-login
         uses: docker/login-action@49ed152c8eca782a232dede0303416e8f356c37b

--- a/.github/workflows/build-joinservice-image.yml
+++ b/.github/workflows/build-joinservice-image.yml
@@ -25,11 +25,16 @@ jobs:
         id: checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Build and upload join-service container image
         id: build-and-upload
         uses: ./.github/actions/build_micro_service
         with:
           name: join-service
-          projectVersion: '0.0.0'
+          projectVersion: "0.0.0"
           dockerfile: joinservice/Dockerfile
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-kms-image.yml
+++ b/.github/workflows/build-kms-image.yml
@@ -24,11 +24,16 @@ jobs:
         id: checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Build and upload KMS server container image
         id: build-and-upload
         uses: ./.github/actions/build_micro_service
         with:
           name: kmsserver
-          projectVersion: '0.0.0'
+          projectVersion: "0.0.0"
           dockerfile: kms/Dockerfile
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-micro-service-manual.yml
+++ b/.github/workflows/build-micro-service-manual.yml
@@ -4,23 +4,23 @@ on:
   workflow_dispatch:
     inputs:
       microService:
-        description: 'Name of the micro-service image to build'
+        description: "Name of the micro-service image to build"
         type: choice
         options:
-          - 'access-manager'
-          - 'join-service'
-          - 'kmsserver'
-          - 'verification-service'
+          - "access-manager"
+          - "join-service"
+          - "kmsserver"
+          - "verification-service"
         required: true
-        default: 'access-manager'
+        default: "access-manager"
       imageTag:
-        description: 'Container image tag'
+        description: "Container image tag"
         required: true
-        default: 'manual-build'
+        default: "manual-build"
       version:
-        description: 'Version of the image to build'
+        description: "Version of the image to build"
         required: true
-        default: '0.0.0'
+        default: "0.0.0"
 
 jobs:
   build-micro-service:
@@ -32,6 +32,11 @@ jobs:
       - name: Check out repository
         id: checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
 
       # choose the correct Dockerfile depending on what micro-service is being build
       - name: Set Dockerfile variable

--- a/.github/workflows/build-operator-manual.yml
+++ b/.github/workflows/build-operator-manual.yml
@@ -19,6 +19,11 @@ jobs:
         id: checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Build and upload constellation-node-operator container image
         uses: ./.github/actions/build_operator
         with:

--- a/.github/workflows/build-verification-service.yml
+++ b/.github/workflows/build-verification-service.yml
@@ -21,11 +21,16 @@ jobs:
         id: checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Build and upload verification-service container image
         id: build-and-upload
         uses: ./.github/actions/build_micro_service
         with:
           name: verification-service
-          projectVersion: '0.0.0'
+          projectVersion: "0.0.0"
           dockerfile: verify/Dockerfile
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - name: Install Go
+      - name: Setup Go environment
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
         with:
           go-version: "1.19.1"

--- a/.github/workflows/e2e-test-azure-weekly.yml
+++ b/.github/workflows/e2e-test-azure-weekly.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Login to Azure
         uses: ./.github/actions/azure_login
         with:

--- a/.github/workflows/e2e-test-azure.yml
+++ b/.github/workflows/e2e-test-azure.yml
@@ -13,6 +13,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Login to Azure
         uses: ./.github/actions/azure_login
         with:
@@ -80,6 +85,11 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
+
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
 
       - name: Login to Azure
         uses: ./.github/actions/azure_login

--- a/.github/workflows/e2e-test-gcp-weekly.yml
+++ b/.github/workflows/e2e-test-gcp-weekly.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Run GCP E2E test
         uses: ./.github/actions/e2e_test
         with:

--- a/.github/workflows/e2e-test-gcp.yml
+++ b/.github/workflows/e2e-test-gcp.yml
@@ -13,6 +13,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Run GCP E2E test
         uses: ./.github/actions/e2e_test
         with:
@@ -55,6 +60,11 @@ jobs:
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
+
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
 
       - name: Run GCP E2E test
         uses: ./.github/actions/e2e_test

--- a/.github/workflows/e2e-test-manual-macos.yml
+++ b/.github/workflows/e2e-test-manual-macos.yml
@@ -1,0 +1,157 @@
+name: e2e Test Manual (macOS CLI)
+
+on:
+  workflow_dispatch:
+    inputs:
+      workerNodesCount:
+        description: "Number of worker nodes to spawn."
+        default: "2"
+        required: true
+      controlNodesCount:
+        description: "Number of control-plane nodes to spawn."
+        default: "1"
+        required: true
+      autoscale:
+        description: "Autoscale?"
+        type: boolean
+        default: false
+        required: true
+      cloudProvider:
+        description: "Which cloud provider to use."
+        type: choice
+        options:
+          - "gcp"
+          - "azure"
+        default: "gcp"
+        required: true
+      sonobuoyTestSuiteCmd:
+        description: "Which tests should be run? Check README for guidance!"
+        default: "--mode quick"
+        required: true
+      kubernetesVersion:
+        description: "Kubernetes version to create the cluster from."
+        default: "1.24"
+        required: true
+      coreosImage:
+        description: "CoreOS image (full path). Examples are in internal/config/config.go."
+        default: "debug-latest"
+        type: string
+        required: true
+      isDebugImage:
+        description: "Is CoreOS image a debug image?"
+        type: boolean
+        default: true
+        required: false
+      machineType:
+        description: "Override VM machine type. Leave as 'default' or empty to use the default VM type for the selected cloud provider."
+        type: string
+        default: "default"
+        required: false
+
+jobs:
+  build-bootstrapper-linux:
+    name: "Build bootstrapper (debug image)"
+    runs-on: ubuntu-latest
+    if: ${{ github.event.inputs.isDebugImage == 'true' }}
+    steps:
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        if: ${{ github.event.steps.check-bootstrapper-cache.cache-hit != 'true'}}
+        with:
+          go-version: "1.19.1"
+
+      - name: Check out repository
+        if: ${{ github.event.steps.check-bootstrapper-cache.cache-hit != 'true'}}
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Build bootstrapper
+        if: ${{ github.event.steps.check-bootstrapper-cache.cache-hit != 'true'}}
+        uses: ./.github/actions/build_bootstrapper
+
+      - name: Upload bootstrapper to cache
+        if: ${{ github.event.steps.check-bootstrapper-cache.cache-hit != 'true'}}
+        uses: actions/cache@v3
+        with:
+          key: bootstrapper-${{ github.sha }}
+          path: "build/bootstrapper"
+
+  e2e-test-manual-darwin:
+    name: "e2e Test Manual (macOS)"
+    runs-on: macos-12
+    needs: build-bootstrapper-linux
+    if: ${{ always() && !cancelled() && (needs.build-bootstrapper-linux.result == 'success' || needs.build-bootstrapper-linux.result == 'skipped') }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
+      - name: Login to Azure
+        if: ${{ github.event.inputs.cloudProvider == 'azure' }}
+        uses: ./.github/actions/azure_login
+        with:
+          azure_credentials: ${{ secrets.AZURE_E2E_CREDENTIALS }}
+
+      - name: Create Azure resource group
+        id: az_resource_group_gen
+        if: ${{ github.event.inputs.cloudProvider == 'azure' }}
+        shell: bash
+        run: |
+          uuid=$(uuidgen)
+          name=e2e-test-${uuid%%-*}
+          az group create --location westus --name $name --tags e2e
+          echo "::set-output name=res_group_name::$name"
+
+      - name: Set up gcloud CLI
+        if: ${{ github.event.inputs.cloudProvider == 'gcp' }}
+        uses: google-github-actions/setup-gcloud@877d4953d2c70a0ba7ef3290ae968eb24af233bb
+
+      - name: Run manual E2E test
+        uses: ./.github/actions/e2e_test
+        with:
+          workerNodesCount: ${{ github.event.inputs.workerNodesCount }}
+          controlNodesCount: ${{ github.event.inputs.controlNodesCount }}
+          autoscale: ${{ github.event.inputs.autoscale }}
+          cloudProvider: ${{ github.event.inputs.cloudProvider }}
+          machineType: ${{ github.event.inputs.machineType }}
+          gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
+          sonobuoyTestSuiteCmd: ${{ github.event.inputs.sonobuoyTestSuiteCmd }}
+          kubernetesVersion: ${{ github.event.inputs.kubernetesVersion }}
+          azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
+          azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
+          coreosImage: ${{ github.event.inputs.coreosImage }}
+          isDebugImage: ${{ github.event.inputs.isDebugImage }}
+
+      - name: Always terminate cluster
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/constellation_destroy
+
+      - name: Notify teams channel
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        run: |
+          brew install gettext && brew link --force gettext
+          export TEAMS_JOB_NAME="${{ github.event.inputs.cloudProvider }} (macOS, manual)"
+          export TEAMS_RUN_ID=${{ github.run_id }}
+          envsubst < teams-payload.json > to-be-send.json
+          curl                                          \
+            -H "Content-Type: application/json"         \
+            -d @to-be-send.json                         \
+            "${{  secrets.MS_TEAMS_WEBHOOK_URI }}"
+        shell: bash
+        working-directory: .github/actions/e2e_test
+
+      - name: Always destroy Azure resource group
+        if: ${{ always() && github.event.inputs.cloudProvider == 'azure' }}
+        shell: bash
+        run: |
+          az group delete \
+            --name ${{ steps.az_resource_group_gen.outputs.res_group_name }} \
+            --force-deletion-types Microsoft.Compute/virtualMachineScaleSets \
+            --force-deletion-types Microsoft.Compute/virtualMachines \
+            --no-wait \
+            --yes

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Login to Azure
         if: ${{ github.event.inputs.cloudProvider == 'azure' }}
         uses: ./.github/actions/azure_login

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -101,7 +101,7 @@ jobs:
         if: ${{ failure() && github.ref == 'refs/heads/main' }}
         run: |
           sudo apt-get install gettext-base -y
-          export TEAMS_JOB_NAME=azure
+          export TEAMS_JOB_NAME="${{ github.event.inputs.cloudProvider }} (manual)"
           export TEAMS_RUN_ID=${{ github.run_id }}
           envsubst < teams-payload.json > to-be-send.json
           curl                                          \

--- a/.github/workflows/generate-measurements.yml
+++ b/.github/workflows/generate-measurements.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Login to Azure
         if: ${{ github.event.inputs.cloudProvider == 'azure' }}
         uses: ./.github/actions/azure_login

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -11,6 +11,11 @@ jobs:
         id: checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+
       - name: Build cli-linux-amd64
         uses: ./.github/actions/build_cli
         with:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
       - name: Setup Go environment
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
         with:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -20,7 +20,6 @@ jobs:
   integration-test:
     runs-on: ubuntu-latest
     env:
-      GOPRIVATE: github.com/edgelesssys/*
       CTEST_OUTPUT_ON_FAILURE: True
     steps:
       - name: Checkout

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -24,8 +24,6 @@ jobs:
   golangci:
     name: lint
     runs-on: ubuntu-latest
-    env:
-      GOPRIVATE: github.com/edgelesssys/*
     steps:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b

--- a/.github/workflows/test-unittest.yml
+++ b/.github/workflows/test-unittest.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  test:
+  test-linux:
     runs-on: ubuntu-latest
     env:
       GOPRIVATE: github.com/edgelesssys/*
@@ -39,5 +39,23 @@ jobs:
         run: mkdir build && cd build && cmake ..
 
       - name: Unit Tests
-        run: ctest -j $(nproc) -R unit
+        run: ctest -R unit
         working-directory: build
+
+  test-cli-darwin:
+    runs-on: macos-12
+    env:
+      GOPRIVATE: github.com/edgelesssys/*
+      CTEST_OUTPUT_ON_FAILURE: True
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
+          cache: true
+
+      - name: Unit Tests
+        run: go test -race -count=3 ./cli/...

--- a/.github/workflows/test-unittest.yml
+++ b/.github/workflows/test-unittest.yml
@@ -20,7 +20,6 @@ jobs:
   test-linux:
     runs-on: ubuntu-latest
     env:
-      GOPRIVATE: github.com/edgelesssys/*
       CTEST_OUTPUT_ON_FAILURE: True
     steps:
       - name: Checkout
@@ -45,7 +44,6 @@ jobs:
   test-darwin:
     runs-on: macos-12
     env:
-      GOPRIVATE: github.com/edgelesssys/*
       CTEST_OUTPUT_ON_FAILURE: True
     steps:
       - name: Checkout

--- a/.github/workflows/test-unittest.yml
+++ b/.github/workflows/test-unittest.yml
@@ -42,7 +42,7 @@ jobs:
         run: ctest -R unit
         working-directory: build
 
-  test-cli-darwin:
+  test-darwin:
     runs-on: macos-12
     env:
       GOPRIVATE: github.com/edgelesssys/*
@@ -57,5 +57,8 @@ jobs:
           go-version: "1.19.1"
           cache: true
 
-      - name: Unit Tests
+      - name: CLI Unit Tests
         run: go test -race -count=3 ./cli/...
+
+      - name: cdbg/debugd Unit Tests
+        run: go test -race -count=3 ./debugd/...

--- a/.github/workflows/test-unittest.yml
+++ b/.github/workflows/test-unittest.yml
@@ -26,14 +26,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - name: Set up Go
+      - name: Setup Go environment
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
         with:
-          go-version: 1.18
+          go-version: "1.19.1"
           cache: true
 
       - name: Install Dependencies
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libcryptsetup12 libcryptsetup-dev cmake libvirt-dev
+        run: sudo apt-get update && sudo apt-get install -y pkg-config libcryptsetup12 libcryptsetup-dev libvirt-dev
 
       - name: Create and populate build folder
         run: mkdir build && cd build && cmake ..

--- a/.github/workflows/update-cli-reference.yml
+++ b/.github/workflows/update-cli-reference.yml
@@ -16,10 +16,11 @@ jobs:
       - name: Checkout Constellation
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
-      - name: Set up Go
+      - name: Setup Go environment
         uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
         with:
-          go-version: 1.18
+          go-version: "1.19.1"
+          cache: true
 
       - name: Generate reference docs
         run: go run . | cat header.md - > ../../cli.md

--- a/image/Makefile
+++ b/image/Makefile
@@ -72,6 +72,7 @@ cosa-image:
 	make -j 1 -C $(COSA_BUILDDIR)
 
 cosa-init:
+	 mkdir -p $(COREOS_BUILD_PATH)
 	-flock $(COSA_LOCKFILE) -c '. $(COSA_ENV) && cd $(COREOS_BUILD_PATH) && NETRC=$(NETRC) cosa init --branch $(COSA_INIT_BRANCH) $(COSA_INIT_REPO)'
 
 cosa-fetch: cosa-init kernel $(BOOTSTRAPPER_OVERRIDE_PATH) $(DISK_MAPPER_OVERRIDE_PATH)


### PR DESCRIPTION
This is quite a lot of changes at a lot of different places, so I suggest reviewing commit-by-commit for a bit more clarity. Also not sure who wants to review this, so I will just tag some reviewers here ;)

### Proposed change(s)
- Remove many setup steps from actions (dumped them under `setup_linux` for now, it's unused though since Github-hosted runners have most stuff preinstalled anyways)
- Add macOS + multi-arch builds to "Build Constellation binaries" action (cross-compiled under Linux, same as we do for releases)
- Run unit tests for CLI & cdbg/debugd under macOS 
- Add manual e2e test using macOS
- Update sonobuoy to 0.56.10
- Update rekor-cli to 0.12.10
- Some VS Code auto-formatting

All macOS actions use macOS Monterey (12). This is _not_ `macos-latest` which is on Big Sur (11), however since macOS update adoption usually is than for Ubuntu and Monterey is almost a year old already, I think it makes sense to use the more latest version rather than what GitHub declares as latest here.

Note that since that the changes also apply to some release actions we usually only run before we actually release something, I could not test everything in-depth. There could be breakage on private runners, but usually this should be easily resolvable since it's just missing install steps (and they should be under `setup_linux`).

Otherwise, most stuff we use such as Docker Buildx, AWS/Azure/GCloud CLI. CMake, jq, yq and more are already preinstalled in the public runner images. The stuff is often fairly recent since the images are often updated, but not always 100% up-to-date (e.g. GCloud CLI is a few versions older). Not sure why the [Ubuntu 20.04 / `ubuntu-latest`](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#cli-tools) and [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#cli-tools) have differences for the GCloud SDK even though it's downloaded externally... but that can/should serve as an exercise on unexpected version dependencies for us.

All stuff that actually ends up in the images and thus in confidential space should be under our control, however, so Go is installed manually every time and for CGo binaries (bootstrapper, disk-mapper etc.) we use Docker anyways. 

For macOS, Docker is missing due to licensing issues and GCloud CLI is also not installed (not sure why). While we can easily install GCloud using an action, I don't personally know about Docker. I think it's technically possible, but not sure about that license issue. We don't need to use the macOS runner for everything, so it should not be an huge issue. For e2e tests, Docker is only required to build the bootstrapper. Here, in case an e2e test is running with an debug-image, we prepend a Linux VM that builds the bootstrapper, uploads it to the Github Actions cache and later download it in the e2e test action instead of building it manually. This step is restricted to macOS runners, so nothing should change for Linux runners.

Apart from that, only minor changes were required. For example: `nproc` does not exist under macOS. While this can be aliased with an equivalent (e.g.: `sysctl -n hw.logicalcpu`), it's often defined redundantly anyways since we only build one job. Apart from that, most changes should be apparent hopefully or restricted to the newly created e2e action.