### PR TITLE
Remove exporting of PCRs from QEMU metadata API

### DIFF
--- a/hack/qemu-metadata-api/main.go
+++ b/hack/qemu-metadata-api/main.go
@@ -11,9 +11,7 @@ import (
 
 	"github.com/edgelesssys/constellation/hack/qemu-metadata-api/server"
 	"github.com/edgelesssys/constellation/hack/qemu-metadata-api/virtwrapper"
-	"github.com/edgelesssys/constellation/internal/file"
 	"github.com/edgelesssys/constellation/internal/logger"
-	"github.com/spf13/afero"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"libvirt.org/go/libvirt"
@@ -31,7 +29,7 @@ func main() {
 	}
 	defer conn.Close()
 
-	serv := server.New(log, &virtwrapper.Connect{Conn: conn}, file.NewHandler(afero.NewOsFs()))
+	serv := server.New(log, &virtwrapper.Connect{Conn: conn})
 	if err := serv.ListenAndServe(*bindPort); err != nil {
 		log.With(zap.Error(err)).Fatalf("Failed to serve")
 	}

--- a/hack/qemu-metadata-api/server/server_test.go
+++ b/hack/qemu-metadata-api/server/server_test.go
@@ -18,9 +18,7 @@ import (
 
 	"github.com/edgelesssys/constellation/hack/qemu-metadata-api/virtwrapper"
 	"github.com/edgelesssys/constellation/internal/cloud/metadata"
-	"github.com/edgelesssys/constellation/internal/file"
 	"github.com/edgelesssys/constellation/internal/logger"
-	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"libvirt.org/go/libvirt"
@@ -73,7 +71,7 @@ func TestListAll(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			server := New(logger.NewTest(t), tc.connect, file.Handler{})
+			server := New(logger.NewTest(t), tc.connect)
 
 			res, err := server.listAll()
 
@@ -150,7 +148,7 @@ func TestListSelf(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			server := New(logger.NewTest(t), tc.connect, file.Handler{})
+			server := New(logger.NewTest(t), tc.connect)
 
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://192.0.0.1/self", nil)
 			require.NoError(err)
@@ -212,7 +210,7 @@ func TestListPeers(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			server := New(logger.NewTest(t), tc.connect, file.Handler{})
+			server := New(logger.NewTest(t), tc.connect)
 
 			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://192.0.0.1/peers", nil)
 			require.NoError(err)
@@ -267,7 +265,7 @@ func TestPostLog(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			server := New(logger.NewTest(t), &stubConnect{}, file.NewHandler(afero.NewMemMapFs()))
+			server := New(logger.NewTest(t), &stubConnect{})
 
 			req, err := http.NewRequestWithContext(context.Background(), tc.method, "http://192.0.0.1/logs", tc.message)
 			require.NoError(err)
@@ -347,8 +345,7 @@ func TestExportPCRs(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			file := file.NewHandler(afero.NewMemMapFs())
-			server := New(logger.NewTest(t), tc.connect, file)
+			server := New(logger.NewTest(t), tc.connect)
 
 			req, err := http.NewRequestWithContext(context.Background(), tc.method, "http://192.0.0.1/pcrs", strings.NewReader(tc.message))
 			require.NoError(err)
@@ -363,9 +360,6 @@ func TestExportPCRs(t *testing.T) {
 			}
 
 			assert.Equal(http.StatusOK, w.Code)
-			output, err := file.Read(exportedPCRsDir + tc.connect.network.leases[0].Hostname + "_pcrs.json")
-			require.NoError(err)
-			assert.JSONEq(tc.message, string(output))
 		})
 	}
 }

--- a/terraform/libvirt/README.md
+++ b/terraform/libvirt/README.md
@@ -13,7 +13,6 @@ See [variables.tf](./variables.tf) for a description of all available variables.
 ```tfvars
 constellation_coreos_image="/path/to/image.qcow2"
 # optional other vars, uncomment and change as needed
-# metadata_api_log_dir="path/to/folder/for/metadata"
 # control_plane_count=3
 # worker_count=2
 # vcpus=2

--- a/terraform/libvirt/main.tf
+++ b/terraform/libvirt/main.tf
@@ -39,11 +39,6 @@ resource "docker_container" "qemu-metadata" {
     target = "/var/run/libvirt/libvirt-sock"
     type   = "bind"
   }
-  mounts {
-    source = var.metadata_api_log_dir
-    target = "/pcrs"
-    type   = "bind"
-  }
 }
 
 module "control_plane" {

--- a/terraform/libvirt/variables.tf
+++ b/terraform/libvirt/variables.tf
@@ -51,8 +51,3 @@ variable "machine" {
   default     = "q35"
   description = "machine type. use 'q35' for secure boot and 'pc' for non secure boot. See 'qemu-system-x86_64 -machine help'"
 }
-
-variable "metadata_api_log_dir" {
-  type = string
-  description = "directory to store metadata log files. This must be an absolute path"
-}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
Retrieving image measurements is done by a separate tool. We no longer need to start a QEMU cluster to do so.
This PR removes the need to mount a log directory for the metadata container when using terraform to create a QEMU based cluster, since the metadata api no longer writes anything to disk.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->
