### PR TITLE
Run macos builds as separate jobs

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Build debugd
         uses: ./.github/actions/build_debugd
 
-  build-cdbg:
+  build-cdbg-linux:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -75,16 +75,28 @@ jobs:
           targetOS: "linux"
           targetArch: "arm64"
 
+  build-cdbg-macos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
       - name: Build cdbg (macOS, amd64)
         uses: ./.github/actions/build_cdbg
         with:
-          targetOS: "linux"
+          targetOS: "darwin"
           targetArch: "arm64"
 
       - name: Build cdbg (macOS, arm64)
         uses: ./.github/actions/build_cdbg
         with:
-          targetOS: "linux"
+          targetOS: "darwin"
           targetArch: "arm64"
 
   build-disk-mapper:
@@ -102,7 +114,7 @@ jobs:
       - name: Build disk-mapper
         uses: ./.github/actions/build_disk_mapper
 
-  build-cli:
+  build-cli-linux:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -126,6 +138,19 @@ jobs:
         with:
           targetOS: linux
           targetArch: arm64
+
+  build-cli-macos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup Go environment
+        uses: actions/setup-go@268d8c0ca0432bb2cf416faae41297df9d262d7f
+        with:
+          go-version: "1.19.1"
 
       - name: Build CLI (macOS, amd64)
         uses: ./.github/actions/build_cli


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Speed up workflow run times by building macOS binaries in separate jobs
  - Reduces build time from 10-12 minutes to ~7 minutes
- Fix cdbg being built for the wrong OS Arch

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->