### PR TITLE
Add gocyclo to golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - bodyclose
     - errname
     - exportloopref
+    - gocyclo
     - godot
     - gofmt
     - gofumpt
@@ -42,3 +43,6 @@ linters-settings:
     exclude-functions:
       - (*go.uber.org/zap.Logger).Sync
       - (*google.golang.org/grpc.Server).Serve
+  gocyclo:
+    # Minimum code complexity to report, 15 is used by goreportcard.com.
+    min-complexity: 15

--- a/cli/internal/gcp/client/client.go
+++ b/cli/internal/gcp/client/client.go
@@ -67,6 +67,8 @@ type Client struct {
 }
 
 // NewFromDefault creates an uninitialized client.
+//
+//gocyclo:ignore
 func NewFromDefault(ctx context.Context) (*Client, error) {
 	var closers []closer
 	insAPI, err := compute.NewInstancesRESTClient(ctx)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Run gocyclo with golangci-lint, as the check is also used in the goreportcard

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

**Problems to solve:**
- [ ] access_manager/access_manager.go:109:1                                                    complexity 24 of func `deployKeys` is high (> 15)
- [ ] bootstrapper/cmd/bootstrapper/main.go:47:1                                                complexity 18 of func `main` is high (> 15)
- [ ] bootstrapper/internal/kubernetes/k8sapi/install.go:81:1                                   complexity 22 of func `(*osInstaller).extractArchive` is high (> 15)
- [ ] bootstrapper/internal/kubernetes/kubernetes.go:78:1                                       complexity 31 of func `(*KubeWrapper).InitCluster` is high (> 15)
- [ ] cli/internal/cmd/create.go:50:1                                                           complexity 17 of func `create` is high (> 15)
- [ ] hack/image-measurement/main.go:82:1                                                       complexity 16 of func `(*libvirtInstance).createLibvirtInstance` is high (> 15)
- [ ] hack/pseudo-version/pseudo-version.go:22:1                                                complexity 16 of func `main` is high (> 15)
- [ ] operators/constellation-node-operator/controllers/autoscalingstrategy_controller.go:45:1  complexity 29 of func `(*AutoscalingStrategyReconciler).Reconcile` is high (> 15)
- [ ] operators/constellation-node-operator/controllers/nodeimage_controller.go:79:1            complexity 22 of func `(*NodeImageReconciler).Reconcile` is high (> 15)
- [ ] operators/constellation-node-operator/controllers/nodeimage_controller.go:511:1           complexity 19 of func `(*NodeImageReconciler).createNewNodes` is high (> 15)
- [ ] operators/constellation-node-operator/controllers/nodeimage_controller.go:652:1           complexity 18 of func `nodeImageStatus` is high (> 15)
- [ ] operators/constellation-node-operator/controllers/pendingnode_controller.go:64:1          complexity 16 of func `(*PendingNodeReconciler).Reconcile` is high (> 15)
- [ ] operators/constellation-node-operator/internal/azure/client/nodeimage.go:50:1             complexity 16 of func `(*Client).CreateNode` is high (> 15)
- [ ] operators/constellation-node-operator/main.go:59:1                                        complexity 18 of func `main` is high (> 15)

**How does gocyclo compute complexity?**

> The cyclomatic complexity of a function is calculated according to the following rules:
> 
>  1 is the base complexity of a function
> +1 for each 'if', 'for', 'case', '&&' or '||'
