### PR TITLE
enable konnectivity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Local cluster creation based on QEMU
 - Verification of Azure trusted launch attestation keys
 - Kubernetes version v1.25 is now fully supported.
+- Enabled Konnectivity.
 
 ### Changed
 <!-- For changes in existing functionality.  -->

--- a/bootstrapper/internal/kubernetes/k8sapi/kubeadm_config.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/kubeadm_config.go
@@ -66,14 +66,13 @@ func (c *CoreOSConfiguration) InitConfiguration(externalCloudProvider bool, k8sV
 			APIServer: kubeadm.APIServer{
 				ControlPlaneComponent: kubeadm.ControlPlaneComponent{
 					ExtraArgs: map[string]string{
-						"audit-policy-file":   auditPolicyPath,
-						"audit-log-path":      filepath.Join(auditLogDir, auditLogFile), // CIS benchmark
-						"audit-log-maxage":    "30",                                     // CIS benchmark - Default value of Rancher
-						"audit-log-maxbackup": "10",                                     // CIS benchmark - Default value of Rancher
-						"audit-log-maxsize":   "100",                                    // CIS benchmark - Default value of Rancher
-						"profiling":           "false",                                  // CIS benchmark
-						// Disabled konnectivity until agents have stable connections
-						// "egress-selector-config-file": "/etc/kubernetes/egress-selector-configuration.yaml",
+						"audit-policy-file":           auditPolicyPath,
+						"audit-log-path":              filepath.Join(auditLogDir, auditLogFile), // CIS benchmark
+						"audit-log-maxage":            "30",                                     // CIS benchmark - Default value of Rancher
+						"audit-log-maxbackup":         "10",                                     // CIS benchmark - Default value of Rancher
+						"audit-log-maxsize":           "100",                                    // CIS benchmark - Default value of Rancher
+						"profiling":                   "false",                                  // CIS benchmark
+						"egress-selector-config-file": "/etc/kubernetes/egress-selector-configuration.yaml",
 						"kubelet-certificate-authority": filepath.Join(
 							kubeconstants.KubernetesDir,
 							kubeconstants.DefaultCertificateDir,

--- a/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
@@ -113,10 +113,10 @@ func NewKonnectivityAgents(konnectivityServerAddress string) *KonnectivityAgents
 									// https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/273
 									"--sync-forever=true",
 									// Ensure stable connection to the konnectivity server.
-									"--keepalive-time=60s",
-									"--sync-interval=1s",
-									"--sync-interval-cap=3s",
-									"--probe-interval=1s",
+									"--keepalive-time=60m",
+									"--sync-interval=5s",
+									"--sync-interval-cap=30s",
+									"--probe-interval=5s",
 									"--v=3",
 								},
 								Env: []corev1.EnvVar{
@@ -253,7 +253,7 @@ func NewKonnectivityServerStaticPod() *KonnectivityServerStaticPod {
 							"--agent-service-account=konnectivity-agent",
 							"--kubeconfig=/etc/kubernetes/konnectivity-server.conf",
 							"--authentication-audience=system:konnectivity-server",
-							"--proxy-strategies=destHost,default",
+							"--proxy-strategies=default",
 						},
 						LivenessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{

--- a/cli/internal/terraform/terraform/gcp/modules/loadbalancer/main.tf
+++ b/cli/internal/terraform/terraform/gcp/modules/loadbalancer/main.tf
@@ -39,6 +39,7 @@ resource "google_compute_backend_service" "backend" {
   load_balancing_scheme = "EXTERNAL"
   health_checks         = [google_compute_health_check.health.self_link]
   port_name             = var.backend_port_name
+  timeout_sec           = 240
 
   backend {
     group          = var.backend_instance_group


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Route KubeAPI -> kubelet/pod/svc traffic over konnectivity

Note that with these settings it is possible (and likely) that the traffic will do another hop from the worker node kkonnecitivity routed the traffic to. 

As stability test I ran our e2e sonobuoy test on Azure and GCP with 3 control-plane / 3 worker nodes. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [x] Link to Milestone
