### PR TITLE
delete unused config test

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -108,52 +108,6 @@ func TestFromFile(t *testing.T) {
 	}
 }
 
-func TestFromFileStrictErrors(t *testing.T) {
-	testCases := map[string]struct {
-		yamlConfig string
-		wantErr    bool
-	}{
-		"valid config": {
-			yamlConfig: `
-			autoscalingNodeGroupMin: 5
-			autoscalingNodeGroupMax: 10
-			stateDisksizeGB: 25
-			`,
-		},
-		"typo": {
-			yamlConfig: `
-			autoscalingNodeGroupMini: 5
-			autoscalingNodeGroupMax: 10
-			stateDisksizeGB: 25
-			`,
-			wantErr: true,
-		},
-		"unsupported version": {
-			yamlConfig: `
-			version: v5
-			autoscalingNodeGroupMin: 1
-			autoscalingNodeGroupMax: 10
-			stateDisksizeGB: 30
-			`,
-			wantErr: true,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			assert := assert.New(t)
-
-			fileHandler := file.NewHandler(afero.NewMemMapFs())
-			err := fileHandler.Write(constants.ConfigFilename, []byte(tc.yamlConfig), file.OptNone)
-			assert.NoError(err)
-
-			// TODO: Test should fail because of unknown field "autoscalingNodeGroupMin" but it doesn't.
-			_, err = FromFile(fileHandler, constants.ConfigFilename)
-			assert.Error(err)
-		})
-	}
-}
-
 func TestValidate(t *testing.T) {
 	const defaultMsgCount = 15 // expect this number of error messages by default because user-specific values are not set and multiple providers are defined by default
 


### PR DESCRIPTION
Signed-off-by: Fabian Kammel <fk@edgeless.systems>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- The tests were supposed validate config, but were never updated to actually call `Validate()` function. Since we have a dedicated unit test `TestValidate`, I suggest we simply delete this test. I don't see any added value by keeping / fixing it.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
