### PR TITLE
[CLI] Activity indicator for init command

### DIFF
--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -114,7 +114,10 @@ func create(cmd *cobra.Command, creator cloudCreator, fileHandler file.Handler) 
 		}
 	}
 
+	spinner := newSpinner(cmd, "Loading ", true)
+	spinner.Start()
 	state, err := creator.Create(cmd.Context(), provider, config, flags.name, instanceType, flags.controllerCount, flags.workerCount)
+	spinner.Stop()
 	if err != nil {
 		return err
 	}

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -124,7 +124,8 @@ func initialize(cmd *cobra.Command, newDialer func(validator *cloudcmd.Validator
 		return fmt.Errorf("parsing or generating master secret from file %s: %w", flags.masterSecretPath, err)
 	}
 
-	cmd.Println("Initializing cluster ...")
+	spinner := NewSpinner(cmd, "Initializing cluster ", true)
+	spinner.Start()
 	req := &initproto.InitRequest{
 		MasterSecret:           masterSecret.Key,
 		Salt:                   masterSecret.Salt,
@@ -141,6 +142,7 @@ func initialize(cmd *cobra.Command, newDialer func(validator *cloudcmd.Validator
 		ConformanceMode:        flags.conformance,
 	}
 	resp, err := initCall(cmd.Context(), newDialer(validator), flags.endpoint, req)
+	spinner.Stop()
 	if err != nil {
 		return err
 	}

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -124,7 +124,7 @@ func initialize(cmd *cobra.Command, newDialer func(validator *cloudcmd.Validator
 		return fmt.Errorf("parsing or generating master secret from file %s: %w", flags.masterSecretPath, err)
 	}
 
-	spinner := NewSpinner(cmd, "Initializing cluster ", true)
+	spinner := newSpinner(cmd, "Initializing cluster ", true)
 	spinner.Start()
 	req := &initproto.InitRequest{
 		MasterSecret:           masterSecret.Key,

--- a/cli/internal/cmd/spinner.go
+++ b/cli/internal/cmd/spinner.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var spinnerStates = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
+var dotsStates = []string{".", "..", "..."}
+
+type Spinner struct {
+	out      *cobra.Command
+	text     string
+	showDots bool
+	delay    time.Duration
+	wg       *sync.WaitGroup
+	stop     int32
+}
+
+func NewSpinner(c *cobra.Command, text string, showDots bool) *Spinner {
+	return &Spinner{out: c,
+		text:     text,
+		showDots: showDots,
+		wg:       &sync.WaitGroup{},
+		delay:    100 * time.Millisecond,
+		stop:     0,
+	}
+}
+
+func (s *Spinner) Start() {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+	out:
+		for {
+			for i := 0; i < len(spinnerStates); i++ {
+				if atomic.LoadInt32(&s.stop) == 0 {
+					dotsState := ""
+					if s.showDots {
+						dotsState = dotsStates[i%len(dotsStates)]
+					}
+					state := fmt.Sprintf("\r%s %s%s", spinnerStates[i], s.text, dotsState)
+					s.out.Print(state)
+					time.Sleep(s.delay)
+				} else {
+					break out
+				}
+			}
+		}
+
+		dotsState := ""
+		if s.showDots {
+			dotsState = dotsStates[len(dotsStates)-1]
+		}
+		finalState := fmt.Sprintf("\r%s%s", s.text, dotsState)
+		s.out.Println(finalState)
+	}()
+}
+
+func (s *Spinner) Stop() {
+	atomic.StoreInt32(&s.stop, 1)
+	s.wg.Wait()
+}

--- a/cli/internal/cmd/spinner.go
+++ b/cli/internal/cmd/spinner.go
@@ -1,15 +1,24 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
 package cmd
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
-var spinnerStates = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
-var dotsStates = []string{".", "..", "..."}
+var (
+	spinnerStates = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
+	dotsStates    = []string{".", "..", "..."}
+)
 
 type Spinner struct {
 	out      *cobra.Command
@@ -21,7 +30,8 @@ type Spinner struct {
 }
 
 func NewSpinner(c *cobra.Command, text string, showDots bool) *Spinner {
-	return &Spinner{out: c,
+	return &Spinner{
+		out:      c,
 		text:     text,
 		showDots: showDots,
 		wg:       &sync.WaitGroup{},

--- a/cli/internal/cmd/spinner_test.go
+++ b/cli/internal/cmd/spinner_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"strings"
+	"testing"
+	"time"
+)
+
+const baseWait = 1
+const baseText = "Loading"
+
+func TestSpinnerInitialState(t *testing.T) {
+	// Command
+	cmd := NewInitCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	var errOut bytes.Buffer
+	cmd.SetErr(&errOut)
+
+	s := NewSpinner(cmd, baseText, true)
+	s.Start()
+	time.Sleep(baseWait * time.Second)
+	s.Stop()
+	require.True(t, out.Len() > 0)
+	require.True(t, errOut.Len() == 0)
+
+	outStr := out.String()
+	require.True(t, strings.HasPrefix(outStr, generateAllStatesAsString(baseText, true)))
+}
+
+func TestSpinnerFinalState(t *testing.T) {
+	// Command
+	cmd := NewInitCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	var errOut bytes.Buffer
+	cmd.SetErr(&errOut)
+
+	s := NewSpinner(cmd, baseText, true)
+	s.Start()
+	time.Sleep(baseWait * time.Second)
+	s.Stop()
+	require.True(t, out.Len() > 0)
+	require.True(t, errOut.Len() == 0)
+
+	outStr := out.String()
+	require.True(t, strings.HasSuffix(outStr, baseText+"...\n"))
+}
+
+func TestSpinnerDisabledShowDotsFlag(t *testing.T) {
+	// Command
+	cmd := NewInitCmd()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	var errOut bytes.Buffer
+	cmd.SetErr(&errOut)
+
+	s := NewSpinner(cmd, baseText, false)
+	s.Start()
+	time.Sleep(baseWait * time.Second)
+	s.Stop()
+	require.True(t, out.Len() > 0)
+	require.True(t, errOut.Len() == 0)
+
+	outStr := out.String()
+	require.True(t, strings.HasPrefix(outStr, generateAllStatesAsString(baseText, false)))
+}
+
+func generateAllStatesAsString(text string, showDots bool) string {
+	var builder strings.Builder
+
+	for i := 0; i < len(spinnerStates); i++ {
+		dotsState := ""
+		if showDots {
+			dotsState = dotsStates[i%len(dotsStates)]
+		}
+		builder.WriteString(fmt.Sprintf("\r%s %s%s", spinnerStates[i], text, dotsState))
+	}
+
+	return builder.String()
+}

--- a/cli/internal/cmd/spinner_test.go
+++ b/cli/internal/cmd/spinner_test.go
@@ -1,16 +1,25 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
 package cmd
 
 import (
 	"bytes"
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
-const baseWait = 1
-const baseText = "Loading"
+const (
+	baseWait = 1
+	baseText = "Loading"
+)
 
 func TestSpinnerInitialState(t *testing.T) {
 	// Command

--- a/cli/internal/cmd/spinner_test.go
+++ b/cli/internal/cmd/spinner_test.go
@@ -22,14 +22,13 @@ const (
 )
 
 func TestSpinnerInitialState(t *testing.T) {
-	// Command
 	cmd := NewInitCmd()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	var errOut bytes.Buffer
 	cmd.SetErr(&errOut)
 
-	s := NewSpinner(cmd, baseText, true)
+	s := newSpinner(cmd, baseText, true)
 	s.Start()
 	time.Sleep(baseWait * time.Second)
 	s.Stop()
@@ -41,14 +40,13 @@ func TestSpinnerInitialState(t *testing.T) {
 }
 
 func TestSpinnerFinalState(t *testing.T) {
-	// Command
 	cmd := NewInitCmd()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	var errOut bytes.Buffer
 	cmd.SetErr(&errOut)
 
-	s := NewSpinner(cmd, baseText, true)
+	s := newSpinner(cmd, baseText, true)
 	s.Start()
 	time.Sleep(baseWait * time.Second)
 	s.Stop()
@@ -56,18 +54,17 @@ func TestSpinnerFinalState(t *testing.T) {
 	require.True(t, errOut.Len() == 0)
 
 	outStr := out.String()
-	require.True(t, strings.HasSuffix(outStr, baseText+"...\n"))
+	require.True(t, strings.HasSuffix(outStr, baseText+"...  \n"))
 }
 
 func TestSpinnerDisabledShowDotsFlag(t *testing.T) {
-	// Command
 	cmd := NewInitCmd()
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	var errOut bytes.Buffer
 	cmd.SetErr(&errOut)
 
-	s := NewSpinner(cmd, baseText, false)
+	s := newSpinner(cmd, baseText, false)
 	s.Start()
 	time.Sleep(baseWait * time.Second)
 	s.Stop()
@@ -76,6 +73,7 @@ func TestSpinnerDisabledShowDotsFlag(t *testing.T) {
 
 	outStr := out.String()
 	require.True(t, strings.HasPrefix(outStr, generateAllStatesAsString(baseText, false)))
+	require.True(t, strings.HasSuffix(outStr, baseText+"  \n"))
 }
 
 func generateAllStatesAsString(text string, showDots bool) string {

--- a/cli/internal/cmd/terminate.go
+++ b/cli/internal/cmd/terminate.go
@@ -47,9 +47,11 @@ func terminate(cmd *cobra.Command, terminator cloudTerminator, fileHandler file.
 		return fmt.Errorf("reading Constellation state: %w", err)
 	}
 
-	cmd.Println("Terminating ...")
-
-	if err := terminator.Terminate(cmd.Context(), stat); err != nil {
+	spinner := newSpinner(cmd, "Terminating ", true)
+	spinner.Start()
+	err := terminator.Terminate(cmd.Context(), stat)
+	spinner.Stop()
+	if err != nil {
 		return fmt.Errorf("terminating Constellation cluster: %w", err)
 	}
 


### PR DESCRIPTION
### Proposed change(s)
This is my solution to #189 

- created `Spinner` class with basic functionality to reuse it later if needed
- integrated my spinner with `init` command as was proposed in the issue
- covered my spinner with several dummy tests

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Link to Milestone
