### PR TITLE
AB#2480: Increased CRD timeout

### DIFF
--- a/bootstrapper/internal/kubernetes/k8sapi/util.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/util.go
@@ -51,7 +51,7 @@ const (
 	// kubeletStartTimeout is the maximum time given to the kubelet service to (re)start.
 	kubeletStartTimeout = 10 * time.Minute
 	// crdTimeout is the maximum time given to the CRDs to be created.
-	crdTimeout = 15 * time.Second
+	crdTimeout = 30 * time.Second
 	// helmTimeout is the maximum time given to the helm client.
 	helmTimeout = 5 * time.Minute
 )


### PR DESCRIPTION
Signed-off-by: Fabian Kammel <fk@edgeless.systems>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Double CRD timeout to prevent timeouts during `mini up`.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- There is currently no way for users to overwrite this setting if necessary. A better fix would be to allow users to overwrite this value if necessary. Do we want to implement this?

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
