### PR TITLE
Fix CLI version injection in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ add_custom_target(bootstrapper ALL
 # cli
 #
 add_custom_target(cli ALL
-  CGO_ENABLED=0 go build -o ${CMAKE_BINARY_DIR}/constellation -tags='${CLI_BUILD_TAGS}' -ldflags "-buildid='' -X github.com/edgelesssys/constellation/internal/constants.VersionInfo=${PROJECT_VERSION}"
+  CGO_ENABLED=0 go build -o ${CMAKE_BINARY_DIR}/constellation -tags='${CLI_BUILD_TAGS}' -ldflags "-buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}"
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/cli
   BYPRODUCTS constellation
 )

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -25,7 +25,7 @@ FROM build AS build-bootstrapper
 WORKDIR /constellation/bootstrapper/
 
 ARG PROJECT_VERSION
-RUN go build -o bootstrapper -tags=disable_tpm_simulator -buildvcs=false -ldflags "-s -w -buildid='' -X main.version=${PROJECT_VERSION}" ./cmd/bootstrapper/
+RUN go build -o bootstrapper -tags=disable_tpm_simulator -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/bootstrapper/
 
 FROM build AS build-disk-mapper
 WORKDIR /constellation/disk-mapper/

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -30,7 +30,7 @@ RUN go build -o bootstrapper -tags=disable_tpm_simulator -buildvcs=false -ldflag
 FROM build AS build-disk-mapper
 WORKDIR /constellation/disk-mapper/
 
-RUN go build -o disk-mapper -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/
+RUN go build -o disk-mapper -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/
 
 FROM scratch AS bootstrapper
 COPY --from=build-bootstrapper /constellation/bootstrapper/bootstrapper /

--- a/bootstrapper/cmd/bootstrapper/run.go
+++ b/bootstrapper/cmd/bootstrapper/run.go
@@ -17,13 +17,12 @@ import (
 	"github.com/edgelesssys/constellation/v2/bootstrapper/internal/logging"
 	"github.com/edgelesssys/constellation/v2/bootstrapper/internal/nodelock"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/vtpm"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/grpc/dialer"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"go.uber.org/zap"
 )
-
-var version = "0.0.0"
 
 func run(issuerWrapper initserver.IssuerWrapper, tpm vtpm.TPMOpenFunc, fileHandler file.Handler,
 	kube clusterInitJoiner, metadata metadataAPI,
@@ -32,7 +31,7 @@ func run(issuerWrapper initserver.IssuerWrapper, tpm vtpm.TPMOpenFunc, fileHandl
 ) {
 	defer cloudLogger.Close()
 
-	log.With(zap.String("version", version)).Infof("Starting bootstrapper")
+	log.With(zap.String("version", constants.VersionInfo)).Infof("Starting bootstrapper")
 	cloudLogger.Disclose("bootstrapper started running...")
 
 	uuid, err := getDiskUUID()

--- a/joinservice/Dockerfile
+++ b/joinservice/Dockerfile
@@ -23,7 +23,7 @@ RUN rm -rf ./hack/
 
 WORKDIR /constellation/joinservice
 ARG PROJECT_VERSION=0.0.0
-RUN CGO_ENABLED=0 go build -o join-service -trimpath -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/
+RUN CGO_ENABLED=0 go build -o join-service -trimpath -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/
 
 # Use gcr.io/distroless/static here since we need CA certificates to be installed for aTLS operations on GCP.
 FROM gcr.io/distroless/static@sha256:d673e44035b1435c88f63c4b7066501e21fe5c6b111cd9ada7d9301f780b2416 as release

--- a/kms/Dockerfile
+++ b/kms/Dockerfile
@@ -24,7 +24,7 @@ RUN rm -rf ./hack/
 RUN mkdir -p /constellation/build
 WORKDIR /constellation/kms/cmd
 ARG PROJECT_VERSION=0.0.0
-RUN CGO_ENABLED=0 go build -o /constellation/build/kmsserver -trimpath -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/internal/constants.VersionInfo=${PROJECT_VERSION}"
+RUN CGO_ENABLED=0 go build -o /constellation/build/kmsserver -trimpath -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}"
 
 # Use gcr.io/distroless/static here since we need CA certificates to be installed for aTLS operations on GCP.
 FROM gcr.io/distroless/static@sha256:d673e44035b1435c88f63c4b7066501e21fe5c6b111cd9ada7d9301f780b2416 as release

--- a/verify/Dockerfile
+++ b/verify/Dockerfile
@@ -23,7 +23,7 @@ RUN rm -rf ./hack/
 
 WORKDIR /constellation/verify
 ARG PROJECT_VERSION=0.0.0
-RUN CGO_ENABLED=0 go build -o verify-service -trimpath -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/
+RUN CGO_ENABLED=0 go build -o verify-service -trimpath -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/
 
 FROM scratch AS release
 COPY --from=build /constellation/verify/verify-service /verify


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix version injection for CLI in cmake file, which was broken by upgrading to v2 Go module

