### PR TITLE
Replace deprecated set-output syntax

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -148,7 +148,7 @@ runs:
       id: constellation-init
       run: |
         constellation init
-        echo "::set-output name=KUBECONFIG::$(pwd)/constellation-admin.conf"
+        echo "KUBECONFIG=$(pwd)/constellation-admin.conf >> $GITHUB_OUTPUT"
       shell: bash
 
     - name: Wait for nodes to join and become ready

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -47,8 +47,8 @@ runs:
       id: determine-build-target
       shell: bash
       run: |
-        echo "::set-output name=hostOS::$(go env GOOS)"
-        echo "::set-output name=hostArch::$(go env GOARCH)"
+        echo "hostOS=$(go env GOOS) >> $GITHUB_OUTPUT"
+        echo "hostArch=$(go env GOARCH) >> $GITHUB_OUTPUT"
 
     - name: Build CLI
       uses: ./.github/actions/build_cli

--- a/.github/actions/pseudo_version/action.yml
+++ b/.github/actions/pseudo_version/action.yml
@@ -39,10 +39,10 @@ runs:
         timestamp=$(go run . -print-timestamp)
         branchName=$(go run . -print-branch)
         releaseVersion=$(go run . -print-release-branch)
-        echo "::set-output name=pseudoVersion::${pseudoVersion}"
-        echo "::set-output name=semanticVersion::${semanticVersion}"
-        echo "::set-output name=timestamp::${timestamp}"
-        echo "::set-output name=branchName::${branchName}"
-        echo "::set-output name=releaseVersion::${releaseVersion}"
+        echo "pseudoVersion=${pseudoVersion} >> $GITHUB_OUTPUT"
+        echo "semanticVersion=${semanticVersion} >> $GITHUB_OUTPUT"
+        echo "timestamp=${timestamp} >> $GITHUB_OUTPUT"
+        echo "branchName=${branchName} >> $GITHUB_OUTPUT"
+        echo "releaseVersion=${releaseVersion} >> $GITHUB_OUTPUT"
       working-directory: hack/pseudo-version
       shell: bash

--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -1,5 +1,6 @@
 name: Check licenses
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths:

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,6 +1,7 @@
 name: Links
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/docs-update-reference.yml
+++ b/.github/workflows/docs-update-reference.yml
@@ -1,5 +1,6 @@
 name: Create Pull Request for CLI reference update
 on:
+  workflow_dispatch:
   push:
     branches:
       - action/constellation/update-cli-reference

--- a/.github/workflows/docs-vale.yml
+++ b/.github/workflows/docs-vale.yml
@@ -1,5 +1,6 @@
 name: Linting
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/e2e-test-azure-weekly.yml
+++ b/.github/workflows/e2e-test-azure-weekly.yml
@@ -35,7 +35,7 @@ jobs:
           uuid=$(cat /proc/sys/kernel/random/uuid)
           name=e2e-test-${uuid%%-*}
           az group create --location westus --name $name --tags e2e
-          echo "::set-output name=res_group_name::$name"
+          echo "res_group_name=$name >> $GITHUB_OUTPUT"
 
       - name: Run Azure E2E test
         uses: ./.github/actions/e2e_test

--- a/.github/workflows/e2e-test-azure.yml
+++ b/.github/workflows/e2e-test-azure.yml
@@ -30,7 +30,7 @@ jobs:
           uuid=$(cat /proc/sys/kernel/random/uuid)
           name=e2e-test-${uuid%%-*}
           az group create --location westus --name $name --tags e2e
-          echo "::set-output name=res_group_name::$name"
+          echo "res_group_name=$name >> $GITHUB_OUTPUT"
 
       - name: Run Azure E2E test
         uses: ./.github/actions/e2e_test
@@ -102,7 +102,7 @@ jobs:
           uuid=$(cat /proc/sys/kernel/random/uuid)
           name=e2e-test-${uuid%%-*}
           az group create --location westus --name $name --tags e2e
-          echo "::set-output name=res_group_name::$name"
+          echo "res_group_name=$name >> $GITHUB_OUTPUT"
 
       - name: Run Azure E2E test
         uses: ./.github/actions/e2e_test

--- a/.github/workflows/e2e-test-manual-macos.yml
+++ b/.github/workflows/e2e-test-manual-macos.yml
@@ -102,7 +102,7 @@ jobs:
           uuid=$(uuidgen)
           name=e2e-test-${uuid%%-*}
           az group create --location westus --name $name --tags e2e
-          echo "::set-output name=res_group_name::$name"
+          echo "res_group_name=$name >> $GITHUB_OUTPUT"
 
       - name: Set up gcloud CLI
         if: ${{ github.event.inputs.cloudProvider == 'gcp' }}

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -68,7 +68,7 @@ jobs:
           uuid=$(cat /proc/sys/kernel/random/uuid)
           name=e2e-test-${uuid%%-*}
           az group create --location westus --name $name --tags e2e
-          echo "::set-output name=res_group_name::$name"
+          echo "res_group_name=$name >> $GITHUB_OUTPUT"
 
       - name: Run manual E2E test
         uses: ./.github/actions/e2e_test

--- a/.github/workflows/generate-measurements.yml
+++ b/.github/workflows/generate-measurements.yml
@@ -46,7 +46,7 @@ jobs:
           uuid=$(cat /proc/sys/kernel/random/uuid)
           name=e2e-test-${uuid%%-*}
           az group create --location westus --name $name --tags e2e
-          echo "::set-output name=res_group_name::$name"
+          echo "res_group_name=$name >> $GITHUB_OUTPUT"
 
       - name: Create Cluster & Generate Measurements
         uses: ./.github/actions/generate_measurements

--- a/.github/workflows/test-govulncheck.yml
+++ b/.github/workflows/test-govulncheck.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           mods=$(go list -f '{{.Dir}}/...' -m | xargs)
           echo "Found mods: $mods"
-          echo "::set-output name=submods::${mods}"
+          echo "submods=${mods} >> $GITHUB_OUTPUT"
 
       - name: Govulncheck
         shell: bash

--- a/.github/workflows/test-govulncheck.yml
+++ b/.github/workflows/test-govulncheck.yml
@@ -1,6 +1,7 @@
 name: Govulncheck
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           mods=$(go list -f '{{.Dir}}/...' -m | xargs)
           echo "Found mods: $mods"
-          echo "::set-output name=submods::${mods}"
+          echo "submods=${mods} >> $GITHUB_OUTPUT"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -1,6 +1,7 @@
 name: Golangci-lint
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/test-shellcheck.yml
+++ b/.github/workflows/test-shellcheck.yml
@@ -1,5 +1,6 @@
 name: Shellcheck
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/test-tidy.yml
+++ b/.github/workflows/test-tidy.yml
@@ -1,6 +1,7 @@
 name: Go mod tidy check
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/test-tidy.yml
+++ b/.github/workflows/test-tidy.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           mods=$(go list -f '{{.Dir}}' -m | xargs)
           echo "Found mods: $mods"
-          echo "::set-output name=submods::${mods}"
+          echo "submods=${mods} >> $GITHUB_OUTPUT"
 
       - name: Go tidy check
         uses: katexochen/go-tidy-check@45731e0013a976d5d616d79007c7ba52de6ce542

--- a/.github/workflows/update-cli-reference.yml
+++ b/.github/workflows/update-cli-reference.yml
@@ -1,5 +1,6 @@
 name: Publish CLI reference to documentation
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -7,7 +8,6 @@ on:
       - "cli/cmd/**"
       - "cli/internal/cmd/**"
       - "hack/clidocgen/**"
-  workflow_dispatch:
 
 jobs:
   publish-to-docs:


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- GitHub deprecated `set-output` syntax for workflows/actions yesterday, see [this announcement](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).
- Add dispatch trigger to every workflow. Sometimes workflows aren't triggered because the targeted files aren't changed.

--

Documenting the find/sed command I used here in case I need it again.

```sh
find .github -type f -name "*.yml" -exec sed -i 's/::set-output name=\([^::]*\)::\([^"]*\)/\1=\2 >> $GITHUB_OUTPUT/' {} +
```
