### PR TITLE
Case-insensitive replace for every user-input that can go wrong

### DIFF
--- a/cli/internal/cloudcmd/create_test.go
+++ b/cli/internal/cloudcmd/create_test.go
@@ -156,6 +156,16 @@ func TestNormalizeAzureURIs(t *testing.T) {
 				UserAssignedIdentity: "/subscriptions/foo/resourceGroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uai",
 			},
 		},
+		"fix arbitrary casing": {
+			in: terraform.AzureVariables{
+				ImageID:              "/CoMMUnitygaLLeries/foo/iMAges/constellation/vERsions/2.1.0",
+				UserAssignedIdentity: "/subsCRiptions/foo/resoURCegroups/test/proViDers/MICROsoft.mANAgedIdentity/USerASsignediDENtities/uai",
+			},
+			want: terraform.AzureVariables{
+				ImageID:              "/communityGalleries/foo/images/constellation/versions/2.1.0",
+				UserAssignedIdentity: "/subscriptions/foo/resourceGroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uai",
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,7 +32,7 @@ const (
 )
 
 var (
-	azureReleaseImageRegex = regexp.MustCompile(`^\/CommunityGalleries\/ConstellationCVM-b3782fa0-0df7-4f2f-963e-fc7fc42663df\/Images\/constellation\/Versions\/[\d]+.[\d]+.[\d]+$`)
+	azureReleaseImageRegex = regexp.MustCompile(`^(?i)\/CommunityGalleries\/ConstellationCVM-b3782fa0-0df7-4f2f-963e-fc7fc42663df\/Images\/constellation\/Versions\/[\d]+.[\d]+.[\d]+$`)
 	gcpReleaseImageRegex   = regexp.MustCompile(`^projects\/constellation-images\/global\/images\/constellation-v[\d]+-[\d]+-[\d]+$`)
 )
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
The azurerm provider has it's own convention of enforcing spelling which Azure itself does not enforce or even provide. This is a bit of bad design decision, but we can work around that. While #233 already had basic re-writing, I thought we can get a bit further to fix all edge-cases (at least the ones I see) plus keeping the #249 regex searchable for maintanence. The result is this lunacy of regex.ReplaceAllString :)  

@katexochen Sorry!

### Related issue
- Can supersede #249 

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
