### PR TITLE
Downgrade vale action

### DIFF
--- a/.github/workflows/docs-vale.yml
+++ b/.github/workflows/docs-vale.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Vale
-        uses: errata-ai/vale-action@c4213d4de3d5f718b8497bd86161531c78992084 # tag=v2.0.1
+        uses: errata-ai/vale-action@753427452ff1d6cf7a7b76a552aa0cbee3971551 # tag=v1.5.0
         with:
           files: docs/docs
         env:


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Downgrade vale action


### Additional info
- Slipped in by https://github.com/edgelesssys/constellation/pull/237
- @thomasten: 
    > Seems we updated the Vale action to a new major version. In addition to treating Warnings as Errors (which may be configured somehow with the new version), it also includes a vale version that produces some FPs. So I'd suggest to downgrade the action to the previous major version.

