### PR TITLE
Make renovate tidy all go modules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,9 +10,17 @@
     "dependencies"
   ],
   "postUpdateOptions": [
-    "gomodTidy",
     "gomodUpdateImportPaths"
   ],
+  "postUpgradeTasks": {
+    "commands": [
+      "for mod in $(go list -f '{{.Dir}}' -m); do (cd $mod; go mod tidy); done"
+    ],
+    "fileFilters": [
+      "**/go.mod",
+      "**/go.sum"
+    ]
+  },
   "ignorePaths": [
     "cli/internal/helm/charts/cilium/**"
   ],


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Currently, renovate doesn't tidy submodules when updating Go dependencies. This change tries to add this functionality, so you don't have to manually update submods.

