### PR TITLE
Revert "Make renovate tidy all go modules"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,17 +10,9 @@
     "dependencies"
   ],
   "postUpdateOptions": [
+    "gomodTidy",
     "gomodUpdateImportPaths"
   ],
-  "postUpgradeTasks": {
-    "commands": [
-      "for mod in $(go list -f '{{.Dir}}' -m); do (cd $mod; go mod tidy); done"
-    ],
-    "fileFilters": [
-      "**/go.mod",
-      "**/go.sum"
-    ]
-  },
   "ignorePaths": [
     "cli/internal/helm/charts/cilium/**"
   ],


### PR DESCRIPTION
Reverts edgelesssys/constellation#296

This options is only available for self-hosted runners: https://docs.renovatebot.com/self-hosted-configuration/#allowpostupgradecommandtemplating

Error was: https://github.com/edgelesssys/constellation/pull/297#issuecomment-1281035878
