### PR TITLE
Use HTTPS for kube lb health check on Azure

### DIFF
--- a/cli/internal/terraform/terraform/azure/main.tf
+++ b/cli/internal/terraform/terraform/azure/main.tf
@@ -70,12 +70,42 @@ module "loadbalancer_backend_control_plane" {
   name            = "${local.name}-control-plane"
   loadbalancer_id = azurerm_lb.loadbalancer.id
   ports = flatten([
-    { name = "bootstrapper", port = local.ports_bootstrapper },
-    { name = "kubernetes", port = local.ports_kubernetes },
-    { name = "konnectivity", port = local.ports_konnectivity },
-    { name = "verify", port = local.ports_verify },
-    { name = "recovery", port = local.ports_recovery },
-    var.debug ? [{ name = "debugd", port = local.ports_debugd }] : [],
+    {
+      name     = "bootstrapper",
+      port     = local.ports_bootstrapper,
+      protocol = "Tcp",
+      path     = null
+    },
+    {
+      name     = "kubernetes",
+      port     = local.ports_kubernetes,
+      protocol = "Https",
+      path     = "/readyz"
+    },
+    {
+      name     = "konnectivity",
+      port     = local.ports_konnectivity,
+      protocol = "Tcp",
+      path     = null
+    },
+    {
+      name     = "verify",
+      port     = local.ports_verify,
+      protocol = "Tcp",
+      path     = null
+    },
+    {
+      name     = "recovery",
+      port     = local.ports_recovery,
+      protocol = "Tcp",
+      path     = null
+    },
+    var.debug ? [{
+      name     = "debugd",
+      port     = local.ports_debugd,
+      protocol = "Tcp",
+      path     = null
+    }] : [],
   ])
 }
 

--- a/cli/internal/terraform/terraform/azure/modules/load_balancer_backend/main.tf
+++ b/cli/internal/terraform/terraform/azure/modules/load_balancer_backend/main.tf
@@ -18,7 +18,8 @@ resource "azurerm_lb_probe" "health_probes" {
   loadbalancer_id     = var.loadbalancer_id
   name                = each.value.name
   port                = each.value.port
-  protocol            = "Tcp"
+  protocol            = each.value.protocol
+  request_path        = each.value.path
   interval_in_seconds = 5
 }
 
@@ -27,7 +28,7 @@ resource "azurerm_lb_rule" "rules" {
 
   loadbalancer_id                = var.loadbalancer_id
   name                           = each.value.name
-  protocol                       = each.value.protocol
+  protocol                       = "Tcp"
   frontend_port                  = each.value.port
   backend_port                   = each.value.port
   frontend_ip_configuration_name = "PublicIPAddress"

--- a/cli/internal/terraform/terraform/azure/modules/load_balancer_backend/variables.tf
+++ b/cli/internal/terraform/terraform/azure/modules/load_balancer_backend/variables.tf
@@ -11,8 +11,10 @@ variable "loadbalancer_id" {
 
 variable "ports" {
   type = list(object({
-    name = string
-    port = number
+    name     = string
+    port     = number
+    protocol = string
+    path     = string
   }))
-  description = "The ports to add to the backend."
+  description = "The ports to add to the backend. Protocol can be either 'Tcp' or 'Https'. Path is only used for 'Https' protocol and can otherwise be null."
 }


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- We used HTTPS health probe before, but it got lost during the transition to Terraform. This change fixes the some of the recent e2e test failures on Azure, where the check for the readiness of nodes would fail because kubectl connected to an unready kubeapi server of one of the control planes that joined the cluster.

--

**Error output** that should be fixed by this test:

[e2e test Azure:](https://github.com/edgelesssys/constellation/actions/runs/3266646192/jobs/5370681136#step:6:9362)

```sh
  1/5 nodes have joined.. waiting..
  1/5 nodes have joined.. waiting..
  1/5 nodes have joined.. waiting..
  3/5 nodes have joined.. waiting..
  5/5 nodes have joined
  Unable to connect to the server: net/http: TLS handshake timeout
  Error: Process completed with exit code 1.
```

[e2e test Azure:](https://github.com/edgelesssys/constellation/actions/runs/3265906236/jobs/5368853732#step:6:9547)

```sh
  1/5 nodes have joined.. waiting..
  1/5 nodes have joined.. waiting..
  1/5 nodes have joined.. waiting..
  1/5 nodes have joined.. waiting..
  5/5 nodes have joined
  The connection to the server 137.135.16.54:6443 was refused - did you specify the right host or port?
  Error: Process completed with exit code 1.
```
