### PR TITLE
Let renovate ignore constellation module

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,9 @@
   "ignorePaths": [
     "cli/internal/helm/charts/cilium/**"
   ],
+  "ignoreDeps": [
+    "github.com/edgelesssys/constellation/v2"
+  ],
   "packageRules": [
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Renovate shouldn't update imports of constellation in hack, as those are replaced anyway.
