### PR TITLE
AB#2510 disk-mapper AWS support

### DIFF
--- a/disk-mapper/cmd/main.go
+++ b/disk-mapper/cmd/main.go
@@ -15,7 +15,6 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
-	"strings"
 
 	"github.com/edgelesssys/constellation/v2/disk-mapper/internal/mapper"
 	"github.com/edgelesssys/constellation/v2/disk-mapper/internal/recoveryserver"
@@ -26,7 +25,9 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/attestation/gcp"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/qemu"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/vtpm"
+	awscloud "github.com/edgelesssys/constellation/v2/internal/cloud/aws"
 	azurecloud "github.com/edgelesssys/constellation/v2/internal/cloud/azure"
+	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	gcpcloud "github.com/edgelesssys/constellation/v2/internal/cloud/gcp"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/metadata"
 	qemucloud "github.com/edgelesssys/constellation/v2/internal/cloud/qemu"
@@ -43,6 +44,7 @@ import (
 const (
 	gcpStateDiskPath   = "/dev/disk/by-id/google-state-disk"
 	azureStateDiskPath = "/dev/disk/azure/scsi1/lun0"
+	awsStateDiskPath   = "/dev/sdb"
 	qemuStateDiskPath  = "/dev/vda"
 )
 
@@ -60,8 +62,24 @@ func main() {
 	var diskPath string
 	var issuer atls.Issuer
 	var metadataAPI setup.MetadataAPI
-	switch strings.ToLower(*csp) {
-	case "azure":
+	switch cloudprovider.FromString(*csp) {
+	case cloudprovider.AWS:
+		// on AWS Nitro platform, disks are attached over NVMe
+		// using udev rules, a symlink for our disk is created at /dev/sdb
+		diskPath, err = filepath.EvalSymlinks(awsStateDiskPath)
+		if err != nil {
+			_ = exportPCRs()
+			log.With(zap.Error(err)).Fatalf("Unable to resolve Azure state disk path")
+		}
+		metadataAPI, err = awscloud.New(context.Background())
+		if err != nil {
+			log.With(zap.Error(err)).Fatalf("Failed to set up AWS metadata API")
+		}
+
+		// TODO: Add attestation issuer for AWS
+		// issuer = aws.NewIssuer()
+
+	case cloudprovider.Azure:
 		diskPath, err = filepath.EvalSymlinks(azureStateDiskPath)
 		if err != nil {
 			_ = exportPCRs()
@@ -69,12 +87,12 @@ func main() {
 		}
 		metadataAPI, err = azurecloud.NewMetadata(context.Background())
 		if err != nil {
-			log.With(zap.Error).Fatalf("Failed to create Azure metadata API")
+			log.With(zap.Error).Fatalf("Failed to set up Azure metadata API")
 		}
 
 		issuer = azure.NewIssuer()
 
-	case "gcp":
+	case cloudprovider.GCP:
 		diskPath, err = filepath.EvalSymlinks(gcpStateDiskPath)
 		if err != nil {
 			_ = exportPCRs()
@@ -87,7 +105,7 @@ func main() {
 		}
 		metadataAPI = gcpcloud.New(gcpClient)
 
-	case "qemu":
+	case cloudprovider.QEMU:
 		diskPath = qemuStateDiskPath
 		issuer = qemu.NewIssuer()
 		metadataAPI = &qemucloud.Metadata{}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add support for AWS to the disk-mapper

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
The device name of the state disk is expected to be `/dev/sdb`.
Linux may not respect the selected device name and instead choose a difference prefix. E.g. `/dev/sdb` may be available as `/dev/xvdb` or `/dev/hdb`.
On Nitro instances, disks are attached over NVMe, this means disks are named using the `/dev/nvmeXnY` naming scheme.
Naming is not consistent across instance reboots.

However, AWS provides udev rules to fix this problem: https://github.com/amazonlinux/amazon-ec2-utils
When installed, these rules automatically create symlinks for the disks at the path selected as the device name.
This means regardless of where the actual device is, or on what platform we are, when we attach a disk with the device name `/dev/sdb`, and the udev rules are installed, we can use the disk as `/dev/sdb`.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
