### PR TITLE
AB#2508 Use release cosign key only when releasing

### DIFF
--- a/.github/workflows/generate-measurements.yml
+++ b/.github/workflows/generate-measurements.yml
@@ -58,9 +58,9 @@ jobs:
           azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
           coreosImage: ${{ github.event.inputs.coreosImage }}
           isDebugImage: ${{ github.event.inputs.isDebugImage }}
-          cosignPublicKey: ${{ secrets.COSIGN_PUBLIC_KEY }}
-          cosignPrivateKey: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          cosignPassword: ${{ secrets.COSIGN_PASSWORD }}
+          cosignPublicKey: ${{ startsWith(github.ref, 'refs/heads/release/v') && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
+          cosignPrivateKey: ${{ startsWith(github.ref, 'refs/heads/release/v') && secrets.COSIGN_PRIVATE_KEY || secrets.COSIGN_DEV_PRIVATE_KEY }}
+          cosignPassword: ${{ startsWith(github.ref, 'refs/heads/release/v') && secrets.COSIGN_PASSWORD || secrets.COSIGN_DEV_PASSWORD }}
           awsAccessKeyID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           awsSecretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           awsDefaultRegion: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -22,9 +22,9 @@ jobs:
           targetOS: linux
           targetArch: amd64
           enterpriseCLI: true
-          cosignPublicKey: ${{ secrets.COSIGN_PUBLIC_KEY }}
-          cosignPrivateKey: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          cosignPassword: ${{ secrets.COSIGN_PASSWORD }}
+          cosignPublicKey: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
+          cosignPrivateKey: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PRIVATE_KEY || secrets.COSIGN_DEV_PRIVATE_KEY }}
+          cosignPassword: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PASSWORD || secrets.COSIGN_DEV_PASSWORD }}
 
       - name: Build cli-linux-arm64
         uses: ./.github/actions/build_cli
@@ -32,9 +32,9 @@ jobs:
           targetOS: linux
           targetArch: arm64
           enterpriseCLI: true
-          cosignPublicKey: ${{ secrets.COSIGN_PUBLIC_KEY }}
-          cosignPrivateKey: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          cosignPassword: ${{ secrets.COSIGN_PASSWORD }}
+          cosignPublicKey: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
+          cosignPrivateKey: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PRIVATE_KEY || secrets.COSIGN_DEV_PRIVATE_KEY }}
+          cosignPassword: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PASSWORD || secrets.COSIGN_DEV_PASSWORD }}
 
       - name: Build cli-darwin-amd64
         uses: ./.github/actions/build_cli
@@ -42,9 +42,9 @@ jobs:
           targetOS: darwin
           targetArch: amd64
           enterpriseCLI: true
-          cosignPublicKey: ${{ secrets.COSIGN_PUBLIC_KEY }}
-          cosignPrivateKey: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          cosignPassword: ${{ secrets.COSIGN_PASSWORD }}
+          cosignPublicKey: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
+          cosignPrivateKey: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PRIVATE_KEY || secrets.COSIGN_DEV_PRIVATE_KEY }}
+          cosignPassword: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PASSWORD || secrets.COSIGN_DEV_PASSWORD }}
 
       - name: Build cli-darwin-arm64
         uses: ./.github/actions/build_cli
@@ -52,9 +52,9 @@ jobs:
           targetOS: darwin
           targetArch: arm64
           enterpriseCLI: true
-          cosignPublicKey: ${{ secrets.COSIGN_PUBLIC_KEY }}
-          cosignPrivateKey: ${{ secrets.COSIGN_PRIVATE_KEY }}
-          cosignPassword: ${{ secrets.COSIGN_PASSWORD }}
+          cosignPublicKey: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
+          cosignPrivateKey: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PRIVATE_KEY || secrets.COSIGN_DEV_PRIVATE_KEY }}
+          cosignPassword: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PASSWORD || secrets.COSIGN_DEV_PASSWORD }}
 
       - name: Login to Azure
         uses: ./.github/actions/azure_login


### PR DESCRIPTION
Signed-off-by: Fabian Kammel <fk@edgeless.systems>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Configured a second cosign key-pair `COSIGN_DEV_*` as action secret to be used for non-release builds
  - Keypair and password was also stored in internal secrets manager

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info
- I tried to use `KEY: ${{ github.ref_protected && 'PROD KEY' || 'DEV KEY' }}`, but `github.ref_protected` [seems to be `false` on protected tags.](https://github.com/datosh/some-action/actions/runs/3281988742/jobs/5404766209) I suspect this is because [protected tags are still in beta](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/configuring-tag-protection-rules). I [checked with GitHub folks](https://github.com/community/community/discussions/10906#discussioncomment-3915816). I don't think we need to wait for an answer. We can change implementation later.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
