### PR TITLE
AB#2511 Implement minimal feature support for bootstrapper on AWS

### DIFF
--- a/internal/attestation/vtpm/attestation.go
+++ b/internal/attestation/vtpm/attestation.go
@@ -24,6 +24,12 @@ import (
 )
 
 var (
+	// AWSPCRSelection are the PCR values verified for AWS Nitro TPM based Constellations.
+	// TODO: determine which PCRs are required.
+	AWSPCRSelection = tpm2.PCRSelection{
+		Hash: tpm2.AlgSHA256,
+		PCRs: []int{},
+	}
 	// AzurePCRSelection are the PCR values verified for Azure Constellations.
 	// PCR[0] is excluded due to changing rarely, but unpredictably.
 	// PCR[6] is excluded due to being different for any 2 VMs. See: https://trustedcomputinggroup.org/wp-content/uploads/TCG_PCClient_PFP_r1p05_v23_pub.pdf#%5B%7B%22num%22%3A157%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C33%2C400%2C0%5D


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Bootstrapper no longer panics when CSP is set to `aws`
- Implement missing metadata methods (some stubs) for AWS to satisfy required interfaces 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- While this should allow booting a Constellation image with bootstrapper on AWS, `init` calls will not work and likely cause the bootstrapper to panic
- Missing features for full operation:
  - TPM based attestation
  - Cloud/Metadata functions required to install and run Cilium

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
