### PR TITLE
Let tfsec fail soft in CI

### DIFF
--- a/.github/workflows/test-tfsec.yml
+++ b/.github/workflows/test-tfsec.yml
@@ -29,6 +29,7 @@ jobs:
       - name: tfsec
         uses: aquasecurity/tfsec-pr-commenter-action@d9fa64305ec243e19f9be1200dfc8e8154dc364f
         with:
+          soft_fail_commenter: true
           tfsec_formats: default,text
           tfsec_args: --force-all-dirs
           github_token: ${{ github.token }}


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Let tfsec comment, but not fail CI.
