### PR TITLE
AB#2532 Dont clean up workspace if rollback fails

### DIFF
--- a/cli/internal/cloudcmd/clients.go
+++ b/cli/internal/cloudcmd/clients.go
@@ -10,10 +10,11 @@ import (
 	"context"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
+	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 )
 
 type terraformClient interface {
-	CreateCluster(ctx context.Context, name string, input terraform.Variables) (string, error)
+	CreateCluster(ctx context.Context, provider cloudprovider.Provider, name string, input terraform.Variables) (string, error)
 	DestroyCluster(ctx context.Context) error
 	CleanUpWorkspace() error
 	RemoveInstaller()

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
+	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"go.uber.org/goleak"
 )
 
@@ -31,7 +32,7 @@ type stubTerraformClient struct {
 	cleanUpWorkspaceErr    error
 }
 
-func (c *stubTerraformClient) CreateCluster(ctx context.Context, name string, input terraform.Variables) (string, error) {
+func (c *stubTerraformClient) CreateCluster(ctx context.Context, provider cloudprovider.Provider, name string, input terraform.Variables) (string, error) {
 	return c.ip, c.createClusterErr
 }
 

--- a/cli/internal/cloudcmd/create_test.go
+++ b/cli/internal/cloudcmd/create_test.go
@@ -94,7 +94,7 @@ func TestCreator(t *testing.T) {
 
 			creator := &Creator{
 				out: &bytes.Buffer{},
-				newTerraformClient: func(ctx context.Context, provider cloudprovider.Provider) (terraformClient, error) {
+				newTerraformClient: func(ctx context.Context) (terraformClient, error) {
 					return tc.tfClient, tc.newTfClientErr
 				},
 				newLibvirtRunner: func() libvirtRunner {

--- a/cli/internal/cloudcmd/rollback.go
+++ b/cli/internal/cloudcmd/rollback.go
@@ -41,7 +41,9 @@ type rollbackerTerraform struct {
 func (r *rollbackerTerraform) rollback(ctx context.Context) error {
 	var err error
 	err = multierr.Append(err, r.client.DestroyCluster(ctx))
-	err = multierr.Append(err, r.client.CleanUpWorkspace())
+	if err == nil {
+		err = multierr.Append(err, r.client.CleanUpWorkspace())
+	}
 	return err
 }
 
@@ -54,6 +56,8 @@ func (r *rollbackerQEMU) rollback(ctx context.Context) error {
 	var err error
 	err = multierr.Append(err, r.client.DestroyCluster(ctx))
 	err = multierr.Append(err, r.libvirt.Stop(ctx))
-	err = multierr.Append(err, r.client.CleanUpWorkspace())
+	if err == nil {
+		err = r.client.CleanUpWorkspace()
+	}
 	return err
 }

--- a/cli/internal/cloudcmd/rollback_test.go
+++ b/cli/internal/cloudcmd/rollback_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package cloudcmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRollbackTerraform(t *testing.T) {
+	someErr := errors.New("failed")
+
+	testCases := map[string]struct {
+		tfClient *stubTerraformClient
+		wantErr  bool
+	}{
+		"success": {
+			tfClient: &stubTerraformClient{},
+		},
+		"destroy cluster error": {
+			tfClient: &stubTerraformClient{destroyClusterErr: someErr},
+			wantErr:  true,
+		},
+		"clean up workspace error": {
+			tfClient: &stubTerraformClient{cleanUpWorkspaceErr: someErr},
+			wantErr:  true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rollbacker := &rollbackerTerraform{
+				client: tc.tfClient,
+			}
+
+			err := rollbacker.rollback(context.Background())
+			if tc.wantErr {
+				assert.Error(err)
+				if tc.tfClient.cleanUpWorkspaceErr == nil {
+					assert.False(tc.tfClient.cleanUpWorkspaceCalled)
+				}
+				return
+			}
+			assert.NoError(err)
+			assert.True(tc.tfClient.destroyClusterCalled)
+			assert.True(tc.tfClient.cleanUpWorkspaceCalled)
+		})
+	}
+}
+
+func TestRollbackQEMU(t *testing.T) {
+	someErr := errors.New("failed")
+
+	testCases := map[string]struct {
+		libvirt  *stubLibvirtRunner
+		tfClient *stubTerraformClient
+		wantErr  bool
+	}{
+		"success": {
+			libvirt:  &stubLibvirtRunner{},
+			tfClient: &stubTerraformClient{},
+		},
+		"stop libvirt error": {
+			libvirt:  &stubLibvirtRunner{stopErr: someErr},
+			tfClient: &stubTerraformClient{},
+			wantErr:  true,
+		},
+		"destroy cluster error": {
+			libvirt:  &stubLibvirtRunner{stopErr: someErr},
+			tfClient: &stubTerraformClient{destroyClusterErr: someErr},
+			wantErr:  true,
+		},
+		"clean up workspace error": {
+			libvirt:  &stubLibvirtRunner{},
+			tfClient: &stubTerraformClient{cleanUpWorkspaceErr: someErr},
+			wantErr:  true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			rollbacker := &rollbackerQEMU{
+				libvirt: tc.libvirt,
+				client:  tc.tfClient,
+			}
+
+			err := rollbacker.rollback(context.Background())
+			if tc.wantErr {
+				assert.Error(err)
+				if tc.tfClient.cleanUpWorkspaceErr == nil {
+					assert.False(tc.tfClient.cleanUpWorkspaceCalled)
+				}
+				return
+			}
+			assert.NoError(err)
+			assert.True(tc.libvirt.stopCalled)
+			assert.True(tc.tfClient.destroyClusterCalled)
+			assert.True(tc.tfClient.cleanUpWorkspaceCalled)
+		})
+	}
+}

--- a/cli/internal/cmd/cloud.go
+++ b/cli/internal/cmd/cloud.go
@@ -25,5 +25,5 @@ type cloudCreator interface {
 }
 
 type cloudTerminator interface {
-	Terminate(context.Context, cloudprovider.Provider) error
+	Terminate(context.Context) error
 }

--- a/cli/internal/cmd/cloud_test.go
+++ b/cli/internal/cmd/cloud_test.go
@@ -46,7 +46,7 @@ type stubCloudTerminator struct {
 	terminateErr error
 }
 
-func (c *stubCloudTerminator) Terminate(context.Context, cloudprovider.Provider) error {
+func (c *stubCloudTerminator) Terminate(context.Context) error {
 	c.called = true
 	return c.terminateErr
 }

--- a/cli/internal/cmd/terminate.go
+++ b/cli/internal/cmd/terminate.go
@@ -16,7 +16,6 @@ import (
 	"go.uber.org/multierr"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 )
@@ -45,13 +44,8 @@ func runTerminate(cmd *cobra.Command, args []string) error {
 
 func terminate(cmd *cobra.Command, terminator cloudTerminator, fileHandler file.Handler, spinner spinnerInterf,
 ) error {
-	var idFile clusterid.File
-	if err := fileHandler.ReadJSON(constants.ClusterIDsFileName, &idFile); err != nil {
-		return err
-	}
-
 	spinner.Start("Terminating", false)
-	err := terminator.Terminate(cmd.Context(), idFile.CloudProvider)
+	err := terminator.Terminate(cmd.Context())
 	spinner.Stop()
 	if err != nil {
 		return fmt.Errorf("terminating Constellation cluster: %w", err)

--- a/cli/internal/cmd/terminate_test.go
+++ b/cli/internal/cmd/terminate_test.go
@@ -83,7 +83,7 @@ func TestTerminate(t *testing.T) {
 			terminator: &stubCloudTerminator{terminateErr: someErr},
 			wantErr:    true,
 		},
-		"missing id file": {
+		"missing id file does not error": {
 			idFile: clusterid.File{CloudProvider: cloudprovider.GCP},
 			setupFs: func(require *require.Assertions, idFile clusterid.File) afero.Fs {
 				fs := afero.NewMemMapFs()
@@ -92,7 +92,6 @@ func TestTerminate(t *testing.T) {
 				return fs
 			},
 			terminator: &stubCloudTerminator{},
-			wantErr:    true,
 		},
 		"remove file fails": {
 			idFile: clusterid.File{CloudProvider: cloudprovider.GCP},

--- a/cli/internal/terraform/loader_test.go
+++ b/cli/internal/terraform/loader_test.go
@@ -63,7 +63,7 @@ func TestLoader(t *testing.T) {
 
 			checkFiles(t, file, func(err error) { assert.NoError(err) }, tc.fileList)
 
-			err = cleanUpWorkspace(file, tc.provider)
+			err = cleanUpWorkspace(file)
 			require.NoError(err)
 
 			checkFiles(t, file, func(err error) { assert.ErrorIs(err, fs.ErrNotExist) }, tc.fileList)

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -32,14 +32,12 @@ const (
 type Client struct {
 	tf tfInterface
 
-	provider cloudprovider.Provider
-
 	file   file.Handler
 	remove func()
 }
 
 // New sets up a new Client for Terraform.
-func New(ctx context.Context, provider cloudprovider.Provider) (*Client, error) {
+func New(ctx context.Context) (*Client, error) {
 	tf, remove, err := GetExecutable(ctx, ".")
 	if err != nil {
 		return nil, err
@@ -48,16 +46,17 @@ func New(ctx context.Context, provider cloudprovider.Provider) (*Client, error) 
 	file := file.NewHandler(afero.NewOsFs())
 
 	return &Client{
-		tf:       tf,
-		provider: provider,
-		remove:   remove,
-		file:     file,
+		tf:     tf,
+		remove: remove,
+		file:   file,
 	}, nil
 }
 
 // CreateCluster creates a Constellation cluster using Terraform.
-func (c *Client) CreateCluster(ctx context.Context, name string, vars Variables) (string, error) {
-	if err := prepareWorkspace(c.file, c.provider); err != nil {
+func (c *Client) CreateCluster(
+	ctx context.Context, provider cloudprovider.Provider, name string, vars Variables,
+) (string, error) {
+	if err := prepareWorkspace(c.file, provider); err != nil {
 		return "", err
 	}
 
@@ -102,7 +101,7 @@ func (c *Client) RemoveInstaller() {
 
 // CleanUpWorkspace removes terraform files from the current directory.
 func (c *Client) CleanUpWorkspace() error {
-	if err := cleanUpWorkspace(c.file, c.provider); err != nil {
+	if err := cleanUpWorkspace(c.file); err != nil {
 		return err
 	}
 

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -122,12 +122,11 @@ func TestCreateCluster(t *testing.T) {
 			assert := assert.New(t)
 
 			c := &Client{
-				provider: tc.provider,
-				tf:       tc.tf,
-				file:     file.NewHandler(tc.fs),
+				tf:   tc.tf,
+				file: file.NewHandler(tc.fs),
 			}
 
-			ip, err := c.CreateCluster(context.Background(), "test", tc.vars)
+			ip, err := c.CreateCluster(context.Background(), tc.provider, "test", tc.vars)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -160,8 +159,7 @@ func TestDestroyInstances(t *testing.T) {
 			assert := assert.New(t)
 
 			c := &Client{
-				provider: cloudprovider.QEMU,
-				tf:       tc.tf,
+				tf: tc.tf,
 			}
 
 			err := c.DestroyCluster(context.Background())
@@ -207,9 +205,8 @@ func TestCleanupWorkspace(t *testing.T) {
 			require.NoError(tc.prepareFS(file))
 
 			c := &Client{
-				provider: tc.provider,
-				file:     file,
-				tf:       &stubTerraform{},
+				file: file,
+				tf:   &stubTerraform{},
 			}
 
 			err := c.CleanUpWorkspace()


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
If an error occurred during rollback, terraform files were deleted, resulting in dangling resources that are difficult to clean up.
This adds a check to only clean up the workspace if rollback succeeded without errors

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
