### PR TITLE
Rollback fix: Allow terminate when constellation-id.json is missing

### DIFF
--- a/cli/internal/cloudcmd/rollback.go
+++ b/cli/internal/cloudcmd/rollback.go
@@ -29,6 +29,8 @@ func rollbackOnError(ctx context.Context, w io.Writer, onErr *error, roll rollba
 	fmt.Fprintln(w, "Attempting to roll back.")
 	if err := roll.rollback(ctx); err != nil {
 		*onErr = multierr.Append(*onErr, fmt.Errorf("on rollback: %w", err)) // TODO: print the error, or return it?
+		fmt.Println("Automatic rollback failed.")
+		fmt.Println("Please manually clean up any resources on your CSP and try running 'constellation terminate' again.")
 		return
 	}
 	fmt.Fprintln(w, "Rollback succeeded.")

--- a/cli/internal/cloudcmd/rollback.go
+++ b/cli/internal/cloudcmd/rollback.go
@@ -28,7 +28,7 @@ func rollbackOnError(ctx context.Context, w io.Writer, onErr *error, roll rollba
 	fmt.Fprintf(w, "An error occurred: %s\n", *onErr)
 	fmt.Fprintln(w, "Attempting to roll back.")
 	if err := roll.rollback(ctx); err != nil {
-		*onErr = multierr.Append(*onErr, fmt.Errorf("Rollback failed: %w", err)) // TODO: print the error, or return it?
+		*onErr = multierr.Append(*onErr, fmt.Errorf("rollback failed: %w", err)) // TODO: print the error, or return it?
 		fmt.Fprintln(w, "Try running 'constellation terminate', or manually clean up dangling resources on your CSP.")
 		return
 	}

--- a/cli/internal/cloudcmd/rollback.go
+++ b/cli/internal/cloudcmd/rollback.go
@@ -28,9 +28,8 @@ func rollbackOnError(ctx context.Context, w io.Writer, onErr *error, roll rollba
 	fmt.Fprintf(w, "An error occurred: %s\n", *onErr)
 	fmt.Fprintln(w, "Attempting to roll back.")
 	if err := roll.rollback(ctx); err != nil {
-		*onErr = multierr.Append(*onErr, fmt.Errorf("on rollback: %w", err)) // TODO: print the error, or return it?
-		fmt.Println("Automatic rollback failed.")
-		fmt.Println("Please manually clean up any resources on your CSP and try running 'constellation terminate' again.")
+		*onErr = multierr.Append(*onErr, fmt.Errorf("Rollback failed: %w", err)) // TODO: print the error, or return it?
+		fmt.Fprintln(w, "Try running 'constellation terminate', or manually clean up dangling resources on your CSP.")
 		return
 	}
 	fmt.Fprintln(w, "Rollback succeeded.")

--- a/cli/internal/cmd/terminate.go
+++ b/cli/internal/cmd/terminate.go
@@ -50,8 +50,7 @@ func terminate(cmd *cobra.Command, terminator cloudTerminator, fileHandler file.
 	}
 
 	if !foundTerraformData {
-		fmt.Println("Did not find a cluster to terminate.")
-		return nil
+		return fmt.Errorf("did not find a cluster to terminate")
 	}
 
 	configPath, err := cmd.Flags().GetString("config")

--- a/cli/internal/cmd/terminate.go
+++ b/cli/internal/cmd/terminate.go
@@ -44,12 +44,12 @@ func runTerminate(cmd *cobra.Command, args []string) error {
 
 func terminate(cmd *cobra.Command, terminator cloudTerminator, fileHandler file.Handler, spinner spinnerInterf,
 ) error {
-	foundTerraformData, err := checkForTerraformData(fileHandler)
+	foundExistingClusterData, err := checkForExistingClusterData(fileHandler)
 	if err != nil {
 		return err
 	}
 
-	if !foundTerraformData {
+	if !foundExistingClusterData {
 		return fmt.Errorf("did not find a cluster to terminate")
 	}
 
@@ -88,7 +88,7 @@ func terminate(cmd *cobra.Command, terminator cloudTerminator, fileHandler file.
 	return retErr
 }
 
-func checkForTerraformData(fileHandler file.Handler) (bool, error) {
+func checkForExistingClusterData(fileHandler file.Handler) (bool, error) {
 	currentDirectory, err := fileHandler.ReadDir(".")
 	if err != nil {
 		return false, err
@@ -97,6 +97,10 @@ func checkForTerraformData(fileHandler file.Handler) (bool, error) {
 	for _, file := range currentDirectory {
 		filename := file.Name()
 		switch filename {
+		// libvirt container (QEMU only)
+		case "libvirt.name":
+			return true, nil
+		// Terraform resources
 		case "terraform.tfvars":
 			return true, nil
 		case "terraform.tfstate":

--- a/cli/internal/cmd/terminate_test.go
+++ b/cli/internal/cmd/terminate_test.go
@@ -162,14 +162,14 @@ func TestForTerraformData(t *testing.T) {
 	expectedDirs := []string{".terraform"}
 
 	// Check empty current directory
-	result, err := checkForTerraformData(fileHandler)
+	result, err := checkForExistingClusterData(fileHandler)
 	assert.NoError(err)
 	assert.False(result)
 
 	for _, singleFilename := range expectedFiles {
 		_, err := fs.Create(singleFilename)
 		require.NoError(err)
-		foundTerraformData, err := checkForTerraformData(fileHandler)
+		foundTerraformData, err := checkForExistingClusterData(fileHandler)
 		require.NoError(err)
 		assert.True(foundTerraformData)
 		require.NoError(fs.Remove(singleFilename))
@@ -177,7 +177,7 @@ func TestForTerraformData(t *testing.T) {
 
 	for _, singleDirname := range expectedDirs {
 		require.NoError(fs.Mkdir(singleDirname, 0o700))
-		foundTerraformData, err := checkForTerraformData(fileHandler)
+		foundTerraformData, err := checkForExistingClusterData(fileHandler)
 		require.NoError(err)
 		assert.True(foundTerraformData)
 		require.NoError(fs.Remove(singleDirname))

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -75,6 +75,14 @@ func (h *Handler) Read(name string) ([]byte, error) {
 	return io.ReadAll(file)
 }
 
+func (h *Handler) ReadDir(name string) ([]os.FileInfo, error) {
+	dir, err := h.fs.ReadDir(name)
+	if err != nil {
+		return nil, err
+	}
+	return dir, nil
+}
+
 // Write writes the data bytes into the file with the given name.
 func (h *Handler) Write(name string, data []byte, options ...Option) error {
 	if hasOption(options, OptMkdirAll) {

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -75,6 +75,7 @@ func (h *Handler) Read(name string) ([]byte, error) {
 	return io.ReadAll(file)
 }
 
+// ReadDir reads the directory with the given name and returns os.FileInfo for each entry in it.
 func (h *Handler) ReadDir(name string) ([]os.FileInfo, error) {
 	dir, err := h.fs.ReadDir(name)
 	if err != nil {


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Prompt user they can run `constellation terminate again` to fix a failed rollback
- Make terminate independent of constellation-id.json and instead rely on config (could potentially be completely removed if we know how to deal with QEMU)
- Adapt unit tests to reflect the changes

The TestTerminate does not properly check for the Terraform terminator since the stub does not implement it correctly. It is tested by terraform_test.go. So I just adjusted the TestTerminate test to create a stub file to pass the "cluster does exist" test.


<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
