### PR TITLE
Join-service helm chart: use correct casing for provider name

### DIFF
--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/join-service/templates/configmap.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/join-service/templates/configmap.yaml
@@ -7,7 +7,7 @@ data:
   # mustToJson is required so the json-strings passed from go are properly quoted in the rendered yaml.
   enforcedPCRs: {{ .Values.enforcedPCRs | mustToJson }}
   measurements: {{ .Values.measurements | mustToJson }}
-  {{- if eq .Values.csp "azure" }}
+  {{- if eq .Values.csp "Azure" }}
   enforceIdKeyDigest: {{ .Values.enforceIdKeyDigest }}
   idkeydigest: {{ .Values.idkeydigest }}
   {{- end }}


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Join-service helm chart: use correct casing for provider name

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

Node are unable to join on azure because of missing pieces in the join-service configmap:

```
[root@fedora ~]# k -n kube-system logs -f join-service-c87kd
{"level":"INFO","ts":"2022-10-25T09:10:00Z","caller":"cmd/main.go:48","msg":"Constellation Node Join Service","version":"0.0.0","cloudProvider":"Azure"}
{"level":"INFO","ts":"2022-10-25T09:10:00Z","logger":"validator","caller":"watcher/validator.go:96","msg":"Updating expected measurements"}
{"level":"INFO","ts":"2022-10-25T09:10:00Z","logger":"validator","caller":"watcher/validator.go:113","msg":"Updating encforceIdKeyDigest value"}
Usage of /joinservice:
  -cloud-provider string
        cloud service provider this binary is running on
  -kms-endpoint string
        endpoint of Constellations key management service
  -v int
        log verbosity in zap logging levels. Use -1 for debug information, 0 for info, 1 for warn, 2 for error
{"level":"FATAL","ts":"2022-10-25T09:10:00Z","caller":"cmd/main.go:64","msg":"Failed to create validator","error":"open /var/config/enforceIdKeyDigest: no such file or directory"}
```
