### PR TITLE
bootstrapper: undefine -v flag to avoid collision

### DIFF
--- a/bootstrapper/cmd/bootstrapper/main.go
+++ b/bootstrapper/cmd/bootstrapper/main.go
@@ -49,9 +49,12 @@ const (
 
 func main() {
 	gRPCDebug := flag.Bool("debug", false, "Enable gRPC debug logging")
-	verbosity := flag.Int("v", 0, logger.CmdLineVerbosityDescription)
+
+	// FIXME: define flag again once its definition no longer collides with glog.
+	// This should happen as soon as https://github.com/google/go-sev-guest/issues/23 is merged and consumed by us.
+	verbosity := 0 // flag.Int("v", 0, logger.CmdLineVerbosityDescription)
 	flag.Parse()
-	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity)).Named("bootstrapper")
+	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(verbosity)).Named("bootstrapper")
 	defer log.Sync()
 
 	if *gRPCDebug {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Temporarily undefine -v flag as it collided with glogs definition. 

As far as I can see, we never used the flag in our images anyway to setting to the flag's default.

The other solution would be to revert [79f52e67cb0d078c951f7ebcff97e6a91b9253a8 ](https://github.com/edgelesssys/constellation/commit/79f52e67cb0d078c951f7ebcff97e6a91b9253a8). In my opinion this is less preferable since this will block AWS support again. 

As soon as https://github.com/google/go-sev-guest/issues/23 is merged and used downstream, we can re-enable the flag. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->