### PR TITLE
undefine more -v flags due to glog

### DIFF
--- a/disk-mapper/cmd/main.go
+++ b/disk-mapper/cmd/main.go
@@ -50,10 +50,12 @@ const (
 
 func main() {
 	csp := flag.String("csp", "", "Cloud Service Provider the image is running on")
-	verbosity := flag.Int("v", 0, logger.CmdLineVerbosityDescription)
+	// FIXME: define flag again once its definition no longer collides with glog.
+	// This should happen as soon as https://github.com/google/go-sev-guest/issues/23 is merged and consumed by us.
+	verbosity := 0 // flag.Int("v", 0, logger.CmdLineVerbosityDescription)
 
 	flag.Parse()
-	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity))
+	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(verbosity))
 	log.With(zap.String("version", constants.VersionInfo), zap.String("cloudProvider", *csp)).
 		Infof("Starting disk-mapper")
 

--- a/joinservice/cmd/main.go
+++ b/joinservice/cmd/main.go
@@ -40,10 +40,12 @@ const vpcIPTimeout = 30 * time.Second
 func main() {
 	provider := flag.String("cloud-provider", "", "cloud service provider this binary is running on")
 	kmsEndpoint := flag.String("kms-endpoint", "", "endpoint of Constellations key management service")
-	verbosity := flag.Int("v", 0, logger.CmdLineVerbosityDescription)
+	// FIXME: define flag again once its definition no longer collides with glog.
+	// This should happen as soon as https://github.com/google/go-sev-guest/issues/23 is merged and consumed by us.
+	verbosity := 0 // flag.Int("v", 0, logger.CmdLineVerbosityDescription)
 	flag.Parse()
 
-	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity))
+	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(verbosity))
 	log.With(zap.String("version", constants.VersionInfo), zap.String("cloudProvider", *provider)).
 		Infof("Constellation Node Join Service")
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Undefine more -v flags due to glog collision

Need to undefine -v in disk-mapper and join-service as both import atls which depends on go tpm and so on. 
Not sure about if undefining more -v flags is the right way forward, though. Again, the flags should be unused. A user could change the join-service deployment and add the flag, but this is unlikely as they should keep their hands off our deployments anyway. Furthermore, hopefully this is a very temporary fix (tm). 

Also, the AWS support is almost finished. Only testing needed. Reverting https://github.com/edgelesssys/constellation/commit/79f52e67cb0d078c951f7ebcff97e6a91b9253a8 would block AWS, We'll probably need to decide for the next release if we want AWS or not. I guess we could also build a fork of go-tpm-tools which includes the AWS fix, but is purposefully outdated to not include the glog dependency. Interested in opinions here.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
