### PR TITLE
Fix measurements for case-insensitive Azure 

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -11,6 +11,9 @@ inputs:
   cloudProvider:
     description: "Either 'gcp' or 'azure'."
     required: true
+  gcpProject:
+    description: "The GCP project to deploy Constellation in."
+    required: false
   gcpClusterServiceAccountKey:
     description: "Service account to use inside the created Constellation cluster on GCP."
     required: false
@@ -26,8 +29,20 @@ inputs:
   kubernetesVersion:
     description: "Kubernetes version to create the cluster from."
     required: false
+  azureSubscription:
+    description: "The Azure subscription ID to deploy Constellation in."
+    required: false
+  azureTenant:
+    description: "The Azure tenant ID to deploy Constellation in."
+    required: false
+  azureClientID:
+    description: "The client ID of the application registration created for Constellation in Azure."
+    required: false
   azureClientSecret:
     description: "The client secret value of the used secret"
+    required: false
+  azureUserAssignedIdentity:
+    description: "The Azure user assigned identity to use for Constellation."
     required: false
   azureResourceGroup:
     description: "The resource group to use for Constellation cluster"
@@ -47,17 +62,17 @@ runs:
         constellation config generate ${{ inputs.cloudProvider }}
 
         yq eval -i \
-          "(.provider | select(. | has(\"azure\")).azure.subscription) = \"0d202bbb-4fa7-4af8-8125-58c269a05435\" |
-            (.provider | select(. | has(\"azure\")).azure.tenant) = \"adb650a8-5da3-4b15-b4b0-3daf65ff7626\" |
+          "(.provider | select(. | has(\"azure\")).azure.subscription) = \"${{ inputs.azureSubscription }}\" |
+            (.provider | select(. | has(\"azure\")).azure.tenant) = \"${{ inputs.azureTenant }}\" |
             (.provider | select(. | has(\"azure\")).azure.location) = \"North Europe\" |
-            (.provider | select(. | has(\"azure\")).azure.userAssignedIdentity) = \"/subscriptions/0d202bbb-4fa7-4af8-8125-58c269a05435/resourceGroups/e2e-test-creds/providers/Microsoft.ManagedIdentity/userAssignedIdentities/e2e-test-user-assigned-id\" |
+            (.provider | select(. | has(\"azure\")).azure.userAssignedIdentity) = \"${{ inputs.azureUserAssignedIdentity }}\" |
             (.provider | select(. | has(\"azure\")).azure.resourceGroup) = \"${{ inputs.azureResourceGroup }}\" |
-            (.provider | select(. | has(\"azure\")).azure.appClientID) = \"b657a00e-813a-4dc7-9b09-fa498a254d71\" |
+            (.provider | select(. | has(\"azure\")).azure.appClientID) = \"${{ inputs.azureClientID }}\" |
             (.provider | select(. | has(\"azure\")).azure.clientSecretValue) = \"${{ inputs.azureClientSecret }}\" |
             (.provider | select(. | has(\"azure\")).azure.enforcedMeasurements) = [11,12]" \
           constellation-conf.yaml
         yq eval -i \
-          "(.provider | select(. | has(\"gcp\")).gcp.project) = \"constellation-331613\" |
+          "(.provider | select(. | has(\"gcp\")).gcp.project) = \"${{ inputs.gcpProject }}\" |
             (.provider | select(. | has(\"gcp\")).gcp.region) = \"europe-west3\" |
             (.provider | select(. | has(\"gcp\")).gcp.zone) = \"europe-west3-b\" |
             (.provider | select(. | has(\"gcp\")).gcp.enforcedMeasurements) = [11,12] |

--- a/.github/actions/constellation_measure/action.yml
+++ b/.github/actions/constellation_measure/action.yml
@@ -49,7 +49,7 @@ runs:
     - name: Fetch PCRs
       run: |
         KUBECONFIG="$PWD/constellation-admin.conf" kubectl rollout status ds/verification-service -n kube-system --timeout=3m
-        CONSTELL_IP=$(jq -r ".bootstrapperhost" constellation-state.json)
+        CONSTELL_IP=$(jq -r ".ip" constellation-id.json)
         pcr-reader --constell-ip ${CONSTELL_IP} -format yaml > measurements.yaml
         case $CSP in
           azure)

--- a/.github/actions/constellation_measure/action.yml
+++ b/.github/actions/constellation_measure/action.yml
@@ -39,6 +39,7 @@ runs:
   steps:
     - name: Build hack/pcr-reader
       run: |
+        echo "::group::Build pcr-reader"
         go build .
         echo "$(pwd)" >> $GITHUB_PATH
       working-directory: hack/pcr-reader

--- a/.github/actions/constellation_measure/action.yml
+++ b/.github/actions/constellation_measure/action.yml
@@ -99,7 +99,7 @@ runs:
     - name: Upload to S3
       run: |
         IMAGE=$(yq e ".provider.${CSP}.image" constellation-conf.yaml)
-        S3_PATH=s3://${PUBLIC_BUCKET_NAME}/${IMAGE}
+        S3_PATH=s3://${PUBLIC_BUCKET_NAME}/${IMAGE,,}
         aws s3 cp measurements.yaml ${S3_PATH}/measurements.yaml
         if test -f measurements.yaml.sig; then
           aws s3 cp measurements.yaml.sig ${S3_PATH}/measurements.yaml.sig

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -27,14 +27,29 @@ inputs:
   kubernetesVersion:
     description: "Kubernetes version to create the cluster from."
     required: false
+  gcpProject:
+    description: "The GCP project to deploy Constellation in."
+    required: false
   gcp_service_account_json:
     description: "Service account with permissions to create Constellation on GCP."
     required: false
   gcpClusterServiceAccountKey:
     description: "Service account to use inside the created Constellation cluster on GCP."
     required: false
+  azureSubscription:
+    description: "The Azure subscription ID to deploy Constellation in."
+    required: false
+  azureTenant:
+    description: "The Azure tenant ID to deploy Constellation in."
+    required: false
+  azureClientID:
+    description: "The client ID of the application registration created for Constellation in Azure."
+    required: false
   azureClientSecret:
     description: "The client secret value of the used secret"
+    required: false
+  azureUserAssignedIdentity:
+    description: "The Azure user assigned identity to use for Constellation."
     required: false
   azureResourceGroup:
     description: "The resource group to use"
@@ -113,6 +128,7 @@ runs:
       uses: ./.github/actions/constellation_create
       with:
         cloudProvider: ${{ inputs.cloudProvider }}
+        gcpProject: ${{ inputs.gcpProject }}
         gcpClusterServiceAccountKey: ${{ inputs.gcpClusterServiceAccountKey }}
         workerNodesCount: ${{ inputs.workerNodesCount }}
         controlNodesCount: ${{ inputs.controlNodesCount }}
@@ -120,7 +136,11 @@ runs:
         osImage: ${{ inputs.osImage }}
         isDebugImage: ${{ inputs.isDebugImage }}
         kubernetesVersion: ${{ inputs.kubernetesVersion }}
+        azureSubscription: ${{ inputs.azureSubscription }}
+        azureTenant: ${{ inputs.azureTenant }}
+        azureClientID: ${{ inputs.azureClientID }}
         azureClientSecret: ${{ inputs.azureClientSecret }}
+        azureUserAssignedIdentity: ${{ inputs.azureUserAssignedIdentity }}
         azureResourceGroup: ${{ inputs.azureResourceGroup }}
 
     #

--- a/.github/actions/generate_measurements/action.yml
+++ b/.github/actions/generate_measurements/action.yml
@@ -25,11 +25,23 @@ inputs:
     description: "Kubernetes version to create the cluster from."
     required: false
     default: "1.23"
+  gcpProject:
+    description: "The GCP project to deploy Constellation in."
+    required: false
   gcp_service_account_json:
     description: "Service account with permissions to create Constellation on GCP."
     required: false
   gcpClusterServiceAccountKey:
     description: "Service account to use inside the created Constellation cluster on GCP."
+    required: false
+  azureSubscription:
+    description: "The Azure subscription ID to deploy Constellation in."
+    required: false
+  azureTenant:
+    description: "The Azure tenant ID to deploy Constellation in."
+    required: false
+  azureClientID:
+    description: "The client ID of the application registration created for Constellation in Azure."
     required: false
   azureClientSecret:
     description: "The client secret value of the used secret"

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -6,10 +6,10 @@ on:
     - cron: "0 3 * * 2-5" # At 03:00 on every day-of-week from Tuesday through Friday.
 
 env:
-  ARM_CLIENT_ID: "b657a00e-813a-4dc7-9b09-fa498a254d71"
+  ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: "0d202bbb-4fa7-4af8-8125-58c269a05435"
-  ARM_TENANT_ID: "adb650a8-5da3-4b15-b4b0-3daf65ff7626"
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
 
 jobs:
   e2e-daily:

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -50,8 +50,13 @@ jobs:
           workerNodesCount: "2"
           controlNodesCount: "3"
           cloudProvider: ${{ matrix.provider }}
+          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+          azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
+          azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
           azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
+          azureUserAssignedIdentity: ${{ secrets.AZURE_E2E_USER_ASSIGNED_IDENTITY }}
           azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
+          gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: "sonobuoy full"

--- a/.github/workflows/e2e-test-manual-macos.yml
+++ b/.github/workflows/e2e-test-manual-macos.yml
@@ -127,11 +127,16 @@ jobs:
           controlNodesCount: ${{ github.event.inputs.controlNodesCount }}
           cloudProvider: ${{ github.event.inputs.cloudProvider }}
           machineType: ${{ github.event.inputs.machineType }}
+          gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ github.event.inputs.test }}
           kubernetesVersion: ${{ github.event.inputs.kubernetesVersion }}
+          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+          azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
+          azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
           azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
+          azureUserAssignedIdentity: ${{ secrets.AZURE_E2E_USER_ASSIGNED_IDENTITY }}
           azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
           osImage: ${{ github.event.inputs.osImage }}
           isDebugImage: ${{ github.event.inputs.isDebugImage }}

--- a/.github/workflows/e2e-test-manual-macos.yml
+++ b/.github/workflows/e2e-test-manual-macos.yml
@@ -50,10 +50,10 @@ on:
         required: false
 
 env:
-  ARM_CLIENT_ID: "b657a00e-813a-4dc7-9b09-fa498a254d71"
+  ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: "0d202bbb-4fa7-4af8-8125-58c269a05435"
-  ARM_TENANT_ID: "adb650a8-5da3-4b15-b4b0-3daf65ff7626"
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
 
 jobs:
   build-bootstrapper-linux:

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -91,11 +91,16 @@ jobs:
           controlNodesCount: ${{ github.event.inputs.controlNodesCount }}
           cloudProvider: ${{ github.event.inputs.cloudProvider }}
           machineType: ${{ github.event.inputs.machineType }}
+          gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ github.event.inputs.test }}
           kubernetesVersion: ${{ github.event.inputs.kubernetesVersion }}
+          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+          azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
+          azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
           azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
+          azureUserAssignedIdentity: ${{ secrets.AZURE_E2E_USER_ASSIGNED_IDENTITY }}
           azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
           osImage: ${{ github.event.inputs.osImage }}
           isDebugImage: ${{ github.event.inputs.isDebugImage }}

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -49,10 +49,10 @@ on:
         required: false
 
 env:
-  ARM_CLIENT_ID: "b657a00e-813a-4dc7-9b09-fa498a254d71"
+  ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: "0d202bbb-4fa7-4af8-8125-58c269a05435"
-  ARM_TENANT_ID: "adb650a8-5da3-4b15-b4b0-3daf65ff7626"
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
 
 jobs:
   e2e-test-manual:

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -60,15 +60,20 @@ jobs:
           az group create --location northeurope --name $name --tags e2e
           echo "res_group_name=$name" >> $GITHUB_OUTPUT
 
-      - name: Run Azure E2E test
+      - name: Run E2E test
         uses: ./.github/actions/e2e_test
         with:
           workerNodesCount: "2"
           controlNodesCount: "3"
           cloudProvider: ${{ matrix.provider }}
           kubernetesVersion: ${{ matrix.version }}
+          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+          azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
+          azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
           azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
+          azureUserAssignedIdentity: ${{ secrets.AZURE_E2E_USER_ASSIGNED_IDENTITY }}
           azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
+          gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ matrix.test }}

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -6,10 +6,10 @@ on:
     - cron: "0 3 * * 6" # At 03:00 on Saturday.
 
 env:
-  ARM_CLIENT_ID: "b657a00e-813a-4dc7-9b09-fa498a254d71"
+  ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: "0d202bbb-4fa7-4af8-8125-58c269a05435"
-  ARM_TENANT_ID: "adb650a8-5da3-4b15-b4b0-3daf65ff7626"
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
 
 jobs:
   e2e-weekly:

--- a/.github/workflows/generate-measurements.yml
+++ b/.github/workflows/generate-measurements.yml
@@ -58,9 +58,14 @@ jobs:
         uses: ./.github/actions/generate_measurements
         with:
           cloudProvider: ${{ github.event.inputs.cloudProvider }}
+          gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
+          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+          azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
+          azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
           azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
+          azureUserAssignedIdentity: ${{ secrets.AZURE_E2E_USER_ASSIGNED_IDENTITY }}
           azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
           osImage: ${{ github.event.inputs.osImage }}
           isDebugImage: ${{ github.event.inputs.isDebugImage }}

--- a/.github/workflows/generate-measurements.yml
+++ b/.github/workflows/generate-measurements.yml
@@ -20,6 +20,12 @@ on:
         type: boolean
         required: true
 
+env:
+  ARM_CLIENT_ID: "b657a00e-813a-4dc7-9b09-fa498a254d71"
+  ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
+  ARM_SUBSCRIPTION_ID: "0d202bbb-4fa7-4af8-8125-58c269a05435"
+  ARM_TENANT_ID: "adb650a8-5da3-4b15-b4b0-3daf65ff7626"
+
 jobs:
   generate-measurements-manual:
     runs-on: ubuntu-latest

--- a/.github/workflows/generate-measurements.yml
+++ b/.github/workflows/generate-measurements.yml
@@ -21,10 +21,10 @@ on:
         required: true
 
 env:
-  ARM_CLIENT_ID: "b657a00e-813a-4dc7-9b09-fa498a254d71"
+  ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: "0d202bbb-4fa7-4af8-8125-58c269a05435"
-  ARM_TENANT_ID: "adb650a8-5da3-4b15-b4b0-3daf65ff7626"
+  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+  ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
 
 jobs:
   generate-measurements-manual:

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ bootstrapper-*
 
 # VS Code configuration folder
 .vscode
+# IntelliJ-based IDEs configuration folder (e.g. GoLand)
+.idea
+
 # Debug and testing files
 debug/
 

--- a/cli/internal/cmd/configfetchmeasurements.go
+++ b/cli/internal/cmd/configfetchmeasurements.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/edgelesssys/constellation/v2/internal/config"
@@ -128,7 +129,7 @@ func parseFetchMeasurementsFlags(cmd *cobra.Command) (*fetchMeasurementsFlags, e
 
 func (f *fetchMeasurementsFlags) updateURLs(conf *config.Config) error {
 	if f.measurementsURL == nil {
-		parsedURL, err := url.Parse(constants.S3PublicBucket + conf.Image() + "/measurements.yaml")
+		parsedURL, err := url.Parse(constants.S3PublicBucket + strings.ToLower(conf.Image()) + "/measurements.yaml")
 		if err != nil {
 			return err
 		}
@@ -136,7 +137,7 @@ func (f *fetchMeasurementsFlags) updateURLs(conf *config.Config) error {
 	}
 
 	if f.signatureURL == nil {
-		parsedURL, err := url.Parse(constants.S3PublicBucket + conf.Image() + "/measurements.yaml.sig")
+		parsedURL, err := url.Parse(constants.S3PublicBucket + strings.ToLower(conf.Image()) + "/measurements.yaml.sig")
 		if err != nil {
 			return err
 		}

--- a/cli/internal/cmd/upgradeplan.go
+++ b/cli/internal/cmd/upgradeplan.go
@@ -181,12 +181,12 @@ func getCompatibleImages(csp cloudprovider.Provider, currentVersion string, imag
 // getCompatibleImageMeasurements retrieves the expected measurements for each image.
 func getCompatibleImageMeasurements(ctx context.Context, client *http.Client, rekor rekorVerifier, pubK []byte, images map[string]config.UpgradeConfig) error {
 	for idx, img := range images {
-		measurementsURL, err := url.Parse(constants.S3PublicBucket + img.Image + "/measurements.yaml")
+		measurementsURL, err := url.Parse(constants.S3PublicBucket + strings.ToLower(img.Image) + "/measurements.yaml")
 		if err != nil {
 			return err
 		}
 
-		signatureURL, err := url.Parse(constants.S3PublicBucket + img.Image + "/measurements.yaml.sig")
+		signatureURL, err := url.Parse(constants.S3PublicBucket + strings.ToLower(img.Image) + "/measurements.yaml.sig")
 		if err != nil {
 			return err
 		}

--- a/cli/internal/cmd/upgradeplan.go
+++ b/cli/internal/cmd/upgradeplan.go
@@ -33,7 +33,7 @@ import (
 const imageReleaseURL = "https://github.com/edgelesssys/constellation/releases/latest/download/versions-manifest.json"
 
 var (
-	azureCVMRxp = regexp.MustCompile(`^\/CommunityGalleries\/ConstellationCVM-b3782fa0-0df7-4f2f-963e-fc7fc42663df\/Images\/constellation\/Versions\/[\d]+.[\d]+.[\d]+$`)
+	azureCVMRxp = regexp.MustCompile(`^(?i)\/CommunityGalleries\/ConstellationCVM-b3782fa0-0df7-4f2f-963e-fc7fc42663df\/Images\/constellation\/Versions\/[\d]+.[\d]+.[\d]+$`)
 	gcpCVMRxp   = regexp.MustCompile(`^projects\/constellation-images\/global\/images\/constellation-(v[\d]+-[\d]+-[\d]+)$`)
 )
 


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix measurements for case-insensitive Azure
- Fix CI pipeline in general (I believe, main is broken so cannot test...)

Since the AzureRM terraform provider enforces certain spelling according to their arbitrary standards, we added image name normalisation to make this process a bit user-friendlier. However, since S3 is case-sensitive, we also need to normalise file names there, too. 

As a stop-gap measure before we completely rework the measurement fetching anyway, this PR does that plus fixes the pipeline which was broken before. 

It might still be broken as my test currently dies at the verification-service. Hope main is fixed soon so I can re-base and build a new image any try again since I don't like merging untested code.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
