### PR TITLE
Prompt before terminate

### DIFF
--- a/.github/actions/constellation_destroy/action.yml
+++ b/.github/actions/constellation_destroy/action.yml
@@ -4,5 +4,5 @@ runs:
   using: 'composite'
   steps:
   - name: Constellation terminate
-    run: constellation terminate
+    run: constellation terminate --yes
     shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Verify measurements using [Rekor](https://github.com/sigstore/rekor) transparency log.
 - The `constellation create` on Azure now uses Terraform to create and destroy cloud resources.
 - Constellation OS images are now based on Fedora directly and are built using [mkosi](https://github.com/systemd/mkosi).
+- `constellation terminate` will now prompt the user for confirmation before destroying any resources (can be skipped with `--yes`).
 
 ### Deprecated
 <!-- For soon-to-be removed features. -->

--- a/cli/internal/cmd/configgenerate.go
+++ b/cli/internal/cmd/configgenerate.go
@@ -74,7 +74,7 @@ func configGenerate(cmd *cobra.Command, fileHandler file.Handler, provider cloud
 	}
 	cmd.Println("Config file written to", flags.file)
 	cmd.Println("Please fill in your CSP-specific configuration before proceeding.")
-	cmd.Println("Fore more information refer to the documentation:")
+	cmd.Println("For more information refer to the documentation:")
 	cmd.Println("\thttps://docs.edgeless.systems/constellation/getting-started/first-steps")
 
 	return nil

--- a/cli/internal/cmd/create_test.go
+++ b/cli/internal/cmd/create_test.go
@@ -44,7 +44,7 @@ func TestCreate(t *testing.T) {
 		nameFlag            string
 		stdin               string
 		wantErr             bool
-		wantAbbort          bool
+		wantAbort           bool
 	}{
 		"create": {
 			setupFs:             fsWithDefaultConfig,
@@ -69,7 +69,7 @@ func TestCreate(t *testing.T) {
 			controllerCountFlag: intPtr(1),
 			workerCountFlag:     intPtr(1),
 			stdin:               "no\n",
-			wantAbbort:          true,
+			wantAbort:           true,
 		},
 		"interactive error": {
 			setupFs:             fsWithDefaultConfig,
@@ -218,7 +218,7 @@ func TestCreate(t *testing.T) {
 				assert.Error(err)
 			} else {
 				assert.NoError(err)
-				if tc.wantAbbort {
+				if tc.wantAbort {
 					assert.False(tc.creator.createCalled)
 				} else {
 					assert.True(tc.creator.createCalled)

--- a/cli/internal/cmd/terminate.go
+++ b/cli/internal/cmd/terminate.go
@@ -45,12 +45,12 @@ func runTerminate(cmd *cobra.Command, args []string) error {
 
 func terminate(cmd *cobra.Command, terminator cloudTerminator, fileHandler file.Handler, spinner spinnerInterf,
 ) error {
-	flags, err := parseTerminateFlags(cmd)
+	yesFlag, err := cmd.Flags().GetBool("yes")
 	if err != nil {
 		return err
 	}
 
-	if !flags.yes {
+	if !yesFlag {
 		cmd.Println("You are about to terminate a Constellation cluster.")
 		cmd.Println("All of its associated resources will be DESTROYED.")
 		cmd.Println("This includes any other Terraform workspace in the current directory.")
@@ -84,19 +84,4 @@ func terminate(cmd *cobra.Command, terminator cloudTerminator, fileHandler file.
 	}
 
 	return retErr
-}
-
-type terminateFlags struct {
-	yes bool
-}
-
-func parseTerminateFlags(cmd *cobra.Command) (terminateFlags, error) {
-	yes, err := cmd.Flags().GetBool("yes")
-	if err != nil {
-		return terminateFlags{}, err
-	}
-
-	return terminateFlags{
-		yes: yes,
-	}, nil
 }

--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -271,7 +271,7 @@ This action is irreversible and ALL DATA WILL BE LOST.
 Do you want to continue? [y/n]:
 ```
 
-After confirming with either "y" or "yes", the cluster will be terminated :
+After confirming with either `y` or `yes`, the cluster will be terminated :
 
 ```shell-session
 Terminating ...

--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -264,9 +264,21 @@ This should give the following output:
 
 ```shell-session
 $ constellation terminate
+You are about to terminate a Constellation cluster.
+All of its associated resources will be DESTROYED.
+This includes any other Terraform workspace in the current directory.
+This action is irreversible and ALL DATA WILL BE LOST.
+Do you want to continue? [y/n]:
+```
+
+After confirming with either "y" or "yes", the cluster will be terminated :
+
+```shell-session
 Terminating ...
 Your Constellation cluster was terminated successfully.
 ```
+
+For automation purposes, you can skip the prompt by passing `--yes` as a flag to `constellation terminate`.
 
 :::tip
 

--- a/hack/fetch-broken-e2e/find.sh
+++ b/hack/fetch-broken-e2e/find.sh
@@ -9,5 +9,5 @@ then
 else
     printf "Statefile found. You should run:\n\n"
     printf "cd %s\n" $TO_DELETE
-    printf "constellation terminate\n\n"
+    printf "constellation terminate --yes\n\n"
 fi


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a prompt to `constellation terminate` before terminating any resources
- Add a `--yes` flag to bypass this for CI and other automation scripts.

You can choose if you'd like the separate parse function (initial commits) or if we just include the check in the terminate function itself (last commit) since it's just one check. The former one is more consistent with the other CLI functions, but we don't need any other flags anyway currently so it's kinda obsolete except for consistency.

### Related issue
I suggested this initially in #360. 
While one could argue that if someone calls `constellation terminate` they would be doing this by intention (similar to `rm`), in my opinion, there's multiple good reasons to prompt the user before terminating:
- We prompt the user on `create` despite `terminate` being the action with significantly worse unintended consequences.
- Prompting before terminating is similar behaviour within the Azure and GCP CLI and Terraform itself. The AWS CLI does not prompt.
- The change from #360 means that `constellation terminate` has no checks on its current directory. It will not only destroy any Constellation cluster without asking, but also _any_ Terraform workspace in the current working directory. This can create significant headaches unintentionally due to us saving on checks; thus we should not automatically allow this.

If anyone wants to skip this, they can bypass this with a `--yes` flag, similarly as in `constellation create`.

- [x] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Link to Milestone
