### PR TITLE
terraform: fix azure password constraints

### DIFF
--- a/cli/internal/terraform/terraform/azure/modules/scale_set/main.tf
+++ b/cli/internal/terraform/terraform/azure/modules/scale_set/main.tf
@@ -12,7 +12,11 @@ terraform {
 }
 
 resource "random_password" "password" {
-  length = 16
+  length      = 16
+  min_lower   = 1
+  min_upper   = 1
+  min_numeric = 1
+  min_special = 1
 }
 
 resource "azurerm_linux_virtual_machine_scale_set" "scale_set" {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add needed Azure password constraints

Fixes:
```
An error occurred: exit status 1

Error: creating Linux Virtual Machine Scale Set: (Name "leo-24d2ba9f-worker" / Resource Group "XXX"): compute.VirtualMachineScaleSetsClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="InvalidParameter" Message="The supplied password must be between 6-72 characters long and must satisfy at least 3 of password complexity requirements from the following:\r\n1) Contains an uppercase character\r\n2) Contains a lowercase character\r\n3) Contains a numeric digit\r\n4) Contains a special character\r\n5) Control characters are not allowed" Target="adminPassword"

  with module.scale_set_worker.azurerm_linux_virtual_machine_scale_set.scale_set,
  on modules/scale_set/main.tf line 18, in resource "azurerm_linux_virtual_machine_scale_set" "scale_set":
  18: resource "azurerm_linux_virtual_machine_scale_set" "scale_set" {
```

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

