### PR TITLE
Fix link checker

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,3 +1,7 @@
 http://localhost:
 https://github.com/edgelesssys/wiki/blob/master/documentation/constellation/customer-onboarding.md
 https://github.com/edgelesssys/wiki/blob/master/documentation/rebasing_forks.md
+# medium.com based links disabled for now until Lychee gains cookie support (medium.com requires cookies to avoid infinite redirects)
+https://blog.edgeless.systems/
+https://blog.sigstore.dev/kubernetes-signals-massive-adoption-of-sigstore-for-protecting-open-source-ecosystem-73a6757da73
+


### PR DESCRIPTION
### Proposed change(s)
- Disable medium.com based links (blog.edgeless.systems, blog.sigstore.dev) from link checking until Lychee gains cookie support.

This is due to medium.com having integrated some redirects which require cookies to be set in order to be redirected back to the original URL. Not sure why exactly (L7 protection against bots?) they added this but until then there's not much we can do until Lychee supports storing cookies or we build/use some alternative solution.

### Related issues
- https://github.com/lycheeverse/lychee/issues/645

### Additional info
The check is still broken since www.linux-kvm.org seems to be misconfigured and not serve the full TLS chain currently. I tried to contact them if they are aware of this, but for now I would wait and keep this PR a draft to see if they fix it on their side.
