### PR TITLE
fix: don't run CI K-Bench with less than 2 worker nodes

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -56,6 +56,16 @@ runs:
         echo "Invalid input for test field: ${{ inputs.test }}"
         exit 1
 
+    # K-Bench's network benchmarks require at least two distinct worker nodes.
+    - name: Validate k-bench inputs
+      if: inputs.test == 'k-bench'
+      shell: bash
+      run: |
+        if [[ "${{ inputs.workerNodesCount }}" -lt 2 ]]; then
+          echo "::error::Test K-Bench requires at least 2 worker nodes."
+          exit 1
+        fi
+
     - name: Determine build target
       id: determine-build-target
       shell: bash


### PR DESCRIPTION
K-Bench's network benchmarks require two distinct worker nodes.: https://github.com/edgelesssys/k-bench/blob/feat/constellation/config/dp_network_internode/iperf_client_pod.yaml

Thanks @katexochen for the discovery in #421 


<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add check prior to running the K-Bench action to terminate early if not enough workers are scheduled.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

