### PR TITLE
Wait for kube api during init

### DIFF
--- a/bootstrapper/cmd/bootstrapper/main.go
+++ b/bootstrapper/cmd/bootstrapper/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/bootstrapper/internal/kubernetes"
 	"github.com/edgelesssys/constellation/v2/bootstrapper/internal/kubernetes/k8sapi"
 	"github.com/edgelesssys/constellation/v2/bootstrapper/internal/kubernetes/k8sapi/kubectl"
+	kubewaiter "github.com/edgelesssys/constellation/v2/bootstrapper/internal/kubernetes/kubeWaiter"
 	"github.com/edgelesssys/constellation/v2/bootstrapper/internal/logging"
 	"github.com/edgelesssys/constellation/v2/internal/atls"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/aws"
@@ -107,7 +108,7 @@ func main() {
 		cloudControllerManager := &awscloud.CloudControllerManager{}
 		clusterInitJoiner = kubernetes.New(
 			"aws", k8sapi.NewKubernetesUtil(), &k8sapi.KubdeadmConfiguration{}, kubectl.New(), cloudControllerManager,
-			metadata, pcrsJSON, helmClient,
+			metadata, pcrsJSON, helmClient, &kubewaiter.CloudKubeAPIWaiter{},
 		)
 		openTPM = vtpm.OpenVTPM
 		fs = afero.NewOsFs()
@@ -144,7 +145,7 @@ func main() {
 		}
 		clusterInitJoiner = kubernetes.New(
 			"gcp", k8sapi.NewKubernetesUtil(), &k8sapi.KubdeadmConfiguration{}, kubectl.New(), cloudControllerManager,
-			metadata, pcrsJSON, helmClient,
+			metadata, pcrsJSON, helmClient, &kubewaiter.CloudKubeAPIWaiter{},
 		)
 		openTPM = vtpm.OpenVTPM
 		fs = afero.NewOsFs()
@@ -178,7 +179,7 @@ func main() {
 		}
 		clusterInitJoiner = kubernetes.New(
 			"azure", k8sapi.NewKubernetesUtil(), &k8sapi.KubdeadmConfiguration{}, kubectl.New(), azurecloud.NewCloudControllerManager(metadata),
-			metadata, pcrsJSON, helmClient,
+			metadata, pcrsJSON, helmClient, &kubewaiter.CloudKubeAPIWaiter{},
 		)
 
 		openTPM = vtpm.OpenVTPM
@@ -200,7 +201,7 @@ func main() {
 		}
 		clusterInitJoiner = kubernetes.New(
 			"qemu", k8sapi.NewKubernetesUtil(), &k8sapi.KubdeadmConfiguration{}, kubectl.New(), &qemucloud.CloudControllerManager{},
-			metadata, pcrsJSON, helmClient,
+			metadata, pcrsJSON, helmClient, &kubewaiter.CloudKubeAPIWaiter{},
 		)
 		metadataAPI = metadata
 

--- a/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
@@ -55,6 +55,7 @@ type Client interface {
 	AddTolerationsToDeployment(ctx context.Context, tolerations []corev1.Toleration, name string, namespace string) error
 	AddNodeSelectorsToDeployment(ctx context.Context, selectors map[string]string, name string, namespace string) error
 	WaitForCRDs(ctx context.Context, crds []string) error
+	ListAllNamespaces(ctx context.Context) (*corev1.NamespaceList, error)
 }
 
 type installer interface {

--- a/bootstrapper/internal/kubernetes/k8sapi/kubectl/client/client.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/kubectl/client/client.go
@@ -116,6 +116,11 @@ func (c *Client) CreateConfigMap(ctx context.Context, configMap corev1.ConfigMap
 	return nil
 }
 
+// ListAllNamespaces returns a list of all namespaces.
+func (c *Client) ListAllNamespaces(ctx context.Context) (*corev1.NamespaceList, error) {
+	return c.clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+}
+
 func (c *Client) AddTolerationsToDeployment(ctx context.Context, tolerations []corev1.Toleration, name string, namespace string) error {
 	deployments := c.clientset.AppsV1().Deployments(namespace)
 

--- a/bootstrapper/internal/kubernetes/k8sapi/kubectl/kubectl.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/kubectl/kubectl.go
@@ -30,6 +30,7 @@ type Client interface {
 	AddNodeSelectorsToDeployment(ctx context.Context, selectors map[string]string, name string, namespace string) error
 	// WaitForCRD waits for the given CRD to be established.
 	WaitForCRD(ctx context.Context, crd string) error
+	ListAllNamespaces(ctx context.Context) (*corev1.NamespaceList, error)
 }
 
 // clientGenerator can generate new clients from a kubeconfig.
@@ -86,12 +87,17 @@ func (k *Kubectl) CreateConfigMap(ctx context.Context, configMap corev1.ConfigMa
 		return err
 	}
 
-	err = client.CreateConfigMap(ctx, configMap)
+	return client.CreateConfigMap(ctx, configMap)
+}
+
+// ListAllNamespaces returns all namespaces in the cluster.
+func (k *Kubectl) ListAllNamespaces(ctx context.Context) (*corev1.NamespaceList, error) {
+	client, err := k.clientGenerator.NewClient(k.kubeconfig)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return client.ListAllNamespaces(ctx)
 }
 
 func (k *Kubectl) AddTolerationsToDeployment(ctx context.Context, tolerations []corev1.Toleration, name string, namespace string) error {

--- a/bootstrapper/internal/kubernetes/k8sapi/kubectl/kubectl_test.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/kubectl/kubectl_test.go
@@ -30,6 +30,8 @@ type stubClient struct {
 	addTolerationsToDeploymentErr  error
 	addNodeSelectorToDeploymentErr error
 	waitForCRDErr                  error
+	listAllNamespacesResp          *corev1.NamespaceList
+	listAllNamespacesErr           error
 }
 
 func (s *stubClient) ApplyOneObject(info *resource.Info, forceConflicts bool) error {
@@ -50,6 +52,10 @@ func (s *stubClient) AddTolerationsToDeployment(ctx context.Context, tolerations
 
 func (s *stubClient) AddNodeSelectorsToDeployment(ctx context.Context, selectors map[string]string, name string, namespace string) error {
 	return s.addNodeSelectorToDeploymentErr
+}
+
+func (s *stubClient) ListAllNamespaces(ctx context.Context) (*corev1.NamespaceList, error) {
+	return s.listAllNamespacesResp, s.listAllNamespacesErr
 }
 
 type stubClientGenerator struct {

--- a/bootstrapper/internal/kubernetes/kubeWaiter/waiter.go
+++ b/bootstrapper/internal/kubernetes/kubeWaiter/waiter.go
@@ -15,6 +15,8 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/retry"
 )
 
+// KubernetesClient is an interface for the Kubernetes client.
+// It is used to check if the Kubernetes API is available.
 type KubernetesClient interface {
 	ListAllNamespaces(ctx context.Context) (*corev1.NamespaceList, error)
 }
@@ -24,10 +26,7 @@ type CloudKubeAPIWaiter struct{}
 
 // Wait waits for the Kubernetes API to be available.
 // Note that the kubernetesClient must have the kubeconfig already set.
-func (w *CloudKubeAPIWaiter) Wait(ctx context.Context, kubernetesClient KubernetesClient, timeout time.Duration) error {
-	ctx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
+func (w *CloudKubeAPIWaiter) Wait(ctx context.Context, kubernetesClient KubernetesClient) error {
 	funcAlwaysRetriable := func(err error) bool { return true }
 
 	doer := &kubeDoer{kubeClient: kubernetesClient}

--- a/bootstrapper/internal/kubernetes/kubeWaiter/waiter.go
+++ b/bootstrapper/internal/kubernetes/kubeWaiter/waiter.go
@@ -1,0 +1,48 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package kubewaiter
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/edgelesssys/constellation/v2/internal/retry"
+)
+
+type KubernetesClient interface {
+	ListAllNamespaces(ctx context.Context) (*corev1.NamespaceList, error)
+}
+
+// CloudKubeAPIWaiter waits for the Kubernetes API to be available.
+type CloudKubeAPIWaiter struct{}
+
+// Wait waits for the Kubernetes API to be available.
+// Note that the kubernetesClient must have the kubeconfig already set.
+func (w *CloudKubeAPIWaiter) Wait(ctx context.Context, kubernetesClient KubernetesClient, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	funcAlwaysRetriable := func(err error) bool { return true }
+
+	doer := &kubeDoer{kubeClient: kubernetesClient}
+	retrier := retry.NewIntervalRetrier(doer, 5*time.Second, funcAlwaysRetriable)
+	if err := retrier.Do(ctx); err != nil {
+		return doer.Do(context.Background())
+	}
+	return nil
+}
+
+type kubeDoer struct {
+	kubeClient KubernetesClient
+}
+
+func (d *kubeDoer) Do(ctx context.Context) error {
+	_, err := d.kubeClient.ListAllNamespaces(ctx)
+	return err
+}

--- a/bootstrapper/internal/kubernetes/kubeWaiter/waiter_test.go
+++ b/bootstrapper/internal/kubernetes/kubeWaiter/waiter_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package kubewaiter
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func TestCloudKubeAPIWaiter(t *testing.T) {
+	testCases := map[string]struct {
+		kubeClient KubernetesClient
+		wantErr    bool
+	}{
+		"success": {
+			kubeClient: &stubKubernetesClient{},
+		},
+		"error": {
+			kubeClient: &stubKubernetesClient{listAllNamespacesErr: errors.New("error")},
+			wantErr:    true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			waiter := &CloudKubeAPIWaiter{}
+			err := waiter.Wait(context.Background(), tc.kubeClient, 0)
+			if tc.wantErr {
+				require.Error(err)
+			} else {
+				require.NoError(err)
+			}
+		})
+	}
+}
+
+type stubKubernetesClient struct {
+	listAllNamespacesErr error
+}
+
+func (c *stubKubernetesClient) ListAllNamespaces(ctx context.Context) (*corev1.NamespaceList, error) {
+	return nil, c.listAllNamespacesErr
+}

--- a/bootstrapper/internal/kubernetes/kubeWaiter/waiter_test.go
+++ b/bootstrapper/internal/kubernetes/kubeWaiter/waiter_test.go
@@ -39,7 +39,9 @@ func TestCloudKubeAPIWaiter(t *testing.T) {
 			require := require.New(t)
 
 			waiter := &CloudKubeAPIWaiter{}
-			err := waiter.Wait(context.Background(), tc.kubeClient, 0)
+			ctx, cancel := context.WithTimeout(context.Background(), 0)
+			defer cancel()
+			err := waiter.Wait(ctx, tc.kubeClient)
 			if tc.wantErr {
 				require.Error(err)
 			} else {

--- a/bootstrapper/internal/kubernetes/kubernetes.go
+++ b/bootstrapper/internal/kubernetes/kubernetes.go
@@ -49,7 +49,7 @@ type configurationProvider interface {
 }
 
 type kubeAPIWaiter interface {
-	Wait(ctx context.Context, kubernetesClient kubewaiter.KubernetesClient, timeout time.Duration) error
+	Wait(ctx context.Context, kubernetesClient kubewaiter.KubernetesClient) error
 }
 
 // KubeWrapper implements Cluster interface.
@@ -166,7 +166,9 @@ func (k *KubeWrapper) InitCluster(
 	}
 	k.client.SetKubeconfig(kubeConfig)
 
-	if err := k.kubeAPIWaiter.Wait(ctx, k.client, 2*time.Minute); err != nil {
+	waitCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	if err := k.kubeAPIWaiter.Wait(waitCtx, k.client); err != nil {
 		return nil, fmt.Errorf("waiting for Kubernetes API to be available: %w", err)
 	}
 

--- a/bootstrapper/internal/kubernetes/kubernetes_test.go
+++ b/bootstrapper/internal/kubernetes/kubernetes_test.go
@@ -13,7 +13,6 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/edgelesssys/constellation/v2/bootstrapper/internal/kubernetes/k8sapi"
 	kubewaiter "github.com/edgelesssys/constellation/v2/bootstrapper/internal/kubernetes/kubeWaiter"
@@ -659,6 +658,6 @@ type stubKubeAPIWaiter struct {
 	waitErr error
 }
 
-func (s *stubKubeAPIWaiter) Wait(_ context.Context, _ kubewaiter.KubernetesClient, _ time.Duration) error {
+func (s *stubKubeAPIWaiter) Wait(_ context.Context, _ kubewaiter.KubernetesClient) error {
 	return s.waitErr
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a kubewaiter which can be used to wait between the startup of the kubelet and the first deployment of K8s resources which both happens on the first control-plane node. 

This is mostly needed on AWS because the load balancer health checks are quite slow there. It was common to get a `connection refused` error during the first deployment of K8s resources since the load balancer has no healthy backends. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

