### PR TITLE
docs: remove constellation-state.json

### DIFF
--- a/docs/docs/architecture/orchestration.md
+++ b/docs/docs/architecture/orchestration.md
@@ -21,14 +21,12 @@ To allow for fine-grained configuration of your cluster and cloud environment, C
 Altogether, the following files are generated during the creation of a Constellation cluster and stored in the current workspace:
 
 * a configuration file
-* a state file
 * an ID file
 * a Base64-encoded master secret
+* Terraform artifacts such as `terraform.tfstate`
 * a Kubernetes `kubeconfig` file.
 
-Constellation must store the state of its created infrastructure and configuration.
-This state is used by Constellation to map real-world resources to your configuration and keep track of metadata.
-This state is stored in a local file named `constellation-state.json`.
+Constellation uses Terraform for infrastructure management. No setup of Terraform is needed. The CLI automatically fetches a copy of Terraform when required.
 
 After the creation of your cluster, the CLI will provide you with a Kubernetes `kubeconfig` file.
 This file grants you access to your Kubernetes cluster and configures the [kubectl](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) tool.
@@ -53,7 +51,7 @@ Post-installation the CLI provides a configuration for [accessing the cluster us
 The `kubeconfig` file provides the credentials and configuration for connecting and authenticating to the API server.
 Once configured, orchestrate the Kubernetes cluster via `kubectl`.
 
-Keep the state files in the workspace directory such as the `constellation-state.json` for the CLI to be able to manage your cluster.
+Make sure to keep the state files such as `terraform.tfstate` in the workspace directory to be able to manage your cluster later on.
 Without it, you won't be able to modify or terminate your cluster.
 
 After the initialization, the CLI will present you with a couple of tokens:

--- a/docs/docs/workflows/create.md
+++ b/docs/docs/workflows/create.md
@@ -57,7 +57,7 @@ constellation create --control-plane-nodes 1 --worker-nodes 2
 
 For details on the flags, consult the command help via `constellation create -h`.
 
-*create* stores your cluster's configuration to a file named [`constellation-state.json`](../architecture/orchestration.md#installation-process) in your current directory.
+*create* stores your cluster's state into a [`terraform.tfstate`](../architecture/orchestration.md#installation-process) file in your current directory.
 
 ## The *init* step
 

--- a/docs/docs/workflows/terminate.md
+++ b/docs/docs/workflows/terminate.md
@@ -1,6 +1,6 @@
 # Terminate your cluster
 
-You can terminate your cluster using the CLI. For this, you need the state file of your running cluster named `constellation-state.json` in the current directory.
+You can terminate your cluster using the CLI. For this, you need the Terraform state file named `terraform.tfstate` in the current directory.
 
 :::danger
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- `constellation-state.json` does not exists anymore. The infrastructure part is taken over by Terraform and the terraform.tfstate. Some background information was moved to constellation-id.json (such as the load balancer endpoint for initializing the cluster). 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->
