### PR TITLE
Install systemd-resolved in dracut to enable DNS

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -69,13 +69,13 @@ runs:
             (.provider | select(. | has(\"azure\")).azure.resourceGroup) = \"${{ inputs.azureResourceGroup }}\" |
             (.provider | select(. | has(\"azure\")).azure.appClientID) = \"${{ inputs.azureClientID }}\" |
             (.provider | select(. | has(\"azure\")).azure.clientSecretValue) = \"${{ inputs.azureClientSecret }}\" |
-            (.provider | select(. | has(\"azure\")).azure.enforcedMeasurements) = [11,12]" \
+            (.provider | select(. | has(\"azure\")).azure.enforcedMeasurements) = [15]" \
           constellation-conf.yaml
         yq eval -i \
           "(.provider | select(. | has(\"gcp\")).gcp.project) = \"${{ inputs.gcpProject }}\" |
             (.provider | select(. | has(\"gcp\")).gcp.region) = \"europe-west3\" |
             (.provider | select(. | has(\"gcp\")).gcp.zone) = \"europe-west3-b\" |
-            (.provider | select(. | has(\"gcp\")).gcp.enforcedMeasurements) = [11,12] |
+            (.provider | select(. | has(\"gcp\")).gcp.enforcedMeasurements) = [15] |
             (.provider | select(. | has(\"gcp\")).gcp.serviceAccountKeyPath) = \"serviceAccountKey.json\"" \
           constellation-conf.yaml
 

--- a/.github/actions/os_build_variables/action.yml
+++ b/.github/actions/os_build_variables/action.yml
@@ -78,6 +78,9 @@ outputs:
   azureImageDefinition:
     description: "Azure image definition"
     value: ${{ steps.azure.outputs.imageDefinition }}
+  azureImageOffer:
+    description: "Azure image offer"
+    value: ${{ steps.azure.outputs.imageOffer }}
   azureImageVersion:
     description: "Azure image version"
     value: ${{ steps.azure.outputs.imageVersion }}

--- a/cli/internal/terraform/terraform/aws/main.tf
+++ b/cli/internal/terraform/terraform/aws/main.tf
@@ -25,6 +25,7 @@ locals {
   ports_bootstrapper = "9000"
   ports_konnectivity = "8132"
   ports_verify       = "30081"
+  ports_recovery     = "9999"
   ports_debugd       = "4000"
 
   tags = { constellation-uid = local.uid }
@@ -126,6 +127,14 @@ resource "aws_security_group" "security_group" {
   }
 
   ingress {
+    from_port   = local.ports_recovery
+    to_port     = local.ports_recovery
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "recovery"
+  }
+
+  ingress {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
@@ -182,6 +191,16 @@ module "load_balancer_target_verify" {
   healthcheck_protocol = "TCP"
 }
 
+module "load_balancer_target_recovery" {
+  source               = "./modules/load_balancer_target"
+  name                 = "${local.name}-recovery"
+  vpc_id               = aws_vpc.vpc.id
+  lb_arn               = aws_lb.front_end.arn
+  port                 = local.ports_recovery
+  tags                 = local.tags
+  healthcheck_protocol = "TCP"
+}
+
 module "load_balancer_target_debugd" {
   count                = var.debug ? 1 : 0 // only deploy debugd in debug mode
   source               = "./modules/load_balancer_target"
@@ -229,6 +248,7 @@ module "instance_group_control_plane" {
     module.load_balancer_target_bootstrapper.target_group_arn,
     module.load_balancer_target_kubernetes.target_group_arn,
     module.load_balancer_target_verify.target_group_arn,
+    module.load_balancer_target_recovery.target_group_arn,
     module.load_balancer_target_konnectivity.target_group_arn,
     var.debug ? [module.load_balancer_target_debugd[0].target_group_arn,
     module.load_balancer_target_ssh[0].target_group_arn] : [],

--- a/image/mkosi.prepare
+++ b/image/mkosi.prepare
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -euxo pipefail
+
+# backport of https://github.com/dracutdevs/dracut/commit/dcbe23c14d13ca335ad327b7bb985071ca442f12
+sed -i 's/WantedBy=multi-user.target/WantedBy=basic.target/' /usr/lib/systemd/system/systemd-resolved.service

--- a/image/mkosi.skeleton/etc/dracut.conf.d/90-networkd.conf
+++ b/image/mkosi.skeleton/etc/dracut.conf.d/90-networkd.conf
@@ -1,4 +1,5 @@
 # enable networking in initrd (initramfs) with dracut and systemd-networkd
 install_items+=" /usr/lib/systemd/network/20-wired.network "
 install_items+=" /usr/lib/systemd/network/21-azure.network "
-add_dracutmodules+=" systemd-networkd "
+# see https://github.com/dracutdevs/dracut/tree/master/modules.d for a list of modules
+add_dracutmodules+=" systemd-networkd systemd-resolved "

--- a/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/module-setup.sh
+++ b/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/module-setup.sh
@@ -70,4 +70,7 @@ install() {
     install_path /etc/pki/tls/certs/
     inst_simple /etc/pki/tls/certs/ca-bundle.crt \
         /etc/pki/tls/certs/ca-bundle.crt
+
+    # backport of https://github.com/dracutdevs/dracut/commit/dcbe23c14d13ca335ad327b7bb985071ca442f12
+    inst_simple "$moddir/sysusers-dracut.conf" "$systemdsystemunitdir/systemd-sysusers.service.d/sysusers-dracut.conf"
 }

--- a/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/module-setup.sh
+++ b/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/module-setup.sh
@@ -4,7 +4,8 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 
 depends() {
-    echo systemd
+    # expands to: systemd systemd-hostnamed systemd-networkd systemd-resolved systemd-timedated systemd-timesyncd
+    echo systemd-network-management
 }
 
 install_and_enable_unit() {

--- a/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/module-setup.sh
+++ b/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/module-setup.sh
@@ -17,6 +17,11 @@ install_and_enable_unit() {
         "${systemdsystemconfdir}/${target}.wants/${unit}"
 }
 
+install_path() {
+    local dir="$1"; shift
+    mkdir -p "${initdir}/${dir}"
+}
+
 install() {
     inst_multiple \
         bash
@@ -60,4 +65,9 @@ install() {
         "/usr/sbin/aws-nvme-disk"
     install_and_enable_unit "aws-nvme-disk.service" \
         "basic.target"
+
+    # TLS / CA store in initramfs
+    install_path /etc/pki/tls/certs/
+    inst_simple /etc/pki/tls/certs/ca-bundle.crt \
+        /etc/pki/tls/certs/ca-bundle.crt
 }

--- a/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.service
+++ b/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Prepare encrypted state disk
 Before=initrd-fs.target
-After=network-online.target configure-constel-csp.service
+After=network-online.target nss-lookup.target configure-constel-csp.service
 Wants=network-online.target
 Requires=initrd-root-fs.target
 FailureAction=reboot-immediate

--- a/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/sysusers-dracut.conf
+++ b/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/sysusers-dracut.conf
@@ -1,0 +1,3 @@
+# backport of https://github.com/dracutdevs/dracut/commit/dcbe23c14d13ca335ad327b7bb985071ca442f12
+[Unit]
+ConditionNeedsUpdate=


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Install systemd-resolved in dracut to enable DNS
- Backport fixes for systemd-resolved for Fedora 36
- Install CA certs in initramfs
- Deploy recovery LB on AWS

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

- Issues in older dracut:
  - https://github.com/dracutdevs/dracut/pull/1658
  - https://github.com/systemd/systemd/pull/22045

- Images: https://github.com/edgelesssys/constellation/actions/runs/3414152529
- e2e run Azure: https://github.com/edgelesssys/constellation/actions/runs/3414502629
- e2e run GCP: https://github.com/edgelesssys/constellation/actions/runs/3414478494

The following files will be added to the initrd by this change:

```
/usr/lib/sysusers.d/systemd-resolve.conf
/usr/lib/systemd/systemd-resolved
/usr/lib/systemd/system/systemd-resolved.service
/etc/systemd/system/multi-user.target.wants/systemd-resolved.service
```


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Link to Milestone
