### PR TITLE
AWS: Apply security group to worker nodes

### DIFF
--- a/cli/internal/terraform/terraform/aws/main.tf
+++ b/cli/internal/terraform/terraform/aws/main.tf
@@ -244,6 +244,6 @@ module "instance_group_worker_nodes" {
   state_disk_size      = var.state_disk_size
   subnetwork           = module.public_private_subnet.private_subnet_id
   target_group_arns    = []
-  security_groups      = []
+  security_groups      = [aws_security_group.security_group.id]
   iam_instance_profile = var.iam_instance_profile_worker_nodes
 }


### PR DESCRIPTION
### Proposed change(s)
- Apply the security group to worker nodes on AWS, too

### Additional info
- For a next release we should further harden down the rules for worker nodes on all CSPs. They are only reachable internally and not exposed to the internet, but could pose an issue for lateral movement.

