### PR TITLE
AB#2546 Set SELinux from disabled to permissive

### DIFF
--- a/debugd/internal/debugd/constants.go
+++ b/debugd/internal/debugd/constants.go
@@ -27,7 +27,6 @@ RemainAfterExit=yes
 Restart=on-failure
 EnvironmentFile=/run/constellation.env
 Environment=PATH=/run/state/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-ExecStartPre=-setenforce Permissive
 ExecStart=/run/state/bin/bootstrapper
 [Install]
 WantedBy=multi-user.target

--- a/image/mkosi.conf.d/selinux.conf
+++ b/image/mkosi.conf.d/selinux.conf
@@ -1,0 +1,3 @@
+[Output]
+# set selinux to permissive
+KernelCommandLine=!selinux=0 selinux=1 enforcing=0

--- a/image/mkosi.prepare
+++ b/image/mkosi.prepare
@@ -1,5 +1,8 @@
 #!/bin/sh
 set -euxo pipefail
 
+# set selinux to permissive
+sed -i 's/^SELINUX=.*/SELINUX=permissive/' /etc/selinux/config
+
 # backport of https://github.com/dracutdevs/dracut/commit/dcbe23c14d13ca335ad327b7bb985071ca442f12
 sed -i 's/WantedBy=multi-user.target/WantedBy=basic.target/' /usr/lib/systemd/system/systemd-resolved.service


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Enable SELinux in permissive mode

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Tested manually and verified it does not interfere with Constellation

```
[root@fedora ~]# sestatus 
SELinux status:                 enabled
SELinuxfs mount:                /sys/fs/selinux
SELinux root directory:         /etc/selinux
Loaded policy name:             targeted
Current mode:                   permissive
Mode from config file:          permissive
Policy MLS status:              enabled
Policy deny_unknown status:     allowed
Memory protection checking:     actual (secure)
Max kernel policy version:      33
[root@fedora ~]# cat /proc/cmdline 
rhgb audit=0 constel.csp=qemu mitigations=auto,nosmt preempt=full selinux=1 enforcing=0 console=ttyS0 loglevel=4 roothash=bb0011e4e008ba72e41da36b173f04365600bdbb33cbe3e412fda6de775df297
[root@fedora ~]# cat /etc/selinux/config 

# This file controls the state of SELinux on the system.
# SELINUX= can take one of these three values:
#     enforcing - SELinux security policy is enforced.
#     permissive - SELinux prints warnings instead of enforcing.
#     disabled - No SELinux policy is loaded.
# See also:
# https://docs.fedoraproject.org/en-US/quick-docs/getting-started-with-selinux/#getting-started-with-selinux-selinux-states-and-modes
#
# NOTE: In earlier Fedora kernel builds, SELINUX=disabled would also
# fully disable SELinux during boot. If you need a system with SELinux
# fully disabled instead of SELinux running with no policy loaded, you
# need to pass selinux=0 to the kernel command line. You can use grubby
# to persistently set the bootloader to boot with selinux=0:
#
#    grubby --update-kernel ALL --args selinux=0
#
# To revert back to SELinux enabled:
#
#    grubby --update-kernel ALL --remove-args selinux
#
SELINUX=permissive
# SELINUXTYPE= can take one of these three values:
#     targeted - Targeted processes are protected,
#     minimum - Modification of targeted policy. Only selected processes are protected.
#     mls - Multi Level Security protection.
SELINUXTYPE=targeted
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Link to Milestone
