### PR TITLE
ci: don't run cli reference gen on release branch

### DIFF
--- a/.github/workflows/update-cli-reference.yml
+++ b/.github/workflows/update-cli-reference.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - "release/**"
     paths:
       - "cli/cmd/**"
       - "cli/internal/cmd/**"


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>


