### PR TITLE
Fix Spinner TTY detection on stderr

### DIFF
--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -60,7 +60,7 @@ func runInitialize(cmd *cobra.Command, args []string) error {
 		return dialer.New(nil, validator.V(cmd), &net.Dialer{})
 	}
 
-	spinner := newSpinner(cmd.OutOrStdout())
+	spinner := newSpinner(cmd.ErrOrStderr())
 	defer spinner.Stop()
 
 	ctx, cancel := context.WithTimeout(cmd.Context(), time.Hour)

--- a/cli/internal/cmd/spinner.go
+++ b/cli/internal/cmd/spinner.go
@@ -51,7 +51,7 @@ func newSpinner(writer io.Writer) *spinner {
 
 	s.spinFunc = spinTTY
 
-	if !(writer == os.Stdout && tty.IsTerminal(os.Stdout.Fd())) {
+	if !(writer == os.Stderr && tty.IsTerminal(os.Stderr.Fd())) {
 		s.spinFunc = spinNoTTY
 	}
 


### PR DESCRIPTION
I was creating a cluster when I noticed that the CLI spinner was suddenly broken. I thought my computer was broken, restarted multiple times, reinstalled everything but could not get it working and was considering to buy a new computer that supports something as modern as a TTY.

But it turns out that #502 just forgot to switch the TTY detection from stdout to stderr.

So let's fix it. Also the "constellation init" message on stdout seems to be a left over so I fixed it, too.

Countless hours lost on this issue!!