### PR TITLE
Increase timeout for fetch-measurements

### DIFF
--- a/cli/internal/cmd/configfetchmeasurements.go
+++ b/cli/internal/cmd/configfetchmeasurements.go
@@ -70,7 +70,7 @@ func configFetchMeasurements(cmd *cobra.Command, verifier rekorVerifier, fileHan
 		return err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 	var fetchedMeasurements config.Measurements
 	hash, err := fetchedMeasurements.FetchAndVerify(ctx, client, flags.measurementsURL, flags.signatureURL, []byte(constants.CosignPublicKey))


### PR DESCRIPTION
### Proposed change(s)
- Bump timeout for fetch-measurements from 3 seconds to 60 seconds.

This should be plenty for slow connections / long-distance traffic.

### Related issues
- See Discord
