### PR TITLE
Extend AWS e2e test token expiration to 6 hours

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -134,6 +134,8 @@ runs:
       with:
         role-to-assume: arn:aws:iam::795746500882:role/GithubActionsE2E
         aws-region: eu-central-1
+        # extend token expiry to 6 hours to ensure constellation can terminate
+        role-duration-seconds: 21600
 
     - name: Create cluster
       id: constellation-create


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Extend AWS e2e test token expiration to 6 hours

### Additional info
- e2e tests would not clean up successfully: `Error: error configuring Terraform AWS Provider: error validating provider credentials: error calling sts:GetCallerIdentity: operation error STS: GetCallerIdentity, https response error StatusCode: 403, RequestID: 27a1f1cb-2fa6-4f1e-99ba-c7fe33d53718, api error ExpiredToken: The security token included in the request is expired`

