### PR TITLE
Hardcode azure subscription "secret" to avoid masking

### DIFF
--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -8,7 +8,7 @@ on:
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+  ARM_SUBSCRIPTION_ID: "0d202bbb-4fa7-4af8-8125-58c269a05435"
   ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
 
 jobs:
@@ -55,7 +55,7 @@ jobs:
           workerNodesCount: "2"
           controlNodesCount: "3"
           cloudProvider: ${{ matrix.provider }}
-          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+          azureSubscription: "0d202bbb-4fa7-4af8-8125-58c269a05435"
           azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
           azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
           azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}

--- a/.github/workflows/e2e-test-manual-macos.yml
+++ b/.github/workflows/e2e-test-manual-macos.yml
@@ -52,7 +52,7 @@ on:
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+  ARM_SUBSCRIPTION_ID: "0d202bbb-4fa7-4af8-8125-58c269a05435"
   ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
 
 jobs:
@@ -140,7 +140,7 @@ jobs:
           gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ github.event.inputs.test }}
           kubernetesVersion: ${{ github.event.inputs.kubernetesVersion }}
-          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+          azureSubscription: "0d202bbb-4fa7-4af8-8125-58c269a05435"
           azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
           azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
           azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -52,7 +52,7 @@ on:
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+  ARM_SUBSCRIPTION_ID: "0d202bbb-4fa7-4af8-8125-58c269a05435"
   ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
 
 jobs:
@@ -101,7 +101,7 @@ jobs:
           gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ github.event.inputs.test }}
           kubernetesVersion: ${{ github.event.inputs.kubernetesVersion }}
-          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+          azureSubscription: "0d202bbb-4fa7-4af8-8125-58c269a05435"
           azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
           azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
           azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -8,7 +8,7 @@ on:
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+  ARM_SUBSCRIPTION_ID: "0d202bbb-4fa7-4af8-8125-58c269a05435"
   ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
 
 jobs:
@@ -76,7 +76,7 @@ jobs:
           controlNodesCount: "3"
           cloudProvider: ${{ matrix.provider }}
           kubernetesVersion: ${{ matrix.version }}
-          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+          azureSubscription: "0d202bbb-4fa7-4af8-8125-58c269a05435"
           azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
           azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
           azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}

--- a/.github/workflows/generate-measurements.yml
+++ b/.github/workflows/generate-measurements.yml
@@ -23,7 +23,7 @@ on:
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+  ARM_SUBSCRIPTION_ID: "0d202bbb-4fa7-4af8-8125-58c269a05435"
   ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
 
 jobs:
@@ -64,7 +64,7 @@ jobs:
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcp_service_account_json: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
-          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
+          azureSubscription: "0d202bbb-4fa7-4af8-8125-58c269a05435"
           azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
           azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
           azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}


### PR DESCRIPTION

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Hardcode azure subscription "secret" to avoid masking

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- I want to use the subscription id as part of a gtihub actions job output
- Job outputs are searched for secrets
- If job outputs contain secrets as a substring, the whole output is replaced with null
  - `'imageLookupTableAzureTrustedLaunch' => {"azure":{"trustedlaunch":"/subscriptions/***/resourceGroups/constellation-images/providers/Microsoft.Compute/galleries/Constellation_Testing/images/feat-os-images-version-uids/versions/2022.1114.151640"}}`
  - `Warning: Skip output 'imageLookupTableAzureTrustedLaunch' since it may contain secret.`

