### PR TITLE
e2e: deactivate fail-fast for e2e daily

### DIFF
--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   e2e-daily:
     strategy:
+      fail-fast: false
       matrix:
         provider: ["gcp", "azure", "aws"]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Currently, if a test job fails in the e2e-daily, other jobs are canceled. With this change, the other test jobs will continue, like it is already the case with the e2e-weekly.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->
