### PR TITLE
AB#2616: Fix "stuck" Terraform states as best as we safely can

### DIFF
--- a/cli/internal/cloudcmd/clients.go
+++ b/cli/internal/cloudcmd/clients.go
@@ -14,7 +14,8 @@ import (
 )
 
 type terraformClient interface {
-	CreateCluster(ctx context.Context, provider cloudprovider.Provider, input terraform.Variables) (string, error)
+	PrepareWorkspace(provider cloudprovider.Provider, input terraform.Variables) error
+	CreateCluster(ctx context.Context) (string, error)
 	DestroyCluster(ctx context.Context) error
 	CleanUpWorkspace() error
 	RemoveInstaller()

--- a/cli/internal/cloudcmd/clients.go
+++ b/cli/internal/cloudcmd/clients.go
@@ -14,7 +14,7 @@ import (
 )
 
 type terraformClient interface {
-	CreateCluster(ctx context.Context, provider cloudprovider.Provider, name string, input terraform.Variables) (string, error)
+	CreateCluster(ctx context.Context, provider cloudprovider.Provider, input terraform.Variables) (string, error)
 	DestroyCluster(ctx context.Context) error
 	CleanUpWorkspace() error
 	RemoveInstaller()

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -32,7 +32,7 @@ type stubTerraformClient struct {
 	cleanUpWorkspaceErr    error
 }
 
-func (c *stubTerraformClient) CreateCluster(ctx context.Context, provider cloudprovider.Provider, name string, input terraform.Variables) (string, error) {
+func (c *stubTerraformClient) CreateCluster(ctx context.Context, provider cloudprovider.Provider, input terraform.Variables) (string, error) {
 	return c.ip, c.createClusterErr
 }
 

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
+
 	"go.uber.org/goleak"
 )
 
@@ -29,11 +30,16 @@ type stubTerraformClient struct {
 	destroyClusterCalled   bool
 	createClusterErr       error
 	destroyClusterErr      error
+	prepareWorkspaceErr    error
 	cleanUpWorkspaceErr    error
 }
 
-func (c *stubTerraformClient) CreateCluster(ctx context.Context, provider cloudprovider.Provider, input terraform.Variables) (string, error) {
+func (c *stubTerraformClient) CreateCluster(ctx context.Context) (string, error) {
 	return c.ip, c.createClusterErr
+}
+
+func (c *stubTerraformClient) PrepareWorkspace(provider cloudprovider.Provider, input terraform.Variables) error {
+	return c.prepareWorkspaceErr
 }
 
 func (c *stubTerraformClient) DestroyCluster(ctx context.Context) error {

--- a/cli/internal/cloudcmd/create.go
+++ b/cli/internal/cloudcmd/create.go
@@ -107,7 +107,7 @@ func (c *Creator) createAWS(ctx context.Context, cl terraformClient, config *con
 		Debug:                  config.IsDebugCluster(),
 	}
 
-	ip, err := cl.CreateCluster(ctx, cloudprovider.AWS, name, vars)
+	ip, err := cl.CreateCluster(ctx, cloudprovider.AWS, vars)
 	if err != nil {
 		return clusterid.File{}, err
 	}
@@ -140,7 +140,7 @@ func (c *Creator) createGCP(ctx context.Context, cl terraformClient, config *con
 		Debug:           config.IsDebugCluster(),
 	}
 
-	ip, err := cl.CreateCluster(ctx, cloudprovider.GCP, name, &vars)
+	ip, err := cl.CreateCluster(ctx, cloudprovider.GCP, &vars)
 	if err != nil {
 		return clusterid.File{}, err
 	}
@@ -176,7 +176,7 @@ func (c *Creator) createAzure(ctx context.Context, cl terraformClient, config *c
 
 	vars = normalizeAzureURIs(vars)
 
-	ip, err := cl.CreateCluster(ctx, cloudprovider.Azure, name, &vars)
+	ip, err := cl.CreateCluster(ctx, cloudprovider.Azure, &vars)
 	if err != nil {
 		return clusterid.File{}, err
 	}
@@ -273,7 +273,7 @@ func (c *Creator) createQEMU(ctx context.Context, cl terraformClient, lv libvirt
 		Firmware:           config.Provider.QEMU.Firmware,
 	}
 
-	ip, err := cl.CreateCluster(ctx, cloudprovider.QEMU, name, &vars)
+	ip, err := cl.CreateCluster(ctx, cloudprovider.QEMU, &vars)
 	if err != nil {
 		return clusterid.File{}, err
 	}

--- a/cli/internal/cloudcmd/create.go
+++ b/cli/internal/cloudcmd/create.go
@@ -90,7 +90,7 @@ func (c *Creator) createAWS(ctx context.Context, cl terraformClient, config *con
 ) (idFile clusterid.File, retErr error) {
 	defer rollbackOnError(context.Background(), c.out, &retErr, &rollbackerTerraform{client: cl})
 
-	vars := &terraform.AWSVariables{
+	vars := terraform.AWSVariables{
 		CommonVariables: terraform.CommonVariables{
 			Name:               name,
 			CountControlPlanes: controlPlaneCount,
@@ -107,7 +107,7 @@ func (c *Creator) createAWS(ctx context.Context, cl terraformClient, config *con
 		Debug:                  config.IsDebugCluster(),
 	}
 
-	ip, err := cl.CreateCluster(ctx, cloudprovider.AWS, vars)
+	ip, err := cl.CreateCluster(ctx, cloudprovider.AWS, &vars)
 	if err != nil {
 		return clusterid.File{}, err
 	}

--- a/cli/internal/cloudcmd/create.go
+++ b/cli/internal/cloudcmd/create.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 )
 
 // Creator creates cloud resources.
@@ -35,7 +36,7 @@ func NewCreator(out io.Writer) *Creator {
 	return &Creator{
 		out: out,
 		newTerraformClient: func(ctx context.Context) (terraformClient, error) {
-			return terraform.New(ctx)
+			return terraform.New(ctx, constants.TerraformWorkingDir)
 		},
 		newLibvirtRunner: func() libvirtRunner {
 			return libvirt.New()

--- a/cli/internal/cloudcmd/rollback.go
+++ b/cli/internal/cloudcmd/rollback.go
@@ -48,13 +48,16 @@ func (r *rollbackerTerraform) rollback(ctx context.Context) error {
 }
 
 type rollbackerQEMU struct {
-	client  terraformClient
-	libvirt libvirtRunner
+	client           terraformClient
+	libvirt          libvirtRunner
+	createdWorkspace bool
 }
 
 func (r *rollbackerQEMU) rollback(ctx context.Context) error {
 	var err error
-	err = multierr.Append(err, r.client.DestroyCluster(ctx))
+	if r.createdWorkspace {
+		err = multierr.Append(err, r.client.DestroyCluster(ctx))
+	}
 	err = multierr.Append(err, r.libvirt.Stop(ctx))
 	if err == nil {
 		err = r.client.CleanUpWorkspace()

--- a/cli/internal/cloudcmd/terminate.go
+++ b/cli/internal/cloudcmd/terminate.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/libvirt"
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 )
 
 // Terminator deletes cloud provider resources.
@@ -23,7 +24,7 @@ type Terminator struct {
 func NewTerminator() *Terminator {
 	return &Terminator{
 		newTerraformClient: func(ctx context.Context) (terraformClient, error) {
-			return terraform.New(ctx)
+			return terraform.New(ctx, constants.TerraformWorkingDir)
 		},
 		newLibvirtRunner: func() libvirtRunner {
 			return libvirt.New()

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -12,6 +12,7 @@ import (
 	"io/fs"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
+	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
@@ -126,7 +127,7 @@ func create(cmd *cobra.Command, creator cloudCreator, fileHandler file.Handler, 
 	idFile, err := creator.Create(cmd.Context(), provider, conf, flags.name, instanceType, flags.controllerCount, flags.workerCount)
 	spinner.Stop()
 	if err != nil {
-		return err
+		return translateCreateErrors(cmd, err)
 	}
 
 	if err := fileHandler.WriteJSON(constants.ClusterIDsFileName, idFile, file.OptNone); err != nil {
@@ -207,6 +208,27 @@ func checkDirClean(fileHandler file.Handler) error {
 	}
 
 	return nil
+}
+
+func translateCreateErrors(cmd *cobra.Command, err error) error {
+	switch {
+	case errors.Is(err, terraform.ErrTerraformWorkspaceDifferentFiles):
+		cmd.PrintErrln("\nYour current working directory contains an existing Terraform workspace which does not match the expected state.")
+		cmd.PrintErrln("This can be due to a mix up between providers, versions or an otherwise corrupted workspace.")
+		cmd.PrintErrln("Before creating a new cluster, try \"constellation terminate\".")
+		cmd.PrintErrf("If this does not work, either move or delete the directory %q.\n", constants.TerraformWorkingDir)
+		cmd.PrintErrln("Please only delete the directory if you made sure that all created cloud resources have been terminated.")
+		return err
+	case errors.Is(err, terraform.ErrTerraformWorkspaceExistsWithDifferentVariables):
+		cmd.PrintErrln("\nYour current working directory contains an existing Terraform workspace which was initiated with different input variables.")
+		cmd.PrintErrln("This can be the case if you have tried to create a cluster before with different options which did not complete, or the workspace is corrupted.")
+		cmd.PrintErrln("Before creating a new cluster, try \"constellation terminate\".")
+		cmd.PrintErrf("If this does not work, either move or delete the directory %q.\n", constants.TerraformWorkingDir)
+		cmd.PrintErrln("Please only delete the directory if you made sure that all created cloud resources have been terminated.")
+		return err
+	default:
+		return err
+	}
 }
 
 func must(err error) {

--- a/cli/internal/cmd/terminate.go
+++ b/cli/internal/cmd/terminate.go
@@ -53,7 +53,6 @@ func terminate(cmd *cobra.Command, terminator cloudTerminator, fileHandler file.
 	if !yesFlag {
 		cmd.Println("You are about to terminate a Constellation cluster.")
 		cmd.Println("All of its associated resources will be DESTROYED.")
-		cmd.Println("This includes any other Terraform workspace in the current directory.")
 		cmd.Println("This action is irreversible and ALL DATA WILL BE LOST.")
 		ok, err := askToConfirm(cmd, "Do you want to continue?")
 		if err != nil {

--- a/cli/internal/terraform/loader.go
+++ b/cli/internal/terraform/loader.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"embed"
 	"errors"
-	"fmt"
 	"io/fs"
 	"path"
 	"path/filepath"
@@ -20,6 +19,9 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/spf13/afero"
 )
+
+// ErrTerraformWorkspaceDifferentFiles is returned when a re-used existing Terraform workspace has different files than the ones to be extracted (e.g. due to a version mix-up or incomplete writes).
+var ErrTerraformWorkspaceDifferentFiles = errors.New("creating cluster: trying to overwrite an existing Terraform file with a different version")
 
 //go:embed terraform/*
 //go:embed terraform/*/.terraform.lock.hcl
@@ -53,7 +55,7 @@ func prepareWorkspace(fileHandler file.Handler, provider cloudprovider.Provider,
 			}
 
 			if !bytes.Equal(content, existingFileContent) {
-				return fmt.Errorf("trying to overwrite existing Terraform file with different version")
+				return ErrTerraformWorkspaceDifferentFiles
 			}
 			return nil
 		} else if err != nil {

--- a/cli/internal/terraform/loader_test.go
+++ b/cli/internal/terraform/loader_test.go
@@ -8,9 +8,11 @@ package terraform
 
 import (
 	"io/fs"
+	"path/filepath"
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -58,12 +60,12 @@ func TestLoader(t *testing.T) {
 
 			file := file.NewHandler(afero.NewMemMapFs())
 
-			err := prepareWorkspace(file, tc.provider)
+			err := prepareWorkspace(file, tc.provider, constants.TerraformWorkingDir)
 			require.NoError(err)
 
 			checkFiles(t, file, func(err error) { assert.NoError(err) }, tc.fileList)
 
-			err = cleanUpWorkspace(file)
+			err = cleanUpWorkspace(file, constants.TerraformWorkingDir)
 			require.NoError(err)
 
 			checkFiles(t, file, func(err error) { assert.ErrorIs(err, fs.ErrNotExist) }, tc.fileList)
@@ -74,7 +76,8 @@ func TestLoader(t *testing.T) {
 func checkFiles(t *testing.T, file file.Handler, assertion func(error), files []string) {
 	t.Helper()
 	for _, f := range files {
-		_, err := file.Stat(f)
+		path := filepath.Join(constants.TerraformWorkingDir, f)
+		_, err := file.Stat(path)
 		assertion(err)
 	}
 }

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -58,9 +58,7 @@ func New(ctx context.Context, workingDir string) (*Client, error) {
 }
 
 // CreateCluster creates a Constellation cluster using Terraform.
-func (c *Client) CreateCluster(
-	ctx context.Context, provider cloudprovider.Provider, name string, vars Variables,
-) (string, error) {
+func (c *Client) CreateCluster(ctx context.Context, provider cloudprovider.Provider, vars Variables) (string, error) {
 	if err := prepareWorkspace(c.file, provider, c.workingDir); err != nil {
 		return "", err
 	}

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -29,6 +29,9 @@ const (
 	terraformVarsFile = "terraform.tfvars"
 )
 
+// ErrTerraformWorkspaceExistsWithDifferentVariables is returned when existing Terraform files differ from the version the CLI wants to extract.
+var ErrTerraformWorkspaceExistsWithDifferentVariables = errors.New("creating cluster: a Terraform workspace already exists with different variables")
+
 // Client manages interaction with Terraform.
 type Client struct {
 	tf tfInterface
@@ -162,7 +165,7 @@ func (c *Client) writeVars(vars Variables) error {
 			return err
 		}
 		if vars.String() != string(varsContent) {
-			return errors.New("creating cluster: workspace already exists with different variables")
+			return ErrTerraformWorkspaceExistsWithDifferentVariables
 		}
 	} else if err != nil {
 		return err

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -57,16 +57,21 @@ func New(ctx context.Context, workingDir string) (*Client, error) {
 	}, nil
 }
 
-// CreateCluster creates a Constellation cluster using Terraform.
-func (c *Client) CreateCluster(ctx context.Context, provider cloudprovider.Provider, vars Variables) (string, error) {
+// PrepareWorkspace prepares a Terraform workspace for a Constellation cluster.
+func (c *Client) PrepareWorkspace(provider cloudprovider.Provider, vars Variables) error {
 	if err := prepareWorkspace(c.file, provider, c.workingDir); err != nil {
-		return "", err
+		return err
 	}
 
 	if err := c.writeVars(vars); err != nil {
-		return "", err
+		return err
 	}
 
+	return nil
+}
+
+// CreateCluster creates a Constellation cluster using Terraform.
+func (c *Client) CreateCluster(ctx context.Context) (string, error) {
 	if err := c.tf.Init(ctx); err != nil {
 		return "", err
 	}

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -96,6 +96,9 @@ func (c *Client) CreateCluster(
 
 // DestroyCluster destroys a Constellation cluster using Terraform.
 func (c *Client) DestroyCluster(ctx context.Context) error {
+	if err := c.tf.Init(ctx); err != nil {
+		return err
+	}
 	return c.tf.Destroy(ctx)
 }
 

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -129,7 +129,7 @@ func TestCreateCluster(t *testing.T) {
 				workingDir: constants.TerraformWorkingDir,
 			}
 
-			ip, err := c.CreateCluster(context.Background(), tc.provider, "test", tc.vars)
+			ip, err := c.CreateCluster(context.Background(), tc.provider, tc.vars)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -325,7 +325,6 @@ This should give the following output:
 $ constellation terminate
 You are about to terminate a Constellation cluster.
 All of its associated resources will be DESTROYED.
-This includes any other Terraform workspace in the current directory.
 This action is irreversible and ALL DATA WILL BE LOST.
 Do you want to continue? [y/n]:
 ```

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -77,6 +77,8 @@ const (
 	AdminConfFilename = "constellation-admin.conf"
 	// MasterSecretFilename filename of Constellation mastersecret.
 	MasterSecretFilename = "constellation-mastersecret.json"
+	// TerraformWorkingDir is the directory name for the TerraformClient workspace.
+	TerraformWorkingDir = "constellation-terraform"
 	// ControlPlaneAdminConfFilename filepath to control plane kubernetes admin config.
 	ControlPlaneAdminConfFilename = "/etc/kubernetes/admin.conf"
 	// KubectlPath path to kubectl binary.

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -170,3 +170,8 @@ func (h *Handler) RemoveAll(name string) error {
 func (h *Handler) Stat(name string) (fs.FileInfo, error) {
 	return h.fs.Stat(name)
 }
+
+// MkdirAll creates a directory path and all parents that does not exist yet.
+func (h *Handler) MkdirAll(name string) error {
+	return h.fs.MkdirAll(name, 0o700)
+}


### PR DESCRIPTION
### Proposed change(s)
- Move Constellation Terraform workspace to `./constellation-workspace` (thus simplify cleanup code and avoid destroying random Terraform clusters)
- Make "create" on unclean states retryable by checking if file on disk == expected file to write
- Make "destroy" work with missing Terraform plugins by calling "terraform init" before trying to "terraform destroy".

When reviewing, please read the issues I was trying to solve and see if that makes sense as a whole. Practical testing with random abortions and CTRL+C hitting might be useful.

Other ideas to the issues are also greatly appreciated.

### Related issue
To understand the changes here, let me explain the issue(s).
Currently, when you do `constellation create` and either:
- rapidly abort with CTRL+C
- Have wonky or no internet
- Terraform fails to download the provider plugins for some other reason

You will end up in a state where create fails, the rollback fails and terminate also fails. You are essentially stuck until you manually delete all Terraform files and directories in the current directory (`.terraform .terraform.hcl.lock modules main.tf variables.tf output.tf terraform.tfstate terraform.tfvars`).

So the first idea is to move all Terraform related files into a separate Terraform workspace directory. This is a feature Terraform officially supports and should makes things way cleaner. It unfortunately breaks version compatibility, but many changes aiming for v2.3.0 do and this can be easily migrated if we have an update flow. Might also be useful if we use Terraform for other features (IAM).

The second idea is that every file we try to write from the embedded filesystem and the .tfvars file should not error when they already exist. Terraform is able to continue applying when it has a .tfstate and the variables match. 

However, here I wasn't sure if we want to allow overwriting the files from the embedded filesystem to the disk or if we should error on something unknown. I opted for checking for equality and failing to allow the rollback mechanism clean up the previous state just in case we have a mismatch. This has the disadvantage that there's a slight window where e.g. `.terraform.lock.hcl` could be created, not written and blocks the rollback/terminate process.

The last idea is to allow the cleanup even when Terraform plugins are missing. There are many ways to do that and almost all are flawed without requiring manual user interaction. What I compromised on here is trying to initialize Terraform first and then try to destroy an existing cluster. The downside of this is when `terraform init` already fails during create for any case which is not CTRL+C (or we just hit the moment where not all files are written to disk), it will likely also fail on terminate. So we are stuck again until the user manually cleans up.

An alternative solution I was considering was to skip the `terraform destroy` when there's a lack of a .tfstate. The major benefit here would be that `terraform init` is not required for this and thus would allow even offline cleanup and fixing even more "stuck states". However, we already had the discussion using the state file as a proxy of existing once and did not want to go that route. This could break some expectations or statuses Terraform has (e.g. running in the background, .tfstate not written to disk yet). 

So I went for `terraform init` before `terraform destroy` it is, in trade off for slightly more "stuck" states where manual user interaction is required. 

In any case, even if we are in another "stuck" state now, manual cleanup is as easy as deleting `constellation-terraform` instead of finding all files and directories, both visible and hidden. Thus it should be an improvement over what we had before.

