### PR TITLE
reserve enough time for stable tests

### DIFF
--- a/cli/internal/cmd/spinner_test.go
+++ b/cli/internal/cmd/spinner_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	baseWait = 100
+	baseWait = 300
 	baseText = "Loading"
 )
 
@@ -35,7 +35,8 @@ func TestSpinnerInitialState(t *testing.T) {
 	assert.Greater(out.Len(), 0)
 
 	outStr := out.String()
-	assert.True(strings.HasPrefix(outStr, hideCursor+generateAllStatesAsString(t, baseText, true)))
+	prefix := hideCursor + generateAllStatesAsString(t, baseText, true)
+	assert.True(strings.HasPrefix(outStr, prefix), fmt.Sprintf("\nOutStr: %#v\nPrefix: %#v\n", outStr, prefix))
 }
 
 func TestSpinnerFinalState(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Fabian Kammel <fk@edgeless.systems>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
`TestSpinnerInitialState` is a flaky test:
- [Failure](https://github.com/edgelesssys/constellation/actions/runs/3477963019/attempts/1)
- [Re-Run Success](https://github.com/edgelesssys/constellation/actions/runs/3477963019)

I have added some extra messages to test so we can see root cause more easily

```
=== RUN   TestSpinnerInitialState
    spinner_test.go:39: 
                Error Trace:    /home/datosh/code/constellation/cli/internal/cmd/spinner_test.go:39
                Error:          Should be true
                Test:           TestSpinnerInitialState
                Messages:   
                                OutStr: "\x1b[?25l\r⣷ Loading.  \r⣯ Loading.. \r⣟ Loading...\r⡿ Loading.  \r⢿ Loading.. \r⣻ Loading...\rLoading...  \n\x1b[?25h"
                                Prefix: "\x1b[?25l\r⣷ Loading.  \r⣯ Loading.. \r⣟ Loading...\r⡿ Loading.  \r⢿ Loading.. \r⣻ Loading...\r⣽ Loading.  \r⣾ Loading.. "
```

After some local debugging I found that the only consistent fix was to increase `baseWait`, because deviation when repeatedly running tests was huge, in this example >60% on a performant machine. I am not sure how big it get's for GitHub Actions runners

```
go test -timeout 300s -tags integration -run ^TestSpinnerInitialState$ github.com/edgelesssys/constellation/v2/cli/internal/cmd -race -v --count=200
=== RUN   TestSpinnerInitialState
--- PASS: TestSpinnerInitialState (0.10s)
=== RUN   TestSpinnerInitialState
--- PASS: TestSpinnerInitialState (0.10s)
=== RUN   TestSpinnerInitialState
--- PASS: TestSpinnerInitialState (0.10s)
=== RUN   TestSpinnerInitialState
--- PASS: TestSpinnerInitialState (0.10s)
=== RUN   TestSpinnerInitialState
--- PASS: TestSpinnerInitialState (0.16s)
=== RUN   TestSpinnerInitialState
```

It was stable for me locally when increasing to `baseWait = 300` which leads to a single test taking 0.3s. Which is not great...

I think the only real fix would be to migrate this test code to a test clock. 
Should we merge this anyway to get stable tests and rework tests in another branch?

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
