### PR TITLE
Terraform GCP: Always use local account for resource creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 <!-- For security related changes. -->
 
+### Fixed
+
+- `constellation create` on GCP now always uses the local default credentials.
+
 
 ## [2.2.1] - 2022-11-14
 

--- a/cli/internal/terraform/terraform/gcp/main.tf
+++ b/cli/internal/terraform/terraform/gcp/main.tf
@@ -12,8 +12,6 @@ terraform {
 }
 
 provider "google" {
-  credentials = file(var.credentials_file)
-
   project = var.project
   region  = var.region
   zone    = var.zone

--- a/cli/internal/terraform/terraform/gcp/variables.tf
+++ b/cli/internal/terraform/terraform/gcp/variables.tf
@@ -35,11 +35,6 @@ variable "zone" {
   description = "The GCP zone to deploy the cluster in."
 }
 
-variable "credentials_file" {
-  type        = string
-  description = "The path to the GCP credentials file."
-}
-
 variable "instance_type" {
   type        = string
   description = "The GCP instance type to deploy."

--- a/cli/internal/terraform/variables.go
+++ b/cli/internal/terraform/variables.go
@@ -106,7 +106,6 @@ func (v *GCPVariables) String() string {
 	writeLinef(b, "project = %q", v.Project)
 	writeLinef(b, "region = %q", v.Region)
 	writeLinef(b, "zone = %q", v.Zone)
-	writeLinef(b, "credentials_file = %q", v.CredentialsFile)
 	writeLinef(b, "instance_type = %q", v.InstanceType)
 	writeLinef(b, "state_disk_type = %q", v.StateDiskType)
 	writeLinef(b, "image_id = %q", v.ImageID)


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Terraform GCP: Always use local account for resource creation


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
