### PR TITLE
ci: use /usr/bin/env instead of /bin/env

### DIFF
--- a/image/mkosi.postinst
+++ b/image/mkosi.postinst
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 # This will work in sd-boot 251 to auto-enroll secure boot keys.

--- a/image/mkosi.prepare
+++ b/image/mkosi.prepare
@@ -1,4 +1,4 @@
-#!/bin/env bash
+#!/usr/bin/env bash
 set -euxo pipefail
 
 # set selinux to permissive


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

