### PR TITLE
Fix disk-mapper version injection

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -30,6 +30,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build go build -o bootstrapper -ta
 FROM build AS build-disk-mapper
 WORKDIR /constellation/disk-mapper/
 
+ARG PROJECT_VERSION
 RUN --mount=type=cache,target=/root/.cache/go-build go build -o disk-mapper -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/
 
 FROM scratch AS bootstrapper


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- disk-mapper was not printing any version information, this PR fixes that

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
Currently, all services receive the version set in `CMakeLists.txt`. Which is the latest release version (`v2.2.2` at the time of writing this)
We should consider updating this to `v<major>.<minor+1>.0-pre` when creating the `v<major>.<minor+1>.0-pre` tag on main.
This way we can more easily identify from what version the binaries were built

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
