### PR TITLE
AB#2567 Use semantic versioning to allow upgrades between constellation container pseudo-versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -109,7 +109,7 @@
       "matchPackagePrefixes": [
         "ghcr.io/edgelesssys/constellation/"
       ],
-      "versioning": "regex:^v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(-(?<build>.*))?$",
+      "versioning": "semver",
       "groupName": "Constellation containers"
     },
     {


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use semantic versioning to allow upgrades between constellation container pseudo-versions

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info

> Although suffixes in SemVer indicate pre-releases (e.g. v1.2.0-alpha.2), in Docker they typically indicate compatibility, e.g. 1.2.0-alpine. By default Renovate assumes suffixes indicate compatibility, for this reason Renovate will not change any suffixes. Renovate will update 1.2.0-alpine to 1.2.1-alpine but never updates to 1.2.1 or 1.2.1-stretch as that would change the suffix.
If this behavior does not suit a particular package you have, Renovate allows you to customize the versioning scheme it uses. For example, you have a Docker image foo/bar that sticks to SemVer versioning. This means that you need to tell Renovate that suffixes indicate pre-release versions, and not compatibility.

https://docs.renovatebot.com/docker/

See this as an example of the rule change in effect: https://github.com/malt3/renovate-regex-test/pull/2

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Link to Milestone
