### PR TITLE
Prioritize renovate PRs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "constellation",
-  "lockfileVersion": 2,
-  "requires": true,
-  "packages": {}
-}

--- a/renovate.json
+++ b/renovate.json
@@ -38,7 +38,8 @@
       "matchPackagePatterns": [
         "^github.com/aws/aws-sdk-go-v2"
       ],
-      "groupName": "AWS SDK"
+      "groupName": "AWS SDK",
+      "prPriority": -10
     },
     {
       "matchPackagePatterns": [
@@ -52,6 +53,12 @@
         "^cloud.google.com/go"
       ],
       "groupName": "Google SDK"
+    },
+    {
+      "matchPackagePatterns": [
+        "^google.golang.org/genproto"
+      ],
+      "prPriority": -10
     },
     {
       "matchPackagePatterns": [
@@ -96,21 +103,24 @@
         "k8s.gcr.io/autoscaling/cluster-autoscaler"
       ],
       "versioning": "regex:^(?<compatibility>v?\\d+\\.\\d+\\.)(?<patch>\\d+)$",
-      "groupName": "K8s constrained versions"
+      "groupName": "K8s constrained versions",
+      "prPriority": 15
     },
     {
       "matchPackageNames": [
         "ghcr.io/edgelesssys/cloud-provider-gcp"
       ],
       "versioning": "regex:^(?<compatibility>v\\d+\\.)(?<minor>\\d+)\\.(?<patch>\\d+)$",
-      "groupName": "K8s version constrained containers (missing v1 prefix)"
+      "groupName": "K8s version constrained containers (missing v1 prefix)",
+      "prPriority": 15
     },
     {
       "matchPackagePrefixes": [
         "ghcr.io/edgelesssys/constellation/"
       ],
       "versioning": "semver",
-      "groupName": "Constellation containers"
+      "groupName": "Constellation containers",
+      "prPriority": 20
     },
     {
       "matchPackageNames": [
@@ -118,7 +128,16 @@
         "registry.k8s.io/kas-network-proxy/proxy-server"
       ],
       "versioning": "semver",
-      "groupName": "K8s version independent containers"
+      "groupName": "K8s version independent containers",
+      "prPriority": 15
+    },
+    {
+      "matchLanguages": [
+        "python",
+        "js",
+        "node"
+      ],
+      "prPriority": -20
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Prioritize renovate PRs so that:
   - Internal container images are upgraded first (prio 20)
   - Kubernetes dependencies are upgraded preferred (prio 15)
   - Dependencies with daily/frequent new versions have lowered priority (-10)
   - Dev and doc dependencies (Python, JS, Node) are upgraded last (prio -20)
