### PR TITLE
bootstrapper: fix GracefulStop of InitServer

### DIFF
--- a/bootstrapper/internal/initserver/initserver.go
+++ b/bootstrapper/internal/initserver/initserver.go
@@ -148,7 +148,11 @@ func (s *Server) Init(ctx context.Context, req *initproto.InitRequest) (*initpro
 
 // Stop stops the initialization server gracefully.
 func (s *Server) Stop() {
+	s.log.Infof("Stopping")
+
 	s.grpcServer.GracefulStop()
+
+	s.log.Infof("Stopped")
 }
 
 func (s *Server) setupDisk(masterSecret, salt []byte) error {


### PR DESCRIPTION
Let joinclient stop initserver only when itself initializes the node.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
During the initialization of the first Bootstrapper, the JoinClient used to call Clean, which called the Clean function on the JoinClient and the InitServer. If the initialization takes a few minutes, the InitServer still needs to send back the InitResponse. But the gRPC connection will be shut down since the `GracefulStop()` lets the connection idle which is then closed by the keepalive routine of the  http2 server underneath the InitServer. Therefore, the CLI never receives the InitResponse and eventually times out. 

Changes:
- Only the component which initializes the node calls `Clean()`.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Link to Milestone
