### PR TITLE
Use config structs to limit nr of function args

### DIFF
--- a/operators/constellation-node-operator/controllers/nodeimage_controller_test.go
+++ b/operators/constellation-node-operator/controllers/nodeimage_controller_test.go
@@ -590,7 +590,8 @@ func TestCreateNewNodes(t *testing.T) {
 				},
 				Scheme: getScheme(t),
 			}
-			err := reconciler.createNewNodes(context.Background(), desiredNodeImage, tc.outdatedNodes, tc.pendingNodes, tc.scalingGroupByID, tc.budget)
+			newNodeConfig := newNodeConfig{desiredNodeImage, tc.outdatedNodes, tc.pendingNodes, tc.scalingGroupByID, tc.budget}
+			err := reconciler.createNewNodes(context.Background(), newNodeConfig)
 			require.NoError(err)
 			assert.Equal(tc.wantCreateCalls, reconciler.nodeReplacer.(*stubNodeReplacerWriter).createCalls)
 		})

--- a/operators/constellation-node-operator/internal/deploy/deploy_test.go
+++ b/operators/constellation-node-operator/internal/deploy/deploy_test.go
@@ -273,7 +273,8 @@ func TestCreateScalingGroup(t *testing.T) {
 			require := require.New(t)
 
 			k8sClient := &stubK8sClient{createErr: tc.createErr}
-			err := createScalingGroup(context.Background(), k8sClient, "group-id", "group-Name", "group-Name", updatev1alpha1.WorkerRole)
+			newScalingGroupConfig := newScalingGroupConfig{k8sClient, "group-id", "group-Name", "group-Name", updatev1alpha1.WorkerRole}
+			err := createScalingGroup(context.Background(), newScalingGroupConfig)
 			if tc.wantErr {
 				assert.Error(err)
 				return


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- I forgot to run golangci-lint on the sub packages when introducing the revive-ignore comments. This PR introduces some config structs for the missing functions.
