### PR TITLE
Run cert-manager startupapicheck with verbose flag

### DIFF
--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -217,7 +217,8 @@ func (i *ChartLoader) loadCertManagerHelper() (*chart.Chart, map[string]any, err
 			},
 		},
 		"startupapicheck": map[string]any{
-			"timeout": "5m",
+			"timeout":   "5m",
+			"extraArgs": "--verbose",
 			"tolerations": []map[string]any{
 				{
 					"key":      "node-role.kubernetes.io/control-plane",


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
There are seldom cases where the cert-manager deployment fails with the error: `timed out waiting for the condition`. To combat this we already increase the timeout from 1m to 5m. The underlying issue is most likely that CRDs or the webhook can not be installed in time as the node is only starting. However, it is not clear which component we would need to wait for. To understand the issue a bit better I propose to print verbose logs for a few days so we get a chance to debug further on failed attempts.

Relevant cert-manager issue: https://github.com/cert-manager/cert-manager/issues/4646. 
The main culprit suspected in the issue is different network configs between the control-plane and the node that the failing `Job` is scheduled on. However, I don't think that is the problem in our case as everything should be on one node in the beginning.