### PR TITLE
deps: only upgrade to errata-ai/vale-action >2.0.1

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -138,6 +138,12 @@
         "node"
       ],
       "prPriority": -20
+    },
+    {
+      "matchPackageNames": [
+        "^errata-ai/vale-action$"
+      ],
+      "allowedVersions": ">2.0.1"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- As discussed in #623, we wan't to avoid upgrading to vale-action v2.0.1 as we had problems with it previously.
<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

