### PR TITLE
Fix type for cert-manager verbose flag

### DIFF
--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -221,8 +221,10 @@ func (i *ChartLoader) loadCertManagerHelper() (*chart.Chart, map[string]any, err
 			},
 		},
 		"startupapicheck": map[string]any{
-			"timeout":   "5m",
-			"extraArgs": "--verbose",
+			"timeout": "5m",
+			"extraArgs": []string{
+				"--verbose",
+			},
 			"tolerations": []map[string]any{
 				{
 					"key":      "node-role.kubernetes.io/control-plane",


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
#630 introduced a syntax error for the cert-manager deployment. Tested on GCP & Azure. 

