### PR TITLE
Fix potential data race when accessing a validators OID

### DIFF
--- a/internal/watcher/validator.go
+++ b/internal/watcher/validator.go
@@ -93,6 +93,8 @@ func (u *Updatable) Validate(attDoc []byte, nonce []byte) ([]byte, error) {
 
 // OID returns the validators Object Identifier.
 func (u *Updatable) OID() asn1.ObjectIdentifier {
+	u.mux.Lock()
+	defer u.mux.Unlock()
 	return u.Validator.OID()
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a lock to `*Updatable.OID()` to prevent data race when calling the function in parallel to `*Updatable.Update()`, which can happen if a client connects to the server at the same time the sever is updating its validator

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
