### PR TITLE
Revert "deps: only upgrade to errata-ai/vale-action >2.0.1"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -138,12 +138,6 @@
         "node"
       ],
       "prPriority": -20
-    },
-    {
-      "matchPackageNames": [
-        "^errata-ai/vale-action$"
-      ],
-      "allowedVersions": ">2.0.1"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
Reverts edgelesssys/constellation#633, as renovate bot doesn't close the open PR for the upgrade. I'm unsure why it isn't working. I will close #623, I subscribed to releases of the action and will update by hand.