### PR TITLE
deps: disable major upgrades for k8s.io/client-go

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -132,6 +132,15 @@
       "prPriority": 15
     },
     {
+      "matchPackageNames": [
+        "^k8s.io/client-go"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "enabled": false
+    },
+    {
       "matchLanguages": [
         "python",
         "js",


### PR DESCRIPTION
There are older versions tagged like v12.0.0, but latest version is v.0.25.4.

Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

