### PR TITLE
Add helm's quote function to various fields

### DIFF
--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/autoscaler/templates/aws-deployment.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/autoscaler/templates/aws-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: cluster-autoscaler
-          image: {{ .Values.image }}
+          image: {{ .Values.image | quote }}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/autoscaler/templates/azure-deployment.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/autoscaler/templates/azure-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: cluster-autoscaler
-          image: {{ .Values.image }}
+          image: {{ .Values.image | quote }}
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/autoscaler/templates/gcp-deployment.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/autoscaler/templates/gcp-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
       - name: cluster-autoscaler
-        image: {{ .Values.image }}
+        image: {{ .Values.image | quote }}
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/ccm/templates/aws-daemonset.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/ccm/templates/aws-daemonset.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: cloud-controller-manager
-          image: {{ .Values.AWS.image }}
+          image: {{ .Values.AWS.image | quote }}
           args:
           - --cloud-provider=aws
           - --leader-elect=true

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/ccm/templates/azure-daemonset.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/ccm/templates/azure-daemonset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: cloud-controller-manager
-  namespace: {{ .Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
   labels:
     k8s-app: cloud-controller-manager
 spec:
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: cloud-controller-manager
-          image: {{ .Values.Azure.image }}
+          image: {{ .Values.Azure.image | quote }}
           command:
           - cloud-controller-manager
           - --cloud-provider=azure

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/ccm/templates/gcp-daemonset.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/ccm/templates/gcp-daemonset.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
         - name: cloud-controller-manager
-          image: {{ .Values.GCP.image }}
+          image: {{ .Values.GCP.image | quote }}
           command:
           - /cloud-controller-manager
           - --cloud-provider=gce

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/cnm/templates/azure-daemonset.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/cnm/templates/azure-daemonset.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: cloud-node-manager
-        image: {{ .Values.image }}
+        image: {{ .Values.image | quote }}
         imagePullPolicy: IfNotPresent
         command:
           - cloud-node-manager

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/cnm/templates/clusterrolebinding.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/cnm/templates/clusterrolebinding.yaml
@@ -13,4 +13,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: cloud-node-manager
-  namespace: {{ .Release.Namespace}}
+  namespace: {{ .Release.Namespace }}

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/cnm/templates/serviceaccount.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/cnm/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cloud-node-manager
-  namespace: {{ .Release.Namespace}}
+  namespace: {{ .Release.Namespace }}
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: cloud-node-manager

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-guest-agent/templates/daemonset.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-guest-agent/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
         k8s-app: gcp-guest-agent
     spec:
       containers:
-      - image: {{ .Values.image }}
+      - image: {{ .Values.image | quote }}
         name: gcp-guest-agent
         resources: {}
         securityContext:

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/join-service/templates/daemonset.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/join-service/templates/daemonset.yaml
@@ -35,12 +35,12 @@ spec:
         node-role.kubernetes.io/control-plane: ""
       containers:
         - name: join-service
-          image: {{ .Values.image }}
+          image: {{ .Values.image | quote }}
           args:
             - --cloud-provider={{ .Values.csp }}
             - --kms-endpoint=kms.{{ .Release.Namespace }}:{{ .Values.global.kmsPort }}
           volumeMounts:
-            - mountPath: {{ .Values.global.serviceBasePath }}
+            - mountPath: {{ .Values.global.serviceBasePath | quote }}
               name: config
               readOnly: true
             - mountPath: /etc/kubernetes
@@ -57,11 +57,11 @@ spec:
           projected:
             sources:
               - configMap:
-                  name: {{ .Values.global.joinConfigCMName }}
+                  name: {{ .Values.global.joinConfigCMName | quote }}
               - configMap:
-                  name: {{ .Values.global.k8sVersionCMName }}
+                  name: {{ .Values.global.k8sVersionCMName | quote }}
               - configMap:
-                  name: {{ .Values.global.internalCMName }}
+                  name: {{ .Values.global.internalCMName | quote }}
         - name: kubeadm
           hostPath:
             path: /etc/kubernetes

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/kms/templates/daemonset.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/kms/templates/daemonset.yaml
@@ -18,11 +18,11 @@ spec:
     spec:
       containers:
         - name: kms
-          image: {{ .Values.image }}
+          image: {{ .Values.image | quote }}
           args:
             - --port={{ .Values.global.kmsPort }}
           volumeMounts:
-            - mountPath: {{ .Values.global.serviceBasePath }}
+            - mountPath: {{ .Values.global.serviceBasePath | quote }}
               name: config
               readOnly: true
           resources: {}
@@ -49,14 +49,14 @@ spec:
           sources:
           - configMap:
               items:
-              - key: {{ .Values.measurementsFilename }}
-                path: {{ .Values.measurementsFilename }}
-              name: {{ .Values.global.joinConfigCMName }}
+              - key: {{ .Values.measurementsFilename | quote }}
+                path: {{ .Values.measurementsFilename | quote }}
+              name: {{ .Values.global.joinConfigCMName | quote }}
           - secret:
               items:
-              - key: {{ .Values.masterSecretKeyName }}
-                path: {{ .Values.masterSecretKeyName }}
-              - key: {{ .Values.saltKeyName }}
-                path: {{ .Values.saltKeyName }}
-              name: {{ .Values.masterSecretName }}
+              - key: {{ .Values.masterSecretKeyName | quote }}
+                path: {{ .Values.masterSecretKeyName | quote }}
+              - key: {{ .Values.saltKeyName | quote }}
+                path: {{ .Values.saltKeyName | quote }}
+              name: {{ .Values.masterSecretName | quote }}
   updateStrategy: {}

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/kms/templates/mastersecret.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/kms/templates/mastersecret.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: {{ .Values.masterSecretName }}
+  name: {{ .Values.masterSecretName | quote }}
   namespace: {{ .Release.Namespace }}
 data:
-  mastersecret: {{ .Values.masterSecret }}
-  salt: {{ .Values.salt }}
+  mastersecret: {{ .Values.masterSecret | quote }}
+  salt: {{ .Values.salt | quote }}

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/konnectivity/templates/daemonset.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/konnectivity/templates/daemonset.yaml
@@ -39,7 +39,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: {{ .Values.image }}
+        image: {{ .Values.image | quote }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/verification-service/templates/daemonset.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/verification-service/templates/daemonset.yaml
@@ -18,7 +18,7 @@ spec:
       containers:
       - args:
         - --cloud-provider={{ .Values.csp }}
-        image: {{ .Values.image }}
+        image: {{ .Values.image | quote }}
         name: verification-service
         ports:
         - containerPort: {{ .Values.httpContainerPort }}

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/verification-service/templates/loadbalancer-service.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/verification-service/templates/loadbalancer-service.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   allocateLoadBalancerNodePorts: false
   externalIPs:
-  - {{ .Values.loadBalancerIP }}
+  - {{ .Values.loadBalancerIP | quote }}
   loadBalancerClass: constellation
   ports:
   - name: grpc

--- a/cli/internal/helm/charts/edgeless/operators/charts/constellation-operator/templates/deployment.yaml
+++ b/cli/internal/helm/charts/edgeless/operators/charts/constellation-operator/templates/deployment.yaml
@@ -56,10 +56,10 @@ spec:
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ .Values.kubernetesClusterDomain }}
         - name: CONSTEL_CSP
-          value: {{ .Values.csp }}
+          value: {{ .Values.csp | quote }}
         - name: constellation-uid
-          value: {{ .Values.constellationUID }}
-        image: {{ .Values.controllerManager.manager.image }}
+          value: {{ .Values.constellationUID | quote }}
+        image: {{ .Values.controllerManager.manager.image | quote }}
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cli/internal/helm/charts/edgeless/operators/charts/constellation-operator/templates/manager-config.yaml
+++ b/cli/internal/helm/charts/edgeless/operators/charts/constellation-operator/templates/manager-config.yaml
@@ -13,12 +13,9 @@ data:
         | quote }}
     kind: ControllerManagerConfig
     leaderElection:
-      leaderElect: {{ .Values.managerConfig.controllerManagerConfigYaml.leaderElection.leaderElect
-        }}
-      resourceName: {{ .Values.managerConfig.controllerManagerConfigYaml.leaderElection.resourceName
-        | quote }}
+      leaderElect: {{ .Values.managerConfig.controllerManagerConfigYaml.leaderElection.leaderElect }}
+      resourceName: {{ .Values.managerConfig.controllerManagerConfigYaml.leaderElection.resourceName | quote }}
     metrics:
-      bindAddress: {{ .Values.managerConfig.controllerManagerConfigYaml.metrics.bindAddress
-        | quote }}
+      bindAddress: {{ .Values.managerConfig.controllerManagerConfigYaml.metrics.bindAddress | quote }}
     webhook:
       port: {{ .Values.managerConfig.controllerManagerConfigYaml.webhook.port }}

--- a/cli/internal/helm/charts/edgeless/operators/charts/node-maintenance-operator/templates/deployment.yaml
+++ b/cli/internal/helm/charts/edgeless/operators/charts/node-maintenance-operator/templates/deployment.yaml
@@ -55,8 +55,8 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
-          value: {{ .Values.kubernetesClusterDomain }}
-        image: {{ .Values.controllerManager.manager.image }}
+          value: {{ .Values.kubernetesClusterDomain | quote }}
+        image: {{ .Values.controllerManager.manager.image | quote }}
         livenessProbe:
           httpGet:
             path: /healthz
@@ -74,8 +74,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        resources: {{- toYaml .Values.controllerManager.manager.resources | nindent 10
-          }}
+        resources: {{- toYaml .Values.controllerManager.manager.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
         volumeMounts:

--- a/cli/internal/helm/charts/edgeless/operators/charts/node-maintenance-operator/templates/metrics-service.yaml
+++ b/cli/internal/helm/charts/edgeless/operators/charts/node-maintenance-operator/templates/metrics-service.yaml
@@ -8,7 +8,7 @@ metadata:
     node-maintenance-operator: ""
   {{- include "chart.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.metricsService.type }}
+  type: {{ .Values.metricsService.type | quote }}
   selector:
     control-plane: controller-manager
     node-maintenance-operator: ""

--- a/cli/internal/helm/charts/edgeless/operators/charts/node-maintenance-operator/templates/serving-cert.yaml
+++ b/cli/internal/helm/charts/edgeless/operators/charts/node-maintenance-operator/templates/serving-cert.yaml
@@ -8,8 +8,7 @@ metadata:
 spec:
   dnsNames:
   - 'node-maintenance-operator-webhook-service.{{ .Release.Namespace }}.svc'
-  - 'node-maintenance-operator-webhook-service.{{ .Release.Namespace }}.svc.{{
-    .Values.kubernetesClusterDomain }}'
+  - 'node-maintenance-operator-webhook-service.{{ .Release.Namespace }}.svc.{{ .Values.kubernetesClusterDomain }}'
   issuerRef:
     kind: Issuer
     name: node-maintenance-operator-selfsigned-issuer

--- a/cli/internal/helm/charts/edgeless/operators/charts/node-maintenance-operator/templates/webhook-service.yaml
+++ b/cli/internal/helm/charts/edgeless/operators/charts/node-maintenance-operator/templates/webhook-service.yaml
@@ -7,7 +7,7 @@ metadata:
     node-maintenance-operator: ""
   {{- include "chart.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.webhookService.type }}
+  type: {{ .Values.webhookService.type | quote }}
   selector:
     control-plane: controller-manager
     node-maintenance-operator: ""

--- a/cli/internal/helm/loader_test.go
+++ b/cli/internal/helm/loader_test.go
@@ -94,6 +94,8 @@ func TestConstellationServices(t *testing.T) {
 				cnmImage:                 tc.cnmImage,
 				autoscalerImage:          "autoscalerImage",
 				verificationServiceImage: "verificationImage",
+				konnectivityImage:        "konnectivityImage",
+				gcpGuestAgentImage:       "gcpGuestAgentImage",
 			}
 			chart, values, err := chartLoader.loadConstellationServicesHelper(tc.config, []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
 			require.NoError(err)

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
         - name: CONSTEL_CSP
           value: Azure
         - name: constellation-uid
-          value: 42424242424242
+          value: "42424242424242"
         image: ghcr.io/edgelesssys/constellation/node-operator:v2.3.0-pre.0.20221125134926-1af3ff00adbc@sha256:fae7160eba0259d3dcbe974460ff983ae2c6cab18319a5b8ef585dd1630cb077
         livenessProbe:
           httpGet:

--- a/cli/internal/helm/testdata/Azure/constellation-services/charts/konnectivity/templates/daemonset.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-services/charts/konnectivity/templates/daemonset.yaml
@@ -39,7 +39,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: 
+        image: konnectivityImage
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
         - name: CONSTEL_CSP
           value: GCP
         - name: constellation-uid
-          value: 42424242424242
+          value: "42424242424242"
         image: ghcr.io/edgelesssys/constellation/node-operator:v2.3.0-pre.0.20221125134926-1af3ff00adbc@sha256:fae7160eba0259d3dcbe974460ff983ae2c6cab18319a5b8ef585dd1630cb077
         livenessProbe:
           httpGet:

--- a/cli/internal/helm/testdata/GCP/constellation-services/charts/gcp-guest-agent/templates/daemonset.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-services/charts/gcp-guest-agent/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
         k8s-app: gcp-guest-agent
     spec:
       containers:
-      - image: 
+      - image: gcpGuestAgentImage
         name: gcp-guest-agent
         resources: {}
         securityContext:

--- a/cli/internal/helm/testdata/GCP/constellation-services/charts/konnectivity/templates/daemonset.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-services/charts/konnectivity/templates/daemonset.yaml
@@ -39,7 +39,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: 
+        image: konnectivityImage
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
         - name: CONSTEL_CSP
           value: QEMU
         - name: constellation-uid
-          value: 42424242424242
+          value: "42424242424242"
         image: ghcr.io/edgelesssys/constellation/node-operator:v2.3.0-pre.0.20221108173951-34435e439604
         livenessProbe:
           httpGet:

--- a/cli/internal/helm/testdata/QEMU/constellation-services/charts/konnectivity/templates/daemonset.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-services/charts/konnectivity/templates/daemonset.yaml
@@ -39,7 +39,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: 
+        image: konnectivityImage
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
The constellationUID is sometimes interpreted as integer if it contains 0e, as the yaml parsing interprets that as scientific notation. Since it is a [best practices](https://helm.sh/docs/chart_best_practices/values/#make-types-clear) to quote string fields anyways this patch also quotes other fields where an actual string is required.

Manually tested on Azure & GCP.
e2e test runs: [azure](https://github.com/edgelesssys/constellation/actions/runs/3546643517), [gcp](https://github.com/edgelesssys/constellation/actions/runs/3546644802), [aws](https://github.com/edgelesssys/constellation/actions/runs/3546650017).
