### PR TITLE
Remove SSHUsers and UserKey from config v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 <!-- For changes in existing functionality.  -->
+<!-- TODO: Remove `/next/` from URL before release -->
 - Constellation operators are now deployed using Helm.
+- Updated the config version to v2. Check [how to migrate your config](https://constellation-docs.edgeless.systems/constellation/next/reference/config-migration).
 - OS images are now configured globally in the `images` field of the configuration file.
 
 ### Deprecated
@@ -38,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 <!-- For now removed features. -->
 - `access-manager` was removed from code base. K8s native way to SSH into nodes documented.
+- `SSHUsers` has been removed from the user configuration following the removal of `access-manager`.
 
 ### Fixed
 

--- a/docs/docs/reference/config-migration.md
+++ b/docs/docs/reference/config-migration.md
@@ -4,6 +4,8 @@ This document describes breaking changes in the configuration file format betwee
 
 ## Migrating from CLI versions < 2.3
 
+- The `sshUsers` was deprecated in v2.2 and now has been eventually removed from the configuration in v2.3.
+  As an alternative for SSH, check the workflow section [Connect to nodes](https://constellation-docs.edgeless.systems/constellation/workflows/troubleshooting#connect-to-nodes).
 - The `image` field for each cloud service provider has been replaced with a global `image` field. Use the following mapping to migrate your configuration:
     <details>
     <summary>Show all</summary>

--- a/docs/docs/workflows/troubleshooting.md
+++ b/docs/docs/workflows/troubleshooting.md
@@ -46,7 +46,7 @@ Constellation uses the default bucket to store logs. Its [default retention peri
 </tabItem>
 </tabs>
 
-## Connect to nodes via SSH
+## Connect to nodes
 
 Debugging via a shell on a node is [directly supported by Kubernetes](https://kubernetes.io/docs/tasks/debug/debug-application/debug-running-pod/#node-shell-session).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -59,11 +59,6 @@ type Config struct {
 	//   Supported cloud providers and their specific configurations.
 	Provider ProviderConfig `yaml:"provider" validate:"dive"`
 	// description: |
-	//   Deprecated: Does nothing! To get node SSH access, see: https://constellation-docs.edgeless.systems/constellation/workflows/troubleshooting#connect-to-nodes-via-ssh
-	// examples:
-	//   - value: '[]UserKey{ { Username:  "Alice", PublicKey: "ssh-rsa AAAAB3NzaC...5QXHKW1rufgtJeSeJ8= alice@domain.com" } }'
-	SSHUsers []UserKey `yaml:"sshUsers,omitempty" validate:"dive"`
-	// description: |
 	//   Configuration to apply during constellation upgrade.
 	// examples:
 	//   - value: 'UpgradeConfig{ Image: "", Measurements: Measurements{} }'
@@ -78,24 +73,6 @@ type UpgradeConfig struct {
 	// description: |
 	//   Measurements of the updated image.
 	Measurements Measurements `yaml:"measurements"`
-}
-
-// UserKey describes a user that should be created with corresponding public SSH key.
-//
-// Deprecated: UserKey was used as configuration for access-manager, which was removed
-// in v2.2, but config needs to retain these values for backwards compatibility and
-// config validation.
-type UserKey struct {
-	// description: |
-	//   Username of new SSH user.
-	//
-	//   Deprecated: See UserKey.
-	Username string `yaml:"username" validate:"required"`
-	// description: |
-	//   Public key of new SSH user.
-	//
-	//   Deprecated: See UserKey.
-	PublicKey string `yaml:"publicKey" validate:"required"`
 }
 
 // ProviderConfig are cloud-provider specific configuration values used by the CLI.

--- a/internal/config/config_doc.go
+++ b/internal/config/config_doc.go
@@ -13,7 +13,6 @@ import (
 var (
 	ConfigDoc         encoder.Doc
 	UpgradeConfigDoc  encoder.Doc
-	UserKeyDoc        encoder.Doc
 	ProviderConfigDoc encoder.Doc
 	AWSConfigDoc      encoder.Doc
 	AzureConfigDoc    encoder.Doc
@@ -25,7 +24,7 @@ func init() {
 	ConfigDoc.Type = "Config"
 	ConfigDoc.Comments[encoder.LineComment] = "Config defines configuration used by CLI."
 	ConfigDoc.Description = "Config defines configuration used by CLI."
-	ConfigDoc.Fields = make([]encoder.Doc, 8)
+	ConfigDoc.Fields = make([]encoder.Doc, 7)
 	ConfigDoc.Fields[0].Name = "version"
 	ConfigDoc.Fields[0].Type = "string"
 	ConfigDoc.Fields[0].Note = ""
@@ -56,20 +55,13 @@ func init() {
 	ConfigDoc.Fields[5].Note = ""
 	ConfigDoc.Fields[5].Description = "Supported cloud providers and their specific configurations."
 	ConfigDoc.Fields[5].Comments[encoder.LineComment] = "Supported cloud providers and their specific configurations."
-	ConfigDoc.Fields[6].Name = "sshUsers"
-	ConfigDoc.Fields[6].Type = "[]UserKey"
+	ConfigDoc.Fields[6].Name = "upgrade"
+	ConfigDoc.Fields[6].Type = "UpgradeConfig"
 	ConfigDoc.Fields[6].Note = ""
-	ConfigDoc.Fields[6].Description = "Deprecated: Does nothing! To get node SSH access, see: https://constellation-docs.edgeless.systems/constellation/workflows/troubleshooting#connect-to-nodes-via-ssh"
-	ConfigDoc.Fields[6].Comments[encoder.LineComment] = "Deprecated: Does nothing! To get node SSH access, see: https://constellation-docs.edgeless.systems/constellation/workflows/troubleshooting#connect-to-nodes-via-ssh"
+	ConfigDoc.Fields[6].Description = "Configuration to apply during constellation upgrade."
+	ConfigDoc.Fields[6].Comments[encoder.LineComment] = "Configuration to apply during constellation upgrade."
 
-	ConfigDoc.Fields[6].AddExample("", []UserKey{{Username: "Alice", PublicKey: "ssh-rsa AAAAB3NzaC...5QXHKW1rufgtJeSeJ8= alice@domain.com"}})
-	ConfigDoc.Fields[7].Name = "upgrade"
-	ConfigDoc.Fields[7].Type = "UpgradeConfig"
-	ConfigDoc.Fields[7].Note = ""
-	ConfigDoc.Fields[7].Description = "Configuration to apply during constellation upgrade."
-	ConfigDoc.Fields[7].Comments[encoder.LineComment] = "Configuration to apply during constellation upgrade."
-
-	ConfigDoc.Fields[7].AddExample("", UpgradeConfig{Image: "", Measurements: Measurements{}})
+	ConfigDoc.Fields[6].AddExample("", UpgradeConfig{Image: "", Measurements: Measurements{}})
 
 	UpgradeConfigDoc.Type = "UpgradeConfig"
 	UpgradeConfigDoc.Comments[encoder.LineComment] = "UpgradeConfig defines configuration used during constellation upgrade."
@@ -93,29 +85,6 @@ func init() {
 	UpgradeConfigDoc.Fields[1].Note = ""
 	UpgradeConfigDoc.Fields[1].Description = "Measurements of the updated image."
 	UpgradeConfigDoc.Fields[1].Comments[encoder.LineComment] = "Measurements of the updated image."
-
-	UserKeyDoc.Type = "UserKey"
-	UserKeyDoc.Comments[encoder.LineComment] = "UserKey describes a user that should be created with corresponding public SSH key."
-	UserKeyDoc.Description = "UserKey describes a user that should be created with corresponding public SSH key.\n\nDeprecated: UserKey was used as configuration for access-manager, which was removed\nin v2.2, but config needs to retain these values for backwards compatibility and\nconfig validation.\n"
-
-	UserKeyDoc.AddExample("", []UserKey{{Username: "Alice", PublicKey: "ssh-rsa AAAAB3NzaC...5QXHKW1rufgtJeSeJ8= alice@domain.com"}})
-	UserKeyDoc.AppearsIn = []encoder.Appearance{
-		{
-			TypeName:  "Config",
-			FieldName: "sshUsers",
-		},
-	}
-	UserKeyDoc.Fields = make([]encoder.Doc, 2)
-	UserKeyDoc.Fields[0].Name = "username"
-	UserKeyDoc.Fields[0].Type = "string"
-	UserKeyDoc.Fields[0].Note = ""
-	UserKeyDoc.Fields[0].Description = "Username of new SSH user.\n\nDeprecated: See UserKey."
-	UserKeyDoc.Fields[0].Comments[encoder.LineComment] = "Username of new SSH user."
-	UserKeyDoc.Fields[1].Name = "publicKey"
-	UserKeyDoc.Fields[1].Type = "string"
-	UserKeyDoc.Fields[1].Note = ""
-	UserKeyDoc.Fields[1].Description = "Public key of new SSH user.\n\nDeprecated: See UserKey."
-	UserKeyDoc.Fields[1].Comments[encoder.LineComment] = "Public key of new SSH user."
 
 	ProviderConfigDoc.Type = "ProviderConfig"
 	ProviderConfigDoc.Comments[encoder.LineComment] = "ProviderConfig are cloud-provider specific configuration values used by the CLI."
@@ -396,10 +365,6 @@ func (_ UpgradeConfig) Doc() *encoder.Doc {
 	return &UpgradeConfigDoc
 }
 
-func (_ UserKey) Doc() *encoder.Doc {
-	return &UserKeyDoc
-}
-
 func (_ ProviderConfig) Doc() *encoder.Doc {
 	return &ProviderConfigDoc
 }
@@ -428,7 +393,6 @@ func GetConfigurationDoc() *encoder.FileDoc {
 		Structs: []*encoder.Doc{
 			&ConfigDoc,
 			&UpgradeConfigDoc,
-			&UserKeyDoc,
 			&ProviderConfigDoc,
 			&AWSConfigDoc,
 			&AzureConfigDoc,


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove SSHUsers
- Remove UserKey

Both have been deprecated since v2.2.0, but since we now switch to configVersion 2, we can eventually remove them. Users are advised to `kubectl debug`. 


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Link to Milestone
