### PR TITLE
AB#2644 Fetch measurements from CDN and perform metadata validation

### DIFF
--- a/hack/pcr-reader/main.go
+++ b/hack/pcr-reader/main.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/vtpm"
+	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/crypto"
 	"github.com/edgelesssys/constellation/v2/verify/verifyproto"
@@ -73,7 +74,7 @@ func main() {
 
 	if *metadata {
 		outputWithMetadata := measurements.WithMetadata{
-			CSP:          strings.ToLower(*csp),
+			CSP:          cloudprovider.FromString(*csp),
 			Image:        strings.ToLower(*image),
 			Measurements: pcrs,
 		}

--- a/hack/pcr-reader/main_test.go
+++ b/hack/pcr-reader/main_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/vtpm"
+	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/google/go-tpm-tools/proto/attest"
 	"github.com/google/go-tpm-tools/proto/tpm"
 	"github.com/stretchr/testify/assert"
@@ -152,22 +153,22 @@ func TestPrintPCRs(t *testing.T) {
 func TestPrintPCRsWithMetadata(t *testing.T) {
 	testCases := map[string]struct {
 		format string
-		csp    string
+		csp    cloudprovider.Provider
 		image  string
 	}{
 		"json": {
 			format: "json",
-			csp:    "azure",
+			csp:    cloudprovider.Azure,
 			image:  "v2.0.0",
 		},
 		"yaml": {
-			csp:    "gcp",
+			csp:    cloudprovider.GCP,
 			image:  "v2.0.0-testimage",
 			format: "yaml",
 		},
 		"empty format": {
 			format: "",
-			csp:    "qemu",
+			csp:    cloudprovider.QEMU,
 			image:  "v2.0.0-testimage",
 		},
 		"empty": {},

--- a/internal/attestation/measurements/measurements_test.go
+++ b/internal/attestation/measurements/measurements_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
@@ -278,80 +279,86 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 	// TDcvRjBBVy9vUDVqZXR3dmJMNmQxOEhjck9kWE8yVmYxY2w0YzNLZjVRcnFSZzlN
 	// dlRxQWFsNXJCNHNpY1JaMVhpUUJjb0YwNHc9PSJ9
 	// -----END ENCRYPTED COSIGN PRIVATE KEY-----
+	cosignPublicKey := []byte("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu78QgxOOcao6U91CSzEXxrKhvFTt\nJHNy+eX6EMePtDm8CnDF9HSwnTlD0itGJ/XHPQA5YX10fJAqI1y+ehlFMw==\n-----END PUBLIC KEY-----")
 
 	testCases := map[string]struct {
 		measurements       string
+		metadata           WithMetadata
 		measurementsStatus int
 		signature          string
 		signatureStatus    int
-		publicKey          []byte
 		wantMeasurements   M
 		wantSHA            string
 		wantError          bool
 	}{
-		"simple": {
-			measurements:       "0: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n",
-			measurementsStatus: http.StatusOK,
-			signature:          "MEUCIQDcHS2bLls7OrLHpQKuiFGXhPrTcehPDwgVyERHl4V02wIgeIxK4J9oJpXWRBjokbog2lgifRXuJK8ljlAID26MbHk=",
-			signatureStatus:    http.StatusOK,
-			publicKey:          []byte("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu78QgxOOcao6U91CSzEXxrKhvFTt\nJHNy+eX6EMePtDm8CnDF9HSwnTlD0itGJ/XHPQA5YX10fJAqI1y+ehlFMw==\n-----END PUBLIC KEY-----"),
-			wantMeasurements: M{
-				0: WithAllBytes(0x00, false),
-			},
-			wantSHA: "4cd9d6ed8d9322150dff7738994c5e2fabff35f3bae6f5c993412d13249a5e87",
-		},
 		"json measurements": {
-			measurements:       `{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}`,
+			measurements:       `{"csp":"test","image":"test","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}`,
+			metadata:           WithMetadata{CSP: cloudprovider.Unknown, Image: "test"},
 			measurementsStatus: http.StatusOK,
-			signature:          "MEUCIQDh3nCgrdTiYWiV4NkiaZ6vxovj79Pk8V90mdWAnmCEOwIgMAVWAx5dW0saut+8X15SgtBEiKqEixYiSICSqqhxUMg=",
+			signature:          "MEYCIQD1RR91pWPw1BMWXTSmTBHg/JtfKerbZNQ9PJTWDdW0sgIhANQbETJGb67qzQmMVmcq007VUFbHRMtYWKZeeyRf0gVa",
 			signatureStatus:    http.StatusOK,
-			publicKey:          []byte("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu78QgxOOcao6U91CSzEXxrKhvFTt\nJHNy+eX6EMePtDm8CnDF9HSwnTlD0itGJ/XHPQA5YX10fJAqI1y+ehlFMw==\n-----END PUBLIC KEY-----"),
 			wantMeasurements: M{
 				0: WithAllBytes(0x00, false),
 			},
-			wantSHA: "1da09758c89537946496358f80b892e508563fcbbc695c90b6c16bf158e69c11",
+			wantSHA: "c04e13c1312b6f5659303871d14bf49b05c99a6515548763b6322f60bbb61a24",
 		},
 		"yaml measurements": {
-			measurements:       "0:\n expected: \"0000000000000000000000000000000000000000000000000000000000000000\"\n warnOnly: false\n",
+			measurements:       "csp: test\nimage: test\nmeasurements:\n 0:\n  expected: \"0000000000000000000000000000000000000000000000000000000000000000\"\n  warnOnly: false\n",
+			metadata:           WithMetadata{CSP: cloudprovider.Unknown, Image: "test"},
 			measurementsStatus: http.StatusOK,
-			signature:          "MEUCIFzQdwBS92aJjY0bcIag1uQRl42lUSBmmjEvO0tM/N0ZAiEAvuWaP744qYMw5uEmc7BY4mm4Ij3TEqAWFgxNhFkckp4=",
+			signature:          "MEUCIQC9WI2ijlQjBktYFctKpbnqkUTey3U9W99Jp1NTLi5AbQIgNZxxOtiawgTkWPXLoH9D2CxpEjxQrqLn/zWF6NoKxWQ=",
 			signatureStatus:    http.StatusOK,
-			publicKey:          []byte("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu78QgxOOcao6U91CSzEXxrKhvFTt\nJHNy+eX6EMePtDm8CnDF9HSwnTlD0itGJ/XHPQA5YX10fJAqI1y+ehlFMw==\n-----END PUBLIC KEY-----"),
 			wantMeasurements: M{
 				0: WithAllBytes(0x00, false),
 			},
-			wantSHA: "c651cd419fd536c63cfc5349ad44da140a09987465e31192660059d383413807",
+			wantSHA: "648fcfd5d22e623a948ab2dd4eb334be2701d8f158231726084323003daab8d4",
 		},
 		"404 measurements": {
-			measurements:       `{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}`,
+			measurements:       `{"csp":"test","image":"test","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}`,
+			metadata:           WithMetadata{CSP: cloudprovider.Unknown, Image: "test"},
 			measurementsStatus: http.StatusNotFound,
-			signature:          "MEUCIQDh3nCgrdTiYWiV4NkiaZ6vxovj79Pk8V90mdWAnmCEOwIgMAVWAx5dW0saut+8X15SgtBEiKqEixYiSICSqqhxUMg=",
+			signature:          "MEYCIQD1RR91pWPw1BMWXTSmTBHg/JtfKerbZNQ9PJTWDdW0sgIhANQbETJGb67qzQmMVmcq007VUFbHRMtYWKZeeyRf0gVa",
 			signatureStatus:    http.StatusOK,
-			publicKey:          []byte("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu78QgxOOcao6U91CSzEXxrKhvFTt\nJHNy+eX6EMePtDm8CnDF9HSwnTlD0itGJ/XHPQA5YX10fJAqI1y+ehlFMw==\n-----END PUBLIC KEY-----"),
 			wantError:          true,
 		},
 		"404 signature": {
-			measurements:       `{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}`,
+			measurements:       `{"csp":"test","image":"test","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}`,
+			metadata:           WithMetadata{CSP: cloudprovider.Unknown, Image: "test"},
 			measurementsStatus: http.StatusOK,
-			signature:          "MEUCIQDh3nCgrdTiYWiV4NkiaZ6vxovj79Pk8V90mdWAnmCEOwIgMAVWAx5dW0saut+8X15SgtBEiKqEixYiSICSqqhxUMg=",
+			signature:          "MEYCIQD1RR91pWPw1BMWXTSmTBHg/JtfKerbZNQ9PJTWDdW0sgIhANQbETJGb67qzQmMVmcq007VUFbHRMtYWKZeeyRf0gVa",
 			signatureStatus:    http.StatusNotFound,
-			publicKey:          []byte("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu78QgxOOcao6U91CSzEXxrKhvFTt\nJHNy+eX6EMePtDm8CnDF9HSwnTlD0itGJ/XHPQA5YX10fJAqI1y+ehlFMw==\n-----END PUBLIC KEY-----"),
 			wantError:          true,
 		},
 		"broken signature": {
-			measurements:       `{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}`,
+			measurements:       `{"csp":"test","image":"test","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}`,
+			metadata:           WithMetadata{CSP: cloudprovider.Unknown, Image: "test"},
 			measurementsStatus: http.StatusOK,
-			signature:          "AAAAAAAA3nCgrdTiYWiV4NkiaZ6vxovj79Pk8V90mdWAnmCEOwIgMAVWAx5dW0saut+8X15SgtBEiKqEixYiSICSqqhxUMg=",
+			signature:          "AAAAAAA1RR91pWPw1BMWXTSmTBHg/JtfKerbZNQ9PJTWDdW0sgIhANQbETJGb67qzQmMVmcq007VUFbHRMtYWKZeeyRf0gVa",
 			signatureStatus:    http.StatusOK,
-			publicKey:          []byte("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu78QgxOOcao6U91CSzEXxrKhvFTt\nJHNy+eX6EMePtDm8CnDF9HSwnTlD0itGJ/XHPQA5YX10fJAqI1y+ehlFMw==\n-----END PUBLIC KEY-----"),
+			wantError:          true,
+		},
+		"metadata CSP mismatch": {
+			measurements:       `{"csp":"test","image":"test","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}`,
+			metadata:           WithMetadata{CSP: cloudprovider.GCP, Image: "test"},
+			measurementsStatus: http.StatusOK,
+			signature:          "MEYCIQD1RR91pWPw1BMWXTSmTBHg/JtfKerbZNQ9PJTWDdW0sgIhANQbETJGb67qzQmMVmcq007VUFbHRMtYWKZeeyRf0gVa",
+			signatureStatus:    http.StatusOK,
+			wantError:          true,
+		},
+		"metadata image mismatch": {
+			measurements:       `{"csp":"test","image":"test","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}`,
+			metadata:           WithMetadata{CSP: cloudprovider.Unknown, Image: "another-image"},
+			measurementsStatus: http.StatusOK,
+			signature:          "MEYCIQD1RR91pWPw1BMWXTSmTBHg/JtfKerbZNQ9PJTWDdW0sgIhANQbETJGb67qzQmMVmcq007VUFbHRMtYWKZeeyRf0gVa",
+			signatureStatus:    http.StatusOK,
 			wantError:          true,
 		},
 		"not yaml or json": {
 			measurements:       "This is some content to be signed!\n",
+			metadata:           WithMetadata{CSP: cloudprovider.Unknown, Image: "test"},
 			measurementsStatus: http.StatusOK,
 			signature:          "MEUCIQCGA/lSu5qCJgNNvgMaTKJ9rj6vQMecUDaQo3ukaiAfUgIgWoxXRoDKLY9naN7YgxokM7r2fwnyYk3M2WKJJO1g6yo=",
 			signatureStatus:    http.StatusOK,
-			publicKey:          []byte("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu78QgxOOcao6U91CSzEXxrKhvFTt\nJHNy+eX6EMePtDm8CnDF9HSwnTlD0itGJ/XHPQA5YX10fJAqI1y+ehlFMw==\n-----END PUBLIC KEY-----"),
 			wantError:          true,
 		},
 	}
@@ -386,7 +393,13 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 			})
 
 			m := M{}
-			hash, err := m.FetchAndVerify(context.Background(), client, measurementsURL, signatureURL, tc.publicKey)
+
+			hash, err := m.FetchAndVerify(
+				context.Background(), client,
+				measurementsURL, signatureURL,
+				cosignPublicKey,
+				tc.metadata,
+			)
 
 			if tc.wantError {
 				assert.Error(err)

--- a/internal/cloud/cloudprovider/cloudprovider.go
+++ b/internal/cloud/cloudprovider/cloudprovider.go
@@ -44,6 +44,21 @@ func (p *Provider) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// MarshalYAML marshals the Provider to YAML string.
+func (p Provider) MarshalYAML() (interface{}, error) {
+	return p.String(), nil
+}
+
+// UnmarshalYAML unmarshals the Provider from YAML string.
+func (p *Provider) UnmarshalYAML(unmarshal func(any) error) error {
+	var s string
+	if err := unmarshal(&s); err != nil {
+		return err
+	}
+	*p = FromString(s)
+	return nil
+}
+
 // FromString returns cloud provider from string.
 func FromString(s string) Provider {
 	s = strings.ToLower(s)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,6 +73,10 @@ type UpgradeConfig struct {
 	// description: |
 	//   Measurements of the updated image.
 	Measurements Measurements `yaml:"measurements"`
+	// description: |
+	//   temporary field for upgrade migration
+	//   TODO(AB#2654): Remove with refactoring upgrade plan command
+	CSP cloudprovider.Provider `yaml:"csp"`
 }
 
 // ProviderConfig are cloud-provider specific configuration values used by the CLI.

--- a/internal/config/config_doc.go
+++ b/internal/config/config_doc.go
@@ -74,7 +74,7 @@ func init() {
 			FieldName: "upgrade",
 		},
 	}
-	UpgradeConfigDoc.Fields = make([]encoder.Doc, 2)
+	UpgradeConfigDoc.Fields = make([]encoder.Doc, 3)
 	UpgradeConfigDoc.Fields[0].Name = "image"
 	UpgradeConfigDoc.Fields[0].Type = "string"
 	UpgradeConfigDoc.Fields[0].Note = ""
@@ -85,6 +85,11 @@ func init() {
 	UpgradeConfigDoc.Fields[1].Note = ""
 	UpgradeConfigDoc.Fields[1].Description = "Measurements of the updated image."
 	UpgradeConfigDoc.Fields[1].Comments[encoder.LineComment] = "Measurements of the updated image."
+	UpgradeConfigDoc.Fields[2].Name = "csp"
+	UpgradeConfigDoc.Fields[2].Type = "Provider"
+	UpgradeConfigDoc.Fields[2].Note = ""
+	UpgradeConfigDoc.Fields[2].Description = "temporary field for upgrade migration\nTODO(AB#2654): Remove with refactoring upgrade plan command"
+	UpgradeConfigDoc.Fields[2].Comments[encoder.LineComment] = "temporary field for upgrade migration"
 
 	ProviderConfigDoc.Type = "ProviderConfig"
 	ProviderConfigDoc.Comments[encoder.LineComment] = "ProviderConfig are cloud-provider specific configuration values used by the CLI."

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -148,9 +148,6 @@ const (
 	// Releases.
 	//
 
-	// S3PublicBucket contains measurements & releases.
-	S3PublicBucket = "https://public-edgeless-constellation.s3.us-east-2.amazonaws.com/"
-
 	// CDNRepositoryURL is the base URL of the Constellation CDN artifact repository.
 	CDNRepositoryURL = "https://cdn.confidential.cloud"
 	// CDNImagePath is the default path to image references in the CDN repository.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -150,16 +150,13 @@ const (
 
 	// S3PublicBucket contains measurements & releases.
 	S3PublicBucket = "https://public-edgeless-constellation.s3.us-east-2.amazonaws.com/"
-	// CosignPublicKey signs all our releases.
-	CosignPublicKey = `-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEf8F1hpmwE+YCFXzjGtaQcrL6XZVT
-JmEe5iSLvG1SyQSAew7WdMKF6o9t8e2TFuCkzlOhhlws2OHWbiFZnFWCFw==
------END PUBLIC KEY-----
-`
 
-	// ImageVersionRepositoryURL is the base URL of the repository containing
-	// image version information.
-	ImageVersionRepositoryURL = "https://cdn.confidential.cloud"
+	// CDNRepositoryURL is the base URL of the Constellation CDN artifact repository.
+	CDNRepositoryURL = "https://cdn.confidential.cloud"
+	// CDNImagePath is the default path to image references in the CDN repository.
+	CDNImagePath = "constellation/v1/images"
+	// CDNMeasurementsPath is the default path to image measurements in the CDN repository.
+	CDNMeasurementsPath = "constellation/v1/measurements"
 )
 
 // VersionInfo is the version of a binary. Left as a separate variable to allow override during build.

--- a/internal/constants/keys_enterprise.go
+++ b/internal/constants/keys_enterprise.go
@@ -1,0 +1,16 @@
+//go:build enterprise
+
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package constants
+
+// CosignPublicKey signs all our releases.
+const CosignPublicKey = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEf8F1hpmwE+YCFXzjGtaQcrL6XZVT
+JmEe5iSLvG1SyQSAew7WdMKF6o9t8e2TFuCkzlOhhlws2OHWbiFZnFWCFw==
+-----END PUBLIC KEY-----
+`

--- a/internal/constants/keys_oss.go
+++ b/internal/constants/keys_oss.go
@@ -1,0 +1,16 @@
+//go:build !enterprise
+
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package constants
+
+// CosignPublicKey signs all our development builds.
+const CosignPublicKey = `-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELcPl4Ik+qZuH4K049wksoXK/Os3Z
+b92PDCpM7FZAINQF88s1TZS/HmRXYk62UJ4eqPduvUnJmXhNikhLbMi6fw==
+-----END PUBLIC KEY-----
+`

--- a/internal/image/image.go
+++ b/internal/image/image.go
@@ -125,12 +125,12 @@ func getFromFile(fs *afero.Afero, version string) ([]byte, error) {
 
 // getFromURL fetches the image lookup table from a URL.
 func getFromURL(ctx context.Context, client httpc, version string) ([]byte, error) {
-	url, err := url.Parse(constants.ImageVersionRepositoryURL)
+	url, err := url.Parse(constants.CDNRepositoryURL)
 	if err != nil {
 		return nil, fmt.Errorf("parsing image version repository URL: %w", err)
 	}
 	versionFilename := path.Base(version) + ".json"
-	url.Path = path.Join("constellation/v1/images", versionFilename)
+	url.Path = path.Join(constants.CDNImagePath, versionFilename)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), http.NoBody)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
- Only build Constellation CLI with release cosign public key if we build a release CLI
  - Use dev cosign public key otherwise
- Adapt `constellation config fetch-measurements` command to work with new JSON format and our artifact CDN
- Enforce metadata validation on `fetch-measurement`
  - This only works for images/measurements signed using our updated build pipeline from: https://github.com/edgelesssys/constellation/pull/641
  - For fetching measurements of older images, older CLI have to be used. This is not a breaking change, since old CLIs should not be used to upgrade to newer images. New CLIs don't need to fetch measurements for old images, since downgrading is not intended or supported
- Enforce metadata validation for measurements
- Add YAML marshal and unmarshal methods to `cloudprovider.Provider`
- Replace some instances where tests were using signatures generated using the release key

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
There are some transitional changes to tge `upgrade plan` command so unit test pass.
Changes will be dropped/refactored with [AB#2654](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/2654)
 

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
