### PR TITLE
config: sort measurements numerically

### DIFF
--- a/internal/attestation/measurements/measurements.go
+++ b/internal/attestation/measurements/measurements.go
@@ -364,6 +364,8 @@ func (c mYamlContent) Less(i, j int) bool {
 }
 
 func (c mYamlContent) Swap(i, j int) {
+	// The slice is filled like {key1, value1, key2, value2, ...}.
+	// We need to swap both key and value.
 	c[2*i], c[2*j] = c[2*j], c[2*i]
 	c[2*i+1], c[2*j+1] = c[2*j+1], c[2*i+1]
 }

--- a/internal/attestation/measurements/measurements.go
+++ b/internal/attestation/measurements/measurements.go
@@ -17,10 +17,13 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
+	"strconv"
 
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/sigstore"
 	"github.com/google/go-tpm/tpmutil"
+	"github.com/talos-systems/talos/pkg/machinery/config/encoder"
 	"go.uber.org/multierr"
 	"gopkg.in/yaml.v3"
 )
@@ -43,6 +46,20 @@ type WithMetadata struct {
 	CSP          string `json:"csp" yaml:"csp"`
 	Image        string `json:"image" yaml:"image"`
 	Measurements M      `json:"measurements" yaml:"measurements"`
+}
+
+// MarshalYAML returns the YAML encoding of m.
+func (m M) MarshalYAML() (any, error) {
+	// cast to prevent infinite recursion
+	node, err := encoder.NewEncoder(map[uint32]Measurement(m)).Marshal()
+	if err != nil {
+		return nil, err
+	}
+
+	// sort keys numerically
+	sort.Sort(mYamlContent(node.Content))
+
+	return node, nil
 }
 
 // FetchAndVerify fetches measurement and signature files via provided URLs,
@@ -324,4 +341,29 @@ func getFromURL(ctx context.Context, client *http.Client, sourceURL *url.URL) ([
 type encodedMeasurement struct {
 	Expected string `json:"expected" yaml:"expected"`
 	WarnOnly bool   `json:"warnOnly" yaml:"warnOnly"`
+}
+
+// mYamlContent is the Content of a yaml.Node encoding of an M. It implements sort.Interface.
+// The slice is filled like {key1, value1, key2, value2, ...}.
+type mYamlContent []*yaml.Node
+
+func (c mYamlContent) Len() int {
+	return len(c) / 2
+}
+
+func (c mYamlContent) Less(i, j int) bool {
+	lhs, err := strconv.Atoi(c[2*i].Value)
+	if err != nil {
+		panic(err)
+	}
+	rhs, err := strconv.Atoi(c[2*j].Value)
+	if err != nil {
+		panic(err)
+	}
+	return lhs < rhs
+}
+
+func (c mYamlContent) Swap(i, j int) {
+	c[2*i], c[2*j] = c[2*j], c[2*i]
+	c[2*i+1], c[2*j+1] = c[2*j+1], c[2*i+1]
 }

--- a/internal/attestation/measurements/measurements_test.go
+++ b/internal/attestation/measurements/measurements_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/talos-systems/talos/pkg/machinery/config/encoder"
 	"gopkg.in/yaml.v3"
 )
 
@@ -174,6 +175,59 @@ func TestUnmarshal(t *testing.T) {
 					assert.Equal(tc.wantMeasurements, m)
 				}
 			}
+		})
+	}
+}
+
+func TestEncodeM(t *testing.T) {
+	testCases := map[string]struct {
+		m    M
+		want string
+	}{
+		"basic": {
+			m: M{
+				1: WithAllBytes(1, false),
+				2: WithAllBytes(2, true),
+			},
+			want: `1:
+    expected: "0101010101010101010101010101010101010101010101010101010101010101"
+    warnOnly: false
+2:
+    expected: "0202020202020202020202020202020202020202020202020202020202020202"
+    warnOnly: true
+`,
+		},
+		"output is sorted": {
+			m: M{
+				3:  {},
+				1:  {},
+				11: {},
+				2:  {},
+			},
+			want: `1:
+    expected: "0000000000000000000000000000000000000000000000000000000000000000"
+    warnOnly: false
+2:
+    expected: "0000000000000000000000000000000000000000000000000000000000000000"
+    warnOnly: false
+3:
+    expected: "0000000000000000000000000000000000000000000000000000000000000000"
+    warnOnly: false
+11:
+    expected: "0000000000000000000000000000000000000000000000000000000000000000"
+    warnOnly: false
+`,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			encoded, err := encoder.NewEncoder(tc.m).Encode()
+			require.NoError(err)
+			assert.Equal(tc.want, string(encoded))
 		})
 	}
 }


### PR DESCRIPTION
Previously, writing the config file caused the measurements to be randomly ordered. This PR adds a bit of custom marshaling to sort the measurements numerically.