### PR TITLE
Use ChartLoader to set operator deployment images

### DIFF
--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -39,14 +39,16 @@ var helmFS embed.FS
 
 // ChartLoader loads embedded helm charts.
 type ChartLoader struct {
-	joinServiceImage         string
-	kmsImage                 string
-	ccmImage                 string
-	cnmImage                 string
-	autoscalerImage          string
-	verificationServiceImage string
-	gcpGuestAgentImage       string
-	konnectivityImage        string
+	joinServiceImage             string
+	kmsImage                     string
+	ccmImage                     string
+	cnmImage                     string
+	autoscalerImage              string
+	verificationServiceImage     string
+	gcpGuestAgentImage           string
+	konnectivityImage            string
+	constellationOperatorImage   string
+	nodeMaintenanceOperatorImage string
 }
 
 // NewLoader creates a new ChartLoader.
@@ -63,14 +65,16 @@ func NewLoader(csp cloudprovider.Provider, k8sVersion versions.ValidK8sVersion) 
 	}
 
 	return &ChartLoader{
-		joinServiceImage:         versions.JoinImage,
-		kmsImage:                 versions.KmsImage,
-		ccmImage:                 ccmImage,
-		cnmImage:                 cnmImage,
-		autoscalerImage:          versions.VersionConfigs[k8sVersion].ClusterAutoscalerImage,
-		verificationServiceImage: versions.VerificationImage,
-		gcpGuestAgentImage:       versions.GcpGuestImage,
-		konnectivityImage:        versions.KonnectivityAgentImage,
+		joinServiceImage:             versions.JoinImage,
+		kmsImage:                     versions.KmsImage,
+		ccmImage:                     ccmImage,
+		cnmImage:                     cnmImage,
+		autoscalerImage:              versions.VersionConfigs[k8sVersion].ClusterAutoscalerImage,
+		verificationServiceImage:     versions.VerificationImage,
+		gcpGuestAgentImage:           versions.GcpGuestImage,
+		konnectivityImage:            versions.KonnectivityAgentImage,
+		constellationOperatorImage:   versions.ConstellationOperatorImage,
+		nodeMaintenanceOperatorImage: versions.NodeMaintenanceOperatorImage,
 	}
 }
 
@@ -266,14 +270,14 @@ func (i *ChartLoader) loadOperatorsHelper(csp cloudprovider.Provider) (*chart.Ch
 		"constellation-operator": map[string]any{
 			"controllerManager": map[string]any{
 				"manager": map[string]any{
-					"image": versions.ConstellationOperatorImage,
+					"image": i.constellationOperatorImage,
 				},
 			},
 		},
 		"node-maintenance-operator": map[string]any{
 			"controllerManager": map[string]any{
 				"manager": map[string]any{
-					"image": versions.NodeMaintenanceOperatorImage,
+					"image": i.nodeMaintenanceOperatorImage,
 				},
 			},
 		},

--- a/cli/internal/helm/loader_test.go
+++ b/cli/internal/helm/loader_test.go
@@ -170,7 +170,15 @@ func TestOperators(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			chartLoader := ChartLoader{joinServiceImage: "joinServiceImage", kmsImage: "kmsImage", ccmImage: "ccmImage", cnmImage: "cnmImage", autoscalerImage: "autoscalerImage"}
+			chartLoader := ChartLoader{
+				joinServiceImage:             "joinServiceImage",
+				kmsImage:                     "kmsImage",
+				ccmImage:                     "ccmImage",
+				cnmImage:                     "cnmImage",
+				autoscalerImage:              "autoscalerImage",
+				constellationOperatorImage:   "constellationOperatorImage",
+				nodeMaintenanceOperatorImage: "nodeMaintenanceOperatorImage",
+			}
 			chart, vals, err := chartLoader.loadOperatorsHelper(tc.csp)
 			require.NoError(err)
 

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           value: Azure
         - name: constellation-uid
           value: "42424242424242"
-        image: ghcr.io/edgelesssys/constellation/node-operator:v2.3.0-pre.0.20221125134926-1af3ff00adbc@sha256:fae7160eba0259d3dcbe974460ff983ae2c6cab18319a5b8ef585dd1630cb077
+        image: constellationOperatorImage
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: ghcr.io/edgelesssys/constellation/node-maintenance-operator:v0.13.1-alpha1@sha256:e011d428dba3ef66a2a4656a2bf58bcfe89836c62b0a75676f5c12350502a3cf
+        image: nodeMaintenanceOperatorImage
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           value: GCP
         - name: constellation-uid
           value: "42424242424242"
-        image: ghcr.io/edgelesssys/constellation/node-operator:v2.3.0-pre.0.20221125134926-1af3ff00adbc@sha256:fae7160eba0259d3dcbe974460ff983ae2c6cab18319a5b8ef585dd1630cb077
+        image: constellationOperatorImage
         livenessProbe:
           httpGet:
             path: /healthz

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               fieldPath: metadata.namespace
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: cluster.local
-        image: ghcr.io/edgelesssys/constellation/node-maintenance-operator:v0.13.1-alpha1@sha256:e011d428dba3ef66a2a4656a2bf58bcfe89836c62b0a75676f5c12350502a3cf
+        image: nodeMaintenanceOperatorImage
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
#656 showed that the operator images are set based on the versions.go file directly.
This PR allows the (operator) unittests to use dummy values instead of relying on the real image string from versions.go.