### PR TITLE
Fix components diagram

### DIFF
--- a/docs/versioned_docs/version-2.2/architecture/components.md
+++ b/docs/versioned_docs/version-2.2/architecture/components.md
@@ -21,16 +21,15 @@ flowchart LR
         C[Bootstrapper]
     end
     subgraph Kubernetes
-        E[JoinService]
-        F[KMS]
-        G[VerificationService]
+        D[JoinService]
+        E[KMS]
+        F[VerificationService]
     end
     A -- deploys -->
     B -- starts --> C
     C -- deploys --> D
     C -- deploys --> E
     C -- deploys --> F
-    C -- deploys --> G
 ```
 
 ## Bootstrapper


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Components has a dangling reference `D` that referenced the AccessManager before. It is currently [shown as `D` in the Diagram](https://docs.edgeless.systems/constellation/architecture/components)
- Fixes the diagram by updating the references

