### PR TITLE
CSI driver fixes

### DIFF
--- a/image/mkosi.skeleton/usr/lib/udev/rules.d/98-override-systemd.rules
+++ b/image/mkosi.skeleton/usr/lib/udev/rules.d/98-override-systemd.rules
@@ -1,3 +1,4 @@
 # prevent systemd udev rules from marking unformatted device mapper device as unready (SYSTEMD_READY=0)
 # this is the offending rule from systemd: SUBSYSTEM=="block", ENV{DM_UUID}=="CRYPT-*", ENV{ID_PART_TABLE_TYPE}=="", ENV{ID_FS_USAGE}=="", ENV{SYSTEMD_READY}="0"
+SUBSYSTEM=="block", ENV{DM_UUID}=="CRYPT-*", ENV{ID_PART_TABLE_TYPE}=="", ENV{ID_FS_USAGE}="constellation-encrypted-disk"
 SUBSYSTEM=="block", ENV{DM_NAME}=="state", ENV{DM_UUID}=="CRYPT-*", ENV{ID_PART_TABLE_TYPE}=="", ENV{ID_FS_USAGE}="constellation-state"


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
* Fix an issue where CSI resize operations were using a disks volume ID instead of the disk's UID as key ID
* Add a udev rule to label disks with empty usage label

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- ~~We might want to split this PR, since I would like the CSI resize fixes in main before we can release a new CSI driver version~~ Dropped the CSI chart changes for now, will update the chart once we have a new release

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
