### PR TITLE
Add GitLab to demos section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ __pycache__/
 
 # Nix shells
 shell.nix
+
+# Gitpod
+.gitpod.yml

--- a/README.md
+++ b/README.md
@@ -69,11 +69,13 @@ If you're already familiar with Kubernetes, it's easy to get started with Conste
 
 ![Constellation Shell](docs/static/img/shell-windowframe.svg)
 
-## Demo
+## Live demos
 
-We're running a [Rocket.Chat](https://github.com/RocketChat/Rocket.Chat) server on Constellation at <https://rocket.edgeless.systems/>.
+As demos, we're running public instances of popular software on Constellation: 
+* Rocket.Chat: https://rocket.edgeless.systems/ ([blog post](https://dev.to/flxflx/rocketchat-constellation-most-secure-chat-server-ever--50oa))
+* GitLab: https://gitlab.edgeless.systems/ ([blog post](https://dev.to/flxflx/setting-up-a-confidential-gitlab-333h))
 
-This [blog post](https://dev.to/flxflx/rocketchat-constellation-most-secure-chat-server-ever--50oa) gives details on the setup.
+These instances run on CVMs in Azure and Constellation keeps them end-to-end confidential.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ If you're already familiar with Kubernetes, it's easy to get started with Conste
 
 ## Live demos
 
-As demos, we're running public instances of popular software on Constellation: 
+We're running public instances of popular software on Constellation: 
 * Rocket.Chat: https://rocket.edgeless.systems/ ([blog post](https://dev.to/flxflx/rocketchat-constellation-most-secure-chat-server-ever--50oa))
 * GitLab: https://gitlab.edgeless.systems/ ([blog post](https://dev.to/flxflx/setting-up-a-confidential-gitlab-333h))
 


### PR DESCRIPTION
This adds a link to GitLab to the demos section in the README + some rewording.

Bonus: ignores .gitpod.yml files which are auto-generated by Gitpod
