### PR TITLE
Docs: Fix wrong GCP zone

### DIFF
--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -62,10 +62,10 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     <tabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west1-a --serviceAccountID=constell-test
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west1-a` creating a new service account `constell-test`.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
 
     Note that only regions offering CVMs of the `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -89,10 +89,10 @@ Since `clientSecretValue` is a sensitive value, you can leave it empty in the co
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session.
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west1-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west1-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Change the (non-existent) wrong GCP zone `europe-west1-a` to `europe-west2-a` (with `N2D` availability)
- More info [here](https://cloud.google.com/compute/docs/regions-zones) 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Link to Milestone
