### PR TITLE
join: make Azure instance names k8s compliant

### DIFF
--- a/bootstrapper/internal/kubernetes/kubernetes.go
+++ b/bootstrapper/internal/kubernetes/kubernetes.go
@@ -37,7 +37,7 @@ import (
 	kubeadm "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 )
 
-var validHostnameRegex = regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+var validHostnameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 
 // configReader provides kubeconfig as []byte.
 type configReader interface {

--- a/bootstrapper/internal/kubernetes/kubernetes.go
+++ b/bootstrapper/internal/kubernetes/kubernetes.go
@@ -14,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -35,6 +36,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeadm "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
 )
+
+var validHostnameRegex = regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
 
 // configReader provides kubeconfig as []byte.
 type configReader interface {
@@ -110,7 +113,11 @@ func (k *KubeWrapper) InitCluster(
 	if instance.VPCIP != "" {
 		validIPs = append(validIPs, net.ParseIP(instance.VPCIP))
 	}
-	nodeName := k8sCompliantHostname(instance.Name)
+	nodeName, err := k8sCompliantHostname(instance.Name)
+	if err != nil {
+		return nil, fmt.Errorf("generating node name: %w", err)
+	}
+
 	nodeIP := instance.VPCIP
 	subnetworkPodCIDR := instance.SecondaryIPRange
 	if len(instance.AliasIPRanges) > 0 {
@@ -278,7 +285,10 @@ func (k *KubeWrapper) JoinCluster(ctx context.Context, args *kubeadm.BootstrapTo
 	}
 	providerID := instance.ProviderID
 	nodeInternalIP := instance.VPCIP
-	nodeName := k8sCompliantHostname(instance.Name)
+	nodeName, err := k8sCompliantHostname(instance.Name)
+	if err != nil {
+		return fmt.Errorf("generating node name: %w", err)
+	}
 
 	loadbalancerEndpoint, err := k.providerMetadata.GetLoadBalancerEndpoint(ctx)
 	if err != nil {
@@ -401,10 +411,13 @@ func (k *KubeWrapper) setupInternalConfigMap(ctx context.Context, azureCVM strin
 // k8sCompliantHostname transforms a hostname to an RFC 1123 compliant, lowercase subdomain as required by Kubernetes node names.
 // The following regex is used by k8s for validation: /^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$/ .
 // Only a simple heuristic is used for now (to lowercase, replace underscores).
-func k8sCompliantHostname(in string) string {
+func k8sCompliantHostname(in string) (string, error) {
 	hostname := strings.ToLower(in)
 	hostname = strings.ReplaceAll(hostname, "_", "-")
-	return hostname
+	if !validHostnameRegex.MatchString(hostname) {
+		return "", fmt.Errorf("failed to generate a Kubernetes compliant hostname for %s", in)
+	}
+	return hostname, nil
 }
 
 // StartKubelet starts the kubelet service.

--- a/joinservice/internal/kubernetes/kubernetes.go
+++ b/joinservice/internal/kubernetes/kubernetes.go
@@ -152,7 +152,7 @@ func (c *Client) AddReferenceToK8sVersionConfigMap(ctx context.Context, k8sVersi
 	return nil
 }
 
-var validHostnameRegex = regexp.MustCompile("^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$")
+var validHostnameRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`)
 
 // k8sCompliantHostname transforms a hostname to an RFC 1123 compliant, lowercase subdomain as required by Kubernetes node names.
 // Only a simple heuristic is used for now (to lowercase, replace underscores).

--- a/joinservice/internal/kubernetes/kubernetes_test.go
+++ b/joinservice/internal/kubernetes/kubernetes_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func TestK8sCompliantHostname(t *testing.T) {
+	testCases := map[string]struct {
+		input    string
+		expected string
+		wantErr  bool
+	}{
+		"no change": {
+			input:    "test",
+			expected: "test",
+		},
+		"uppercase": {
+			input:    "TEST",
+			expected: "test",
+		},
+		"underscore": {
+			input:    "test_node",
+			expected: "test-node",
+		},
+		"empty": {
+			input:    "",
+			expected: "",
+			wantErr:  true,
+		},
+		"error": {
+			input:    "test_node_",
+			expected: "",
+			wantErr:  true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			actual, err := k8sCompliantHostname(tc.input)
+			if tc.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			assert.Equal(tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Azure machine names contain upper case letters. K8s doesn't allow them for any resource. We already normalize them in the bootstrapper. With 2.3.0 we introduced the joiningnode CRD which is created by the JoinService. For worker nodes the entries are named after the node name from inside the CSR, which is the non-normalized Azure machine name. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
- [x] Check if the name also needs to be normalized in the Spec, since our node operator consumes this field. Yes.
- [x] Update [CHANGELOG.md](https://github.com/edgelesssys/constellation/blob/main/CHANGELOG.md)
- [x] Link to Milestone
