### PR TITLE
deps: disable semantic commit message for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,8 @@
     "config:base",
     ":preserveSemverRanges",
     "helpers:pinGitHubActionDigests",
-    ":separateMajorReleases"
+    ":separateMajorReleases",
+    ":semanticCommitsDisabled"
   ],
   "addLabels": [
     "dependencies"


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Renovate seems to have automatically detected we'd using semantic commit messages, see #789. https://docs.renovatebot.com/semantic-commits/ Disabling this for now.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
