### PR TITLE
Only upgrade helm releases if versions changed

### DIFF
--- a/cli/internal/cloudcmd/upgrade.go
+++ b/cli/internal/cloudcmd/upgrade.go
@@ -118,11 +118,6 @@ func (u *Upgrader) UpgradeHelmServices(ctx context.Context, config *config.Confi
 	return u.helmClient.Upgrade(ctx, config, timeout)
 }
 
-// CurrentHelmVersion returns the version of the currently installed helm release.
-func (u *Upgrader) CurrentHelmVersion(release string) (string, error) {
-	return u.helmClient.CurrentVersion(release)
-}
-
 // KubernetesVersion returns the version of Kubernetes the Constellation is currently running on.
 func (u *Upgrader) KubernetesVersion() (string, error) {
 	return u.stableInterface.kubernetesVersion()
@@ -244,7 +239,6 @@ func (u *stableClient) kubernetesVersion() (string, error) {
 }
 
 type helmInterface interface {
-	CurrentVersion(release string) (string, error)
 	Upgrade(ctx context.Context, config *config.Config, timeout time.Duration) error
 }
 

--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -105,11 +105,14 @@ func (c *Client) upgradeRelease(
 	if err != nil {
 		return fmt.Errorf("getting current version: %w", err)
 	}
-	c.log.Debugf("current %s version: %s", releaseName, currentVersion)
-	c.log.Debugf("new %s version: %s", releaseName, chart.Metadata.Version)
+	c.log.Debugf("Current %s version: %s", releaseName, currentVersion)
+	c.log.Debugf("New %s version: %s", releaseName, chart.Metadata.Version)
 
 	if !isUpgrade(currentVersion, chart.Metadata.Version) {
-		c.log.Debugf("skipping upgrade of %s: no upgrade necessary", releaseName)
+		c.log.Debugf(
+			"Skipping upgrade of %s: new version (%s) is not an upgrade for current version (%s)",
+			releaseName, chart.Metadata.Version, currentVersion,
+		)
 		return nil
 	}
 
@@ -123,7 +126,7 @@ func (c *Client) upgradeRelease(
 		return fmt.Errorf("preparing values: %w", err)
 	}
 
-	c.log.Debugf("upgrading %s from %s to %s", releaseName, currentVersion, chart.Metadata.Version)
+	c.log.Debugf("Upgrading %s from %s to %s", releaseName, currentVersion, chart.Metadata.Version)
 	action := action.NewUpgrade(c.config)
 	action.Atomic = true
 	action.Namespace = constants.HelmNamespace
@@ -204,7 +207,7 @@ func (c *Client) updateCRDs(ctx context.Context, chart *chart.Chart) error {
 	for _, dep := range chart.Dependencies() {
 		for _, crdFile := range dep.Files {
 			if strings.HasPrefix(crdFile.Name, "crds/") {
-				c.log.Debugf("updating crd: %s", crdFile.Name)
+				c.log.Debugf("Updating crd: %s", crdFile.Name)
 				err := c.ApplyCRD(ctx, crdFile.Data)
 				if err != nil {
 					return err

--- a/cli/internal/helm/client_test.go
+++ b/cli/internal/helm/client_test.go
@@ -44,3 +44,69 @@ func TestParseCRDs(t *testing.T) {
 		})
 	}
 }
+
+func TestIsUpgrade(t *testing.T) {
+	testCases := map[string]struct {
+		currentVersion string
+		newVersion     string
+		wantUpgrade    bool
+	}{
+		"upgrade": {
+			currentVersion: "0.1.0",
+			newVersion:     "0.2.0",
+			wantUpgrade:    true,
+		},
+		"downgrade": {
+			currentVersion: "0.2.0",
+			newVersion:     "0.1.0",
+			wantUpgrade:    false,
+		},
+		"equal": {
+			currentVersion: "0.1.0",
+			newVersion:     "0.1.0",
+			wantUpgrade:    false,
+		},
+		"invalid current version": {
+			currentVersion: "asdf",
+			newVersion:     "0.1.0",
+			wantUpgrade:    false,
+		},
+		"invalid new version": {
+			currentVersion: "0.1.0",
+			newVersion:     "asdf",
+			wantUpgrade:    false,
+		},
+		"patch version": {
+			currentVersion: "0.1.0",
+			newVersion:     "0.1.1",
+			wantUpgrade:    true,
+		},
+		"pre-release version": {
+			currentVersion: "0.1.0",
+			newVersion:     "0.1.1-rc1",
+			wantUpgrade:    true,
+		},
+		"pre-release version downgrade": {
+			currentVersion: "0.1.1-rc1",
+			newVersion:     "0.1.0",
+			wantUpgrade:    false,
+		},
+		"pre-release of same version": {
+			currentVersion: "0.1.0",
+			newVersion:     "0.1.0-rc1",
+			wantUpgrade:    false,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			upgrade := isUpgrade(tc.currentVersion, tc.newVersion)
+			assert.Equal(tc.wantUpgrade, upgrade)
+
+			upgrade = isUpgrade("v"+tc.currentVersion, "v"+tc.newVersion)
+			assert.Equal(tc.wantUpgrade, upgrade)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Adapts the `helm.Upgrade` method to only run upgrades for a chart if the local chart version is greater than the one currently installed in Constellation

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- ~[ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)~
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
