### PR TITLE
AB#2581: Move Konnectivity socket to non-persistent /run

### DIFF
--- a/bootstrapper/internal/kubernetes/k8sapi/kubeadm_config.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/kubeadm_config.go
@@ -113,8 +113,8 @@ func (c *KubdeadmConfiguration) InitConfiguration(externalCloudProvider bool, k8
 						},
 						{
 							Name:      "konnectivity-uds",
-							HostPath:  "/etc/kubernetes/konnectivity-server",
-							MountPath: "/etc/kubernetes/konnectivity-server",
+							HostPath:  "/run/konnectivity-server",
+							MountPath: "/run/konnectivity-server",
 							ReadOnly:  false,
 							PathType:  corev1.HostPathDirectoryOrCreate,
 						},

--- a/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
@@ -60,7 +60,7 @@ func NewKonnectivityServerStaticPod() *KonnectivityServerStaticPod {
 						Args: []string{
 							"--logtostderr=true",
 							// This needs to be consistent with the value set in egressSelectorConfiguration.
-							"--uds-name=/etc/kubernetes/konnectivity-server/konnectivity-server.socket",
+							"--uds-name=/run/konnectivity-server/konnectivity-server.socket",
 							// The following two lines assume the Konnectivity server is
 							// deployed on the same machine as the apiserver, and the certs and
 							// key of the API Server are at the specified location.
@@ -119,7 +119,7 @@ func NewKonnectivityServerStaticPod() *KonnectivityServerStaticPod {
 							},
 							{
 								Name:      "konnectivity-uds",
-								MountPath: "/etc/kubernetes/konnectivity-server",
+								MountPath: "/run/konnectivity-server",
 								ReadOnly:  false,
 							},
 						},
@@ -146,7 +146,7 @@ func NewKonnectivityServerStaticPod() *KonnectivityServerStaticPod {
 						Name: "konnectivity-uds",
 						VolumeSource: corev1.VolumeSource{
 							HostPath: &corev1.HostPathVolumeSource{
-								Path: "/etc/kubernetes/konnectivity-server",
+								Path: "/run/konnectivity-server",
 								Type: &udsHostPathType,
 							},
 						},
@@ -172,7 +172,7 @@ func NewEgressSelectorConfiguration() *EgressSelectorConfiguration {
 						ProxyProtocol: "GRPC",
 						Transport: &apiserver.Transport{
 							UDS: &apiserver.UDSTransport{
-								UDSName: "/etc/kubernetes/konnectivity-server/konnectivity-server.socket",
+								UDSName: "/run/konnectivity-server/konnectivity-server.socket",
 							},
 						},
 					},

--- a/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/resources/konnectivity.go
@@ -61,6 +61,8 @@ func NewKonnectivityServerStaticPod() *KonnectivityServerStaticPod {
 							"--logtostderr=true",
 							// This needs to be consistent with the value set in egressSelectorConfiguration.
 							"--uds-name=/run/konnectivity-server/konnectivity-server.socket",
+							// Clean up existing UDS file before starting the server in case the server crashed at some point.
+							"--delete-existing-uds-file=true",
 							// The following two lines assume the Konnectivity server is
 							// deployed on the same machine as the apiserver, and the certs and
 							// key of the API Server are at the specified location.


### PR DESCRIPTION
### Proposed change(s)
- Move Konnectivity socket from default /etc/kubernetes/konnectivity-server/konnectivity-server.socket (persistent) to /run/konnectivity-server/konnectivity-server.socket (non-persistent)


### Related issue
- https://github.com/kubernetes-sigs/apiserver-network-proxy/issues/443

While this is not a fix for the cause of this issue (which is still unknown), it cam serve as a mitigation as the Konnectivity server socket should not persist anymore across reboots of a node.


