### PR TITLE
image: set runtime-endpoint in crictl config

### DIFF
--- a/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
@@ -244,11 +244,13 @@ type SetupPodNetworkInput struct {
 // FixCilium fixes https://github.com/cilium/cilium/issues/19958 but instead of a rollout restart of
 // the cilium daemonset, it only restarts the local cilium pod.
 func (k *KubernetesUtil) FixCilium(log *logger.Logger) {
+	ctx := context.Background()
+
 	// wait for cilium pod to be healthy
 	client := http.Client{}
 	for {
 		time.Sleep(5 * time.Second)
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://127.0.0.1:9879/healthz", http.NoBody)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1:9879/healthz", http.NoBody)
 		if err != nil {
 			log.With(zap.Error(err)).Errorf("Unable to create request")
 			continue
@@ -265,7 +267,7 @@ func (k *KubernetesUtil) FixCilium(log *logger.Logger) {
 	}
 
 	// get cilium container id
-	out, err := exec.CommandContext(context.Background(), "/run/state/bin/crictl", "ps", "--name", "cilium-agent", "-q").CombinedOutput()
+	out, err := exec.CommandContext(ctx, "/run/state/bin/crictl", "ps", "--name", "cilium-agent", "-q").CombinedOutput()
 	if err != nil {
 		log.With(zap.Error(err)).Errorf("Getting cilium container id failed: %s", out)
 		return
@@ -278,7 +280,7 @@ func (k *KubernetesUtil) FixCilium(log *logger.Logger) {
 	containerID := outLines[len(outLines)-2]
 
 	// get cilium pod id
-	out, err = exec.CommandContext(context.Background(), "/run/state/bin/crictl", "inspect", "-o", "go-template", "--template", "{{ .info.sandboxID }}", containerID).CombinedOutput()
+	out, err = exec.CommandContext(ctx, "/run/state/bin/crictl", "inspect", "-o", "go-template", "--template", "{{ .info.sandboxID }}", containerID).CombinedOutput()
 	if err != nil {
 		log.With(zap.Error(err)).Errorf("Getting cilium pod id failed: %s", out)
 		return
@@ -291,12 +293,12 @@ func (k *KubernetesUtil) FixCilium(log *logger.Logger) {
 	podID := outLines[len(outLines)-2]
 
 	// stop and delete pod
-	out, err = exec.CommandContext(context.Background(), "/run/state/bin/crictl", "stopp", podID).CombinedOutput()
+	out, err = exec.CommandContext(ctx, "/run/state/bin/crictl", "stopp", podID).CombinedOutput()
 	if err != nil {
 		log.With(zap.Error(err)).Errorf("Stopping cilium agent pod failed: %s", out)
 		return
 	}
-	out, err = exec.CommandContext(context.Background(), "/run/state/bin/crictl", "rmp", podID).CombinedOutput()
+	out, err = exec.CommandContext(ctx, "/run/state/bin/crictl", "rmp", podID).CombinedOutput()
 	if err != nil {
 		log.With(zap.Error(err)).Errorf("Removing cilium agent pod failed: %s", out)
 	}

--- a/image/mkosi.skeleton/etc/crictl.yaml
+++ b/image/mkosi.skeleton/etc/crictl.yaml
@@ -1,0 +1,1 @@
+runtime-endpoint: "unix:///run/containerd/containerd.sock"


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- configuring the runtime-endpoint in crictl config

### Additional info

Error in FixCilium function when endpoint isn't set (`journalctl -u bootstrapper`):
```
Dec 21 12:33:03 fedora bootstrapper[8985]: {"level":"ERROR","ts":"2022-12-21T12:33:03Z","logger":"bootstrapper.join-client","caller":"k8sapi/k8sutil.go:270","msg":"Getting cilium container id failed: time=\"2022-12-21T12:33:03Z\" level=warning msg=\"runtime connect using default endpoints: [unix:///var/run/dockershim.sock unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock unix:///var/run/cri-dockerd.sock]. As the default settings are now deprecated, you should set the endpoint instead.\"\ntime=\"2022-12-21T12:33:03Z\" level=warning msg=\"image connect using default endpoints: [unix:///var/run/dockershim.sock unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock unix:///var/run/cri-dockerd.sock]. As the default settings are now deprecated, you should set the endpoint instead.\"\nE1221 12:33:03.691587   13207 remote_runtime.go:390] \"ListContainers with filter from runtime service failed\" err=\"rpc error: code = Unavailable desc = connection error: desc = \\\"transport: Error while dialing dial unix /var/run/dockershim.sock: connect: no such file or directory\\\"\" filter=\"&ContainerFilter{Id:,State:&ContainerStateValue{State:CONTAINER_RUNNING,},PodSandboxId:,LabelSelector:map[string]string{},}\"\ntime=\"2022-12-21T12:33:03Z\" level=fatal msg=\"listing containers: rpc error: code = Unavailable desc = connection error: desc = \\\"transport: Error while dialing dial unix /var/run/dockershim.sock: connect: no such file or directory\\\"\"\n","error":"exit status 1"}
```

crictl debug output:

```shell-session
[root@fedora ~]# crictl --debug version
DEBU[0000] get runtime connection                       
WARN[0000] runtime connect using default endpoints: [unix:///var/run/dockershim.sock unix:///run/containerd/containerd.sock unix:///run/crio/crio.sock unix:///var/run/cri-dockerd.sock]. As the default settings are now deprecated, you should set the endpoint instead. 
DEBU[0000] Note that performance maybe affected as each default connection attempt takes n-seconds to complete before timing out and going to the next in sequence. 
DEBU[0000] Connect using endpoint "unix:///var/run/dockershim.sock" with "2s" timeout 
DEBU[0000] Connected successfully using endpoint: unix:///var/run/dockershim.sock 
DEBU[0000] VersionRequest: &VersionRequest{Version:v1,} 
E1221 14:59:58.746784   17478 remote_runtime.go:145] "Version from runtime service failed" err="rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing dial unix /var/run/dockershim.sock: connect: no such file or directory\""
DEBU[0000] VersionResponse: nil                         
FATA[0000] getting the runtime version: rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing dial unix /var/run/dockershim.sock: connect: no such file or directory" 
```

```
[root@fedora ~]# crictl --debug -r unix:///run/containerd/containerd.sock version
DEBU[0000] get runtime connection                       
DEBU[0000] VersionRequest: &VersionRequest{Version:v1,} 
DEBU[0000] VersionResponse: &VersionResponse{Version:0.1.0,RuntimeName:containerd,RuntimeVersion:1.6.10,RuntimeApiVersion:v1,} 
Version:  0.1.0
RuntimeName:  containerd
RuntimeVersion:  1.6.10
RuntimeApiVersion:  v1
```

### Related issue
- Cri-tools were updated in #800, which caused the e2e sonobuoy test to slow from 2h to 4-5h
- Problem was that FixCilium failed because of the unset runtime-endpoint
- It is still unsure, what exactly caused this change in circtl behavior, as it worked before and I couldn't find any changes in the cri-tools changelog that would cause this change in behavior.
- Related issue is likely https://github.com/kubernetes-sigs/cri-tools/issues/1041
- This PR closes #817 

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
