### PR TITLE
versionsapi: fix cache invalidation

### DIFF
--- a/internal/versionsapi/versionsapi.go
+++ b/internal/versionsapi/versionsapi.go
@@ -163,12 +163,12 @@ func New() *Fetcher {
 
 // MinorVersionsOf fetches the list of minor versions for a given stream, major version and kind.
 func (f *Fetcher) MinorVersionsOf(ctx context.Context, ref, stream, major, kind string) (*List, error) {
-	return f.list(ctx, stream, "major", major, ref, kind)
+	return f.list(ctx, ref, stream, "major", major, kind)
 }
 
 // PatchVersionsOf fetches the list of patch versions for a given stream, minor version and kind.
 func (f *Fetcher) PatchVersionsOf(ctx context.Context, ref, stream, minor, kind string) (*List, error) {
-	return f.list(ctx, stream, "minor", minor, ref, kind)
+	return f.list(ctx, ref, stream, "minor", minor, kind)
 }
 
 // list fetches the list of versions for a given stream, granularity, base and kind.


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fixing a bug where the cached latest object wouldn't be invalidated
- Fixing a bug where the validation of the cache invalidation couldn't happen because of a faulty path

[Add 2](https://github.com/edgelesssys/constellation/actions/runs/3758060675/jobs/6386474516#step:8:53):

```
{"level":"INFO","ts":"2022-12-22T13:47:55Z","caller":"add-version/main.go:104","msg":"Waiting for cache invalidation."}
{"level":"WARN","ts":"2022-12-22T13:48:36Z","caller":"add-version/main.go:451","msg":"Failed to ensure minor version exists: fetching versions list: versions list \"[https://cdn.confidential.cloud/constellation/v1/ref/debug/stream/major/versions/v2/main/image.json\](https://cdn.confidential.cloud/constellation/v1/ref/debug/stream/major/versions/v2/main/image.json/)" does not exist. This may be resolved by waiting."}
{"level":"WARN","ts":"2022-12-22T13:48:36Z","caller":"add-version/main.go:456","msg":"Failed to ensure patch version exists: fetching versions list: versions list \"[https://cdn.confidential.cloud/constellation/v1/ref/debug/stream/minor/versions/v2.4/main/image.json\](https://cdn.confidential.cloud/constellation/v1/ref/debug/stream/minor/versions/v2.4/main/image.json/)" does not exist. This may be resolved by waiting."}
```

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
