### PR TITLE
gitignore: add image/prebuilt/*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ debug/
 
 # Image
 image/*.ign
+image/prebuilt/*
 image/build/*
 image/dependencies/bootstrapper
 image/dependencies/cilium


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- We download(?) an older prebuilt kernel for GCP. This folder was not ignored.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

