### PR TITLE
fix e2e lb test on aws: call hostname instead of ip

### DIFF
--- a/e2e/internal/lb/lb_test.go
+++ b/e2e/internal/lb/lb_test.go
@@ -45,7 +45,7 @@ func TestLoadBalancer(t *testing.T) {
 
 	// Wait for external IP to be registered
 	svc := testEventuallyExternalIPAvailable(t, k)
-	loadBalancerIP := svc.Status.LoadBalancer.Ingress[0].IP
+	loadBalancerIP := getIPOrHostname(t, svc)
 	loadBalancerPort := svc.Spec.Ports[0].Port
 	require.Equal(initialPort, loadBalancerPort)
 	url := buildURL(t, loadBalancerIP, loadBalancerPort)
@@ -74,6 +74,14 @@ func TestLoadBalancer(t *testing.T) {
 		allHostnames = testEndpointAvailable(t, newURL, allHostnames)
 	}
 	assert.True(hasNUniqueStrings(allHostnames, numPods))
+}
+
+func getIPOrHostname(t *testing.T, svc *coreV1.Service) string {
+	t.Helper()
+	if ip := svc.Status.LoadBalancer.Ingress[0].IP; ip != "" {
+		return ip
+	}
+	return svc.Status.LoadBalancer.Ingress[0].Hostname
 }
 
 func hasNUniqueStrings(elements []string, n int) bool {


### PR DESCRIPTION
Signed-off-by: Fabian Kammel <fk@edgeless.systems>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- AWS uses hostname (DNS) based loadblancer names as opposed to ip based for GCP and Azure

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
