### PR TITLE
Fix failing e2e test for lb

### DIFF
--- a/.github/actions/e2e_lb/action.yml
+++ b/.github/actions/e2e_lb/action.yml
@@ -28,4 +28,4 @@ runs:
       working-directory: ./.github/actions/e2e_lb
       run: |
         kubectl delete -f lb.yml
-        kubectl delete -f ns.yml
+        kubectl delete -f ns.yml --timeout=5m


### PR DESCRIPTION
Signed-off-by: Fabian Kammel <fk@edgeless.systems>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
Fix for failing [e2e pipeline](https://github.com/edgelesssys/constellation/actions/runs/3823897353/jobs/6505552497), where two things seem to have happened:

1. `kubectl delete -f ns.yaml` was hanging which caused the 6h timeout. I added a 5min timeout to delete.
2. Load balancer was not created in time.
    * Added more debug information
    * Increased timeout to 15min

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
