### PR TITLE
cli: ask user to confirm cert-manager upgrades

### DIFF
--- a/cli/internal/cloudcmd/upgrade.go
+++ b/cli/internal/cloudcmd/upgrade.go
@@ -109,8 +109,8 @@ func (u *Upgrader) GetCurrentImage(ctx context.Context) (*unstructured.Unstructu
 }
 
 // UpgradeHelmServices upgrade helm services.
-func (u *Upgrader) UpgradeHelmServices(ctx context.Context, config *config.Config, timeout time.Duration) error {
-	return u.helmClient.Upgrade(ctx, config, timeout)
+func (u *Upgrader) UpgradeHelmServices(ctx context.Context, config *config.Config, timeout time.Duration, allowDestructive bool) error {
+	return u.helmClient.Upgrade(ctx, config, timeout, allowDestructive)
 }
 
 // KubernetesVersion returns the version of Kubernetes the Constellation is currently running on.
@@ -234,7 +234,7 @@ func (u *stableClient) kubernetesVersion() (string, error) {
 }
 
 type helmInterface interface {
-	Upgrade(ctx context.Context, config *config.Config, timeout time.Duration) error
+	Upgrade(ctx context.Context, config *config.Config, timeout time.Duration, allowDestructive bool) error
 }
 
 type debugLog interface {

--- a/cli/internal/cmd/upgradeexecute.go
+++ b/cli/internal/cmd/upgradeexecute.go
@@ -8,10 +8,12 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
+	"github.com/edgelesssys/constellation/v2/cli/internal/helm"
 	"github.com/edgelesssys/constellation/v2/cli/internal/image"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
 	"github.com/edgelesssys/constellation/v2/internal/config"
@@ -30,6 +32,7 @@ func newUpgradeExecuteCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Bool("helm", false, "Execute helm upgrade. This feature is still in development an may change without anounncement. Upgrades all helm charts deployed during constellation-init.")
+	cmd.Flags().BoolP("yes", "y", false, "Run upgrades without further confirmation. WARNING: might delete your resources in case you are using cert-manager in your cluster. Please read the docs.")
 	cmd.Flags().Duration("timeout", 3*time.Minute, "Change helm upgrade timeout. This feature is still in development an may change without anounncement. Might be useful for slow connections or big clusters.")
 	if err := cmd.Flags().MarkHidden("helm"); err != nil {
 		panic(err)
@@ -59,27 +62,35 @@ func runUpgradeExecute(cmd *cobra.Command, args []string) error {
 }
 
 func upgradeExecute(cmd *cobra.Command, imageFetcher imageFetcher, upgrader cloudUpgrader, fileHandler file.Handler) error {
-	configPath, err := cmd.Flags().GetString("config")
+	flags, err := parseUpgradeExecuteFlags(cmd)
 	if err != nil {
-		return err
+		return fmt.Errorf("parsing flags: %w", err)
 	}
-	conf, err := config.New(fileHandler, configPath)
+	conf, err := config.New(fileHandler, flags.configPath)
 	if err != nil {
 		return displayConfigValidationErrors(cmd.ErrOrStderr(), err)
 	}
 
-	helm, err := cmd.Flags().GetBool("helm")
-	if err != nil {
-		return err
-	}
-	if helm {
-		timeout, err := cmd.Flags().GetDuration("timeout")
-		if err != nil {
-			return err
+	if flags.helmFlag {
+		err = upgrader.UpgradeHelmServices(cmd.Context(), conf, flags.upgradeTimeout, helm.DenyDestructive)
+		if errors.Is(err, helm.ErrConfirmationMissing) {
+			if !flags.yes {
+				cmd.PrintErrln("WARNING: Upgrading cert-manager will destroy all custom resources you have manually created that are based on the current version of cert-manager.")
+				ok, askErr := askToConfirm(cmd, "Do you want to upgrade cert-manager anyway?")
+				if askErr != nil {
+					return fmt.Errorf("asking for confirmation: %w", err)
+				}
+				if !ok {
+					cmd.Println("Aborting upgrade.")
+					return nil
+				}
+			}
+			err = upgrader.UpgradeHelmServices(cmd.Context(), conf, flags.upgradeTimeout, helm.AllowDestructive)
 		}
-		if err := upgrader.UpgradeHelmServices(cmd.Context(), conf, timeout); err != nil {
+		if err != nil {
 			return fmt.Errorf("upgrading helm: %w", err)
 		}
+
 		return nil
 	}
 
@@ -96,9 +107,39 @@ func upgradeExecute(cmd *cobra.Command, imageFetcher imageFetcher, upgrader clou
 	return upgrader.Upgrade(cmd.Context(), imageReference, conf.Upgrade.Image, conf.Upgrade.Measurements)
 }
 
+func parseUpgradeExecuteFlags(cmd *cobra.Command) (upgradeExecuteFlags, error) {
+	configPath, err := cmd.Flags().GetString("config")
+	if err != nil {
+		return upgradeExecuteFlags{}, err
+	}
+
+	helmFlag, err := cmd.Flags().GetBool("helm")
+	if err != nil {
+		return upgradeExecuteFlags{}, err
+	}
+
+	yes, err := cmd.Flags().GetBool("yes")
+	if err != nil {
+		return upgradeExecuteFlags{}, err
+	}
+
+	timeout, err := cmd.Flags().GetDuration("timeout")
+	if err != nil {
+		return upgradeExecuteFlags{}, err
+	}
+	return upgradeExecuteFlags{configPath: configPath, helmFlag: helmFlag, yes: yes, upgradeTimeout: timeout}, nil
+}
+
+type upgradeExecuteFlags struct {
+	configPath     string
+	helmFlag       bool
+	yes            bool
+	upgradeTimeout time.Duration
+}
+
 type cloudUpgrader interface {
 	Upgrade(ctx context.Context, imageReference, imageVersion string, measurements measurements.M) error
-	UpgradeHelmServices(ctx context.Context, config *config.Config, timeout time.Duration) error
+	UpgradeHelmServices(ctx context.Context, config *config.Config, timeout time.Duration, allowDestructive bool) error
 }
 
 type imageFetcher interface {

--- a/cli/internal/cmd/upgradeexecute_test.go
+++ b/cli/internal/cmd/upgradeexecute_test.go
@@ -75,7 +75,7 @@ func (u stubUpgrader) Upgrade(context.Context, string, string, measurements.M) e
 	return u.err
 }
 
-func (u stubUpgrader) UpgradeHelmServices(ctx context.Context, config *config.Config, timeout time.Duration) error {
+func (u stubUpgrader) UpgradeHelmServices(ctx context.Context, config *config.Config, timeout time.Duration, allowDestructive bool) error {
 	return u.helmErr
 }
 


### PR DESCRIPTION
### Proposed change(s)
- Since cert-manager upgrades change CRDs that the user might depend on we now ask for confirmation of the step. An unintended version upgrade will delete resources (e.g. cert-manager issuer) cluster users created.

### Related issue
- #631 


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->


- [x] Link to Milestone
