### PR TITLE
cli: deactivate spinner for debug logging

### DIFF
--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -49,9 +49,13 @@ func runCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("creating logger: %w", err)
 	}
 	defer log.Sync()
-	fileHandler := file.NewHandler(afero.NewOsFs())
-	spinner := newSpinner(cmd.ErrOrStderr())
+	spinner, err := newSpinnerOrStdout(cmd)
+	if err != nil {
+		return fmt.Errorf("creating spinner: %w", err)
+	}
 	defer spinner.Stop()
+
+	fileHandler := file.NewHandler(afero.NewOsFs())
 	creator := cloudcmd.NewCreator(spinner)
 	c := &createCmd{log: log}
 	return c.create(cmd, creator, fileHandler, spinner)

--- a/cli/internal/cmd/create_test.go
+++ b/cli/internal/cmd/create_test.go
@@ -213,7 +213,7 @@ func TestCreate(t *testing.T) {
 
 			fileHandler := file.NewHandler(tc.setupFs(require, tc.provider))
 			c := &createCmd{log: logger.NewTest(t)}
-			err := c.create(cmd, tc.creator, fileHandler, nopSpinner{})
+			err := c.create(cmd, tc.creator, fileHandler, &nopSpinner{})
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cmd/iamcreateaws_test.go
+++ b/cli/internal/cmd/iamcreateaws_test.go
@@ -100,7 +100,7 @@ func TestIAMCreateAWS(t *testing.T) {
 				require.NoError(cmd.Flags().Set("yes", "true"))
 			}
 
-			err := iamCreateAWS(cmd, nopSpinner{}, tc.creator)
+			err := iamCreateAWS(cmd, &nopSpinner{}, tc.creator)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cmd/iamcreateazure_test.go
+++ b/cli/internal/cmd/iamcreateazure_test.go
@@ -101,7 +101,7 @@ func TestIAMCreateAzure(t *testing.T) {
 				require.NoError(cmd.Flags().Set("yes", "true"))
 			}
 
-			err := iamCreateAzure(cmd, nopSpinner{}, tc.creator)
+			err := iamCreateAzure(cmd, &nopSpinner{}, tc.creator)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cmd/iamcreategcp_test.go
+++ b/cli/internal/cmd/iamcreategcp_test.go
@@ -123,7 +123,7 @@ func TestIAMCreateGCP(t *testing.T) {
 
 			fileHandler := file.NewHandler(tc.setupFs(require, tc.provider))
 
-			err := iamCreateGCP(cmd, nopSpinner{}, fileHandler, tc.creator)
+			err := iamCreateGCP(cmd, &nopSpinner{}, fileHandler, tc.creator)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -165,7 +165,7 @@ func TestInitialize(t *testing.T) {
 			defer cancel()
 			cmd.SetContext(ctx)
 			i := &initCmd{log: logger.NewTest(t)}
-			err := i.initialize(cmd, newDialer, fileHandler, &stubLicenseClient{}, nopSpinner{})
+			err := i.initialize(cmd, newDialer, fileHandler, &stubLicenseClient{}, &nopSpinner{})
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -415,7 +415,7 @@ func TestAttestation(t *testing.T) {
 	cmd.SetContext(ctx)
 
 	i := &initCmd{log: logger.NewTest(t)}
-	err := i.initialize(cmd, newDialer, fileHandler, &stubLicenseClient{}, nopSpinner{})
+	err := i.initialize(cmd, newDialer, fileHandler, &stubLicenseClient{}, &nopSpinner{})
 	assert.Error(err)
 	// make sure the error is actually a TLS handshake error
 	assert.Contains(err.Error(), "transport: authentication handshake failed")

--- a/cli/internal/cmd/terminate_test.go
+++ b/cli/internal/cmd/terminate_test.go
@@ -142,7 +142,7 @@ func TestTerminate(t *testing.T) {
 				require.NoError(cmd.Flags().Set("yes", "true"))
 			}
 
-			err := terminate(cmd, tc.terminator, fileHandler, nopSpinner{})
+			err := terminate(cmd, tc.terminator, fileHandler, &nopSpinner{})
 
 			if tc.wantErr {
 				assert.Error(err)


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Currently, the spinner is printed at the start of multiple lines when debug logging in the CLI is enabled. This PR fixes this behavior, leading to a cleaner debug log.


<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
