### PR TITLE
deps: fix kas-network-proxy registry prefix

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -68,12 +68,6 @@
       "groupName": "libvirt.org/go"
     },
     {
-      "matchPackagePatterns": [
-        "^registry.k8s.io/kas-network-proxy"
-      ],
-      "groupName": "registry.k8s.io/kas-network-proxy"
-    },
-    {
       "matchDatasources": [
         "golang-version"
       ],
@@ -131,7 +125,7 @@
     },
     {
       "matchPackageNames": [
-        "us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent",
+        "registry.k8s.io/kas-network-proxy/proxy-agent",
         "registry.k8s.io/kas-network-proxy/proxy-server"
       ],
       "versioning": "semver",


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Grouping maybe ins't working due to the outdated registry prefix of kas network proxy agent

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
