### PR TITLE
renovate: don't group k8s contstrained versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -97,14 +97,35 @@
     },
     {
       "matchPackageNames": [
-        "kubernetes/kubernetes",
-        "registry.k8s.io/provider-aws/cloud-controller-manager",
+        "kubernetes/kubernetes"
+      ],
+      "versioning": "regex:^(?<compatibility>v?\\d+\\.\\d+\\.)(?<patch>\\d+)$",
+      "groupName": "Kubernetes versions",
+      "prPriority": 15
+    },
+    {
+      "matchPackageNames": [
+        "registry.k8s.io/provider-aws/cloud-controller-manager"
+      ],
+      "versioning": "regex:^(?<compatibility>v?\\d+\\.\\d+\\.)(?<patch>\\d+)$",
+      "groupName": "K8s constrained AWS versions",
+      "prPriority": 15
+    },
+    {
+      "matchPackageNames": [
         "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager",
-        "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager",
+        "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager"
+      ],
+      "versioning": "regex:^(?<compatibility>v?\\d+\\.\\d+\\.)(?<patch>\\d+)$",
+      "groupName": "K8s constrained Azure versions",
+      "prPriority": 15
+    },
+    {
+      "matchPackageNames": [
         "registry.k8s.io/autoscaling/cluster-autoscaler"
       ],
       "versioning": "regex:^(?<compatibility>v?\\d+\\.\\d+\\.)(?<patch>\\d+)$",
-      "groupName": "K8s constrained versions",
+      "groupName": "K8s constrained GCP versions",
       "prPriority": 15
     },
     {


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Don't group these as they are not released together and often cause cloud provider specific problems.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
