### PR TITLE
ci: increase Go test timeout in e2e lb

### DIFF
--- a/.github/actions/e2e_lb/action.yml
+++ b/.github/actions/e2e_lb/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         kubectl apply -f ns.yml
         kubectl apply -f lb.yml
-        go test ../../../e2e/internal/lb/lb_test.go -v
+        go test -timeout=3h ../../../e2e/internal/lb/lb_test.go -v
 
     - name: Delete deployment
       if: always()


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Increase go test timeout, which defaults to 10m

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
