### PR TITLE
upgrade: fix broken reference from constellation-os to constellation-version

### DIFF
--- a/cli/internal/cloudcmd/upgrade.go
+++ b/cli/internal/cloudcmd/upgrade.go
@@ -198,7 +198,7 @@ func (u *dynamicClient) getCurrent(ctx context.Context, name string) (*unstructu
 	return u.client.Resource(schema.GroupVersionResource{
 		Group:    "update.edgeless.systems",
 		Version:  "v1alpha1",
-		Resource: "nodeimages",
+		Resource: "nodeversions",
 	}).Get(ctx, name, metav1.GetOptions{})
 }
 
@@ -207,7 +207,7 @@ func (u *dynamicClient) update(ctx context.Context, obj *unstructured.Unstructur
 	return u.client.Resource(schema.GroupVersionResource{
 		Group:    "update.edgeless.systems",
 		Version:  "v1alpha1",
-		Resource: "nodeimages",
+		Resource: "nodeversions",
 	}).Update(ctx, obj, metav1.UpdateOptions{})
 }
 

--- a/cli/internal/cloudcmd/upgrade.go
+++ b/cli/internal/cloudcmd/upgrade.go
@@ -82,7 +82,7 @@ func (u *Upgrader) Upgrade(ctx context.Context, imageReference, imageVersion str
 
 // GetCurrentImage returns the currently used image version of the cluster.
 func (u *Upgrader) GetCurrentImage(ctx context.Context) (*unstructured.Unstructured, string, error) {
-	imageStruct, err := u.dynamicInterface.getCurrent(ctx, "constellation-os")
+	imageStruct, err := u.dynamicInterface.getCurrent(ctx, "constellation-version")
 	if err != nil {
 		return nil, "", err
 	}

--- a/internal/kubernetes/kubectl/kubectl_test.go
+++ b/internal/kubernetes/kubectl/kubectl_test.go
@@ -18,7 +18,7 @@ func TestParseCRDs(t *testing.T) {
 		wantErr bool
 	}{
 		"success": {
-			data:    "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: nodeimages.update.edgeless.systems\nspec:\n  group: update.edgeless.systems\n  names:\n    kind: NodeImage\n",
+			data:    "apiVersion: apiextensions.k8s.io/v1\nkind: CustomResourceDefinition\nmetadata:\n  name: nodeversions.update.edgeless.systems\nspec:\n  group: update.edgeless.systems\n  names:\n    kind: NodeImage\n",
 			wantErr: false,
 		},
 		"wrong kind": {

--- a/operators/constellation-node-operator/README.md
+++ b/operators/constellation-node-operator/README.md
@@ -24,7 +24,7 @@ Example for GCP:
 apiVersion: update.edgeless.systems/v1alpha1
 kind: NodeVersion
 metadata:
-  name: constellation-os
+  name: constellation-version
 spec:
   image: "projects/constellation-images/global/images/<image-name>"
 ```
@@ -34,7 +34,7 @@ Example for Azure:
 apiVersion: update.edgeless.systems/v1alpha1
 kind: NodeVersion
 metadata:
-  name: constellation-os
+  name: constellation-version
 spec:
   image: "/subscriptions/<subscription-id>/resourceGroups/CONSTELLATION-IMAGES/providers/Microsoft.Compute/galleries/Constellation/images/<image-definition-name>/versions/<image-version>"
 ```
@@ -70,7 +70,7 @@ kind: ScalingGroup
 metadata:
   name: scalinggroup-worker
 spec:
-  nodeImage: "constellation-os"
+  nodeImage: "constellation-version"
   groupId: "projects/<project-id>/zones/<zone>/instanceGroupManagers/<instance-group-name>"
   autoscaling: true
 ```
@@ -83,7 +83,7 @@ kind: ScalingGroup
 metadata:
   name: scalinggroup-worker
 spec:
-  nodeImage: "constellation-os"
+  nodeImage: "constellation-version"
   groupId: "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Compute/virtualMachineScaleSets/<scale-set-name>"
   autoscaling: true
 ```

--- a/operators/constellation-node-operator/config/samples/update_v1alpha1_nodeversion.yaml
+++ b/operators/constellation-node-operator/config/samples/update_v1alpha1_nodeversion.yaml
@@ -1,7 +1,7 @@
 apiVersion: update.edgeless.systems/v1alpha1
 kind: NodeVersion
 metadata:
-  name: constellation-os-azure
+  name: constellation-version-azure
   namespace: kube-system
 spec:
   image: "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Compute/galleries/<gallery-name>/images/<image-definition-name>/versions/<version>"
@@ -9,7 +9,7 @@ spec:
 apiVersion: update.edgeless.systems/v1alpha1
 kind: NodeVersion
 metadata:
-  name: constellation-os-gcp
+  name: constellation-version-gcp
   namespace: kube-system
 spec:
   image: projects/<project>/global/images/<image-name>

--- a/operators/constellation-node-operator/config/samples/update_v1alpha1_scalinggroup.yaml
+++ b/operators/constellation-node-operator/config/samples/update_v1alpha1_scalinggroup.yaml
@@ -4,7 +4,7 @@ metadata:
   name: scalinggroup-worker-azure
   namespace: kube-system
 spec:
-  nodeImage: "constellation-os-azure"
+  nodeImage: "constellation-version-azure"
   groupId: "/subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.Compute/virtualMachineScaleSets/<scale-set-name>"
   autoscaling: true
 ---
@@ -14,6 +14,6 @@ metadata:
   name: scalinggroup-worker-gcp
   namespace: kube-system
 spec:
-  nodeImage: "constellation-os-gcp"
+  nodeImage: "constellation-version-gcp"
   groupId: "projects/<project>/zones/<zone>/instanceGroupManagers/<instance-group-name>"
   autoscaling: true


### PR DESCRIPTION
Signed-off-by: Fabian Kammel <fk@edgeless.systems>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- update nodeversion references

Should we also update constellation-os-azure|gcp? @malt3 
- /operators/constellation-node-operator/config/samples/update_v1alpha1_nodeversion.yaml
- /operators/constellation-node-operator/config/samples/update_v1alpha1_scalinggroup.yaml

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
