### PR TITLE
cli: iam destroy

### DIFF
--- a/cli/internal/cloudcmd/clients.go
+++ b/cli/internal/cloudcmd/clients.go
@@ -13,6 +13,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
+	tfjson "github.com/hashicorp/terraform-json"
 )
 
 type terraformClient interface {
@@ -22,6 +23,7 @@ type terraformClient interface {
 	Destroy(ctx context.Context) error
 	CleanUpWorkspace() error
 	RemoveInstaller()
+	Show(ctx context.Context) (*tfjson.State, error)
 }
 
 type libvirtRunner interface {

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
+	tfjson "github.com/hashicorp/terraform-json"
 
 	"go.uber.org/goleak"
 )
@@ -30,6 +31,7 @@ type stubTerraformClient struct {
 	initSecret             string
 	iamOutput              terraform.IAMOutput
 	uid                    string
+	tfjsonState            *tfjson.State
 	cleanUpWorkspaceCalled bool
 	removeInstallerCalled  bool
 	destroyCalled          bool
@@ -38,6 +40,7 @@ type stubTerraformClient struct {
 	prepareWorkspaceErr    error
 	cleanUpWorkspaceErr    error
 	iamOutputErr           error
+	showErr                error
 }
 
 func (c *stubTerraformClient) CreateCluster(ctx context.Context) (terraform.CreateOutput, error) {
@@ -68,6 +71,10 @@ func (c *stubTerraformClient) CleanUpWorkspace() error {
 
 func (c *stubTerraformClient) RemoveInstaller() {
 	c.removeInstallerCalled = true
+}
+
+func (c *stubTerraformClient) Show(ctx context.Context) (*tfjson.State, error) {
+	return c.tfjsonState, c.showErr
 }
 
 type stubLibvirtRunner struct {

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -35,6 +35,7 @@ type stubTerraformClient struct {
 	cleanUpWorkspaceCalled bool
 	removeInstallerCalled  bool
 	destroyCalled          bool
+	showCalled             bool
 	createClusterErr       error
 	destroyErr             error
 	prepareWorkspaceErr    error
@@ -74,6 +75,7 @@ func (c *stubTerraformClient) RemoveInstaller() {
 }
 
 func (c *stubTerraformClient) Show(ctx context.Context) (*tfjson.State, error) {
+	c.showCalled = true
 	return c.tfjsonState, c.showErr
 }
 

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -93,8 +93,8 @@ func (d *IAMDestroyer) deleteGCPKeyFile(ctx context.Context, fsHandler file.Hand
 	return true, nil
 }
 
-// DestroyIAMUser destroys the previously created IAM User and deletes the local IAM terraform files.
-func (d *IAMDestroyer) DestroyIAMUser(ctx context.Context) error {
+// DestroyIAMConfiguration destroys the previously created IAM User and deletes the local IAM terraform files.
+func (d *IAMDestroyer) DestroyIAMConfiguration(ctx context.Context) error {
 	cl, err := d.newTerraformClient(ctx)
 	if err != nil {
 		return err

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -24,7 +24,8 @@ func DestroyIAMUser(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	return c.DestroyCluster(ctx)
+	c.Destroy(ctx)
+	return c.CleanUpWorkspace()
 }
 
 // IAMCreator creates the IAM configuration on the cloud provider.

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -66,7 +66,7 @@ func (d *IAMDestroyer) deleteGCPKeyFile(ctx context.Context, fsHandler file.Hand
 
 	saKeyString, ok := saKeyJSON.Value.(string)
 	if !ok {
-		return false, nil
+		return false, errors.New("sa_key field in terraform state is not a string")
 	}
 	saKey, err := base64.StdEncoding.DecodeString(saKeyString)
 	if err != nil {

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -20,7 +20,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/cloud/gcpshared"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
-	"github.com/spf13/afero"
 )
 
 type IAMDestroyer struct {
@@ -37,7 +36,7 @@ func NewIAMDestroyer(ctx context.Context) *IAMDestroyer {
 }
 
 // DeleteGCPServiceAccountKeyFile deletes gcpServiceAccountKey.json if the IAM users in TerraformIAMWorkingDir and the file match up
-func (d *IAMDestroyer) DeleteGCPServiceAccountKeyFile(ctx context.Context) (bool, error) {
+func (d *IAMDestroyer) DeleteGCPServiceAccountKeyFile(ctx context.Context, fsHandler file.Handler) (bool, error) {
 	cl, err := d.newTerraformClient(ctx)
 	if err != nil {
 		return false, err
@@ -58,12 +57,11 @@ func (d *IAMDestroyer) DeleteGCPServiceAccountKeyFile(ctx context.Context) (bool
 
 	var tfSaKey gcpshared.ServiceAccountKey
 	var fileSaKey gcpshared.ServiceAccountKey
-	fsHandler := file.NewHandler(afero.NewOsFs())
 
 	if err := json.Unmarshal(saKey, &tfSaKey); err != nil {
 		return false, err
 	}
-	if err := fsHandler.ReadJSON("gcpServiceAccountKey.json", &fileSaKey); err != nil {
+	if err := fsHandler.ReadJSON(constants.GCPServiceAccountKeyFile, &fileSaKey); err != nil {
 		return false, err
 	}
 
@@ -71,7 +69,7 @@ func (d *IAMDestroyer) DeleteGCPServiceAccountKeyFile(ctx context.Context) (bool
 		return false, nil
 	}
 
-	if err := fsHandler.Remove("gcpServiceAccountKey.json"); err != nil {
+	if err := fsHandler.Remove(constants.GCPServiceAccountKeyFile); err != nil {
 		return false, err
 	}
 	return true, nil

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -22,7 +22,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 )
 
-// IAMDestroyer destroys an IAM user and deletes their configuration.
+// IAMDestroyer destroys an IAM configuration.
 type IAMDestroyer struct {
 	newTerraformClient func(ctx context.Context) (terraformClient, error)
 }

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -24,11 +24,12 @@ import (
 	"github.com/spf13/afero"
 )
 
+// IAMDestroyer destroys an IAM user and deletes their configuration.
 type IAMDestroyer struct {
 	newTerraformClient func(ctx context.Context) (terraformClient, error)
 }
 
-// NewIAMDestroyer creates a new IAM Destroyer
+// NewIAMDestroyer creates a new IAM Destroyer.
 func NewIAMDestroyer(ctx context.Context) *IAMDestroyer {
 	return &IAMDestroyer{
 		newTerraformClient: func(ctx context.Context) (terraformClient, error) {
@@ -36,6 +37,8 @@ func NewIAMDestroyer(ctx context.Context) *IAMDestroyer {
 		},
 	}
 }
+
+// RunDeleteGCPKeyFile deletes gcpServiceAccountKey.json if the IAM users in TerraformIAMWorkingDir and the file match up.
 func (d *IAMDestroyer) RunDeleteGCPKeyFile(ctx context.Context) (bool, error) {
 	fsHandler := file.NewHandler(afero.NewOsFs())
 	cl, err := d.newTerraformClient(ctx)
@@ -46,7 +49,6 @@ func (d *IAMDestroyer) RunDeleteGCPKeyFile(ctx context.Context) (bool, error) {
 	return d.deleteGCPKeyFile(ctx, fsHandler, cl)
 }
 
-// DeleteGCPKeyFile deletes gcpServiceAccountKey.json if the IAM users in TerraformIAMWorkingDir and the file match up
 func (d *IAMDestroyer) deleteGCPKeyFile(ctx context.Context, fsHandler file.Handler, cl terraformClient) (bool, error) {
 	tfState, err := cl.Show(ctx)
 	if err != nil {

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -46,6 +46,11 @@ func (d *IAMDestroyer) DeleteGCPServiceAccountKeyFile(ctx context.Context, fsHan
 	if err != nil {
 		return false, err
 	}
+
+	if tfState.Values == nil {
+		return false, nil
+	}
+
 	saKeyJSON, containsKey := tfState.Values.Outputs["sa_key"]
 	if !containsKey {
 		return false, nil

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -59,11 +59,16 @@ func (d *IAMDestroyer) deleteGCPKeyFile(ctx context.Context, fsHandler file.Hand
 		return false, errors.New("no Values field in terraform state")
 	}
 
-	saKeyJSON, containsKey := tfState.Values.Outputs["sa_key"]
-	if !containsKey {
+	saKeyJSON := tfState.Values.Outputs["sa_key"]
+	if saKeyJSON == nil {
 		return false, nil
 	}
-	saKey, err := base64.StdEncoding.DecodeString(fmt.Sprintf("%v", saKeyJSON.Value))
+
+	saKeyString, ok := saKeyJSON.Value.(string)
+	if !ok {
+		return false, nil
+	}
+	saKey, err := base64.StdEncoding.DecodeString(saKeyString)
 	if err != nil {
 		return false, err
 	}

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -18,7 +18,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 )
 
-// DestroyIAMUser destroys the previously created IAM User and deletes the local IAM terraform files
+// DestroyIAMUser destroys the previously created IAM User and deletes the local IAM terraform files.
 func DestroyIAMUser(ctx context.Context) error {
 	c, err := terraform.New(ctx, constants.TerraformIAMWorkingDir)
 	if err != nil {

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -24,7 +24,9 @@ func DestroyIAMUser(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	c.Destroy(ctx)
+	if err = c.Destroy(ctx); err != nil {
+		return err
+	}
 	return c.CleanUpWorkspace()
 }
 

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -62,7 +62,6 @@ func (d *IAMDestroyer) GetTfstateServiceAccountKey(ctx context.Context) (gcpshar
 	}
 
 	var tfSaKey gcpshared.ServiceAccountKey
-
 	if err := json.Unmarshal(saKey, &tfSaKey); err != nil {
 		return gcpshared.ServiceAccountKey{}, err
 	}

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -38,11 +38,7 @@ func NewIAMDestroyer(ctx context.Context) (*IAMDestroyer, error) {
 
 // GetTfstateServiceAccountKey returns the sa_key output from the terraform state.
 func (d *IAMDestroyer) GetTfstateServiceAccountKey(ctx context.Context) (gcpshared.ServiceAccountKey, error) {
-	return d.getTfstateServiceAccountKey(ctx, d.client)
-}
-
-func (d *IAMDestroyer) getTfstateServiceAccountKey(ctx context.Context, cl terraformClient) (gcpshared.ServiceAccountKey, error) {
-	tfState, err := cl.Show(ctx)
+	tfState, err := d.client.Show(ctx)
 	if err != nil {
 		return gcpshared.ServiceAccountKey{}, err
 	}

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -48,7 +49,7 @@ func (d *IAMDestroyer) DeleteGCPServiceAccountKeyFile(ctx context.Context, fsHan
 	}
 
 	if tfState.Values == nil {
-		return false, nil
+		return false, errors.New("No Values field in terraform state")
 	}
 
 	saKeyJSON, containsKey := tfState.Values.Outputs["sa_key"]

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -18,16 +18,29 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 )
 
+type IAMDestroyer struct {
+	newTerraformClient func(ctx context.Context) (terraformClient, error)
+}
+
+// NewIAMDestroyer creates a new IAM Destroyer
+func NewIAMDestroyer(ctx context.Context) *IAMDestroyer {
+	return &IAMDestroyer{
+		newTerraformClient: func(ctx context.Context) (terraformClient, error) {
+			return terraform.New(ctx, constants.TerraformIAMWorkingDir)
+		},
+	}
+}
+
 // DestroyIAMUser destroys the previously created IAM User and deletes the local IAM terraform files.
-func DestroyIAMUser(ctx context.Context) error {
-	c, err := terraform.New(ctx, constants.TerraformIAMWorkingDir)
+func (d *IAMDestroyer) DestroyIAMUser(ctx context.Context) error {
+	cl, err := d.newTerraformClient(ctx)
 	if err != nil {
 		return err
 	}
-	if err = c.Destroy(ctx); err != nil {
+	if err := cl.Destroy(ctx); err != nil {
 		return err
 	}
-	return c.CleanUpWorkspace()
+	return cl.CleanUpWorkspace()
 }
 
 // IAMCreator creates the IAM configuration on the cloud provider.

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -36,12 +36,12 @@ func NewIAMDestroyer(ctx context.Context) (*IAMDestroyer, error) {
 	return &IAMDestroyer{client: cl}, nil
 }
 
-// RunGetTfstateSaKey returns the sa_key output from the terraform state.
-func (d *IAMDestroyer) RunGetTfstateSaKey(ctx context.Context) (gcpshared.ServiceAccountKey, error) {
-	return d.getTfstateSaKey(ctx, d.client)
+// GetTfstateServiceAccountKey returns the sa_key output from the terraform state.
+func (d *IAMDestroyer) GetTfstateServiceAccountKey(ctx context.Context) (gcpshared.ServiceAccountKey, error) {
+	return d.getTfstateServiceAccountKey(ctx, d.client)
 }
 
-func (d *IAMDestroyer) getTfstateSaKey(ctx context.Context, cl terraformClient) (gcpshared.ServiceAccountKey, error) {
+func (d *IAMDestroyer) getTfstateServiceAccountKey(ctx context.Context, cl terraformClient) (gcpshared.ServiceAccountKey, error) {
 	tfState, err := cl.Show(ctx)
 	if err != nil {
 		return gcpshared.ServiceAccountKey{}, err

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/iamid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
+	"github.com/edgelesssys/constellation/v2/internal/file"
+	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -187,6 +190,171 @@ func TestDestroyIAMUser(t *testing.T) {
 				assert.Error(err)
 			} else {
 				assert.NoError(err)
+			}
+		})
+	}
+}
+
+func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
+	dummyTfstate := `
+	 {
+	 	"version": 4,
+	 	"terraform_version": "1.3.6",
+	 	"serial": 8,
+	 	"lineage": "",
+	 	"outputs": {
+	 	  "sa_key": {
+	 		"value": "ewoJCSJhdXRoX3Byb3ZpZGVyX3g1MDlfY2VydF91cmwiOiAiIiwKCQkiYXV0aF91cmkiOiAiIiwKCQkiY2xpZW50X2VtYWlsIjogIiIsCgkJImNsaWVudF9pZCI6ICIiLAoJCSJjbGllbnRfeDUwOV9jZXJ0X3VybCI6ICIiLAoJCSJwcml2YXRlX2tleSI6ICJJQU1BTkVYQU1QTEUiLAoJCSJwcml2YXRlX2tleV9pZCI6ICIiLAoJCSJwcm9qZWN0X2lkIjogIiIsCgkJInRva2VuX3VyaSI6ICIiLAoJCSJ0eXBlIjogIiIKCX0=",
+	 		"type": "string",
+	 		"sensitive": true
+	 	  }
+	 	},
+	 	"resources": [
+	 	  {
+	 		"mode": "managed",
+	 		"type": "google_project_iam_binding",
+	 		"name": "iam_service_account_user_role",
+	 		"provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+	 		"instances": [
+	 		  {
+	 			"schema_version": 0,
+	 			"attributes": {
+	 			  "condition": [],
+	 			  "etag": "",
+	 			  "id": "",
+	 			  "members": [
+	 				""
+	 			  ],
+	 			  "project": "",
+	 			  "role": ""
+	 			},
+	 			"sensitive_attributes": [],
+	 			"private": "",
+	 			"dependencies": [
+	 			  "google_service_account.service_account"
+	 			]
+	 		  }
+	 		]
+	 	  }
+	 	],
+	 	"check_results": null
+	   }
+	 `
+	dummyTfstateNoKey := `
+	 {
+	 	"version": 4,
+	 	"terraform_version": "1.3.6",
+	 	"serial": 8,
+	 	"lineage": "",
+	 	"outputs": {},
+	 	"resources": [
+	 	  {
+	 		"mode": "managed",
+	 		"type": "google_project_iam_binding",
+	 		"name": "iam_service_account_user_role",
+	 		"provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
+	 		"instances": [
+	 		  {
+	 			"schema_version": 0,
+	 			"attributes": {
+	 			  "condition": [],
+	 			  "etag": "",
+	 			  "id": "",
+	 			  "members": [
+	 				""
+	 			  ],
+	 			  "project": "",
+	 			  "role": ""
+	 			},
+	 			"sensitive_attributes": [],
+	 			"private": "",
+	 			"dependencies": [
+	 			  "google_service_account.service_account"
+	 			]
+	 		  }
+	 		]
+	 	  }
+	 	],
+	 	"check_results": null
+	   }
+	 `
+
+	dummyGCPKeyFile := `
+	  {
+	  	"auth_provider_x509_cert_url": "",
+	  	"auth_uri": "",
+	  	"client_email": "",
+	  	"client_id": "",
+	  	"client_x509_cert_url": "",
+	  	"private_key": "IAMANEXAMPLE",
+	  	"private_key_id": "",
+	  	"project_id": "",
+	  	"token_uri": "",
+	  	"type": ""
+	  }
+	  `
+	dummyInvalidGCPKeyFile := `
+	 {
+	 	"auth_provider_x509_cert_url": "",
+	 	"auth_uri": "",
+	 	"client_email": "",
+	 	"client_id": "",
+	 	"client_x509_cert_url": "",
+	 	"private_key": "IAMWRONG",
+	 	"private_key_id": "",
+	 	"project_id": "",
+	 	"token_uri": "",
+	 	"type": ""
+	 }
+	 `
+
+	fsWithGCPFile := file.NewHandler(afero.NewMemMapFs())
+	fsWithoutGCPFile := file.NewHandler(afero.NewMemMapFs())
+	fsWithUnmatchingConfig := file.NewHandler(afero.NewMemMapFs())
+	fsNoKey := file.NewHandler(afero.NewMemMapFs())
+
+	// tfstate setup
+	fsNoKey.MkdirAll(constants.TerraformIAMWorkingDir)
+	fsWithGCPFile.MkdirAll(constants.TerraformIAMWorkingDir)
+	fsWithoutGCPFile.MkdirAll(constants.TerraformIAMWorkingDir)
+	fsWithUnmatchingConfig.MkdirAll(constants.TerraformIAMWorkingDir)
+	fsNoKey.Write(constants.TerraformIAMWorkingDir+"/terraform.tfstate", []byte(dummyTfstateNoKey))
+	fsWithGCPFile.Write(constants.TerraformIAMWorkingDir+"/terraform.tfstate", []byte(dummyTfstate))
+	fsWithoutGCPFile.Write(constants.TerraformIAMWorkingDir+"/terraform.tfstate", []byte(dummyTfstate))
+	fsWithUnmatchingConfig.Write(constants.TerraformIAMWorkingDir+"/terraform.tfstate", []byte(dummyTfstate))
+
+	// keyfile setup
+	fsNoKey.Write(constants.GCPServiceAccountKeyFile, []byte(dummyGCPKeyFile))
+	fsWithGCPFile.Write(constants.GCPServiceAccountKeyFile, []byte(dummyGCPKeyFile))
+	fsWithUnmatchingConfig.Write(constants.GCPServiceAccountKeyFile, []byte(dummyInvalidGCPKeyFile))
+
+	testCases := map[string]struct {
+		fsHandler  file.Handler
+		wantErr    bool
+		wantDelete bool
+	}{
+		"no key": {
+			fsHandler: fsNoKey,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			destroyer := NewIAMDestroyer(context.Background())
+			deleted, err := destroyer.DeleteGCPServiceAccountKeyFile(context.Background(), tc.fsHandler)
+
+			if tc.wantErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+
+			if tc.wantDelete {
+				assert.True(deleted)
+			} else {
+				assert.False(deleted)
 			}
 		})
 	}

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -195,16 +195,9 @@ func TestDestroyIAMConfiguration(t *testing.T) {
 			} else {
 				assert.NoError(err)
 			}
-			if tc.wantDestroyCalled {
-				assert.True(tc.tfClient.destroyCalled)
-			} else {
-				assert.False(tc.tfClient.destroyCalled)
-			}
-			if tc.wantCleanupWorkspaceCalled {
-				assert.True(tc.tfClient.cleanUpWorkspaceCalled)
-			} else {
-				assert.False(tc.tfClient.cleanUpWorkspaceCalled)
-			}
+
+			assert.Equal(tc.wantDestroyCalled, tc.tfClient.destroyCalled)
+			assert.Equal(tc.wantCleanupWorkspaceCalled, tc.tfClient.cleanUpWorkspaceCalled)
 		})
 	}
 }
@@ -229,7 +222,7 @@ func TestGetTfstateServiceAccountKey(t *testing.T) {
 	gcpFileB64 := base64.StdEncoding.EncodeToString([]byte(gcpFile))
 
 	testCases := map[string]struct {
-		cl             terraformClient
+		cl             *stubTerraformClient
 		wantValidSaKey bool
 		wantErr        bool
 		wantShowCalled bool
@@ -340,11 +333,7 @@ func TestGetTfstateServiceAccountKey(t *testing.T) {
 
 				assert.Equal(saKey, saKeyComp)
 			}
-			if tc.wantShowCalled {
-				assert.True(destroyer.client.(*stubTerraformClient).showCalled)
-			} else {
-				assert.False(destroyer.client.(*stubTerraformClient).showCalled)
-			}
+			assert.Equal(tc.wantShowCalled, tc.cl.showCalled)
 		})
 	}
 }

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -190,10 +190,7 @@ func TestDestroyIAMUser(t *testing.T) {
 }
 
 func TestGetTfstateServiceAccountKey(t *testing.T) {
-	require := require.New(t)
 	someError := errors.New("failed")
-	destroyer, err := NewIAMDestroyer(context.Background())
-	require.NoError(err)
 
 	gcpFile := `
 	{
@@ -300,7 +297,9 @@ func TestGetTfstateServiceAccountKey(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			saKey, err := destroyer.getTfstateServiceAccountKey(context.Background(), tc.cl)
+			destroyer := IAMDestroyer{client: tc.cl}
+
+			saKey, err := destroyer.GetTfstateServiceAccountKey(context.Background())
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -310,7 +309,7 @@ func TestGetTfstateServiceAccountKey(t *testing.T) {
 
 			if tc.wantValidSaKey {
 				var saKeyComp gcpshared.ServiceAccountKey
-				require.NoError(json.Unmarshal([]byte(gcpFile), &saKeyComp))
+				require.NoError(t, json.Unmarshal([]byte(gcpFile), &saKeyComp))
 
 				assert.Equal(saKey, saKeyComp)
 			}

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -343,6 +343,20 @@ func TestDeleteGCPKeyFile(t *testing.T) {
 				},
 			},
 		},
+		"not string": {
+			fsHandler: newValidTestFs(),
+			cl: &stubTerraformClient{
+				tfjsonState: &tfjson.State{
+					Values: &tfjson.StateValues{
+						Outputs: map[string]*tfjson.StateOutput{
+							"sa_key": {
+								Value: 1,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for name, tc := range testCases {

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -148,3 +148,8 @@ func TestIAMCreator(t *testing.T) {
 		})
 	}
 }
+
+func TestDestroyIAMUser(t *testing.T) {
+	assert := assert.New(t)
+	assert.NoError(DestroyIAMUser(context.Background()))
+}

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -154,7 +154,7 @@ func TestIAMCreator(t *testing.T) {
 	}
 }
 
-func TestDestroyIAMUser(t *testing.T) {
+func TestDestroyIAMConfiguration(t *testing.T) {
 	newError := func() error {
 		return errors.New("failed")
 	}

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -324,15 +324,14 @@ func TestGetTfstateServiceAccountKey(t *testing.T) {
 
 			if tc.wantErr {
 				assert.Error(err)
-			} else {
-				assert.NoError(err)
+				return
 			}
-			if tc.wantValidSaKey {
-				var saKeyComp gcpshared.ServiceAccountKey
-				require.NoError(t, json.Unmarshal([]byte(gcpFile), &saKeyComp))
+			assert.NoError(err)
 
-				assert.Equal(saKey, saKeyComp)
-			}
+			var saKeyComp gcpshared.ServiceAccountKey
+			require.NoError(t, json.Unmarshal([]byte(gcpFile), &saKeyComp))
+
+			assert.Equal(saKey, saKeyComp)
 			assert.Equal(tc.wantShowCalled, tc.cl.showCalled)
 		})
 	}

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -189,7 +189,7 @@ func TestDestroyIAMUser(t *testing.T) {
 				},
 			}
 
-			err := destroyer.DestroyIAMUser(context.Background())
+			err := destroyer.DestroyIAMConfiguration(context.Background())
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -189,7 +189,7 @@ func TestDestroyIAMUser(t *testing.T) {
 	}
 }
 
-func TestGetTfstateSaKey(t *testing.T) {
+func TestGetTfstateServiceAccountKey(t *testing.T) {
 	require := require.New(t)
 	someError := errors.New("failed")
 	destroyer, err := NewIAMDestroyer(context.Background())
@@ -300,7 +300,7 @@ func TestGetTfstateSaKey(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			saKey, err := destroyer.getTfstateSaKey(context.Background(), tc.cl)
+			saKey, err := destroyer.getTfstateServiceAccountKey(context.Background(), tc.cl)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -14,8 +14,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/iamid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
-	"github.com/hashicorp/terraform-exec/tfexec"
-	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -195,28 +193,4 @@ func TestDestroyIAMUser(t *testing.T) {
 }
 
 func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
-}
-
-type stubTerraform struct {
-	applyErr   error
-	destroyErr error
-	initErr    error
-	showErr    error
-	showState  *tfjson.State
-}
-
-func (s *stubTerraform) Apply(context.Context, ...tfexec.ApplyOption) error {
-	return s.applyErr
-}
-
-func (s *stubTerraform) Destroy(context.Context, ...tfexec.DestroyOption) error {
-	return s.destroyErr
-}
-
-func (s *stubTerraform) Init(context.Context, ...tfexec.InitOption) error {
-	return s.initErr
-}
-
-func (s *stubTerraform) Show(context.Context, ...tfexec.ShowOption) (*tfjson.State, error) {
-	return s.showState, s.showErr
 }

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -199,7 +199,7 @@ func TestDestroyIAMUser(t *testing.T) {
 	}
 }
 
-func TestDeleteGCPKeyFile(t *testing.T) {
+func TestGetTfstateSaKey(t *testing.T) {
 	someError := errors.New("failed")
 	destroyer := NewIAMDestroyer(context.Background())
 
@@ -217,36 +217,7 @@ func TestDeleteGCPKeyFile(t *testing.T) {
 		"type": ""
 	}
 	`
-	// gcpFileNotSame := `
-	// {
-	// 	"auth_provider_x509_cert_url": "",
-	// 	"auth_uri": "",
-	// 	"client_email": "",
-	// 	"client_id": "",
-	// 	"client_x509_cert_url": "",
-	// 	"private_key": "NOTTHESAME",
-	// 	"private_key_id": "",
-	// 	"project_id": "",
-	// 	"token_uri": "",
-	// 	"type": ""
-	// }
-	// `
 	gcpFileB64 := base64.StdEncoding.EncodeToString([]byte(gcpFile))
-	// gcpFileNotSameB64 := base64.StdEncoding.EncodeToString([]byte(gcpFileNotSame))
-
-	// newValidTestFs := func() file.Handler {
-	// 	fs := file.NewHandler(afero.NewMemMapFs())
-	// 	require.NoError(fs.Write(constants.GCPServiceAccountKeyFile, []byte(gcpFile)))
-	// 	return fs
-	// }
-
-	// newInvalidTestFs := func() file.Handler {
-	// 	fs := file.NewHandler(afero.NewMemMapFs())
-	// 	require.NoError(fs.Write(constants.GCPServiceAccountKeyFile, []byte(`
-	// 	asdf
-	// 	`)))
-	// 	return fs
-	// }
 
 	testCases := map[string]struct {
 		cl             terraformClient
@@ -287,6 +258,7 @@ func TestDeleteGCPKeyFile(t *testing.T) {
 					Values: &tfjson.StateValues{},
 				},
 			},
+			wantErr: true,
 		},
 		"invalid base64": {
 			cl: &stubTerraformClient{

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -356,6 +356,7 @@ func TestDeleteGCPKeyFile(t *testing.T) {
 					},
 				},
 			},
+			wantErr: true,
 		},
 	}
 

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -160,7 +160,7 @@ func TestDestroyIAMConfiguration(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		tfClient                   terraformClient
+		tfClient                   *stubTerraformClient
 		wantErr                    bool
 		wantDestroyCalled          bool
 		wantCleanupWorkspaceCalled bool
@@ -196,14 +196,14 @@ func TestDestroyIAMConfiguration(t *testing.T) {
 				assert.NoError(err)
 			}
 			if tc.wantDestroyCalled {
-				assert.True(destroyer.client.(*stubTerraformClient).destroyCalled)
+				assert.True(tc.tfClient.destroyCalled)
 			} else {
-				assert.False(destroyer.client.(*stubTerraformClient).destroyCalled)
+				assert.False(tc.tfClient.destroyCalled)
 			}
 			if tc.wantCleanupWorkspaceCalled {
-				assert.True(destroyer.client.(*stubTerraformClient).cleanUpWorkspaceCalled)
+				assert.True(tc.tfClient.cleanUpWorkspaceCalled)
 			} else {
-				assert.False(destroyer.client.(*stubTerraformClient).cleanUpWorkspaceCalled)
+				assert.False(tc.tfClient.cleanUpWorkspaceCalled)
 			}
 		})
 	}

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -170,6 +170,10 @@ func TestDestroyIAMUser(t *testing.T) {
 		"destroy": {
 			tfClient: &stubTerraformClient{},
 		},
+		"cleanup error": {
+			tfClient: &stubTerraformClient{cleanUpWorkspaceErr: newError()},
+			wantErr:  true,
+		},
 	}
 
 	for name, tc := range testCases {

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -14,9 +14,8 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/iamid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
-	"github.com/edgelesssys/constellation/v2/internal/constants"
-	"github.com/edgelesssys/constellation/v2/internal/file"
-	"github.com/spf13/afero"
+	"github.com/hashicorp/terraform-exec/tfexec"
+	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -196,166 +195,28 @@ func TestDestroyIAMUser(t *testing.T) {
 }
 
 func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
-	dummyTfstate := `
-	 {
-	 	"version": 4,
-	 	"terraform_version": "1.3.6",
-	 	"serial": 8,
-	 	"lineage": "",
-	 	"outputs": {
-	 	  "sa_key": {
-	 		"value": "ewoJCSJhdXRoX3Byb3ZpZGVyX3g1MDlfY2VydF91cmwiOiAiIiwKCQkiYXV0aF91cmkiOiAiIiwKCQkiY2xpZW50X2VtYWlsIjogIiIsCgkJImNsaWVudF9pZCI6ICIiLAoJCSJjbGllbnRfeDUwOV9jZXJ0X3VybCI6ICIiLAoJCSJwcml2YXRlX2tleSI6ICJJQU1BTkVYQU1QTEUiLAoJCSJwcml2YXRlX2tleV9pZCI6ICIiLAoJCSJwcm9qZWN0X2lkIjogIiIsCgkJInRva2VuX3VyaSI6ICIiLAoJCSJ0eXBlIjogIiIKCX0=",
-	 		"type": "string",
-	 		"sensitive": true
-	 	  }
-	 	},
-	 	"resources": [
-	 	  {
-	 		"mode": "managed",
-	 		"type": "google_project_iam_binding",
-	 		"name": "iam_service_account_user_role",
-	 		"provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
-	 		"instances": [
-	 		  {
-	 			"schema_version": 0,
-	 			"attributes": {
-	 			  "condition": [],
-	 			  "etag": "",
-	 			  "id": "",
-	 			  "members": [
-	 				""
-	 			  ],
-	 			  "project": "",
-	 			  "role": ""
-	 			},
-	 			"sensitive_attributes": [],
-	 			"private": "",
-	 			"dependencies": [
-	 			  "google_service_account.service_account"
-	 			]
-	 		  }
-	 		]
-	 	  }
-	 	],
-	 	"check_results": null
-	   }
-	 `
-	dummyTfstateNoKey := `
-	 {
-	 	"version": 4,
-	 	"terraform_version": "1.3.6",
-	 	"serial": 8,
-	 	"lineage": "",
-	 	"outputs": {},
-	 	"resources": [
-	 	  {
-	 		"mode": "managed",
-	 		"type": "google_project_iam_binding",
-	 		"name": "iam_service_account_user_role",
-	 		"provider": "provider[\"registry.terraform.io/hashicorp/google\"]",
-	 		"instances": [
-	 		  {
-	 			"schema_version": 0,
-	 			"attributes": {
-	 			  "condition": [],
-	 			  "etag": "",
-	 			  "id": "",
-	 			  "members": [
-	 				""
-	 			  ],
-	 			  "project": "",
-	 			  "role": ""
-	 			},
-	 			"sensitive_attributes": [],
-	 			"private": "",
-	 			"dependencies": [
-	 			  "google_service_account.service_account"
-	 			]
-	 		  }
-	 		]
-	 	  }
-	 	],
-	 	"check_results": null
-	   }
-	 `
+}
 
-	dummyGCPKeyFile := `
-	  {
-	  	"auth_provider_x509_cert_url": "",
-	  	"auth_uri": "",
-	  	"client_email": "",
-	  	"client_id": "",
-	  	"client_x509_cert_url": "",
-	  	"private_key": "IAMANEXAMPLE",
-	  	"private_key_id": "",
-	  	"project_id": "",
-	  	"token_uri": "",
-	  	"type": ""
-	  }
-	  `
-	dummyInvalidGCPKeyFile := `
-	 {
-	 	"auth_provider_x509_cert_url": "",
-	 	"auth_uri": "",
-	 	"client_email": "",
-	 	"client_id": "",
-	 	"client_x509_cert_url": "",
-	 	"private_key": "IAMWRONG",
-	 	"private_key_id": "",
-	 	"project_id": "",
-	 	"token_uri": "",
-	 	"type": ""
-	 }
-	 `
+type stubTerraform struct {
+	applyErr   error
+	destroyErr error
+	initErr    error
+	showErr    error
+	showState  *tfjson.State
+}
 
-	fsWithGCPFile := file.NewHandler(afero.NewMemMapFs())
-	fsWithoutGCPFile := file.NewHandler(afero.NewMemMapFs())
-	fsWithUnmatchingConfig := file.NewHandler(afero.NewMemMapFs())
-	fsNoKey := file.NewHandler(afero.NewMemMapFs())
+func (s *stubTerraform) Apply(context.Context, ...tfexec.ApplyOption) error {
+	return s.applyErr
+}
 
-	// tfstate setup
-	fsNoKey.MkdirAll(constants.TerraformIAMWorkingDir)
-	fsWithGCPFile.MkdirAll(constants.TerraformIAMWorkingDir)
-	fsWithoutGCPFile.MkdirAll(constants.TerraformIAMWorkingDir)
-	fsWithUnmatchingConfig.MkdirAll(constants.TerraformIAMWorkingDir)
-	fsNoKey.Write(constants.TerraformIAMWorkingDir+"/terraform.tfstate", []byte(dummyTfstateNoKey))
-	fsWithGCPFile.Write(constants.TerraformIAMWorkingDir+"/terraform.tfstate", []byte(dummyTfstate))
-	fsWithoutGCPFile.Write(constants.TerraformIAMWorkingDir+"/terraform.tfstate", []byte(dummyTfstate))
-	fsWithUnmatchingConfig.Write(constants.TerraformIAMWorkingDir+"/terraform.tfstate", []byte(dummyTfstate))
+func (s *stubTerraform) Destroy(context.Context, ...tfexec.DestroyOption) error {
+	return s.destroyErr
+}
 
-	// keyfile setup
-	fsNoKey.Write(constants.GCPServiceAccountKeyFile, []byte(dummyGCPKeyFile))
-	fsWithGCPFile.Write(constants.GCPServiceAccountKeyFile, []byte(dummyGCPKeyFile))
-	fsWithUnmatchingConfig.Write(constants.GCPServiceAccountKeyFile, []byte(dummyInvalidGCPKeyFile))
+func (s *stubTerraform) Init(context.Context, ...tfexec.InitOption) error {
+	return s.initErr
+}
 
-	testCases := map[string]struct {
-		fsHandler  file.Handler
-		wantErr    bool
-		wantDelete bool
-	}{
-		"no key": {
-			fsHandler: fsNoKey,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			assert := assert.New(t)
-
-			destroyer := NewIAMDestroyer(context.Background())
-			deleted, err := destroyer.DeleteGCPServiceAccountKeyFile(context.Background(), tc.fsHandler)
-
-			if tc.wantErr {
-				assert.Error(err)
-			} else {
-				assert.NoError(err)
-			}
-
-			if tc.wantDelete {
-				assert.True(deleted)
-			} else {
-				assert.False(deleted)
-			}
-		})
-	}
+func (s *stubTerraform) Show(context.Context, ...tfexec.ShowOption) (*tfjson.State, error) {
+	return s.showState, s.showErr
 }

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -19,6 +19,7 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIAMCreator(t *testing.T) {
@@ -197,11 +198,12 @@ func TestDestroyIAMUser(t *testing.T) {
 }
 
 func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
+	require := require.New(t)
 	someError := errors.New("failed")
 	destroyer := NewIAMDestroyer(context.Background())
 
 	testFsValid := file.NewHandler(afero.NewMemMapFs())
-	testFsValid.Write(constants.GCPServiceAccountKeyFile, []byte(`
+	require.NoError(testFsValid.Write(constants.GCPServiceAccountKeyFile, []byte(`
 	{
 		"auth_provider_x509_cert_url": "",
 		"auth_uri": "",
@@ -214,11 +216,11 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 		"token_uri": "",
 		"type": ""
 	}
-	`))
+	`)))
 	testFsInvalid := file.NewHandler(afero.NewMemMapFs())
-	testFsInvalid.Write(constants.GCPServiceAccountKeyFile, []byte(`
+	require.NoError(testFsInvalid.Write(constants.GCPServiceAccountKeyFile, []byte(`
 	asdf
-	`))
+	`)))
 
 	validTfClient := &stubTerraformClient{
 		tfjsonState: &tfjson.State{

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -163,7 +163,7 @@ func TestDestroyIAMUser(t *testing.T) {
 			wantErr:        true,
 		},
 		"destroy error": {
-			tfClient: &stubTerraformClient{destroyClusterErr: someError},
+			tfClient: &stubTerraformClient{destroyErr: someError},
 			wantErr:  true,
 		},
 		"destroy": {

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -197,7 +197,7 @@ func TestDestroyIAMUser(t *testing.T) {
 	}
 }
 
-func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
+func TestDeleteGCPKeyFile(t *testing.T) {
 	require := require.New(t)
 	someError := errors.New("failed")
 	destroyer := NewIAMDestroyer(context.Background())
@@ -329,6 +329,20 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 
 			if tc.wantDeleted {
 				assert.True(deleted)
+				require.NoError(testFsValid.Write(constants.GCPServiceAccountKeyFile, []byte(`
+			{
+				"auth_provider_x509_cert_url": "",
+				"auth_uri": "",
+				"client_email": "",
+				"client_id": "",
+				"client_x509_cert_url": "",
+				"private_key": "",
+				"private_key_id": "",
+				"project_id": "",
+				"token_uri": "",
+				"type": ""
+			}
+			`)))
 			} else {
 				assert.False(deleted)
 			}

--- a/cli/internal/cmd/cloud.go
+++ b/cli/internal/cmd/cloud.go
@@ -35,9 +35,8 @@ type cloudIAMCreator interface {
 }
 
 type iamDestroyer interface {
-	DestroyIAMUser(
-		ctx context.Context,
-	) error
+	DestroyIAMUser(ctx context.Context) error
+	DeleteGCPServiceAccountKeyFile(ctx context.Context) (bool, error)
 }
 
 type cloudTerminator interface {

--- a/cli/internal/cmd/cloud.go
+++ b/cli/internal/cmd/cloud.go
@@ -14,7 +14,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/iamid"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
-	"github.com/edgelesssys/constellation/v2/internal/file"
 )
 
 type cloudCreator interface {
@@ -37,7 +36,7 @@ type cloudIAMCreator interface {
 
 type iamDestroyer interface {
 	DestroyIAMUser(ctx context.Context) error
-	DeleteGCPServiceAccountKeyFile(ctx context.Context, fsHandler file.Handler) (bool, error)
+	RunDeleteGCPKeyFile(ctx context.Context) (bool, error)
 }
 
 type cloudTerminator interface {

--- a/cli/internal/cmd/cloud.go
+++ b/cli/internal/cmd/cloud.go
@@ -14,6 +14,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/iamid"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
+	"github.com/edgelesssys/constellation/v2/internal/file"
 )
 
 type cloudCreator interface {
@@ -36,7 +37,7 @@ type cloudIAMCreator interface {
 
 type iamDestroyer interface {
 	DestroyIAMUser(ctx context.Context) error
-	DeleteGCPServiceAccountKeyFile(ctx context.Context) (bool, error)
+	DeleteGCPServiceAccountKeyFile(ctx context.Context, fsHandler file.Handler) (bool, error)
 }
 
 type cloudTerminator interface {

--- a/cli/internal/cmd/cloud.go
+++ b/cli/internal/cmd/cloud.go
@@ -37,7 +37,7 @@ type cloudIAMCreator interface {
 
 type iamDestroyer interface {
 	DestroyIAMConfiguration(ctx context.Context) error
-	RunGetTfstateSaKey(ctx context.Context) (gcpshared.ServiceAccountKey, error)
+	GetTfstateServiceAccountKey(ctx context.Context) (gcpshared.ServiceAccountKey, error)
 }
 
 type cloudTerminator interface {

--- a/cli/internal/cmd/cloud.go
+++ b/cli/internal/cmd/cloud.go
@@ -34,6 +34,12 @@ type cloudIAMCreator interface {
 	) (iamid.File, error)
 }
 
+type iamDestroyer interface {
+	DestroyIAMUser(
+		ctx context.Context,
+	) error
+}
+
 type cloudTerminator interface {
 	Terminate(context.Context) error
 }

--- a/cli/internal/cmd/cloud.go
+++ b/cli/internal/cmd/cloud.go
@@ -13,6 +13,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/iamid"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
+	"github.com/edgelesssys/constellation/v2/internal/cloud/gcpshared"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 )
 
@@ -36,7 +37,7 @@ type cloudIAMCreator interface {
 
 type iamDestroyer interface {
 	DestroyIAMConfiguration(ctx context.Context) error
-	RunDeleteGCPKeyFile(ctx context.Context) (bool, error)
+	RunGetTfstateSaKey(ctx context.Context) (gcpshared.ServiceAccountKey, error)
 }
 
 type cloudTerminator interface {

--- a/cli/internal/cmd/cloud.go
+++ b/cli/internal/cmd/cloud.go
@@ -35,7 +35,7 @@ type cloudIAMCreator interface {
 }
 
 type iamDestroyer interface {
-	DestroyIAMUser(ctx context.Context) error
+	DestroyIAMConfiguration(ctx context.Context) error
 	RunDeleteGCPKeyFile(ctx context.Context) (bool, error)
 }
 

--- a/cli/internal/cmd/cloud_test.go
+++ b/cli/internal/cmd/cloud_test.go
@@ -81,7 +81,7 @@ type stubIAMDestroyer struct {
 	deleteGCPFileErr    error
 }
 
-func (d *stubIAMDestroyer) DestroyIAMUser(ctx context.Context) error {
+func (d *stubIAMDestroyer) DestroyIAMConfiguration(ctx context.Context) error {
 	d.destroyCalled = true
 	return d.destroyErr
 }

--- a/cli/internal/cmd/cloud_test.go
+++ b/cli/internal/cmd/cloud_test.go
@@ -74,11 +74,19 @@ func (c *stubIAMCreator) Create(
 }
 
 type stubIAMDestroyer struct {
-	destroyCalled bool
-	destroyErr    error
+	destroyCalled       bool
+	deleteGCPFileCalled bool
+	deletedGCPFile      bool
+	destroyErr          error
+	deleteGCPFileErr    error
 }
 
 func (d *stubIAMDestroyer) DestroyIAMUser(ctx context.Context) error {
 	d.destroyCalled = true
 	return d.destroyErr
+}
+
+func (d *stubIAMDestroyer) DeleteGCPServiceAccountKeyFile(ctx context.Context) (bool, error) {
+	d.deleteGCPFileCalled = true
+	return d.deletedGCPFile, d.deleteGCPFileErr
 }

--- a/cli/internal/cmd/cloud_test.go
+++ b/cli/internal/cmd/cloud_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/iamid"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
+	"github.com/edgelesssys/constellation/v2/internal/cloud/gcpshared"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"go.uber.org/goleak"
 )
@@ -75,10 +76,10 @@ func (c *stubIAMCreator) Create(
 
 type stubIAMDestroyer struct {
 	destroyCalled       bool
-	deleteGCPFileCalled bool
-	deletedGCPFile      bool
+	getTfstateKeyCalled bool
+	gcpSaKey            gcpshared.ServiceAccountKey
 	destroyErr          error
-	deleteGCPFileErr    error
+	getTfstateKeyErr    error
 }
 
 func (d *stubIAMDestroyer) DestroyIAMConfiguration(ctx context.Context) error {
@@ -86,7 +87,7 @@ func (d *stubIAMDestroyer) DestroyIAMConfiguration(ctx context.Context) error {
 	return d.destroyErr
 }
 
-func (d *stubIAMDestroyer) RunDeleteGCPKeyFile(ctx context.Context) (bool, error) {
-	d.deleteGCPFileCalled = true
-	return d.deletedGCPFile, d.deleteGCPFileErr
+func (d *stubIAMDestroyer) RunGetTfstateSaKey(ctx context.Context) (gcpshared.ServiceAccountKey, error) {
+	d.getTfstateKeyCalled = true
+	return d.gcpSaKey, d.getTfstateKeyErr
 }

--- a/cli/internal/cmd/cloud_test.go
+++ b/cli/internal/cmd/cloud_test.go
@@ -87,7 +87,7 @@ func (d *stubIAMDestroyer) DestroyIAMConfiguration(ctx context.Context) error {
 	return d.destroyErr
 }
 
-func (d *stubIAMDestroyer) RunGetTfstateSaKey(ctx context.Context) (gcpshared.ServiceAccountKey, error) {
+func (d *stubIAMDestroyer) GetTfstateServiceAccountKey(ctx context.Context) (gcpshared.ServiceAccountKey, error) {
 	d.getTfstateKeyCalled = true
 	return d.gcpSaKey, d.getTfstateKeyErr
 }

--- a/cli/internal/cmd/cloud_test.go
+++ b/cli/internal/cmd/cloud_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/iamid"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
-	"github.com/edgelesssys/constellation/v2/internal/file"
 	"go.uber.org/goleak"
 )
 
@@ -87,7 +86,7 @@ func (d *stubIAMDestroyer) DestroyIAMUser(ctx context.Context) error {
 	return d.destroyErr
 }
 
-func (d *stubIAMDestroyer) DeleteGCPServiceAccountKeyFile(ctx context.Context, fsHandler file.Handler) (bool, error) {
+func (d *stubIAMDestroyer) RunDeleteGCPKeyFile(ctx context.Context) (bool, error) {
 	d.deleteGCPFileCalled = true
 	return d.deletedGCPFile, d.deleteGCPFileErr
 }

--- a/cli/internal/cmd/cloud_test.go
+++ b/cli/internal/cmd/cloud_test.go
@@ -72,3 +72,13 @@ func (c *stubIAMCreator) Create(
 	c.id.CloudProvider = provider
 	return c.id, c.createErr
 }
+
+type stubIAMDestroyer struct {
+	destroyCalled bool
+	destroyErr    error
+}
+
+func (d *stubIAMDestroyer) DestroyIAMUser(ctx context.Context) error {
+	d.destroyCalled = true
+	return d.destroyErr
+}

--- a/cli/internal/cmd/cloud_test.go
+++ b/cli/internal/cmd/cloud_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/iamid"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
+	"github.com/edgelesssys/constellation/v2/internal/file"
 	"go.uber.org/goleak"
 )
 
@@ -86,7 +87,7 @@ func (d *stubIAMDestroyer) DestroyIAMUser(ctx context.Context) error {
 	return d.destroyErr
 }
 
-func (d *stubIAMDestroyer) DeleteGCPServiceAccountKeyFile(ctx context.Context) (bool, error) {
+func (d *stubIAMDestroyer) DeleteGCPServiceAccountKeyFile(ctx context.Context, fsHandler file.Handler) (bool, error) {
 	d.deleteGCPFileCalled = true
 	return d.deletedGCPFile, d.deleteGCPFileErr
 }

--- a/cli/internal/cmd/iam.go
+++ b/cli/internal/cmd/iam.go
@@ -570,7 +570,7 @@ func newIAMDestroyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "destroy",
 		Short: "Destroy an IAM user and delete local terraform files for the IAM user",
-		Long:  "Destroy an IAM user and delete local terraform files for the IAM user",
+		Long:  "Destroy an IAM user and delete local terraform files for the IAM user.",
 		Args:  cobra.ExactArgs(0),
 		RunE:  runDestroyIAMUser,
 	}

--- a/cli/internal/cmd/iam.go
+++ b/cli/internal/cmd/iam.go
@@ -575,26 +575,3 @@ func newIAMDestroyCmd() *cobra.Command {
 		RunE:  destroyIAMUserHandler,
 	}
 }
-
-func destroyIAMUserHandler(cmd *cobra.Command, _args []string) error {
-	spinner := newSpinner(cmd.ErrOrStderr())
-
-	// Confirmation
-	ok, err := askToConfirm(cmd, "Do you really want to destroy your IAM user?")
-	if err != nil {
-		return err
-	}
-	if !ok {
-		fmt.Println("The destruction of the IAM user was aborted")
-		return nil
-	}
-
-	spinner.Start("Destroying IAM User", false)
-	defer spinner.Stop()
-
-	if err := cloudcmd.NewIAMDestroyer(cmd.Context()).DestroyIAMUser(cmd.Context()); err != nil {
-		return fmt.Errorf("Couldn't destroy IAM User: %w", err)
-	}
-	fmt.Println("Successfully destroyed IAM User")
-	return nil
-}

--- a/cli/internal/cmd/iam.go
+++ b/cli/internal/cmd/iam.go
@@ -572,7 +572,7 @@ func newIAMDestroyCmd() *cobra.Command {
 		Short: "Destroy an IAM user and delete local terraform files for the IAM user",
 		Long:  "Destroy an IAM user and delete local terraform files for the IAM user.",
 		Args:  cobra.ExactArgs(0),
-		RunE:  runDestroyIAMUser,
+		RunE:  runIAMDestroy,
 	}
 
 	cmd.Flags().BoolP("yes", "y", false, "destroy the IAM configuration without asking for confirmation")

--- a/cli/internal/cmd/iam.go
+++ b/cli/internal/cmd/iam.go
@@ -567,11 +567,15 @@ func parseIDFile(serviceAccountKeyBase64 string) (map[string]string, error) {
 
 // NewIAMDestroyCmd returns a new cobra.Command for the iam destroy subcommand.
 func newIAMDestroyCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "destroy",
 		Short: "Destroy an IAM user and delete local terraform files for the IAM user",
 		Long:  "Destroy an IAM user and delete local terraform files for the IAM user",
 		Args:  cobra.ExactArgs(0),
-		RunE:  destroyIAMUserHandler,
+		RunE:  runDestroyIAMUser,
 	}
+
+	cmd.Flags().BoolP("yes", "y", false, "destroy the IAM configuration without asking for confirmation")
+
+	return cmd
 }

--- a/cli/internal/cmd/iam.go
+++ b/cli/internal/cmd/iam.go
@@ -569,8 +569,8 @@ func parseIDFile(serviceAccountKeyBase64 string) (map[string]string, error) {
 func newIAMDestroyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "destroy",
-		Short: "Destroy an IAM user and delete local terraform files for the IAM user",
-		Long:  "Destroy an IAM user and delete local terraform files for the IAM user.",
+		Short: "Destroy an IAM configuration and delete local terraform files",
+		Long:  "Destroy an IAM configuration and delete local terraform files.",
 		Args:  cobra.ExactArgs(0),
 		RunE:  runIAMDestroy,
 	}

--- a/cli/internal/cmd/iam.go
+++ b/cli/internal/cmd/iam.go
@@ -578,11 +578,23 @@ func newIAMDestroyCmd() *cobra.Command {
 
 func destroyIAMUserHandler(cmd *cobra.Command, _args []string) error {
 	spinner := newSpinner(cmd.ErrOrStderr())
+
+	// Confirmation
+	ok, err := askToConfirm(cmd, "Do you really want to destroy your IAM user?")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		fmt.Println("The destruction of the IAM user was aborted")
+		return nil
+	}
+
 	spinner.Start("Destroying IAM User", false)
 	defer spinner.Stop()
 
 	if err := cloudcmd.NewIAMDestroyer(cmd.Context()).DestroyIAMUser(cmd.Context()); err != nil {
 		return fmt.Errorf("Couldn't destroy IAM User: %w", err)
 	}
+	fmt.Println("Successfully destroyed IAM User")
 	return nil
 }

--- a/cli/internal/cmd/iam.go
+++ b/cli/internal/cmd/iam.go
@@ -581,7 +581,7 @@ func destroyIAMUserHandler(cmd *cobra.Command, _args []string) error {
 	spinner.Start("Destroying IAM User", false)
 	defer spinner.Stop()
 
-	if err := cloudcmd.DestroyIAMUser(cmd.Context()); err != nil {
+	if err := cloudcmd.NewIAMDestroyer(cmd.Context()).DestroyIAMUser(cmd.Context()); err != nil {
 		return fmt.Errorf("Couldn't destroy IAM User: %w", err)
 	}
 	return nil

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -45,14 +45,12 @@ func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destr
 	c.log.Debugf("Checking if %s exists", constants.AdminConfFilename)
 	_, err := fsHandler.Stat(constants.AdminConfFilename)
 	if !errors.Is(err, os.ErrNotExist) {
-		cmd.Printf("The file %s still exists, please make sure to terminate your cluster before destroying your IAM configuration.\n", constants.AdminConfFilename)
-		return nil
+		return errors.New("file " + constants.AdminConfFilename + " still exists, please make sure to terminate your cluster before destroying your IAM configuration")
 	}
 	c.log.Debugf("Checking if %s exists", constants.ClusterIDsFileName)
 	_, err = fsHandler.Stat(constants.ClusterIDsFileName)
 	if !errors.Is(err, os.ErrNotExist) {
-		cmd.Printf("The file %s still exists, please make sure to terminate your cluster before destroying your IAM configuration.\n", constants.ClusterIDsFileName)
-		return nil
+		return errors.New("file " + constants.ClusterIDsFileName + " still exists, please make sure to terminate your cluster before destroying your IAM configuration")
 	}
 
 	yes, err := cmd.Flags().GetBool("yes")

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -114,15 +114,6 @@ func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destr
 }
 
 func (c *destroyCmd) deleteGCPServiceAccountKeyFile(cmd *cobra.Command, destroyer iamDestroyer, fsHandler file.Handler) (bool, error) {
-	c.log.Debugf("Checking if %q exists", constants.GCPServiceAccountKeyFile)
-	if _, err := fsHandler.Stat(constants.GCPServiceAccountKeyFile); err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return false, err
-		}
-		c.log.Debugf("File %q doesn't exist", constants.GCPServiceAccountKeyFile)
-		return true, nil // file just doesn't exist
-	}
-
 	var fileSaKey gcpshared.ServiceAccountKey
 
 	c.log.Debugf("Parsing %q", constants.GCPServiceAccountKeyFile)

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
+	"github.com/edgelesssys/constellation/v2/internal/file"
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -33,6 +35,45 @@ func destroyIAMUser(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDest
 		if !ok {
 			fmt.Println("The destruction of the IAM user was aborted")
 			return nil
+		}
+	}
+
+	fsHandler := file.NewHandler(afero.NewOsFs())
+	if _, err := fsHandler.Stat("gcpServiceAccountKey.json"); err == nil {
+		if !yes {
+			ok, err := askToConfirm(cmd, "There seems to be a gcpServiceAccountKey.json file. Do you want to delete it? (Note that you may not be able to save generated private keys for GCP if the file exists)")
+			if err != nil {
+				return err
+			}
+			if ok {
+				destroyed, err := destroyer.DeleteGCPServiceAccountKeyFile(cmd.Context())
+				if err != nil {
+					return err
+				}
+				if !destroyed {
+					ok, err := askToConfirm(cmd, "The file gcpServiceAccountKey.json could not be deleted. Either it does not exist or the file belongs to another IAM user. Do you want to proceed anyway?")
+					if err != nil {
+						return err
+					}
+					if !ok {
+						return nil
+					}
+				}
+			}
+		} else {
+			destroyed, err := destroyer.DeleteGCPServiceAccountKeyFile(cmd.Context())
+			if err != nil {
+				return err
+			}
+			if !destroyed {
+				ok, err := askToConfirm(cmd, "The file gcpServiceAccountKey.json could not be deleted. Either it does not exist or the file belongs to another IAM user. Do you want to proceed anyway?")
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return nil
+				}
+			}
 		}
 	}
 

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -70,11 +70,12 @@ func destroyIAMUser(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDest
 	}
 
 	spinner.Start("Destroying IAM User", false)
+	defer spinner.Stop()
 	if err := destroyer.DestroyIAMUser(cmd.Context()); err != nil {
 		return fmt.Errorf("couldn't destroy IAM User: %w", err)
 	}
 
-	spinner.Stop()
+	spinner.Stop() // stop the spinner to print a new line
 	fmt.Println("Successfully destroyed IAM User")
 	return nil
 }

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -25,7 +25,10 @@ func runIAMDestroy(cmd *cobra.Command, _args []string) error {
 	}
 	defer log.Sync()
 	spinner := newSpinner(cmd.ErrOrStderr())
-	destroyer := cloudcmd.NewIAMDestroyer(cmd.Context())
+	destroyer, err := cloudcmd.NewIAMDestroyer(cmd.Context())
+	if err != nil {
+		return err
+	}
 	fsHandler := file.NewHandler(afero.NewOsFs())
 
 	c := &destroyCmd{log: log}

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -47,7 +47,7 @@ func destroyIAMUser(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDest
 	spinner.Start("Destroying IAM User", false)
 
 	if err := destroyer.DestroyIAMUser(cmd.Context()); err != nil {
-		return fmt.Errorf("Couldn't destroy IAM User: %w", err)
+		return fmt.Errorf("couldn't destroy IAM User: %w", err)
 	}
 	spinner.Stop()
 	fmt.Println("Successfully destroyed IAM User")
@@ -74,7 +74,7 @@ func deleteGCPServiceAccountKeyFile(cmd *cobra.Command, destroyer iamDestroyer, 
 		}
 	}
 
-	destroyed, err := destroyer.DeleteGCPServiceAccountKeyFile(cmd.Context(), fsHandler)
+	destroyed, err := destroyer.RunDeleteGCPKeyFile(cmd.Context())
 	if err != nil {
 		return false, err
 	}

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -80,7 +80,10 @@ func destroyIAMUser(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDest
 
 func deleteGCPServiceAccountKeyFile(cmd *cobra.Command, destroyer iamDestroyer, fsHandler file.Handler) (bool, error) {
 	if _, err := fsHandler.Stat(constants.GCPServiceAccountKeyFile); err != nil {
-		return true, err // file doesn't exist
+		if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+		return true, err // file just doesn't exist
 	}
 
 	destroyed, err := destroyer.RunDeleteGCPKeyFile(cmd.Context())

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -85,7 +85,7 @@ func deleteGCPServiceAccountKeyFile(cmd *cobra.Command, destroyer iamDestroyer, 
 		if !errors.Is(err, os.ErrNotExist) {
 			return false, err
 		}
-		return true, err // file just doesn't exist
+		return true, nil // file just doesn't exist
 	}
 
 	destroyed, err := destroyer.RunDeleteGCPKeyFile(cmd.Context())

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -133,13 +133,7 @@ func (c *destroyCmd) deleteGCPServiceAccountKeyFile(cmd *cobra.Command, destroye
 	}
 
 	if err := fsHandler.Remove(constants.GCPServiceAccountKeyFile); err != nil {
-		ok, err := askToConfirm(cmd, "The file gcpServiceAccountKey.json could not be deleted. Either it does not exist or the file belongs to another IAM configuration. Do you want to proceed anyway?")
-		if err != nil {
-			return false, err
-		}
-		if !ok {
-			return false, nil
-		}
+		return false, err
 	}
 
 	c.log.Debugf("Successfully deleted %q", constants.GCPServiceAccountKeyFile)

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -57,7 +57,6 @@ func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destr
 	if err != nil {
 		return err
 	}
-
 	c.log.Debugf("\"yes\" flag is set to %t", yes)
 
 	gcpFileExists := false

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -22,10 +22,10 @@ func runIAMDestroy(cmd *cobra.Command, _args []string) error {
 	destroyer := cloudcmd.NewIAMDestroyer(cmd.Context())
 	fsHandler := file.NewHandler(afero.NewOsFs())
 
-	return destroyIAM(cmd, spinner, destroyer, fsHandler)
+	return iamDestroy(cmd, spinner, destroyer, fsHandler)
 }
 
-func destroyIAM(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDestroyer, fsHandler file.Handler) error {
+func iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDestroyer, fsHandler file.Handler) error {
 	yes, err := cmd.Flags().GetBool("yes")
 	if err != nil {
 		return err

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -129,6 +129,7 @@ func (c *destroyCmd) deleteGCPServiceAccountKeyFile(cmd *cobra.Command, destroye
 
 	c.log.Debugf("Checking if keys are the same")
 	if tfSaKey != fileSaKey {
+		c.log.Debugf("Keys are not the same, aborting")
 		return false, nil
 	}
 

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -136,7 +136,7 @@ func (c *destroyCmd) deleteGCPServiceAccountKeyFile(cmd *cobra.Command, destroye
 	}
 
 	c.log.Debugf("Getting service account key from the tfstate")
-	tfSaKey, err := destroyer.RunGetTfstateSaKey(cmd.Context())
+	tfSaKey, err := destroyer.GetTfstateServiceAccountKey(cmd.Context())
 	if err != nil {
 		return false, err
 	}

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -69,14 +69,14 @@ func destroyIAMUser(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDest
 		}
 	}
 
-	spinner.Start("Destroying IAM User", false)
+	spinner.Start("Destroying IAM user", false)
 	defer spinner.Stop()
 	if err := destroyer.DestroyIAMUser(cmd.Context()); err != nil {
-		return fmt.Errorf("couldn't destroy IAM User: %w", err)
+		return fmt.Errorf("destroying IAM user: %w", err)
 	}
 
 	spinner.Stop() // stop the spinner to print a new line
-	fmt.Println("Successfully destroyed IAM User")
+	fmt.Println("Successfully destroyed IAM user")
 	return nil
 }
 

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -1,0 +1,41 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
+	"github.com/spf13/cobra"
+)
+
+func destroyIAMUserHandler(cmd *cobra.Command, _args []string) error {
+	spinner := newSpinner(cmd.ErrOrStderr())
+	destroyer := cloudcmd.NewIAMDestroyer(cmd.Context())
+
+	// Confirmation
+	ok, err := askToConfirm(cmd, "Do you really want to destroy your IAM user?")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		fmt.Println("The destruction of the IAM user was aborted")
+		return nil
+	}
+
+	return destroyIAMUser(cmd.Context(), spinner, destroyer)
+}
+
+func destroyIAMUser(ctx context.Context, spinner spinnerInterf, destroyer iamDestroyer) error {
+	spinner.Start("Destroying IAM User", false)
+
+	if err := destroyer.DestroyIAMUser(ctx); err != nil {
+		return fmt.Errorf("Couldn't destroy IAM User: %w", err)
+	}
+	spinner.Stop()
+	fmt.Println("Successfully destroyed IAM User")
+	return nil
+}

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -45,12 +45,12 @@ func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destr
 	c.log.Debugf("Checking if %s exists", constants.AdminConfFilename)
 	_, err := fsHandler.Stat(constants.AdminConfFilename)
 	if !errors.Is(err, os.ErrNotExist) {
-		return errors.New("file " + constants.AdminConfFilename + " still exists, please make sure to terminate your cluster before destroying your IAM configuration")
+		return fmt.Errorf("file %q still exists, please make sure to terminate your cluster before destroying your IAM configuration", constants.AdminConfFilename)
 	}
 	c.log.Debugf("Checking if %s exists", constants.ClusterIDsFileName)
 	_, err = fsHandler.Stat(constants.ClusterIDsFileName)
 	if !errors.Is(err, os.ErrNotExist) {
-		return errors.New("file " + constants.ClusterIDsFileName + " still exists, please make sure to terminate your cluster before destroying your IAM configuration")
+		return fmt.Errorf("file %q still exists, please make sure to terminate your cluster before destroying your IAM configuration", constants.ClusterIDsFileName)
 	}
 
 	yes, err := cmd.Flags().GetBool("yes")

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -45,14 +45,12 @@ func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destr
 	c.log.Debugf("Checking if %s exists", constants.AdminConfFilename)
 	_, err := fsHandler.Stat(constants.AdminConfFilename)
 	if !errors.Is(err, os.ErrNotExist) {
-		c.log.Debugf("File %s exists, cluster is probably running", constants.AdminConfFilename)
 		cmd.Printf("The file %s still exists, please make sure to terminate your cluster before destroying your IAM configuration.\n", constants.AdminConfFilename)
 		return nil
 	}
 	c.log.Debugf("Checking if %s exists", constants.ClusterIDsFileName)
 	_, err = fsHandler.Stat(constants.ClusterIDsFileName)
 	if !errors.Is(err, os.ErrNotExist) {
-		c.log.Debugf("File %s exists, cluster is probably running", constants.ClusterIDsFileName)
 		cmd.Printf("The file %s still exists, please make sure to terminate your cluster before destroying your IAM configuration.\n", constants.ClusterIDsFileName)
 		return nil
 	}

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -42,12 +42,12 @@ type destroyCmd struct {
 
 func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDestroyer, fsHandler file.Handler) error {
 	// check if there is a possibility that the cluster is still running by looking out for specific files
-	c.log.Debugf("Checking if %s exists", constants.AdminConfFilename)
+	c.log.Debugf("Checking if %q exists", constants.AdminConfFilename)
 	_, err := fsHandler.Stat(constants.AdminConfFilename)
 	if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("file %q still exists, please make sure to terminate your cluster before destroying your IAM configuration", constants.AdminConfFilename)
 	}
-	c.log.Debugf("Checking if %s exists", constants.ClusterIDsFileName)
+	c.log.Debugf("Checking if %q exists", constants.ClusterIDsFileName)
 	_, err = fsHandler.Stat(constants.ClusterIDsFileName)
 	if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("file %q still exists, please make sure to terminate your cluster before destroying your IAM configuration", constants.ClusterIDsFileName)
@@ -61,14 +61,14 @@ func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destr
 
 	gcpFileExists := false
 
-	c.log.Debugf("Checking if %s exists", constants.GCPServiceAccountKeyFile)
+	c.log.Debugf("Checking if %q exists", constants.GCPServiceAccountKeyFile)
 	_, err = fsHandler.Stat(constants.GCPServiceAccountKeyFile)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 	} else {
-		c.log.Debugf("%s exists", constants.GCPServiceAccountKeyFile)
+		c.log.Debugf("%q exists", constants.GCPServiceAccountKeyFile)
 		gcpFileExists = true
 	}
 
@@ -76,7 +76,7 @@ func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destr
 		// Confirmation
 		confirmString := "Do you really want to destroy your IAM configuration?"
 		if gcpFileExists {
-			confirmString += " (This will also delete " + constants.GCPServiceAccountKeyFile + ")"
+			confirmString += fmt.Sprintf(" (This will also delete %q)", constants.GCPServiceAccountKeyFile)
 		}
 		ok, err := askToConfirm(cmd, confirmString)
 		if err != nil {
@@ -89,7 +89,7 @@ func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destr
 	}
 
 	if gcpFileExists {
-		c.log.Debugf("Starting to delete %s", constants.GCPServiceAccountKeyFile)
+		c.log.Debugf("Starting to delete %q", constants.GCPServiceAccountKeyFile)
 		proceed, err := c.deleteGCPServiceAccountKeyFile(cmd, destroyer, fsHandler)
 		if err != nil {
 			return err
@@ -114,18 +114,18 @@ func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destr
 }
 
 func (c *destroyCmd) deleteGCPServiceAccountKeyFile(cmd *cobra.Command, destroyer iamDestroyer, fsHandler file.Handler) (bool, error) {
-	c.log.Debugf("Checking if %s exists", constants.GCPServiceAccountKeyFile)
+	c.log.Debugf("Checking if %q exists", constants.GCPServiceAccountKeyFile)
 	if _, err := fsHandler.Stat(constants.GCPServiceAccountKeyFile); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return false, err
 		}
-		c.log.Debugf("File %s doesn't exist", constants.GCPServiceAccountKeyFile)
+		c.log.Debugf("File %q doesn't exist", constants.GCPServiceAccountKeyFile)
 		return true, nil // file just doesn't exist
 	}
 
 	var fileSaKey gcpshared.ServiceAccountKey
 
-	c.log.Debugf("Parsing %s", constants.GCPServiceAccountKeyFile)
+	c.log.Debugf("Parsing %q", constants.GCPServiceAccountKeyFile)
 	if err := fsHandler.ReadJSON(constants.GCPServiceAccountKeyFile, &fileSaKey); err != nil {
 		return false, err
 	}
@@ -151,6 +151,6 @@ func (c *destroyCmd) deleteGCPServiceAccountKeyFile(cmd *cobra.Command, destroye
 		}
 	}
 
-	c.log.Debugf("Successfully deleted %s", constants.GCPServiceAccountKeyFile)
+	c.log.Debugf("Successfully deleted %q", constants.GCPServiceAccountKeyFile)
 	return true, nil
 }

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -17,15 +17,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func runDestroyIAMUser(cmd *cobra.Command, _args []string) error {
+func runIAMDestroy(cmd *cobra.Command, _args []string) error {
 	spinner := newSpinner(cmd.ErrOrStderr())
 	destroyer := cloudcmd.NewIAMDestroyer(cmd.Context())
 	fsHandler := file.NewHandler(afero.NewOsFs())
 
-	return destroyIAMUser(cmd, spinner, destroyer, fsHandler)
+	return destroyIAM(cmd, spinner, destroyer, fsHandler)
 }
 
-func destroyIAMUser(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDestroyer, fsHandler file.Handler) error {
+func destroyIAM(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDestroyer, fsHandler file.Handler) error {
 	yes, err := cmd.Flags().GetBool("yes")
 	if err != nil {
 		return err

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -5,34 +5,40 @@ SPDX-License-Identifier: AGPL-3.0-only
 package cmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
 	"github.com/spf13/cobra"
 )
 
-func destroyIAMUserHandler(cmd *cobra.Command, _args []string) error {
+func runDestroyIAMUser(cmd *cobra.Command, _args []string) error {
 	spinner := newSpinner(cmd.ErrOrStderr())
 	destroyer := cloudcmd.NewIAMDestroyer(cmd.Context())
 
-	// Confirmation
-	ok, err := askToConfirm(cmd, "Do you really want to destroy your IAM user?")
+	return destroyIAMUser(cmd, spinner, destroyer)
+}
+
+func destroyIAMUser(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDestroyer) error {
+	yes, err := cmd.Flags().GetBool("yes")
 	if err != nil {
 		return err
 	}
-	if !ok {
-		fmt.Println("The destruction of the IAM user was aborted")
-		return nil
+
+	if !yes {
+		// Confirmation
+		ok, err := askToConfirm(cmd, "Do you really want to destroy your IAM user?")
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Println("The destruction of the IAM user was aborted")
+			return nil
+		}
 	}
 
-	return destroyIAMUser(cmd.Context(), spinner, destroyer)
-}
-
-func destroyIAMUser(ctx context.Context, spinner spinnerInterf, destroyer iamDestroyer) error {
 	spinner.Start("Destroying IAM User", false)
 
-	if err := destroyer.DestroyIAMUser(ctx); err != nil {
+	if err := destroyer.DestroyIAMUser(cmd.Context()); err != nil {
 		return fmt.Errorf("Couldn't destroy IAM User: %w", err)
 	}
 	spinner.Stop()

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -2,6 +2,7 @@
 Copyright (c) Edgeless Systems GmbH
 SPDX-License-Identifier: AGPL-3.0-only
 */
+
 package cmd
 
 import (

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -44,7 +44,7 @@ func iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDestroye
 
 	if !yes {
 		// Confirmation
-		confirmString := "Do you really want to destroy your IAM user?"
+		confirmString := "Do you really want to destroy your IAM configuration?"
 		if gcpFileExists {
 			confirmString += " (This will also delete " + constants.GCPServiceAccountKeyFile + ")"
 		}
@@ -53,7 +53,7 @@ func iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDestroye
 			return err
 		}
 		if !ok {
-			cmd.Println("The destruction of the IAM user was aborted")
+			cmd.Println("The destruction of the IAM configuration was aborted")
 			return nil
 		}
 	}
@@ -69,14 +69,14 @@ func iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDestroye
 		}
 	}
 
-	spinner.Start("Destroying IAM user", false)
+	spinner.Start("Destroying IAM configuration", false)
 	defer spinner.Stop()
-	if err := destroyer.DestroyIAMUser(cmd.Context()); err != nil {
-		return fmt.Errorf("destroying IAM user: %w", err)
+	if err := destroyer.DestroyIAMConfiguration(cmd.Context()); err != nil {
+		return fmt.Errorf("destroying IAM configuration: %w", err)
 	}
 
 	spinner.Stop() // stop the spinner to print a new line
-	fmt.Println("Successfully destroyed IAM user")
+	fmt.Println("Successfully destroyed IAM configuration")
 	return nil
 }
 
@@ -93,7 +93,7 @@ func deleteGCPServiceAccountKeyFile(cmd *cobra.Command, destroyer iamDestroyer, 
 		return false, err
 	}
 	if !destroyed {
-		ok, err := askToConfirm(cmd, "The file gcpServiceAccountKey.json could not be deleted. Either it does not exist or the file belongs to another IAM user. Do you want to proceed anyway?")
+		ok, err := askToConfirm(cmd, "The file gcpServiceAccountKey.json could not be deleted. Either it does not exist or the file belongs to another IAM configuration. Do you want to proceed anyway?")
 		if err != nil {
 			return false, err
 		}

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -129,8 +129,8 @@ func (c *destroyCmd) deleteGCPServiceAccountKeyFile(cmd *cobra.Command, destroye
 
 	c.log.Debugf("Checking if keys are the same")
 	if tfSaKey != fileSaKey {
-		c.log.Debugf("Keys are not the same, aborting")
-		return false, nil
+		cmd.Printf("The key in %q don't match up with your terraform state. %q will not be deleted.\n", constants.GCPServiceAccountKeyFile, constants.GCPServiceAccountKeyFile)
+		return true, nil
 	}
 
 	if err := fsHandler.Remove(constants.GCPServiceAccountKeyFile); err != nil {

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -38,6 +38,22 @@ type destroyCmd struct {
 }
 
 func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDestroyer, fsHandler file.Handler) error {
+	// check if there is a possibility that the cluster is still running by looking out for specific files
+	c.log.Debugf("Checking if %s exists", constants.AdminConfFilename)
+	_, err := fsHandler.Stat(constants.AdminConfFilename)
+	if !errors.Is(err, os.ErrNotExist) {
+		c.log.Debugf("File %s exists, cluster is probably running", constants.AdminConfFilename)
+		cmd.Printf("The file %s still exists, please make sure to terminate your cluster before destroying your IAM configuration.\n", constants.AdminConfFilename)
+		return nil
+	}
+	c.log.Debugf("Checking if %s exists", constants.ClusterIDsFileName)
+	_, err = fsHandler.Stat(constants.ClusterIDsFileName)
+	if !errors.Is(err, os.ErrNotExist) {
+		c.log.Debugf("File %s exists, cluster is probably running", constants.ClusterIDsFileName)
+		cmd.Printf("The file %s still exists, please make sure to terminate your cluster before destroying your IAM configuration.\n", constants.ClusterIDsFileName)
+		return nil
+	}
+
 	yes, err := cmd.Flags().GetBool("yes")
 	if err != nil {
 		return err

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -35,7 +35,7 @@ func destroyIAMUser(cmd *cobra.Command, spinner spinnerInterf, destroyer iamDest
 			return err
 		}
 		if !ok {
-			fmt.Println("The destruction of the IAM user was aborted")
+			cmd.Println("The destruction of the IAM user was aborted")
 			return nil
 		}
 	}

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDestroyIAM(t *testing.T) {
+func TestIAMDestroy(t *testing.T) {
 	require := require.New(t)
 	someError := errors.New("failed")
 
@@ -84,7 +84,7 @@ func TestDestroyIAM(t *testing.T) {
 			cmd.SetIn(bytes.NewBufferString(tc.stdin))
 			assert.NoError(cmd.Flags().Set("yes", tc.yes))
 
-			err := destroyIAM(cmd, &nopSpinner{}, tc.iamDestroyer, tc.fh)
+			err := iamDestroy(cmd, &nopSpinner{}, tc.iamDestroyer, tc.fh)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
+	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -89,7 +90,9 @@ func TestIAMDestroy(t *testing.T) {
 			cmd.SetIn(bytes.NewBufferString(tc.stdin))
 			assert.NoError(cmd.Flags().Set("yes", tc.yesFlag))
 
-			err := iamDestroy(cmd, &nopSpinner{}, tc.iamDestroyer, tc.fh)
+			c := &destroyCmd{log: logger.NewTest(t)}
+
+			err := c.iamDestroy(cmd, &nopSpinner{}, tc.iamDestroyer, tc.fh)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -157,9 +157,11 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 		require.NoError(fs.Write(constants.GCPServiceAccountKeyFile, []byte(gcpFile)))
 		return fs
 	}
-
-	fsInvalidJson := file.NewHandler(afero.NewMemMapFs())
-	require.NoError(fsInvalidJson.Write(constants.GCPServiceAccountKeyFile, []byte("asdf")))
+	newFsInvalidJson := func() file.Handler {
+		fh := file.NewHandler(afero.NewMemMapFs())
+		require.NoError(fh.Write(constants.GCPServiceAccountKeyFile, []byte("asdf")))
+		return fh
+	}
 
 	testCases := map[string]struct {
 		destroyer          *stubIAMDestroyer
@@ -171,7 +173,7 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 	}{
 		"invalid gcp json": {
 			destroyer: &stubIAMDestroyer{},
-			fsHandler: fsInvalidJson,
+			fsHandler: newFsInvalidJson(),
 			wantErr:   true,
 		},
 		"error getting key terraform": {

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -49,11 +49,13 @@ func TestIAMDestroy(t *testing.T) {
 			fh:           fhWithAdminConf,
 			iamDestroyer: &stubIAMDestroyer{},
 			yesFlag:      "false",
+			wantErr:      true,
 		},
 		"cluster running cluster ids": {
 			fh:           fhWithClusterIDFile,
 			iamDestroyer: &stubIAMDestroyer{},
 			yesFlag:      "false",
+			wantErr:      true,
 		},
 		"file missing abort": {
 			fh:           newFsMissing(),

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -145,7 +145,7 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 		require.NoError(fs.Write(constants.GCPServiceAccountKeyFile, []byte(gcpFile)))
 		return fs
 	}
-	newFsInvalidJson := func() file.Handler {
+	newFsInvalidJSON := func() file.Handler {
 		fh := file.NewHandler(afero.NewMemMapFs())
 		require.NoError(fh.Write(constants.GCPServiceAccountKeyFile, []byte("asdf")))
 		return fh
@@ -161,7 +161,7 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 	}{
 		"invalid gcp json": {
 			destroyer: &stubIAMDestroyer{},
-			fsHandler: newFsInvalidJson(),
+			fsHandler: newFsInvalidJSON(),
 			wantErr:   true,
 		},
 		"error getting key terraform": {

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -147,11 +147,7 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 	}
 	`
 
-	newFsNoExist := func() file.Handler {
-		fs := file.NewHandler(afero.NewMemMapFs())
-		return fs
-	}
-	newFsExist := func() file.Handler {
+	newFs := func() file.Handler {
 		fs := file.NewHandler(afero.NewMemMapFs())
 		require.NoError(fs.Write(constants.GCPServiceAccountKeyFile, []byte(gcpFile)))
 		return fs
@@ -168,11 +164,6 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 		wantProceed        bool
 		wantGetSaKeyCalled bool
 	}{
-		"file doesn't exist": {
-			destroyer:   &stubIAMDestroyer{},
-			fsHandler:   newFsNoExist(),
-			wantProceed: true,
-		},
 		"invalid gcp json": {
 			destroyer: &stubIAMDestroyer{},
 			fsHandler: fsInvalidJson,
@@ -180,7 +171,7 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 		},
 		"error getting key terraform": {
 			destroyer:          &stubIAMDestroyer{getTfstateKeyErr: someError},
-			fsHandler:          newFsExist(),
+			fsHandler:          newFs(),
 			wantErr:            true,
 			wantGetSaKeyCalled: true,
 		},
@@ -188,12 +179,12 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 			destroyer: &stubIAMDestroyer{gcpSaKey: gcpshared.ServiceAccountKey{
 				Type: "somethingelse",
 			}},
-			fsHandler:          newFsExist(),
+			fsHandler:          newFs(),
 			wantGetSaKeyCalled: true,
 		},
 		"valid": {
 			destroyer:          &stubIAMDestroyer{},
-			fsHandler:          newFsExist(),
+			fsHandler:          newFs(),
 			wantGetSaKeyCalled: true,
 			wantProceed:        true,
 		},

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDestroyIAMUser(t *testing.T) {
+func TestDestroyIAM(t *testing.T) {
 	require := require.New(t)
 	someError := errors.New("failed")
 
@@ -84,7 +84,7 @@ func TestDestroyIAMUser(t *testing.T) {
 			cmd.SetIn(bytes.NewBufferString(tc.stdin))
 			assert.NoError(cmd.Flags().Set("yes", tc.yes))
 
-			err := destroyIAMUser(cmd, &nopSpinner{}, tc.iamDestroyer, tc.fh)
+			err := destroyIAM(cmd, &nopSpinner{}, tc.iamDestroyer, tc.fh)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -116,11 +116,7 @@ func TestIAMDestroy(t *testing.T) {
 			} else {
 				assert.NoError(err)
 			}
-			if tc.wantDestroyCalled {
-				assert.True(tc.iamDestroyer.destroyCalled)
-			} else {
-				assert.False(tc.iamDestroyer.destroyCalled)
-			}
+			assert.Equal(tc.wantDestroyCalled, tc.iamDestroyer.destroyCalled)
 		})
 	}
 }
@@ -208,17 +204,8 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 				assert.NoError(err)
 			}
 
-			if tc.wantProceed {
-				assert.True(proceed)
-			} else {
-				assert.False(proceed)
-			}
-
-			if tc.wantGetSaKeyCalled {
-				assert.True(tc.destroyer.getTfstateKeyCalled)
-			} else {
-				assert.False(tc.destroyer.getTfstateKeyCalled)
-			}
+			assert.Equal(tc.wantProceed, proceed)
+			assert.Equal(tc.wantGetSaKeyCalled, tc.destroyer.getTfstateKeyCalled)
 		})
 	}
 }

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -31,11 +31,16 @@ func TestIAMDestroy(t *testing.T) {
 		fh := file.NewHandler(afero.NewMemMapFs())
 		return fh
 	}
-
-	fhWithAdminConf := file.NewHandler(afero.NewMemMapFs())
-	require.NoError(fhWithAdminConf.Write(constants.AdminConfFilename, []byte("")))
-	fhWithClusterIDFile := file.NewHandler(afero.NewMemMapFs())
-	require.NoError(fhWithClusterIDFile.Write(constants.ClusterIDsFileName, []byte("")))
+	newFsWithAdminConf := func() file.Handler {
+		fh := file.NewHandler(afero.NewMemMapFs())
+		require.NoError(fh.Write(constants.AdminConfFilename, []byte("")))
+		return fh
+	}
+	newFsWithClusterIDFile := func() file.Handler {
+		fh := file.NewHandler(afero.NewMemMapFs())
+		require.NoError(fh.Write(constants.ClusterIDsFileName, []byte("")))
+		return fh
+	}
 
 	testCases := map[string]struct {
 		iamDestroyer      *stubIAMDestroyer
@@ -46,13 +51,13 @@ func TestIAMDestroy(t *testing.T) {
 		wantDestroyCalled bool
 	}{
 		"cluster running admin conf": {
-			fh:           fhWithAdminConf,
+			fh:           newFsWithAdminConf(),
 			iamDestroyer: &stubIAMDestroyer{},
 			yesFlag:      "false",
 			wantErr:      true,
 		},
 		"cluster running cluster ids": {
-			fh:           fhWithClusterIDFile,
+			fh:           newFsWithClusterIDFile(),
 			iamDestroyer: &stubIAMDestroyer{},
 			yesFlag:      "false",
 			wantErr:      true,

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -34,41 +34,41 @@ func TestIAMDestroy(t *testing.T) {
 		iamDestroyer iamDestroyer
 		fh           file.Handler
 		stdin        string
-		yes          string
+		yesFlag      string
 		wantErr      bool
 	}{
 		"file missing abort": {
-			fh:    newFsMissing(),
-			stdin: "n\n",
-			yes:   "false",
+			fh:      newFsMissing(),
+			stdin:   "n\n",
+			yesFlag: "false",
 		},
 		"file missing": {
 			fh:           newFsMissing(),
 			stdin:        "y\n",
-			yes:          "false",
+			yesFlag:      "false",
 			iamDestroyer: &stubIAMDestroyer{},
 		},
 		"file exists abort": {
-			fh:    newFsExists(),
-			stdin: "n\n",
-			yes:   "false",
+			fh:      newFsExists(),
+			stdin:   "n\n",
+			yesFlag: "false",
 		},
 		"error destroying user": {
 			fh:           newFsMissing(),
 			stdin:        "y\n",
-			yes:          "false",
+			yesFlag:      "false",
 			iamDestroyer: &stubIAMDestroyer{destroyErr: someError},
 			wantErr:      true,
 		},
 		"gcp delete error": {
 			fh:           newFsExists(),
-			yes:          "true",
+			yesFlag:      "true",
 			iamDestroyer: &stubIAMDestroyer{deleteGCPFileErr: someError},
 			wantErr:      true,
 		},
 		"gcp no proceed": {
 			fh:           newFsExists(),
-			yes:          "true",
+			yesFlag:      "true",
 			stdin:        "n\n",
 			iamDestroyer: &stubIAMDestroyer{deletedGCPFile: false},
 		},
@@ -82,7 +82,7 @@ func TestIAMDestroy(t *testing.T) {
 			cmd.SetOut(&bytes.Buffer{})
 			cmd.SetErr(&bytes.Buffer{})
 			cmd.SetIn(bytes.NewBufferString(tc.stdin))
-			assert.NoError(cmd.Flags().Set("yes", tc.yes))
+			assert.NoError(cmd.Flags().Set("yes", tc.yesFlag))
 
 			err := iamDestroy(cmd, &nopSpinner{}, tc.iamDestroyer, tc.fh)
 

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -120,7 +120,6 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 			destroyer:   &stubIAMDestroyer{},
 			fsHandler:   newFsNoExist(),
 			wantProceed: true,
-			wantErr:     true,
 		},
 		"unsuccessful destroy confirm": {
 			destroyer:   &stubIAMDestroyer{},

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDestroyIAMUser(t *testing.T) {
+	someError := errors.New("failed")
+
+	testCases := map[string]struct {
+		iamDestroyer iamDestroyer
+		wantErr      bool
+	}{
+		"success": {
+			iamDestroyer: &stubIAMDestroyer{},
+		},
+		"failure": {
+			iamDestroyer: &stubIAMDestroyer{destroyErr: someError},
+			wantErr:      true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			err := destroyIAMUser(context.Background(), &nopSpinner{}, tc.iamDestroyer)
+
+			if tc.wantErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -95,14 +95,6 @@ func TestIAMDestroy(t *testing.T) {
 			iamDestroyer: &stubIAMDestroyer{getTfstateKeyErr: someError},
 			wantErr:      true,
 		},
-		"gcp no proceed": {
-			fh:      newFsExists(),
-			yesFlag: "true",
-			stdin:   "n\n",
-			iamDestroyer: &stubIAMDestroyer{gcpSaKey: gcpshared.ServiceAccountKey{
-				Type: "somethingelse",
-			}},
-		},
 	}
 
 	for name, tc := range testCases {
@@ -188,6 +180,7 @@ func TestDeleteGCPServiceAccountKeyFile(t *testing.T) {
 			}},
 			fsHandler:          newFs(),
 			wantGetSaKeyCalled: true,
+			wantProceed:        true,
 		},
 		"valid": {
 			destroyer:          &stubIAMDestroyer{},

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -68,6 +68,11 @@ func New(ctx context.Context, workingDir string) (*Client, error) {
 	}, nil
 }
 
+// Show reads the default state path and outputs the state.
+func (c *Client) Show(ctx context.Context) (*tfjson.State, error) {
+	return c.tf.Show(ctx)
+}
+
 // PrepareWorkspace prepares a Terraform workspace for a Constellation cluster.
 func (c *Client) PrepareWorkspace(path string, vars Variables) error {
 	if err := prepareWorkspace(path, c.file, c.workingDir); err != nil {

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -256,14 +256,7 @@ You can keep created IAM configurations and reuse them for new clusters. Alterna
 * [Terraform](https://developer.hashicorp.com/terraform/downloads) is installed on your machine.
 * Access to the `terraform.tfstate` file created by the `constellation iam create` command.
 
-You can delete the IAM configuration using the following commands:
+You can delete the IAM configuration using the following command in the same directory where you used ```constellation iam create```:
 ```bash
-# Navigate to the directory containing the terraform.tfstate file
-cd constellation-iam-terraform
-# Destroy the IAM configuration via Terraform
-terraform destroy
-# Confirm deletion by typing "yes"
-# Remove the Terraform state directory
-cd ..
-rm -rf constellation-iam-terraform
+constellation iam destroy
 ```

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -256,7 +256,7 @@ You can keep created IAM configurations and reuse them for new clusters. Alterna
 * [Terraform](https://developer.hashicorp.com/terraform/downloads) is installed on your machine.
 * Access to the `terraform.tfstate` file created by the `constellation iam create` command.
 
-You can delete the IAM configuration using the following command in the same directory where you used ```constellation iam create```:
+You can delete the IAM configuration by executing the following command in the same directory where you executed `constellation iam create`:
 ```bash
 constellation iam destroy
 ```


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add the new ```iam destroy``` subcommand to destroy IAM configuration with the Constellation CLI
- Rename the ```DestroyCluster``` function in [terraform.go](https://github.com/edgelesssys/constellation/blob/feat/iam-destroy-user/cli/internal/terraform/terraform.go) to ```Destroy```

This change will allow users to delete their IAM configurations using the constellation CLI instead of the terraform CLI.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Update [docs](https://github.com/edgelesssys/constellation/blob/feat/iam-destroy-user/docs/docs/workflows/config.md)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
