### PR TITLE
cli: remove registry_auth for Docker Terraform module

### DIFF
--- a/.github/actions/e2e_mini/run-e2e.sh
+++ b/.github/actions/e2e_mini/run-e2e.sh
@@ -37,9 +37,6 @@ chmod u+x constellation
 
 sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts'
 
-mkdir -p "$HOME"/.docker
-touch "$HOME"/.docker/config.json
-
 ./constellation mini up
 
 curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"

--- a/cli/internal/terraform/terraform/qemu/main.tf
+++ b/cli/internal/terraform/terraform/qemu/main.tf
@@ -17,11 +17,6 @@ provider "libvirt" {
 
 provider "docker" {
   host = "unix:///var/run/docker.sock"
-
-  registry_auth {
-    address     = "ghcr.io"
-    config_file = pathexpand("~/.docker/config.json")
-  }
 }
 
 resource "random_password" "initSecret" {


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove `registry_auth` for Docker Terraform provider

This seems to be a leftover from back when the repoistory and images were private, but causes Mini Constellation to fail when no config.json for Docker exists under the defined path `~/docker/config.json`.
### Related issue
Trying to run MiniConstellation on a relatively fresh Docker installation where this config file does not exist, you will get this error:

```
./constellation-linux-amd64 mini up
A config file already exists in the current workspace.
Do you want to overwrite it? [y/n]: y
Creating cluster in QEMU   
An error occurred: exit status 1

Error: Error loading registry auth config: could not open config file from filePath: /home/ubuntu/.docker/config.json. Error: open /home/ubuntu/.docker/config.json: no such file or directory

  with provider["registry.terraform.io/kreuzwerker/docker"],
  on main.tf line 18, in provider "docker":
  18: provider "docker" {
```

### Checklist

- [ ] Backport the changes to release/v2.4 (in #956)