### PR TITLE
image: enable serial console access for MiniConstellation to simplify troubleshooting

### DIFF
--- a/image/mkosi.files/mkosi.qemu.conf
+++ b/image/mkosi.files/mkosi.qemu.conf
@@ -4,3 +4,4 @@ OutputDirectory=mkosi.output.qemu
 
 [Content]
 Autologin=yes
+Environment=CONSOLE_MOTD=true

--- a/image/mkosi.files/mkosi.qemu.conf
+++ b/image/mkosi.files/mkosi.qemu.conf
@@ -1,3 +1,6 @@
 [Output]
 KernelCommandLine=constel.csp=qemu
 OutputDirectory=mkosi.output.qemu
+
+[Content]
+Autologin=yes

--- a/image/mkosi.postinst
+++ b/image/mkosi.postinst
@@ -21,6 +21,17 @@ mv /etc/issue.d /usr/lib/issue.d || true
 rm -f /etc/issue
 rm -f /etc/issue.net
 
+# add motd for constellation console access
+if [[ "${CONSOLE_MOTD:-false}" == "true" ]]; then
+cat <<EOF > /usr/lib/motd.d/10-constellation-console-access.motd
+~ Welcome to Constellation! ~
+Usually, on release versions of Constellation running in the cloud, you are not able to login through the serial console.
+This shell access is specifically granted for debug images and MiniConstellation to allow users to research the environment Constellation runs in.
+Have fun! Feel free to report any issues to GitHub or security@edgeless.systems (for security vulnerabilities only).
+EOF
+fi
+
+
 # update /etc/os-release
 echo "IMAGE_ID=\"${IMAGE_ID}\"" >> /etc/os-release
 echo "IMAGE_VERSION=\"${IMAGE_VERSION}\"" >> /etc/os-release

--- a/image/mkosi.skeleton/usr/lib/tmpfiles.d/constellation.conf
+++ b/image/mkosi.skeleton/usr/lib/tmpfiles.d/constellation.conf
@@ -4,5 +4,7 @@ d     /var/log/kubernetes/audit/                            0700   0    0   -   
 d     /run/state/bin                                        0755   0    0   -           -
 C     /run/issue.d                                          -    -    -     -           /usr/lib/issue.d/
 C     /run/issue                                            -    -    -     -           /usr/lib/issue
+C     /run/motd.d                                           -    -    -     -           /usr/lib/motd.d/
+C     /run/motd                                             -    -    -     -           /usr/lib/motd
 # merge all CNI binaries in writable folder until containerd can use multiple CNI bins: https://github.com/containerd/containerd/issues/6600
 C     /opt/cni/bin                                          -    -    -     -           /usr/libexec/cni/


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- image: enable serial console access for QEMU / mini Constellation
- image: print motd if serial console access is enabled

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

This is meant to simplify debugging in customer environments.
The change only targets QEMU / MiniConstellation and does not affect the security of real CVM images.

This is what a serial console login will look like:

```shell-session
Fedora Linux 37 (Thirty Seven)
Kernel 6.0.18-300.fc37.x86_64 on an x86_64 (ttyS0)

constellation v0.0.0
PCR state:
  sha256:
    0 : 0x7D08997028F34F6CCDD2ED9BD31804CF0B0C7FFF9A4D05299E33620001510281
    1 : 0xEE07102D1418518024110872A713A9824BC7F6AE47D62FD0CDE0918C0E249B7E
    2 : 0x72001A25201B263BC60F869ACE2F728B09DC4BE78B9C80ADCA87A013C2D26950
    3 : 0x3D458CFE55CC03EA1F443F1562BEEC8DF51C75E14A9FCF9A7234A13F198E7969
    4 : 0xA8F3446847774248AE966F797AEC726254C142F119F288E9028FB2C9A04AD23C
    5 : 0x5C91B26B348FEA860EFDD55F4F6E21AD437373DC56F0D1FD4C4D4B35BC8F2E43
    6 : 0x3D458CFE55CC03EA1F443F1562BEEC8DF51C75E14A9FCF9A7234A13F198E7969
    7 : 0xDBC0BF1FFBA0307AA4EFECB3766D8A365595BC384A3DCB87D7EF9B5DCF44165B
    8 : 0x0000000000000000000000000000000000000000000000000000000000000000
    9 : 0x6AAC5E17EE6501E48AA17BA26C5559FC83D283C8BFBEC7974D16D1A976BCFE04
    10: 0x8BFCD46863D7C07CEC9A6D77DA335D85365FC862659EB9BB7718455B77263575
    11: 0x0000000000000000000000000000000000000000000000000000000000000000
    12: 0x8FB93B89AA79649D79487AAB2047C58B5AD3733A4F0ABE109136B3F10A07984C
    13: 0x0000000000000000000000000000000000000000000000000000000000000000
    14: 0x1095DA49EE4FC5341966B1D7DF1FB0C78C181AB2E3D9CC4468161FB4592AE404
    15: 0x0000000000000000000000000000000000000000000000000000000000000000
    16: 0x0000000000000000000000000000000000000000000000000000000000000000
    17: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
    18: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
    19: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
    20: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
    21: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
    22: 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF
    23: 0x0000000000000000000000000000000000000000000000000000000000000000

fedora login: root (automatic login)

[   82.869244] cirrus 0000:00:01.0: [drm] drm_plane_enable_fb_damage_clips() not called
[   82.978341] Console: switching to colour frame buffer device 128x48
Last login: Fri Jan 13 12:09:21 on tty1
~ Welcome to MiniConstellation! ~
Usually, you would not have access to login on release versions of Constellation.
This shell access is specifically granted for debug images and MiniConstellation to allow you to explore the environment Constellation runs in.
[root@fedora ~]# 
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)