### PR TITLE
ci: delete old images of all streams on ref main

### DIFF
--- a/.github/workflows/purge-main.yml
+++ b/.github/workflows/purge-main.yml
@@ -3,7 +3,9 @@ name: Purge old images from main branch
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 */2 * * *"
+    - cron: "0 1/3 * * *"
+    - cron: "0 2/3 * * *"
+    - cron: "0 3/3 * * *"
 
 jobs:
   find-version:
@@ -26,13 +28,32 @@ jobs:
           role-to-assume: arn:aws:iam::795746500882:role/GithubConstellationVersionsAPIRead
           aws-region: eu-central-1
 
+      - name: Determine stream
+        id: stream
+        run: |
+          case "${{ github.event.schedule }}" in
+            "0 0/3 * * *")
+              echo "stream=debug" >> "$GITHUB_OUTPUT"
+              ;;
+            "0 1/3 * * *")
+              echo "stream=console" >> "$GITHUB_OUTPUT"
+              ;;
+            "0 2/3 * * *")
+              echo "stream=nightly" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "Unknown schedule: ${{ github.event.schedule }}"
+              exit 1
+              ;;
+          esac
+
       - name: List versions
         id: list
         uses: ./.github/actions/versionsapi
         with:
           command: list
           ref: main
-          stream: debug
+          stream: ${{ steps.stream.outputs.stream }}
 
       - name: Find version to delete
         id: find


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- After frequently building images for all streams in #977, we should also delete images of all streams.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
