### PR TITLE
Configure CodeQL and scorecard workflow.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,10 +26,10 @@ jobs:
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
 
       - name: Setup Go environment
+        if: ${{ matrix.language == 'go' }}
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: "1.19.5"
-        if: ${{ matrix.language == 'go' }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@515828d97454b8354517688ddc5b48402b723750 # v2.1.38
@@ -37,6 +37,7 @@ jobs:
           languages: ${{ matrix.language }}
 
       - name: Install Go Dependencies
+        if: ${{ matrix.language == 'go' }}
         run: |
           echo "::group::Install apt dependencies"
           sudo apt-get update && sudo apt-get install -y libcryptsetup12 libcryptsetup-dev libvirt-dev
@@ -48,7 +49,6 @@ jobs:
             (cd "$mod" || exit; go mod tidy)
           done
           echo "::endgroup::"
-        if: ${{ matrix.language == 'go' }}
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@515828d97454b8354517688ddc5b48402b723750 # v2.1.38

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,17 +5,12 @@ on:
     branches:
       - main
       - release/v*
-      - feat/ci/codeql-and-scorecard
   pull_request:
-    branches:
-      - main
-      - release/v*
-      - feat/ci/codeql-and-scorecard
 
 jobs:
-  analyze:
-    name: Analyze
-    runs-on: ubuntu-latest
+  codeql:
+    name: CodeQL
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read
@@ -42,11 +37,16 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          echo "::group::Install apt dependencies"
           sudo apt-get update && sudo apt-get install -y libcryptsetup12 libcryptsetup-dev libvirt-dev
+          echo "::endgroup::"
+
+          echo "::group::Install go dependencies"
           mods=$(go list -f '{{.Dir}}' -m | xargs)
           for mod in $mods; do
-            (cd $mod; go mod tidy)
+            (cd "$mod" || exit; go mod tidy)
           done
+          echo "::endgroup::"
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@515828d97454b8354517688ddc5b48402b723750 # v2.1.38

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,57 @@
+name: CodeQL
+
+on:
+  push:
+    branches:
+      - main
+      - release/v*
+      - feat/ci/codeql-and-scorecard
+  pull_request:
+    branches:
+      - main
+      - release/v*
+      - feat/ci/codeql-and-scorecard
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["go"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+
+      - name: Setup Go environment
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: "1.19.5"
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@515828d97454b8354517688ddc5b48402b723750 # v2.1.38
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y libcryptsetup12 libcryptsetup-dev libvirt-dev
+          mods=$(go list -f '{{.Dir}}' -m | xargs)
+          for mod in $mods; do
+            (cd $mod; go mod tidy)
+          done
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@515828d97454b8354517688ddc5b48402b723750 # v2.1.38
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@515828d97454b8354517688ddc5b48402b723750 # v2.1.38
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go"]
+        language: ["go", "python"]
 
     steps:
       - name: Checkout repository
@@ -29,13 +29,14 @@ jobs:
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: "1.19.5"
+        if: ${{ matrix.language == 'go' }}
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@515828d97454b8354517688ddc5b48402b723750 # v2.1.38
         with:
           languages: ${{ matrix.language }}
 
-      - name: Install Dependencies
+      - name: Install Go Dependencies
         run: |
           echo "::group::Install apt dependencies"
           sudo apt-get update && sudo apt-get install -y libcryptsetup12 libcryptsetup-dev libvirt-dev
@@ -47,6 +48,7 @@ jobs:
             (cd "$mod" || exit; go mod tidy)
           done
           echo "::endgroup::"
+        if: ${{ matrix.language == 'go' }}
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@515828d97454b8354517688ddc5b48402b723750 # v2.1.38

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+name: Scorecard supply-chain security
+
+on:
+  push:
+    # Only the default branch is supported.
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (for publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@99c53751e09b9529366343771cc321ec74e9bd3d # v2.0.6
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@807578363a7869ca324a79039e6db9c843e0e100 # v2.1.27
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -11,7 +11,7 @@ permissions: read-all
 jobs:
   analysis:
     name: Scorecard analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/keyservice/setup/setup.go
+++ b/keyservice/setup/setup.go
@@ -182,16 +182,16 @@ func getAzureBlobConfig(uri *url.URL) (string, string, error) {
 	return r[0], r[1], nil
 }
 
-func getGCPKMSConfig(uri *url.URL) (string, string, string, int, error) {
+func getGCPKMSConfig(uri *url.URL) (string, string, string, int32, error) {
 	r, err := getConfig(uri.Query(), []string{"project", "location", "keyRing", "protectionLvl"})
 	if err != nil {
 		return "", "", "", 0, err
 	}
-	protectionLvl, err := strconv.Atoi(r[3])
+	protectionLvl, err := strconv.ParseInt(r[3], 10, 32)
 	if err != nil {
 		return "", "", "", 0, err
 	}
-	return r[0], r[1], r[2], protectionLvl, nil
+	return r[0], r[1], r[2], int32(protectionLvl), nil
 }
 
 func getGCPStorageConfig(uri *url.URL) (string, string, error) {

--- a/keyservice/setup/setup_test.go
+++ b/keyservice/setup/setup_test.go
@@ -185,7 +185,7 @@ func TestGetGCPKMSConfig(t *testing.T) {
 	assert.Equal(project, rProject)
 	assert.Equal(location, rLocation)
 	assert.Equal(keyRing, rKeyRing)
-	assert.Equal(2, rProtectionLvl)
+	assert.Equal(int32(2), rProtectionLvl)
 
 	uri, err = url.Parse(fmt.Sprintf(GCPKMSURI, project, location, keyRing, "invalid"))
 	require.NoError(err)


### PR DESCRIPTION
Signed-off-by: Fabian Kammel <fk@edgeless.systems>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Enable CodeQL via [action](https://github.com/github/codeql-action)
  - This populates the [Security -> Code Scanning](https://github.com/edgelesssys/constellation/security/code-scanning) tab in GitHub WebUI. Results are available per branch. See the [results for this branch](https://github.com/edgelesssys/constellation/security/code-scanning?query=is%3Aopen+branch%3Afeat%2Fci%2Fcodeql-and-scorecard), generated in [this workflow run](https://github.com/edgelesssys/constellation/actions/runs/3931088510/jobs/6721898087).
  - Using the [default workflow file](https://github.com/github/codeql-action#usage) for CodeQL [fails in the autobuild step](https://github.com/edgelesssys/constellation/actions/runs/3930144609). As per documentation I replaced autobuild with:
    - [Download deps](https://github.com/edgelesssys/constellation/actions/runs/3931088510)
    - [Download deps + cmake + make](https://github.com/edgelesssys/constellation/actions/runs/3931282249)
    - [Download deps + autobuild](https://github.com/edgelesssys/constellation/actions/runs/3931624953)
  - I settled for the last option, since building a binary does not seem reasonable for a code analyzer, and to keep any config made during autobuild step. All three tests identified the same two issues.
- Enable [Scorecard action](https://github.com/ossf/scorecard-action)
  - This action will report any security violations to the [Security -> Code Scanning](https://github.com/edgelesssys/constellation/security/code-scanning) tab (same as CodeQL). 
  - Scorecard action [only supports running on main branch](https://github.com/ossf/scorecard-action#workflow-example). I have [tested this configuration in an example project](https://github.com/datosh/some-action/actions/runs/3930096147).

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
