### PR TITLE
operator: test JoiningNode in correct order

### DIFF
--- a/operators/constellation-node-operator/controllers/joiningnode_controller_env_test.go
+++ b/operators/constellation-node-operator/controllers/joiningnode_controller_env_test.go
@@ -92,23 +92,6 @@ var _ = Describe("JoiningNode controller", func() {
 	})
 	It("Should annotate the corresponding node when creating the node first", func() {
 		ctx := context.Background()
-		By("creating a node")
-		node := &corev1.Node{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "update.edgeless.systems/v1alpha1",
-				Kind:       "Node",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: nodeName2,
-			},
-			Spec: corev1.NodeSpec{},
-		}
-		Expect(k8sClient.Create(ctx, node)).Should(Succeed())
-		createdNode := &corev1.Node{}
-		Eventually(func() error {
-			return k8sClient.Get(ctx, types.NamespacedName{Name: nodeName2}, createdNode)
-		}, timeout, interval).Should(Succeed())
-		Expect(createdNode.ObjectMeta.Name).Should(Equal(nodeName2))
 
 		By("creating a joining node resource")
 		joiningNode := &updatev1alpha1.JoiningNode{
@@ -131,6 +114,24 @@ var _ = Describe("JoiningNode controller", func() {
 		}, timeout, interval).Should(Succeed())
 		Expect(createdJoiningNode.Spec.Name).Should(Equal(nodeName2))
 		Expect(createdJoiningNode.Spec.ComponentsReference).Should(Equal(ComponentsReference2))
+
+		By("creating a node")
+		node := &corev1.Node{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "update.edgeless.systems/v1alpha1",
+				Kind:       "Node",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nodeName2,
+			},
+			Spec: corev1.NodeSpec{},
+		}
+		Expect(k8sClient.Create(ctx, node)).Should(Succeed())
+		createdNode := &corev1.Node{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: nodeName2}, createdNode)
+		}, timeout, interval).Should(Succeed())
+		Expect(createdNode.ObjectMeta.Name).Should(Equal(nodeName2))
 
 		By("annotating the node")
 		Eventually(func() string {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Obviously the K8s node is expected to exists after the JoiningNode CR. 

Before, we raced the annotation + deletion with the check for creation of the JoiningNode CR.

Broke in: https://github.com/edgelesssys/constellation/actions/runs/3931758103/jobs/6723428260

