### PR TITLE
cli: use non-authoritative methods to manage iam policy memberships

### DIFF
--- a/cli/internal/terraform/terraform/iam/gcp/main.tf
+++ b/cli/internal/terraform/terraform/iam/gcp/main.tf
@@ -19,49 +19,34 @@ resource "google_service_account" "service_account" {
   description  = "Service account used inside Constellation"
 }
 
-resource "google_project_iam_binding" "instance_admin_role" {
+resource "google_project_iam_member" "instance_admin_role" {
   project = var.project_id
   role    = "roles/compute.instanceAdmin.v1"
-
-  members = [
-    "serviceAccount:${google_service_account.service_account.email}",
-  ]
+  member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
-resource "google_project_iam_binding" "network_admin_role" {
+resource "google_project_iam_member" "network_admin_role" {
   project = var.project_id
   role    = "roles/compute.networkAdmin"
-
-  members = [
-    "serviceAccount:${google_service_account.service_account.email}",
-  ]
+  member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
-resource "google_project_iam_binding" "security_admin_role" {
+resource "google_project_iam_member" "security_admin_role" {
   project = var.project_id
   role    = "roles/compute.securityAdmin"
-
-  members = [
-    "serviceAccount:${google_service_account.service_account.email}",
-  ]
+  member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
-resource "google_project_iam_binding" "storage_admin_role" {
+resource "google_project_iam_member" "storage_admin_role" {
   project = var.project_id
   role    = "roles/compute.storageAdmin"
-
-  members = [
-    "serviceAccount:${google_service_account.service_account.email}",
-  ]
+  member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
-resource "google_project_iam_binding" "iam_service_account_user_role" {
+resource "google_project_iam_member" "iam_service_account_user_role" {
   project = var.project_id
   role    = "roles/iam.serviceAccountUser"
-
-  members = [
-    "serviceAccount:${google_service_account.service_account.email}",
-  ]
+  member  = "serviceAccount:${google_service_account.service_account.email}"
 }
 
 resource "google_service_account_key" "service_account_key" {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: use non-authoritative methods to manage iam policy memberships

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

[google_project_iam_binding](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#google_project_iam_binding): Authoritative for a given role. Updates the IAM policy to grant a role to a list of members. Other roles within the IAM policy for the project are preserved.
[google_project_iam_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_project_iam#google_project_iam_member): Non-authoritative. Updates the IAM policy to grant a role to a new member. Other members for the role for the project are preserved.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
