### PR TITLE
ci: adapt to new measurements format

### DIFF
--- a/.github/actions/e2e_verify/action.yml
+++ b/.github/actions/e2e_verify/action.yml
@@ -22,7 +22,7 @@ runs:
         MEASUREMENTS=$(curl -sS https://cdn.confidential.cloud/constellation/v1/${{ inputs.osImage }}/image/csp/${{ inputs.cloudProvider }}/measurements.image.json | jq '.measurements' -r)
         for key in $(echo $MEASUREMENTS | jq 'keys[]' -r); do
             echo Updating $key to $(echo $MEASUREMENTS | jq ".\"$key\"" -r)
-            yq -i ".provider.${{ inputs.cloudProvider }}.measurements.[$key].expected = $(echo $MEASUREMENTS | jq ".\"$key\"")" constellation-conf.yaml
+            yq -i ".provider.${{ inputs.cloudProvider }}.measurements.[$key] = $(echo $MEASUREMENTS | jq ".\"$key\"")" constellation-conf.yaml
             yq -i ".provider.${{ inputs.cloudProvider }}.measurements.[$key].warnOnly = false" constellation-conf.yaml
         done
         yq -i '.provider.${{ inputs.cloudProvider }}.measurements |= array_to_map' constellation-conf.yaml


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- The formatting of the measurements of debug images on the versions API has changed ( from [this](https://cdn.confidential.cloud/constellation/v1/ref/main/stream/debug/image/v2.4.0-pre.0.20221229165011-473e16feb2cc/csp/azure/measurements.image.json) to [this](https://cdn.confidential.cloud/constellation/v1/ref/main/stream/debug/v2.5.0-pre.0.20230112150103-bcd8aa9acc25/image/csp/gcp/measurements.image.json) ) which needs to be taken into account when fetching the measurements in the test. I adapted to said changes. A successful run of the test can be seen [here](https://github.com/edgelesssys/constellation/actions/runs/3938516358/jobs/6737304444)


