### PR TITLE
docs: add docs for automatic config filling of iam values

### DIFF
--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -9,47 +9,19 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
 
 ## Create a cluster
 
-1. Create the configuration file for your selected cloud provider.
+1.  Create the configuration file and IAM resources for your selected cloud provider
 
-    <tabs groupId="csp">
-    <tabItem value="azure" label="Azure">
-
-    ```bash
-    constellation config generate azure
-    ```
-
-    </tabItem>
-    <tabItem value="gcp" label="GCP">
-
-    ```bash
-    constellation config generate gcp
-    ```
-
-    </tabItem>
-    <tabItem value="aws" label="AWS">
-
-    ```bash
-    constellation config generate aws
-    ```
-
-    </tabItem>
-    </tabs>
-
-    This creates the file `constellation-conf.yaml` in your current working directory.
-
-2. Fill in your cloud provider specific information.
-
-    First you need to create an [IAM configuration](../workflows/config.md#creating-an-iam-configuration). The easiest way to do this is the following CLI command:
+    First, you need to create a [configuration file](../workflows/config.md) and an [IAM configuration](../workflows/config.md#creating-an-iam-configuration). The easiest way to do this is the following CLI command:
 
     <tabs groupId="csp">
 
     <tabItem value="azure" label="Azure">
 
     ```bash
-    constellation iam create azure --region=westus --resourceGroup=constellTest --servicePrincipal=spTest
+    constellation iam create azure --region=westus --resourceGroup=constellTest --servicePrincipal=spTest --generate-config
     ```
 
-    This command creates IAM configuration on the Azure region `westus` creating a new resource group `constellTest` and a new service principal `spTest`.
+    This command creates the configuration file `constellation-conf.yaml` in your current directory. It then creates IAM configuration on the Azure region `westus` creating a new resource group `constellTest` and a new service principal `spTest` and fills the values into the configuration file.
 
     Note that CVMs are currently only supported in a few regions, check [Azure's products available by region](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=virtual-machines&regions=all). These are:
     * `westus`
@@ -62,10 +34,10 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     <tabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --generate-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+    This command creates the configuration file `constellation-conf.yaml` in your current directory. It then creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test` and fills the values into the configuration file.
 
     Note that only regions offering CVMs of the `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -74,10 +46,10 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     <tabItem value="aws" label="AWS">
 
     ```bash
-    constellation iam create aws --zone=eu-central-1a --prefix=constellTest
+    constellation iam create aws --zone=eu-central-1a --prefix=constellTest --generate-config
     ```
 
-    This command creates IAM configuration for the AWS zone `eu-central-1a` using the prefix `constellTest` for all named resources being created.
+    This command creates the configuration file `constellation-conf.yaml` in your current directory. It then creates IAM configuration for the AWS zone `eu-central-1a` using the prefix `constellTest` for all named resources being created and fills the values into the configuration file.
 
     Constellation OS images are currently replicated to the following regions:
      * `eu-central-1`
@@ -91,12 +63,8 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     </tabItem>
     </tabs>
 
-    Now, fill the output values of the command into the corresponding fields of the `constellation-conf.yaml` file.
-
     :::tip
-
-    To learn how to delete your IAM configuration and to get more detailed information on the IAM process and the VM types supported by Constellation, see the [Configuration workflow](../workflows/config.md).
-
+    To learn how to create a configuration file without automatic IAM creation and how to delete your IAM configuration and to get more detailed information on the IAM process and the VM types supported by Constellation, see the [Configuration workflow](../workflows/config.md).
     :::
 
 <!--
@@ -107,7 +75,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     :::
 -->
 
-3. Create the cluster with one control-plane node and two worker nodes. `constellation create` uses options set in `constellation-conf.yaml`.
+1. Create the cluster with one control-plane node and two worker nodes. `constellation create` uses options set in `constellation-conf.yaml`.
 
     :::tip
 
@@ -126,7 +94,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     Your Constellation cluster was created successfully.
     ```
 
-4. Initialize the cluster
+2. Initialize the cluster
 
     ```bash
     constellation init
@@ -157,7 +125,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
 
     :::
 
-5. Configure kubectl
+3. Configure kubectl
 
     ```bash
     export KUBECONFIG="$PWD/constellation-admin.conf"

--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -21,7 +21,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     constellation iam create azure --region=westus --resourceGroup=constellTest --servicePrincipal=spTest --generate-config
     ```
 
-    This command creates the configuration file `constellation-conf.yaml` in your current directory. It then creates IAM configuration on the Azure region `westus` creating a new resource group `constellTest` and a new service principal `spTest` and fills the values into the configuration file.
+    This command creates IAM configuration on the Azure region `westus` creating a new resource group `constellTest` and a new service principal `spTest`. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that CVMs are currently only supported in a few regions, check [Azure's products available by region](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=virtual-machines&regions=all). These are:
     * `westus`
@@ -37,7 +37,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --generate-config
     ```
 
-    This command creates the configuration file `constellation-conf.yaml` in your current directory. It then creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test` and fills the values into the configuration file.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -49,7 +49,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     constellation iam create aws --zone=eu-central-1a --prefix=constellTest --generate-config
     ```
 
-    This command creates the configuration file `constellation-conf.yaml` in your current directory. It then creates IAM configuration for the AWS zone `eu-central-1a` using the prefix `constellTest` for all named resources being created and fills the values into the configuration file.
+    This command creates IAM configuration for the AWS zone `eu-central-1a` using the prefix `constellTest` for all named resources being created. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Constellation OS images are currently replicated to the following regions:
      * `eu-central-1`
@@ -64,7 +64,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     </tabs>
 
     :::tip
-    To learn how to create a configuration file without automatic IAM creation and how to delete your IAM configuration and to get more detailed information on the IAM process and the VM types supported by Constellation, see the [Configuration workflow](../workflows/config.md).
+    To learn about all options you have for managing IAM resources and Constellation configuration, see the [Configuration workflow](../workflows/config.md).
     :::
 
 <!--
@@ -75,7 +75,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     :::
 -->
 
-1. Create the cluster with one control-plane node and two worker nodes. `constellation create` uses options set in `constellation-conf.yaml`.
+2. Create the cluster with one control-plane node and two worker nodes. `constellation create` uses options set in `constellation-conf.yaml`.
 
     :::tip
 
@@ -94,7 +94,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     Your Constellation cluster was created successfully.
     ```
 
-2. Initialize the cluster
+3. Initialize the cluster
 
     ```bash
     constellation init
@@ -125,7 +125,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
 
     :::
 
-3. Configure kubectl
+4. Configure kubectl
 
     ```bash
     export KUBECONFIG="$PWD/constellation-admin.conf"

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -64,7 +64,7 @@ Fill the desired VM type into the **instanceType** field in the `constellation-c
 ## Creating an IAM configuration
 
 You can create an IAM configuration for your cluster automatically using the `constellation iam create` command.
-If you did not generate a configuration file yet, you can do so by adding the `--generate-config` flag to the command, which will create a configuration file and populate it with the created IAM values automatically, or by [manually creating a configuration file](#creating-the-configuration-file).
+If you haven't generated a configuration file yet, you can do so by adding the `--generate-config` flag to the command. This creates a configuration file and populates it with the created IAM values.
 
 <tabs groupId="csp">
 <tabItem value="azure" label="Azure">

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -32,6 +32,10 @@ constellation config generate aws
 
 This creates the file `constellation-conf.yaml` in the current directory.
 
+:::tip
+You can also automatically generate a configuration file by adding the `--generate-config` flag to the `constellation iam create` command when [creating an IAM configuration](#creating-an-iam-configuration).
+:::
+
 ## Choosing VM types
 
 Constellation supports the following VM types:
@@ -60,6 +64,8 @@ Fill the desired VM type into the **instanceType** field in the `constellation-c
 ## Creating an IAM configuration
 
 You can create an IAM configuration for your cluster automatically using the `constellation iam create` command.
+If you did not generate a configuration file yet, you can do so by adding the `--generate-config` flag to the command, which will create a configuration file and populate it with the created IAM values automatically, or by [manually creating a configuration file](#creating-the-configuration-file).
+
 <tabs groupId="csp">
 <tabItem value="azure" label="Azure">
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Adding documentation to the `--generate-config` flag of the `constellation iam create` command which automatically generates a configuration file and populates it with the created IAM values.

### Additional info
- The "First steps" section features the shortest way of creating a cluster, by using the 2-in-1 command. It also links to the detailed workflow page for people who are interested in separate IAM / config creation.
- The "Configure your cluster" workflow page then features the workflow of separate IAM / config creation but also explains how to do it in the 2-in-1 way.

