### PR TITLE
ci: fix CLI SBOM generation

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -107,14 +107,15 @@ jobs:
 
       - name: Download Syft & Grype
         shell: bash
+        working-directory: /tmp
         run: |
           SYFT_VERSION=0.66.1
           GRYPE_VERSION=0.55.0
-          curl -LO https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz
+          curl -Lo syft_${SYFT_VERSION}_linux_amd64.tar.gz https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz
           tar -xzf syft_${SYFT_VERSION}_linux_amd64.tar.gz
           sudo install syft /usr/bin/syft
           syft version
-          curl -LO https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz
+          curl -Lo grype_${GRYPE_VERSION}_linux_amd64.tar.gz https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz
           tar -xzf grype_${GRYPE_VERSION}_linux_amd64.tar.gz
           sudo install grype /usr/bin/grype
           grype version

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -100,38 +100,56 @@ jobs:
   signed-sbom:
     runs-on: ubuntu-22.04
     steps:
+      - name: Setup Go environment
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
+        with:
+          go-version: "1.19.5"
+
+      - name: Download Syft & Grype
+        shell: bash
+        run: |
+          SYFT_VERSION=0.66.1
+          GRYPE_VERSION=0.55.0
+          curl -LO https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz
+          tar -xzf syft_${SYFT_VERSION}_linux_amd64.tar.gz
+          sudo install syft /usr/bin/syft
+          syft version
+          curl -LO https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz
+          tar -xzf grype_${GRYPE_VERSION}_linux_amd64.tar.gz
+          sudo install grype /usr/bin/grype
+          grype version
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # tag=v2.8.1
+
       - name: Checkout
         id: checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           ref: ${{ inputs.ref || github.head_ref }}
 
-      - name: Download syft & grype
-        shell: bash
-        run: |
-          SYFT_VERSION=0.62.1
-          GRYPE_VERSION=0.53.1
-          curl -LO https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz
-          tar -xzf syft_${SYFT_VERSION}_linux_amd64.tar.gz
-          ./syft version
-          curl -LO https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz
-          tar -xzf grype_${GRYPE_VERSION}_linux_amd64.tar.gz
-          ./grype version
-          pwd >> "$GITHUB_PATH"
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # tag=v2.8.1
+      # Build one CLI since Syft's go-module catalog will default to binary parsing.
+      # Binary parsing has the advantage that it will not include other dependencies from our repo not included in the CLI.
+      # This seems to work fine for one OS & one arch as long as we don't have OS specific imports.
+      # Luckily, so far this does not seem to be the case.
+      # As of v2.4.0, all SBOMs seem to have the same packages for [linux|darwin] & [amd64|arm64].
+      # If this changes, this should be split up into multiple builds & multiple SBOMs.
+      - name: Build CLI (amd64, linux)
+        uses: ./.github/actions/build_cli
+        with:
+          targetOS: "linux"
+          targetArch: "amd64"
 
       - name: Build signed SBOM
+        run: |
+          syft build/constellation-linux-amd64 --catalogers go-module --file constellation.spdx.sbom -o spdx-json
+          cosign sign-blob --key env://COSIGN_PRIVATE_KEY constellation.spdx.sbom > constellation.spdx.sbom.sig
+          grype constellation.spdx.sbom --fail-on high --only-fixed --add-cpes-if-none
         env:
           COSIGN_EXPERIMENTAL: 1
           COSIGN_PUBLIC_KEY: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
           COSIGN_PRIVATE_KEY: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PRIVATE_KEY || secrets.COSIGN_DEV_PRIVATE_KEY }}
           COSIGN_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PASSWORD || secrets.COSIGN_DEV_PASSWORD }}
-        run: |
-          syft . --catalogers go-module --file constellation.spdx.sbom -o spdx-json
-          cosign sign-blob --key env://COSIGN_PRIVATE_KEY constellation.spdx.sbom > constellation.spdx.sbom.sig
-          grype constellation.spdx.sbom --fail-on high --only-fixed
 
       - name: Upload Constellation CLI SBOM
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2


### PR DESCRIPTION
### Proposed change(s)
- Update Syft to 0.66.1
- Update Grype to 0.55.0
- Install the two tools to `/usr/local/bin` to avoid polluting the git tree
- Build linux/amd64 CLI as reference for Syft to collect the used modules

Syft's `go-module` did not collect the package list correctly before ever since the build was separated from the SBOM generation. The alternative would be to use `go-mod-file`, which would collect every package this monorepo imports - even if it's not inside the CLI. Since we have separate SBOMs for the microservices (which look good to me), that would be somewhat undesirable.

Thus we build the linux/amd64 CLI as reference to collect all the modules. Testing between what we currently ship (Linux/macOS & amd64/arm64), the generated SBOMs hold the same packages for the CLI, so for the moment we can do that and just release one SBOM file for the CLI instead of four.

However, in case we add more platform-specific code in the future to the CLI, it might become necessary to ship multiple SBOMs per platform or architecture to represent accurate package information for each released CLI. 

That should be kept in mind. 
