### PR TITLE
ci: move Syft & Grype installation into an action

### DIFF
--- a/.github/actions/container_sbom/action.yml
+++ b/.github/actions/container_sbom/action.yml
@@ -17,24 +17,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout
+      id: checkout
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+      with:
+        ref: ${{ inputs.ref || github.head_ref }}
+
     - name: Install Cosign
       if: inputs.cosignPublicKey != '' && inputs.cosignPrivateKey != '' && inputs.cosignPassword != ''
       uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # tag=v2.8.1
 
     - name: Download Syft & Grype
-      shell: bash
-      working-directory: /tmp
-      run: |
-        SYFT_VERSION=0.66.2
-        GRYPE_VERSION=0.55.0
-        curl -Lo syft_${SYFT_VERSION}_linux_amd64.tar.gz https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz
-        tar -xzf syft_${SYFT_VERSION}_linux_amd64.tar.gz
-        sudo install syft /usr/bin/syft
-        syft version
-        curl -Lo grype_${GRYPE_VERSION}_linux_amd64.tar.gz https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz
-        tar -xzf grype_${GRYPE_VERSION}_linux_amd64.tar.gz
-        sudo install grype /usr/bin/grype
-        grype version
+      uses: ./.github/actions/install_syft_grype
 
     - name: Generate SBOM
       shell: bash

--- a/.github/actions/container_sbom/action.yml
+++ b/.github/actions/container_sbom/action.yml
@@ -21,18 +21,20 @@ runs:
       if: inputs.cosignPublicKey != '' && inputs.cosignPrivateKey != '' && inputs.cosignPassword != ''
       uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # tag=v2.8.1
 
-    - name: Download syft & grype
+    - name: Download Syft & Grype
       shell: bash
+      working-directory: /tmp
       run: |
         SYFT_VERSION=0.66.2
         GRYPE_VERSION=0.55.0
-        curl -LO https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz
+        curl -Lo syft_${SYFT_VERSION}_linux_amd64.tar.gz https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz
         tar -xzf syft_${SYFT_VERSION}_linux_amd64.tar.gz
-        ./syft version
-        curl -LO https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz
+        sudo install syft /usr/bin/syft
+        syft version
+        curl -Lo grype_${GRYPE_VERSION}_linux_amd64.tar.gz https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz
         tar -xzf grype_${GRYPE_VERSION}_linux_amd64.tar.gz
-        ./grype version
-        echo $(pwd) >> $GITHUB_PATH
+        sudo install grype /usr/bin/grype
+        grype version
 
     - name: Generate SBOM
       shell: bash

--- a/.github/actions/container_sbom/action.yml
+++ b/.github/actions/container_sbom/action.yml
@@ -24,8 +24,8 @@ runs:
     - name: Download syft & grype
       shell: bash
       run: |
-        SYFT_VERSION=0.59.0
-        GRYPE_VERSION=0.51.0
+        SYFT_VERSION=0.66.2
+        GRYPE_VERSION=0.55.0
         curl -LO https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz
         tar -xzf syft_${SYFT_VERSION}_linux_amd64.tar.gz
         ./syft version

--- a/.github/actions/install_syft_grype/action.yml
+++ b/.github/actions/install_syft_grype/action.yml
@@ -1,0 +1,36 @@
+name: Install Syft & Grype
+description: |
+  Installs Syft & Grype.
+inputs:
+  versionSyft:
+    description: "Version of the operator-sdk to install"
+    default: "0.66.2"
+    required: false
+  versionGrype:
+    description: "Version of Grype to install"
+    default: "0.55.0"
+    required: false
+  os:
+    description: "Download build of Syft & Grype for operating system [linux, darwin]"
+    default: "linux"
+    required: false
+  arch:
+    description: "Download build of Syft & Grype for architecture [amd64, arm64]"
+    default: "amd64"
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Syft & Grype
+      shell: bash
+      working-directory: /tmp
+      run: |
+        curl -Lo syft_${{ inputs.versionSyft }}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz https://github.com/anchore/syft/releases/download/v${{ inputs.versionSyft }}/syft_${{ inputs.versionSyft }}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
+        tar -xzf syft_${{ inputs.versionSyft }}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
+        sudo install syft /usr/bin/syft
+        syft version
+        curl -Lo grype_${{ inputs.versionGrype }}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz https://github.com/anchore/grype/releases/download/v${{ inputs.versionGrype }}/grype_${{ inputs.versionGrype }}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
+        tar -xzf grype_${{ inputs.versionGrype }}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
+        sudo install grype /usr/bin/grype
+        grype version

--- a/.github/actions/install_syft_grype/action.yml
+++ b/.github/actions/install_syft_grype/action.yml
@@ -2,14 +2,6 @@ name: Install Syft & Grype
 description: |
   Installs Syft & Grype.
 inputs:
-  versionSyft:
-    description: "Version of Syft to install"
-    default: "0.66.2"
-    required: false
-  versionGrype:
-    description: "Version of Grype to install"
-    default: "0.55.0"
-    required: false
   os:
     description: "Download build of Syft & Grype for operating system [linux, darwin]"
     default: "linux"
@@ -25,12 +17,15 @@ runs:
     - name: Install Syft & Grype
       shell: bash
       working-directory: /tmp
+      env:
+        SYFT_VERSION: "0.66.2"
+        GRYPE_VRSION: "0.55.0"
       run: |
-        curl -Lo syft_${{ inputs.versionSyft }}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz https://github.com/anchore/syft/releases/download/v${{ inputs.versionSyft }}/syft_${{ inputs.versionSyft }}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
-        tar -xzf syft_${{ inputs.versionSyft }}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
+        curl -Lo syft_${SYFT_VERSION}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
+        tar -xzf syft_${SYFT_VERSION}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
         sudo install syft /usr/bin/syft
         syft version
-        curl -Lo grype_${{ inputs.versionGrype }}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz https://github.com/anchore/grype/releases/download/v${{ inputs.versionGrype }}/grype_${{ inputs.versionGrype }}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
-        tar -xzf grype_${{ inputs.versionGrype }}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
+        curl -Lo grype_${GRYPE_VERSION}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
+        tar -xzf grype_${GRYPE_VERSION}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
         sudo install grype /usr/bin/grype
         grype version

--- a/.github/actions/install_syft_grype/action.yml
+++ b/.github/actions/install_syft_grype/action.yml
@@ -1,16 +1,5 @@
 name: Install Syft & Grype
-description: |
-  Installs Syft & Grype.
-inputs:
-  os:
-    description: "Download build of Syft & Grype for operating system [linux, darwin]"
-    default: "linux"
-    required: false
-  arch:
-    description: "Download build of Syft & Grype for architecture [amd64, arm64]"
-    default: "amd64"
-    required: false
-
+description: Installs Syft & Grype.
 runs:
   using: "composite"
   steps:
@@ -19,13 +8,31 @@ runs:
       working-directory: /tmp
       env:
         SYFT_VERSION: "0.66.2"
-        GRYPE_VRSION: "0.55.0"
+        GRYPE_VERSION: "0.55.0"
+        OS: ${{ runner.os }}
+        ARCH: ${{ runner.arch }}
       run: |
-        curl -Lo syft_${SYFT_VERSION}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
-        tar -xzf syft_${SYFT_VERSION}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
+        echo "::group::Download and Install Syft & Grype"
+        # Translate GitHub runner naming conventions to GOOS / GOARCH conventions
+        if [[ "${OS}" = "macOS" ]]; then
+          OS="darwin"
+        else
+          OS=${OS,,}
+        fi
+  
+        if [[ "${ARCH}" = "X64" ]]; then
+          ARCH="amd64"
+        else
+          ARCH=${ARCH,,}
+        fi
+        
+        echo "Downloading for ${OS}/${ARCH}"
+        
+        curl -Lo syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz
+        tar -xzf syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz
         sudo install syft /usr/bin/syft
         syft version
-        curl -Lo grype_${GRYPE_VERSION}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
-        tar -xzf grype_${GRYPE_VERSION}_${{ inputs.os }}_${{ inputs.arch }}.tar.gz
+        curl -Lo grype_${GRYPE_VERSION}_${OS}_${ARCH}.tar.gz https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_${OS}_${ARCH}.tar.gz
+        tar -xzf grype_${GRYPE_VERSION}_${OS}_${ARCH}.tar.gz
         sudo install grype /usr/bin/grype
         grype version

--- a/.github/actions/install_syft_grype/action.yml
+++ b/.github/actions/install_syft_grype/action.yml
@@ -28,11 +28,11 @@ runs:
         
         echo "Downloading for ${OS}/${ARCH}"
         
-        curl -Lo syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz
+        curl -fsSLo syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz
         tar -xzf syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz
         sudo install syft /usr/bin/syft
         syft version
-        curl -Lo grype_${GRYPE_VERSION}_${OS}_${ARCH}.tar.gz https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_${OS}_${ARCH}.tar.gz
+        curl -fsSLo grype_${GRYPE_VERSION}_${OS}_${ARCH}.tar.gz https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_${OS}_${ARCH}.tar.gz
         tar -xzf grype_${GRYPE_VERSION}_${OS}_${ARCH}.tar.gz
         sudo install grype /usr/bin/grype
         grype version

--- a/.github/actions/install_syft_grype/action.yml
+++ b/.github/actions/install_syft_grype/action.yml
@@ -3,7 +3,7 @@ description: |
   Installs Syft & Grype.
 inputs:
   versionSyft:
-    description: "Version of the operator-sdk to install"
+    description: "Version of Syft to install"
     default: "0.66.2"
     required: false
   versionGrype:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -100,34 +100,22 @@ jobs:
   signed-sbom:
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ inputs.ref || github.head_ref }}
+
       - name: Setup Go environment
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: "1.19.5"
 
       - name: Download Syft & Grype
-        shell: bash
-        working-directory: /tmp
-        run: |
-          SYFT_VERSION=0.66.2
-          GRYPE_VERSION=0.55.0
-          curl -Lo syft_${SYFT_VERSION}_linux_amd64.tar.gz https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz
-          tar -xzf syft_${SYFT_VERSION}_linux_amd64.tar.gz
-          sudo install syft /usr/bin/syft
-          syft version
-          curl -Lo grype_${GRYPE_VERSION}_linux_amd64.tar.gz https://github.com/anchore/grype/releases/download/v${GRYPE_VERSION}/grype_${GRYPE_VERSION}_linux_amd64.tar.gz
-          tar -xzf grype_${GRYPE_VERSION}_linux_amd64.tar.gz
-          sudo install grype /usr/bin/grype
-          grype version
+        uses: ./.github/actions/install_syft_grype
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # tag=v2.8.1
-
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          ref: ${{ inputs.ref || github.head_ref }}
 
       # Build one CLI since Syft's go-module catalog will default to binary parsing.
       # Binary parsing has the advantage that it will not include other dependencies from our repo not included in the CLI.

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -109,7 +109,7 @@ jobs:
         shell: bash
         working-directory: /tmp
         run: |
-          SYFT_VERSION=0.66.1
+          SYFT_VERSION=0.66.2
           GRYPE_VERSION=0.55.0
           curl -Lo syft_${SYFT_VERSION}_linux_amd64.tar.gz https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_linux_amd64.tar.gz
           tar -xzf syft_${SYFT_VERSION}_linux_amd64.tar.gz


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Update Syft to v0.66.2 (CLI + container SBOMs) (was released yesterday after I initially opened my previous PR: https://github.com/anchore/syft/releases/tag/v0.66.2)
- Update Grype to v0.55.0 (container SBOMs, CLI was already updated with #1005)
- Use same "download to /tmp and install to /usr/bin" install method for Syft and Grype for the container SBOMs as for the release CLI action
- Move the install into an action

This should make it easier to keep the version for the CLI and containers in sync.
Small disadvantage is that now the Checkout needs to be before the install again. The action does download to /tmp though, so it should keep the git workspace clean.