### PR TITLE
ci: downgrade Syft to v0.65.0

### DIFF
--- a/.github/actions/install_syft_grype/action.yml
+++ b/.github/actions/install_syft_grype/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       working-directory: /tmp
       env:
-        SYFT_VERSION: "0.66.2"
+        SYFT_VERSION: "0.65.0" # Before upgrading, check if this has been fixed: https://github.com/anchore/syft/issues/1465
         GRYPE_VERSION: "0.55.0"
         OS: ${{ runner.os }}
         ARCH: ${{ runner.arch }}


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Downgrade Syft to v0.65.0

### Related issue
- https://github.com/anchore/syft/issues/1465
> We will have an updated README and a new way to specify a private key in the next release of Syft. 


> A second PR will follow that implements custom PKI provided by the user.
