### PR TITLE
config: detailed validation errors for k8s version

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -481,6 +481,10 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if err := validate.RegisterTranslation("supported_k8s_version", trans, registerInvalidK8sVersionError, translateInvalidK8sVersionError); err != nil {
+		return err
+	}
+
 	if err := validate.RegisterValidation("no_placeholders", validateNoPlaceholder); err != nil {
 		return err
 	}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -9,6 +9,7 @@ package config
 import (
 	"bytes"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
@@ -17,10 +18,40 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/versions"
 	ut "github.com/go-playground/universal-translator"
 	"github.com/go-playground/validator/v10"
+	"golang.org/x/mod/semver"
 )
 
 func validateK8sVersion(fl validator.FieldLevel) bool {
 	return versions.IsSupportedK8sVersion(fl.Field().String())
+}
+
+func registerInvalidK8sVersionError(ut ut.Translator) error {
+	return ut.Add("invalid_k8s_version", "{0} specifies an unsupported Kubernetes version. {1}", true)
+}
+
+func translateInvalidK8sVersionError(ut ut.Translator, fe validator.FieldError) string {
+	validVersions := make([]string, len(versions.VersionConfigs))
+	i := 0
+	for k := range versions.VersionConfigs {
+		validVersions[i] = string(k)
+		i++
+	}
+	validVersionsSorted := semver.ByVersion(validVersions)
+	sort.Sort(validVersionsSorted)
+
+	var errorMsg string
+	configured := fe.Value().(string)
+	maxVersion := validVersionsSorted[len(validVersionsSorted)-1]
+	if configured < validVersionsSorted[0] {
+		errorMsg = fmt.Sprintf("You can upgrade to these versions with your current Constellation CLI: %s.", validVersionsSorted)
+	}
+	if configured > maxVersion {
+		errorMsg = fmt.Sprintf("The configured version %s is newer than the newest version supported by this CLI: %s.", configured, maxVersion)
+	}
+
+	t, _ := ut.T("invalid_k8s_version", fe.Field(), errorMsg)
+
+	return t
 }
 
 func validateAWSInstanceType(fl validator.FieldLevel) bool {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -40,10 +40,16 @@ func translateInvalidK8sVersionError(ut ut.Translator, fe validator.FieldError) 
 	sort.Sort(validVersionsSorted)
 
 	var errorMsg string
-	configured := fe.Value().(string)
+	configured, ok := fe.Value().(string)
+	if !ok {
+		errorMsg = "The configured version is not a valid string"
+	}
+
 	maxVersion := validVersionsSorted[len(validVersionsSorted)-1]
-	if configured < validVersionsSorted[0] {
-		errorMsg = fmt.Sprintf("You can upgrade to these versions with your current Constellation CLI: %s.", validVersionsSorted)
+	minVersion := validVersionsSorted[0]
+
+	if configured < minVersion {
+		errorMsg = fmt.Sprintf("The configured version %s is older than the oldest version supported by this CLI: %s.", configured, minVersion)
 	}
 	if configured > maxVersion {
 		errorMsg = fmt.Sprintf("The configured version %s is newer than the newest version supported by this CLI: %s.", configured, maxVersion)


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
These extended error messages help users in understanding what is wrong with the current configuration and how to remediate the issue. 

Target version too new:
```
../constellation create -c 1 -w 2 -y
Problems validating config file:                                                                                                             
        KubernetesVersion specifies an unsupported Kubernetes version. The configured version 1.77 is newer than the newest version supported by this CLI: 1.26                                                                                                                           
Fix the invalid entries or generate a new configuration using `constellation config generate`                                                
Error: invalid configuration
```

Target version too old:
```
../constellation create -c 1 -w 2 -y
Problems validating config file:                                                                                                             
        KubernetesVersion specifies an unsupported Kubernetes version. You can upgrade to these versions with your current Constellation CLI: [1.23 1.24 1.25 1.26]                                                                                                                        
Fix the invalid entries or generate a new configuration using `constellation config generate`                                          
Error: invalid configuration 
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Link to Milestone
