### PR TITLE
ci: downgrade Syft back to 0.59.0

### DIFF
--- a/.github/actions/install_syft_grype/action.yml
+++ b/.github/actions/install_syft_grype/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       working-directory: /tmp
       env:
-        SYFT_VERSION: "0.65.0" # Before upgrading, check if this has been fixed: https://github.com/anchore/syft/issues/1465
+        SYFT_VERSION: "0.59.0" # Before upgrading, check if this has been fixed: https://github.com/anchore/syft/issues/1465
         GRYPE_VERSION: "0.55.0"
         OS: ${{ runner.os }}
         ARCH: ${{ runner.arch }}
@@ -19,15 +19,15 @@ runs:
         else
           OS=${OS,,}
         fi
-  
+
         if [[ "${ARCH}" = "X64" ]]; then
           ARCH="amd64"
         else
           ARCH=${ARCH,,}
         fi
-        
+
         echo "Downloading for ${OS}/${ARCH}"
-        
+
         curl -fsSLo syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz
         tar -xzf syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz
         sudo install syft /usr/bin/syft


### PR DESCRIPTION
### Proposed change(s)
- Downgrade Syft back to 0.59.0

### Related issue
- Can't use ~0.60.0+ (?)~ due to: https://github.com/anchore/syft/issues/1483 (actually the old version we had before yesterday also seems to be affected)
- Can't use 0.65.0 due to: https://github.com/anchore/syft/issues/1465

When upgrading at a later point, please check if both issues are fixed.
