### PR TITLE
ci: fix GCP cloud controller manager build

### DIFF
--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -11,9 +11,12 @@ jobs:
       packages: write
     strategy:
       matrix:
-        version: [v25.2.0, v24.0.0, v23.0.0]
+        version: [v26.0.1]
+        # TODO: Once issue is closed upgrade older versions, rebuild, and update versions.go
+        # https://github.com/kubernetes/cloud-provider-gcp/issues/451
+        # version: [v26.0.1, v25.5.0, v24.0.0]
         include:
-          - version: v25.2.0
+          - version: v26.0.1
             latest: true
     steps:
       - name: Checkout kubernetes/cloud-provider-gcp
@@ -45,7 +48,7 @@ jobs:
 
       - name: Build CCM
         run: |
-          "${GITHUB_WORKSPACE}/bin/bazel" build //cmd/cloud-controller-manager:cloud-controller-manager
+          bazelisk build //cmd/cloud-controller-manager:cloud-controller-manager
 
       - name: Copy CCM
         run: |


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fixed broken build as `"${GITHUB_WORKSPACE}/bin/bazel"` didnt exist anymore after https://github.com/edgelesssys/constellation/commit/8aa84fd7597b69dbd7f4c59c17410eae570b2b7d, but bazelisk is available on all runners.
- As described in linked issue, the bazel build is currently broken for older version, so I have removed them from CI for now.
- Build for latest version works so I have upgraded image in versions.go

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
