### PR TITLE
docs: update security issue warning to use Github warning banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ Refer to [`CONTRIBUTING.md`](CONTRIBUTING.md) on how to contribute. The most imp
 
 * Pull requests are welcome! You need to agree to our [Contributor License Agreement][cla-assistant].
 * Please follow the [Code of Conduct](/CODE_OF_CONDUCT.md).
-* ⚠️ Please report any security issue via a [private GitHub vulnerability report](https://github.com/edgelesssys/constellation/security/advisories/new) or write to security@edgeless.systems.
+
+> **Warning**
+> Please report any security issue via a [private GitHub vulnerability report](https://github.com/edgelesssys/constellation/security/advisories/new) or write to security@edgeless.systems.
 
 ## License
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Update our `Contributing` section in root `README.md` to use Githubs [native](https://github.com/community/community/discussions/16925) warning parkup.