### PR TITLE
ci: move scheduled build into own workflow

### DIFF
--- a/.github/actions/os_build_variables/action.yml
+++ b/.github/actions/os_build_variables/action.yml
@@ -261,8 +261,8 @@ runs:
         echo "rawImagePath=${basePath}/mkosi.output.gcp/fedora~37/image.raw" >> $GITHUB_OUTPUT
         echo "imagePath=${basePath}/mkosi.output.gcp/fedora~37/image.tar.gz" >> $GITHUB_OUTPUT
         echo "jsonOutput=${basePath}/mkosi.output.gcp/fedora~37/image-upload.json" >> $GITHUB_OUTPUT
-        echo "imageName=constellation-${imageVersion//./-}" >> $GITHUB_OUTPUT
-        echo "imageFilename=constellation-${imageVersion//./-}.tar.gz" >> $GITHUB_OUTPUT
+        echo "imageName=${imageVersion//./-}-${stream}" >> $GITHUB_OUTPUT
+        echo "imageFilename=${imageVersion//./-}-${stream}.tar.gz" >> $GITHUB_OUTPUT
         if [[ "${stream}" = "stable" ]]
         then
           echo "imageFamily=constellation" >> $GITHUB_OUTPUT

--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -1,0 +1,40 @@
+name: Build and Upload OS image
+
+on:
+  schedule:
+    - cron: "0 21 * * 5" # At 21:00 on Friday.
+    - cron: "10 21 * * 5" # At 21:10 on Friday.
+    - cron: "20 21 * * 5" # At 21:20 on Friday.
+
+jobs:
+  stream:
+    runs-on: ubuntu-22.04
+    outputs:
+      stream: ${{ steps.stream.outputs.stream }}
+    steps:
+      - name: Determine stream
+        id: stream
+        run: |
+          case "${{ github.event.schedule }}" in
+            "0 21 * * 5")
+              echo "stream=debug" >> "$GITHUB_OUTPUT"
+              ;;
+            "10 21 * * 5")
+              echo "stream=console" >> "$GITHUB_OUTPUT"
+              ;;
+            "20 21 * * 5")
+              echo "stream=nightly" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unknown stream for schedule '${{ github.event.schedule }}'"
+              exit 1
+              ;;
+          esac
+
+  build-image:
+    needs: stream
+    uses: ./.github/workflows/build-os-image.yml
+    secrets: inherit
+    with:
+      stream: ${{ needs.stream.outputs.stream }}
+      ref: main

--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -1,9 +1,6 @@
 name: Build and Upload OS image
+
 on:
-  schedule:
-    - cron: "0 21 * * 5" # At 21:00 on Friday.
-    - cron: "10 21 * * 5" # At 21:10 on Friday.
-    - cron: "20 21 * * 5" # At 21:20 on Friday.
   workflow_dispatch:
     inputs:
       imageVersion:
@@ -142,25 +139,13 @@ jobs:
           if [[ "${{ inputs.isRelease }}" == "true" ]] && [[ "${{ inputs.stream }}" == "nightly" ]]; then
             echo "Nightly builds are not allowed for releases"
             exit 1
-          elif [[ "${{ inputs.isRelease }}" != "true" ]] && [[ "${{ inputs.stream }}" == "stable" ]]; then
+          fi
+          if [[ "${{ inputs.isRelease }}" != "true" ]] && [[ "${{ inputs.stream }}" == "stable" ]]; then
             echo "Stable builds are only allowed for releases"
             exit 1
           fi
 
-          case "${{ github.event.schedule }}" in
-            "0 21 * * 5")
-              echo "stream=debug" >> "$GITHUB_OUTPUT"
-              ;;
-            "10 21 * * 5")
-              echo "stream=console" >> "$GITHUB_OUTPUT"
-              ;;
-            "20 21 * * 5")
-              echo "stream=nightly" >> "$GITHUB_OUTPUT"
-              ;;
-            *)
-              echo "stream=${{ inputs.stream }}" >> "$GITHUB_OUTPUT"
-              ;;
-          esac
+          echo "stream=${{ inputs.stream }}" >> "$GITHUB_OUTPUT"
 
       - name: Determine type of image build
         shell: bash

--- a/internal/versionsapi/cli/rm.go
+++ b/internal/versionsapi/cli/rm.go
@@ -139,14 +139,14 @@ func runRemove(cmd *cobra.Command, args []string) (retErr error) {
 func deleteSingleVersion(ctx context.Context, clients rmImageClients, ver versionsapi.Version, dryrun bool, log *logger.Logger) error {
 	var retErr error
 
-	log.Debugf("Deleting version %s from versions API", ver.Version)
-	if err := clients.version.DeleteVersion(ctx, ver); err != nil {
-		retErr = multierr.Append(retErr, fmt.Errorf("deleting version from versions API: %w", err))
-	}
-
 	log.Debugf("Deleting images for %s", ver.Version)
 	if err := deleteImage(ctx, clients, ver, dryrun, log); err != nil {
 		retErr = multierr.Append(retErr, fmt.Errorf("deleting images: %w", err))
+	}
+
+	log.Debugf("Deleting version %s from versions API", ver.Version)
+	if err := clients.version.DeleteVersion(ctx, ver); err != nil {
+		retErr = multierr.Append(retErr, fmt.Errorf("deleting version from versions API: %w", err))
 	}
 
 	return retErr


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fixing a bug where versionsapi couldn't delete images at the cloud provider because the versionsapi object was deleted first.
- Fixing a bug where the scheduled image build would build a debug image with a bootstrapper in it.
- Moving the scheduled build into an own workflow for better separation. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
