### PR TITLE
cli: set placeholder uid for QEMU / MiniConstellation

### DIFF
--- a/cli/internal/cmd/minidown.go
+++ b/cli/internal/cmd/minidown.go
@@ -52,7 +52,7 @@ func checkForMiniCluster(fileHandler file.Handler) error {
 	if idFile.CloudProvider != cloudprovider.QEMU {
 		return errors.New("cluster is not a QEMU based Constellation")
 	}
-	if idFile.UID != "mini" {
+	if idFile.UID != constants.MiniConstellationUID {
 		return errors.New("cluster is not a MiniConstellation cluster")
 	}
 

--- a/cli/internal/cmd/miniup.go
+++ b/cli/internal/cmd/miniup.go
@@ -223,7 +223,7 @@ func (m *miniUpCmd) createMiniCluster(ctx context.Context, fileHandler file.Hand
 		return err
 	}
 
-	idFile.UID = "mini" // use UID "mini" to identify MiniConstellation clusters.
+	idFile.UID = constants.MiniConstellationUID // use UID "mini" to identify MiniConstellation clusters.
 	m.log.Debugf("Cluster id file contains %v", idFile)
 	return fileHandler.WriteJSON(constants.ClusterIDsFileName, idFile, file.OptNone)
 }

--- a/cli/internal/terraform/terraform/qemu/outputs.tf
+++ b/cli/internal/terraform/terraform/qemu/outputs.tf
@@ -2,6 +2,10 @@ output "ip" {
   value = module.control_plane.instance_ips[0]
 }
 
+output "uid" {
+  value = "qemu" // placeholder
+}
+
 output "initSecret" {
   value     = random_password.initSecret.result
   sensitive = true

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -141,6 +141,8 @@ const (
 	// EnvVarAzureClientSecretValue is environment variable to overwrite
 	// provider.azure.clientSecretValue .
 	EnvVarAzureClientSecretValue = EnvVarPrefix + "AZURE_CLIENT_SECRET_VALUE"
+	// MiniConstellationUID is a sentinel value for the UID of a mini constellation.
+	MiniConstellationUID = "mini"
 
 	//
 	// Kubernetes.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: set placeholder uid for QEMU / MiniConstellation

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### How to reproduce

Download constellation 2.5.0 and try to use MiniConstellation:

```shell-session
constellation mini up
Creating cluster in QEMU
An error occurred: no uid output found
Attempting to roll back.
Rollback succeeded.
Error: creating cluster: no uid output found
```

### Additional info

Fixes a bug in ae2db08f3ae01d9cce2741d4be75df113eea0a83 where a `uid` is expected from all csps in the terraform output.
QEMU does not have a uid so parsing of the output fails.
Fixed by setting a placeholder uid.


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
