### PR TITLE
ci: fix Constellation recover e2e test

### DIFF
--- a/.github/actions/e2e_recover/action.yml
+++ b/.github/actions/e2e_recover/action.yml
@@ -11,15 +11,6 @@ inputs:
   masterSecret:
     description: "The master-secret for the cluster."
     required: true
-  cloudProvider:
-    description: "Which cloud provider to use."
-    required: true
-  gcpProject:
-    description: "The GCP project Constellation is deployed in."
-    required: false
-  resourceGroup:
-    description: "The Azure resource group Constellation is deployed in."
-    required: false
 
 runs:
   using: "composite"
@@ -86,7 +77,7 @@ runs:
               exit 1
           fi
 
-          echo "Cannot reach control plane: $output, retrying in 10 seconds"
+          echo "Cannot reach control plane, retrying in 10 seconds"
           sleep 10
         done
       env:

--- a/.github/actions/e2e_recover/action.yml
+++ b/.github/actions/e2e_recover/action.yml
@@ -55,7 +55,7 @@ runs:
                 i=$(echo "$output" | grep -o "Pushed recovery key." | wc -l | sed 's/ //g')
                 recovered=$((recovered+i))
                 if [[ $recovered -eq ${{ inputs.controlNodesCount }} ]]; then
-                    exit 0
+                    break
                 fi
             fi
 
@@ -68,6 +68,26 @@ runs:
             echo "Did not recover all nodes yet, retrying in 5 seconds [$recovered/${{ inputs.controlNodesCount }}]"
             sleep 5
         done
-        kubectl wait --for=condition=Ready --timeout=10m --all nodes
+    - name: Wait for control plane to get back up
+      shell: bash
+      run: |
+        timeout=600
+        start_time=$(date +%s)
+        while true; do
+          output=$(kubectl wait --for=condition=Ready --timeout=10m --all nodes || true)
+          if echo "$output" | grep -q "condition met"; then
+              echo "$output"
+              exit 0
+          fi
+
+          current_time=$(date +%s)
+          if ((current_time - start_time > timeout)); then
+              echo "Waiting for control plane to get back up timed out after $timeout seconds."
+              exit 1
+          fi
+
+          echo "Cannot reach control plane: $output, retrying in 10 seconds"
+          sleep 10
+        done
       env:
         KUBECONFIG: ${{ inputs.kubeconfig }}

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -233,8 +233,5 @@ runs:
       uses: ./.github/actions/e2e_recover
       with:
         controlNodesCount: ${{ inputs.controlNodesCount }}
-        cloudProvider: ${{ inputs.cloudProvider }}
-        gcpProject: ${{ inputs.gcpProject }}
         kubeconfig: ${{ steps.constellation-create.outputs.kubeconfig }}
         masterSecret: ${{ steps.constellation-create.outputs.masterSecret }}
-        azureResourceGroup: ${{ inputs.azureResourceGroup }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Wait for the control plane nodes to get back up after pushing the recovery keys to ensure control plane availability after recovering the cluster

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info
- [Successful run with 1 CP node](https://github.com/edgelesssys/constellation/actions/runs/4015145256/jobs/6896527567)
- [Successful run with 3 CP nodes](https://github.com/edgelesssys/constellation/actions/runs/4015146173/jobs/6896526073)


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
