### PR TITLE
terraform: make control-planes stateful on gcp

### DIFF
--- a/cli/internal/terraform/terraform/gcp/.terraform.lock.hcl
+++ b/cli/internal/terraform/terraform/gcp/.terraform.lock.hcl
@@ -5,17 +5,11 @@ provider "registry.terraform.io/hashicorp/google" {
   version     = "4.48.0"
   constraints = "4.48.0"
   hashes = [
-    "h1:3/lgbelVSJc91pnG7hXeJCDRwtIBjN0wwl3YCuLmZlo=",
-    "h1:Cv20AHpBqpdwG/zPI73B28RKvPbx+79YIOwjOQkHeww=",
-    "h1:H/MJiICFc/Z4nEpliQdHCAOkdfEMkO2dGa8JMT7x8i0=",
     "h1:KlfCQdOcTNgmBjo71J29RFKVLs4MxN4OP7rQo6gAEwE=",
     "h1:L2cITB+wV+2LoLluG3YUzC2vajygDrKuS4f3wW8YcQ0=",
     "h1:RSlZSo8GFKBNzDlQ/dMz3CCV/cPje929exxrQW+n/OQ=",
-    "h1:dNz4eG3TYUGlz0vQNIpP+A1ovzYRmJlt/3ghtLAF1Q8=",
     "h1:k+3asWyC+EEr3gi4Rq8cSP8kr2JGJGcVuQtBXVYorjM=",
     "h1:s+/NkoAeovIP8Dxo0g3xXOJ+6/MVnzYlIUN5xdwJDgo=",
-    "h1:t6SmnBVaStyL6StgZyRszeoBqU8NNz0QBF9OP/HBPs4=",
-    "h1:yHB4m5SnbJeJCQsaL2iegf46CyJilx24dZjZQE5dvO8=",
     "zh:19c2910e8c555482c28665ad8bed3b6b790ef9b66c565cbb6a5957f8be83048a",
     "zh:25fcb8e54aacdadca12fc9966745f34ae3918fa2a85ee1c1f084ec73c00eb01c",
     "zh:2e54b7902311b1ad69b0eeb2980a83df3df380042be50bf0785ddfc995de0ad8",
@@ -28,6 +22,30 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
     "zh:f6640c0d8780d2eb465f3fc4a4bcb11a4a0fc7d6db23feb79ca088fc8d081813",
     "zh:f6c0aed1c955399239010704894a8c583c61a53ef8ac732f9307d04c366f5e7d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "4.50.0"
+  constraints = "4.50.0"
+  hashes = [
+    "h1:Hk/FiEYCeD5hjnWmSjdieA1ljkU/5IFKZLFliBihoSA=",
+    "h1:UUqaoZf9B/dLII2fzpaIomR5Nfc9dBXeSXdzBV5RmVo=",
+    "h1:hMroxEFG0w6/fnNeCcd8ZGerMwXvhtlONXWN5czn/70=",
+    "h1:j2O+3bt6avOFaK1OQK3cj2rUQ48LpPnR076PfGyFQWw=",
+    "h1:pBa3CRwXRuBfD5NUlN2pT69P4BM7Pg4BEEdo3ZUKncA=",
+    "zh:21279b8b2f248a308a257ed954ea9c9c712ae62cd8881579489ac84c393d18e0",
+    "zh:3d5376c6295205b2d61998085f96054d677fd23ea15a7a626dec7b8e234580fb",
+    "zh:52d7a1fe39bc75293bf1aa949327b0cd3320411ff1ed9adeb80fee623fe7f807",
+    "zh:61a0e74e9686b0762383834364f5170860f49d40dbaca5977c660f96854d5c7b",
+    "zh:66084e3649835ae1f7d882578a1a1efea6051b68a4112110628d1e320b7c6d4f",
+    "zh:7f5d004de80540b938d88535b89f3b0093097a6b4cfd9658d8e788fc8034b2dc",
+    "zh:9e8a5afe13b0c8bda71293eeca8c6127f3c8689acc9d3543602c8af07af520f1",
+    "zh:c194593927f0bfd1c5001fd0e73d14bb424fe0c64dc7d5e4395b3de09499bad4",
+    "zh:cac2c09be56b43f8842de5eafaf26f9bc48be2b00c6bfeab91a7d6030e4ccf7f",
+    "zh:ceca718eb26a3e96dc43e7f21f8869c4b5e7c15a94223a3b53834050047d0e45",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f955c329b01daa9d7c1cd82267c5bd12b48cea5e643e734723af08247a17664c",
   ]
 }
 

--- a/cli/internal/terraform/terraform/gcp/main.tf
+++ b/cli/internal/terraform/terraform/gcp/main.tf
@@ -4,9 +4,15 @@ terraform {
       source  = "hashicorp/google"
       version = "4.48.0"
     }
+
     random = {
       source  = "hashicorp/random"
       version = "3.4.3"
+    }
+
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "4.50.0"
     }
   }
 }

--- a/cli/internal/terraform/terraform/gcp/main.tf
+++ b/cli/internal/terraform/terraform/gcp/main.tf
@@ -17,6 +17,12 @@ provider "google" {
   zone    = var.zone
 }
 
+provider "google-beta" {
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
 locals {
   uid                   = random_id.uid.hex
   name                  = "${var.name}-${local.uid}"

--- a/cli/internal/terraform/terraform/gcp/modules/instance_group/variables.tf
+++ b/cli/internal/terraform/terraform/gcp/modules/instance_group/variables.tf
@@ -5,7 +5,11 @@ variable "name" {
 
 variable "role" {
   type        = string
-  description = "The role of the instance group. Has to be 'ControlPlane' or 'Worker'."
+  description = "The role of the instance group."
+  validation {
+    condition     = contains(["ControlPlane", "Worker"], var.role)
+    error_message = "The role has to be 'ControlPlane' or 'Worker'."
+  }
 }
 
 variable "uid" {

--- a/hack/terraform/gcp/internal-loadbalancer/.terraform.lock.hcl
+++ b/hack/terraform/gcp/internal-loadbalancer/.terraform.lock.hcl
@@ -32,25 +32,26 @@ provider "registry.terraform.io/hashicorp/google" {
 }
 
 provider "registry.terraform.io/hashicorp/google-beta" {
-  version = "4.46.0"
+  version     = "4.50.0"
+  constraints = "4.50.0"
   hashes = [
-    "h1:Aj3ywOJ6IqwOHTMPIZFXQt1x2bMK/D/FHnhr7ft63bY=",
-    "h1:GQgp57Wrf3oDVB/nDtBd/VL3/uMTFN5bLPhPLLADGB4=",
-    "h1:SGL8Ge/ofpY9jtx6bapYkcwDzXNnDydrXpwW5BlbVFk=",
-    "h1:ZbWF1DV/Zdjk9yMpu5iRwxxviwAL1liehBM3/EHOxMw=",
-    "h1:zGs24p4gAJJdVTx2nNxWDtE14Ihd1RT27qU7GwqHQ7Q=",
-    "zh:08aa990fd9944061194138ad4f136f5e6b45f331d110d882e4ddb566619eb9d8",
-    "zh:186b9c7b49ad93a2ab2d8d713429caa8b23dab8d90763c01244205c3455dd813",
-    "zh:221598948eab9c64e13a778c6be17dd1e9cb2e08a3217072d9759202986c3f09",
-    "zh:402d386ea907923bbf36568dc481becda2dd0522c5286602dcb716f364f73d91",
-    "zh:84d70da182503ce312148cc86e110482c88d57041223af00d2ead60fefe851ee",
-    "zh:92bd8e30f6334988d6e7fedff11b99c68fe0d21bfead6f1cbbfc73acb665c36d",
-    "zh:a0e5815460c2a1d720955a2abbd6ca6eef450da7a76c52c223203f5d03ca45d7",
-    "zh:c34c0124f70b86ceb4cf79b93539539286f47175e1a648e37cfb754200cc19b7",
-    "zh:d00769dbfd1bea46da5ac81a9e3384d0f954ed3f912859b21ed3ea2378c2cb1d",
-    "zh:dadd937ed05dcc3d521cd6ca04bc9681fd30acbb42265f748e69f5feb0f5b829",
-    "zh:e4c2d65cf138cc868ae52e3e2cf97e37fbbdbc9c510f1c669fdbcc736256e402",
+    "h1:Hk/FiEYCeD5hjnWmSjdieA1ljkU/5IFKZLFliBihoSA=",
+    "h1:UUqaoZf9B/dLII2fzpaIomR5Nfc9dBXeSXdzBV5RmVo=",
+    "h1:hMroxEFG0w6/fnNeCcd8ZGerMwXvhtlONXWN5czn/70=",
+    "h1:j2O+3bt6avOFaK1OQK3cj2rUQ48LpPnR076PfGyFQWw=",
+    "h1:pBa3CRwXRuBfD5NUlN2pT69P4BM7Pg4BEEdo3ZUKncA=",
+    "zh:21279b8b2f248a308a257ed954ea9c9c712ae62cd8881579489ac84c393d18e0",
+    "zh:3d5376c6295205b2d61998085f96054d677fd23ea15a7a626dec7b8e234580fb",
+    "zh:52d7a1fe39bc75293bf1aa949327b0cd3320411ff1ed9adeb80fee623fe7f807",
+    "zh:61a0e74e9686b0762383834364f5170860f49d40dbaca5977c660f96854d5c7b",
+    "zh:66084e3649835ae1f7d882578a1a1efea6051b68a4112110628d1e320b7c6d4f",
+    "zh:7f5d004de80540b938d88535b89f3b0093097a6b4cfd9658d8e788fc8034b2dc",
+    "zh:9e8a5afe13b0c8bda71293eeca8c6127f3c8689acc9d3543602c8af07af520f1",
+    "zh:c194593927f0bfd1c5001fd0e73d14bb424fe0c64dc7d5e4395b3de09499bad4",
+    "zh:cac2c09be56b43f8842de5eafaf26f9bc48be2b00c6bfeab91a7d6030e4ccf7f",
+    "zh:ceca718eb26a3e96dc43e7f21f8869c4b5e7c15a94223a3b53834050047d0e45",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:f955c329b01daa9d7c1cd82267c5bd12b48cea5e643e734723af08247a17664c",
   ]
 }
 

--- a/hack/terraform/gcp/internal-loadbalancer/main.tf
+++ b/hack/terraform/gcp/internal-loadbalancer/main.tf
@@ -8,6 +8,10 @@ terraform {
       source  = "hashicorp/random"
       version = "3.4.3"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "4.50.0"
+    }
   }
 }
 

--- a/hack/terraform/gcp/internal-loadbalancer/modules/instance_group/main.tf
+++ b/hack/terraform/gcp/internal-loadbalancer/modules/instance_group/main.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/google"
       version = "4.48.0"
     }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "4.50.0"
+    }
   }
 }
 

--- a/hack/terraform/gcp/internal-loadbalancer/modules/instance_group/variables.tf
+++ b/hack/terraform/gcp/internal-loadbalancer/modules/instance_group/variables.tf
@@ -5,7 +5,11 @@ variable "name" {
 
 variable "role" {
   type        = string
-  description = "The role of the instance group. Has to be 'ControlPlane' or 'Worker'."
+  description = "The role of the instance group."
+  validation {
+    condition     = contains(["ControlPlane", "Worker"], var.role)
+    error_message = "The role has to be 'ControlPlane' or 'Worker'."
+  }
 }
 
 variable "uid" {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Make the control-plane instance group stateful by making the disk and internal ip stateful.

Then stopping an instance on GCP, it is automatically re-created from the template. Per default, a new state disk and IP is used. This is problematic when stopping all VMs at the same time.

To stop an instance on GCP do:
1. Go to the details view of the control-plane instance
2. Go back to the instance overview
3. Select all the instances to be stopped
4. Click the "Stop" button.

Steps 1-2 are needed since GCP normally does not really allow you to stop the instance (see greyed out button in the details view of the instance). 

Does anyone have opinions regarding if we should backport this?

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
