### PR TITLE
operator: log awaitingAnnotationNodes

### DIFF
--- a/operators/constellation-node-operator/controllers/nodeversion_controller.go
+++ b/operators/constellation-node-operator/controllers/nodeversion_controller.go
@@ -153,6 +153,7 @@ func (r *NodeVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		"heirNodes", len(groups.Heirs),
 		"mintNodes", len(groups.Mint),
 		"pendingNodes", len(pendingNodeList.Items),
+		"awaitingAnnotationNodes", len(groups.AwaitingAnnotation),
 		"obsoleteNodes", len(groups.Obsolete),
 		"invalidNodes", len(invalidNodes))
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- This minor change should make debugging https://github.com/edgelesssys/constellation/actions/runs/4025356008/jobs/6918466016 clearer. I assume what happens is that 2 node are created, one still in awaitingAnnotationNodes and one in JoiningNodes.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->
