### PR TITLE
ci: prevent empty tags field in build_ko pipeline

### DIFF
--- a/.github/actions/build_ko/action.yml
+++ b/.github/actions/build_ko/action.yml
@@ -8,10 +8,6 @@ inputs:
     description: "Name of the registry to use"
     required: false
     default: "ghcr.io"
-  pseudoVersion:
-    description: "Check if pseudo-version should be generated"
-    default: "false"
-    required: true
   koConfig:
     description: "Path to the .ko.yaml config file"
     required: false
@@ -46,7 +42,7 @@ runs:
   using: "composite"
   steps:
     - name: Determine pseudo version
-      if: inputs.pseudoVersion == 'true'
+      if: ${{ !inputs.pushTag}}
       id: pseudo-version
       uses: ./.github/actions/pseudo_version
 

--- a/.github/actions/build_micro_service_ko/action.yml
+++ b/.github/actions/build_micro_service_ko/action.yml
@@ -8,10 +8,6 @@ inputs:
     description: "Path to the .ko.yaml config file"
     default: ".ko.yaml"
     required: false
-  pseudoVersion:
-    description: "Check if pseudo-version should be generated"
-    default: "false"
-    required: true
   koTarget:
     description: "Go package to build with ko"
     required: true
@@ -39,18 +35,11 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Determine pseudo version
-      if: inputs.pseudoVersion == 'true'
-      uses: ./.github/actions/pseudo_version
-      with:
-        constellationPath: ${{ inputs.constellationPath }}
-
     - name: Build and upload container image
       id: build-and-upload
       uses: ./.github/actions/build_ko
       with:
         name: ${{ inputs.name }}
-        pseudoVersion: ${{ inputs.pseudoVersion }}
         koConfig: ${{ inputs.koConfig }}
         koTarget: ${{ inputs.koTarget }}
         pushTag: ${{ inputs.pushTag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,19 +163,6 @@ jobs:
       ref: ${{ needs.verify-inputs.outputs.RELEASE_BRANCH }}
       release: true
 
-  constellation-node-operator:
-    name: Build Constellation node-operator
-    needs: [verify-inputs, prepare-release-branch]
-    secrets: inherit
-    uses: ./.github/workflows/build-operator-manual.yml
-    permissions:
-      contents: read
-      packages: write
-    with:
-      imageTag: ${{ inputs.version }}
-      ref: ${{ needs.verify-inputs.outputs.RELEASE_BRANCH }}
-      release: true
-
   update-versions:
     name: Update container image versions
     needs: [verify-inputs, micro-services]


### PR DESCRIPTION
### Proposed change(s)
- Currently tags can be empty when building a ko image. However, `--bare` may not work with empty `--tags`. [ko docs](https://ko.build/reference/ko_build/). This change ensures that tags is always set. Either a pushTag is given to the action or it uses a pseudo version.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
