### PR TITLE
cli: use /manager as binary path

### DIFF
--- a/cli/internal/helm/charts/edgeless/operators/charts/node-maintenance-operator/templates/deployment.yaml
+++ b/cli/internal/helm/charts/edgeless/operators/charts/node-maintenance-operator/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - --metrics-bind-address=:8080
         - --leader-elect
         command:
-        -  /ko-app/v2
+        -  /manager
         env:
         - name: OPERATOR_NAMESPACE
           valueFrom:


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- The change to `/ko-app/v2` is incorrect as we are currently not building ko images for this operator.


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
