### PR TITLE
ci: update Syft to 0.72.0 and Grype to 0.57.1

### DIFF
--- a/.github/actions/container_sbom/action.yml
+++ b/.github/actions/container_sbom/action.yml
@@ -34,8 +34,7 @@ runs:
         SYFT_ATTEST_PASSWORD: ${{ inputs.cosignPassword }} # Required for Syft 0.69.0+ as they overwrite COSIGN_PASSWORD
       run: |
         set -ex
-        echo "$COSIGN_PRIVATE_KEY" > cosign.key
-        syft attest --key cosign.key ${{ inputs.containerReference }} -o cyclonedx-json > container-image.att.json
+        syft attest --key env://COSIGN_PRIVATE_KEY ${{ inputs.containerReference }} -o cyclonedx-json > container-image.att.json
         cosign attach attestation ${{ inputs.containerReference }} --attestation container-image.att.json
         # TODO: type should be auto-discovered after issue is resolved:
         # https://github.com/sigstore/cosign/issues/2264

--- a/.github/actions/container_sbom/action.yml
+++ b/.github/actions/container_sbom/action.yml
@@ -31,6 +31,7 @@ runs:
         COSIGN_PUBLIC_KEY: ${{ inputs.cosignPublicKey }}
         COSIGN_PRIVATE_KEY: ${{ inputs.cosignPrivateKey }}
         COSIGN_PASSWORD: ${{ inputs.cosignPassword }}
+        SYFT_ATTEST_PASSWORD: ${{ inputs.cosignPassword }} # Required for Syft 0.69.0+ as they overwrite COSIGN_PASSWORD
       run: |
         set -ex
         echo "$COSIGN_PRIVATE_KEY" > cosign.key

--- a/.github/actions/container_sbom/action.yml
+++ b/.github/actions/container_sbom/action.yml
@@ -39,4 +39,4 @@ runs:
         # TODO: type should be auto-discovered after issue is resolved:
         # https://github.com/sigstore/cosign/issues/2264
         cosign verify-attestation ${{ inputs.containerReference }} --type 'https://cyclonedx.org/bom' --key env://COSIGN_PUBLIC_KEY
-        grype ${{ inputs.containerReference }} --fail-on high --only-fixed
+        grype ${{ inputs.containerReference }} --fail-on high --only-fixed --add-cpes-if-none

--- a/.github/actions/container_sbom/action.yml
+++ b/.github/actions/container_sbom/action.yml
@@ -34,7 +34,7 @@ runs:
       run: |
         set -ex
         syft packages ${{ inputs.containerReference }} -o cyclonedx-json > container-image-predicate.json
-        cosign attest --key env://COSIGN_PRIVATE_KEY --predicate container-image-predicate.json --type cyclonedx > container-image.att.json
+        cosign attest ${{ inputs.containerReference }} --key env://COSIGN_PRIVATE_KEY --predicate container-image-predicate.json --type cyclonedx > container-image.att.json
         cosign attach attestation ${{ inputs.containerReference }} --attestation container-image.att.json
         # TODO: type should be auto-discovered after issue is resolved:
         # https://github.com/sigstore/cosign/issues/2264

--- a/.github/actions/container_sbom/action.yml
+++ b/.github/actions/container_sbom/action.yml
@@ -31,10 +31,10 @@ runs:
         COSIGN_PUBLIC_KEY: ${{ inputs.cosignPublicKey }}
         COSIGN_PRIVATE_KEY: ${{ inputs.cosignPrivateKey }}
         COSIGN_PASSWORD: ${{ inputs.cosignPassword }}
-        SYFT_ATTEST_PASSWORD: ${{ inputs.cosignPassword }} # Required for Syft 0.69.0+ as they overwrite COSIGN_PASSWORD
       run: |
         set -ex
-        syft attest --key env://COSIGN_PRIVATE_KEY ${{ inputs.containerReference }} -o cyclonedx-json > container-image.att.json
+        syft packages ${{ inputs.containerReference }} -o cyclonedx-json > container-image-predicate.json
+        cosign attest --key env://COSIGN_PRIVATE_KEY --predicate container-image-predicate.json --type cyclonedx > container-image.att.json
         cosign attach attestation ${{ inputs.containerReference }} --attestation container-image.att.json
         # TODO: type should be auto-discovered after issue is resolved:
         # https://github.com/sigstore/cosign/issues/2264

--- a/.github/actions/install_syft_grype/action.yml
+++ b/.github/actions/install_syft_grype/action.yml
@@ -7,8 +7,8 @@ runs:
       shell: bash
       working-directory: /tmp
       env:
-        SYFT_VERSION: "0.70.0"
-        GRYPE_VERSION: "0.56.0"
+        SYFT_VERSION: "0.72.0"
+        GRYPE_VERSION: "0.57.1"
         OS: ${{ runner.os }}
         ARCH: ${{ runner.arch }}
       run: |

--- a/.github/actions/install_syft_grype/action.yml
+++ b/.github/actions/install_syft_grype/action.yml
@@ -7,8 +7,8 @@ runs:
       shell: bash
       working-directory: /tmp
       env:
-        SYFT_VERSION: "0.65.0" # Before upgrading, check if this has been fixed: https://github.com/anchore/syft/issues/1465
-        GRYPE_VERSION: "0.55.0"
+        SYFT_VERSION: "0.69.0"
+        GRYPE_VERSION: "0.56.0"
         OS: ${{ runner.os }}
         ARCH: ${{ runner.arch }}
       run: |
@@ -19,15 +19,15 @@ runs:
         else
           OS=${OS,,}
         fi
-  
+
         if [[ "${ARCH}" = "X64" ]]; then
           ARCH="amd64"
         else
           ARCH=${ARCH,,}
         fi
-        
+
         echo "Downloading for ${OS}/${ARCH}"
-        
+
         curl -fsSLo syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz https://github.com/anchore/syft/releases/download/v${SYFT_VERSION}/syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz
         tar -xzf syft_${SYFT_VERSION}_${OS}_${ARCH}.tar.gz
         sudo install syft /usr/bin/syft

--- a/.github/actions/install_syft_grype/action.yml
+++ b/.github/actions/install_syft_grype/action.yml
@@ -7,7 +7,7 @@ runs:
       shell: bash
       working-directory: /tmp
       env:
-        SYFT_VERSION: "0.69.0"
+        SYFT_VERSION: "0.70.0"
         GRYPE_VERSION: "0.56.0"
         OS: ${{ runner.os }}
         ARCH: ${{ runner.arch }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -111,11 +111,11 @@ jobs:
         with:
           go-version: "1.20.1"
 
-      - name: Download Syft & Grype
-        uses: ./.github/actions/install_syft_grype
-
       - name: Install Cosign
         uses: sigstore/cosign-installer@9becc617647dfa20ae7b1151972e9b3a2c338a2b # tag=v2.8.1
+
+      - name: Download Syft & Grype
+        uses: ./.github/actions/install_syft_grype
 
       # Build one CLI since Syft's go-module catalog will default to binary parsing.
       # Binary parsing has the advantage that it will not include other dependencies from our repo not included in the CLI.


### PR DESCRIPTION
### Proposed change(s)
- Upgrade Syft to 0.69.0
- Upgrade Grype to 0.56.0

Syft fixed the APK parsing issues in 0.68.1 caused by apko adding empty fields and finally added private key attestation back with 0.69.0. Let's give it a shot, since it should unblock updating the Alpine base images with newer versions of apko again.

Also updating Grype just for the sake of it. It's based on Syft 0.68.1 which should have any parsing issues fixed hopefully. Not the attestation part, but we don't care about that for Grype.

### Related issues
- #1017 

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
