### PR TITLE
disable lb e2e test on aws until upstream issue is fixed

### DIFF
--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -75,6 +75,9 @@ jobs:
             version: "1.24"
           - test: "lb"
             version: "1.25"
+          # disable on AWS until cleanup is fixed: https://github.com/kubernetes/cloud-provider-aws/issues/566
+          - test: "lb"
+            provider: "aws"
           # Currently not supported on AWS.
           - test: "autoscaling"
             provider: "aws"


### PR DESCRIPTION
Signed-off-by: Fabian Kammel <fk@edgeless.systems>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Disable e2e lb test on aws until https://github.com/kubernetes/cloud-provider-aws/issues/566 is fixed

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- I was not able to reproduce any failings of the tests itself or hanging. The only problem is that the security group created for LB is not correctly cleaned up by CCM and therefore `constellation terminate` fails.
  - I have tested: v1.25 locally, v1.26 locally, [v1.25 manual pipeline ](https://github.com/edgelesssys/constellation/actions/runs/4063031347)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
