### PR TITLE
ci: allow ci reference workflow to create pr

### DIFF
--- a/.github/workflows/update-cli-reference.yml
+++ b/.github/workflows/update-cli-reference.yml
@@ -13,6 +13,9 @@ on:
 jobs:
   update-docs:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout Constellation
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0


### PR DESCRIPTION
Signed-off-by: Fabian Kammel <fk@edgeless.systems>

fix: https://github.com/edgelesssys/constellation/actions/runs/4063404048/jobs/6995599134

required permissions documented in https://github.com/peter-evans/create-pull-request#workflow-permissions
