### PR TITLE
ci: e2e tests for upgrade

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -112,8 +112,9 @@ runs:
       run: |
         curl -fsSL https://github.com/edgelesssys/constellation/releases/download/${{ inputs.cliVersion }}/constellation-linux-amd64 > constellation
         chmod u+x constellation
-        ./constellation version
         echo "$(pwd)" >> $GITHUB_PATH
+        export PATH="$PATH:$(pwd)"
+        constellation version
         # Do not spam license server from pipeline
         sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts'
 

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -23,6 +23,9 @@ inputs:
     description: "Is OS img a debug img?"
     default: "true"
     required: true
+  cliVersion:
+    description: "Version of a released CLI to download, e.g. 'v2.3.0', leave empty to build it."
+    required: false
   kubernetesVersion:
     description: "Kubernetes version to create the cluster from."
     required: false
@@ -96,11 +99,23 @@ runs:
         echo "hostArch=$(go env GOARCH)" >> $GITHUB_OUTPUT
 
     - name: Build CLI
+      if: inputs.cliVersion == ''
       uses: ./.github/actions/build_cli
       with:
         targetOS: ${{ steps.determine-build-target.outputs.hostOS }}
         targetArch: ${{ steps.determine-build-target.outputs.hostArch }}
         enterpriseCLI: ${{ inputs.keepMeasurements }}
+
+    - name: Fetch CLI
+      if: inputs.cliVersion != ''
+      shell: bash
+      run: |
+        curl -L https://github.com/edgelesssys/constellation/releases/download/${{ inputs.cliVersion }}/constellation-linux-amd64 > constellation
+        chmod u+x constellation
+        ./constellation version
+        echo "$(pwd)" >> $GITHUB_PATH
+        # Do not spam license server from pipeline
+        sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts'
 
     # macOS runners don't have Docker preinstalled, so they cannot build the bootstrapper.
     # But we can use a Linux runner to build it and store/retrieve it from the action cache.

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -110,7 +110,7 @@ runs:
       if: inputs.cliVersion != ''
       shell: bash
       run: |
-        curl -L https://github.com/edgelesssys/constellation/releases/download/${{ inputs.cliVersion }}/constellation-linux-amd64 > constellation
+        curl -fsSL https://github.com/edgelesssys/constellation/releases/download/${{ inputs.cliVersion }}/constellation-linux-amd64 > constellation
         chmod u+x constellation
         ./constellation version
         echo "$(pwd)" >> $GITHUB_PATH

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.19.4"
+          go-version: "1.19.5"
 
       - name: Login to Azure
         if: matrix.provider == 'azure'
@@ -73,7 +73,7 @@ jobs:
 
       - name: Run upgrade test
         run: |
-          go test ./e2e/internal/upgrade -v --timeout=0 --tags=e2eupgrade
+          go test ./e2e/internal/upgrade -v --timeout=5h30m --tags=e2eupgrade
         env:
           KUBECONFIG: ${{ steps.e2e_test.outputs.kubeconfig }}
 
@@ -104,7 +104,7 @@ jobs:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
 
       - name: Notify teams channel
-        if: ${{ failure() && github.ref == 'refs/heads/main' }}
+        if: failure() && github.ref == 'refs/heads/main'
         continue-on-error: true
         shell: bash
         working-directory: .github/actions/e2e_test

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -1,10 +1,34 @@
 name: e2e test upgrade
 
 on:
-  # TODO: remove push
-  push:
   workflow_dispatch:
+    inputs:
+      fromVersion:
+        description: CLI version to create a new cluster with. This has to be a released version, e.g., 'v2.1.3'.
+        type: string
+        required: true
+      toVersion:
+        description: CLI version to execute upgrade with, e.g., 'v2.1.3', or empty to build HEAD.
+        type: string
+        required: false
+      toImage:
+        description: Image (shortpath) the cluster is upgraded to, or empty for main/nightly.
+        type: string
+        required: false
   workflow_call:
+    inputs:
+      fromVersion:
+        description: CLI version to create a new cluster with. This has to be a released version, e.g., 'v2.1.3'.
+        type: string
+        required: true
+      toVersion:
+        description: CLI version to execute upgrade with, e.g., 'v2.1.3', or empty to build HEAD.
+        type: string
+        required: false
+      toImage:
+        description: Image (shortpath) the cluster is upgraded to, or empty for main/nightly.
+        type: string
+        required: false
 
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
@@ -50,15 +74,15 @@ jobs:
           az group create --location northeurope --name "$name" --tags e2e
           echo "res_group_name=$name" >> "$GITHUB_OUTPUT"
 
-      - name: Run E2E test (nop)
+      - name: Create cluster with 'fromVersion' CLI.
         id: e2e_test
         uses: ./.github/actions/e2e_test
         with:
           workerNodesCount: "2"
           controlNodesCount: "3"
           cloudProvider: ${{ matrix.provider }}
-          osImage: "v2.5.1"
-          cliVersion: "v2.5.1"
+          osImage: ${{ inputs.fromVersion }}
+          cliVersion: ${{ inputs.fromVersion }}
           isDebugImage: "false"
           azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
           azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
@@ -71,11 +95,40 @@ jobs:
           gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: "nop"
 
+      - name: Build CLI
+        if: inputs.toVersion == ''
+        uses: ./.github/actions/build_cli
+
+      - name: Fetch CLI
+        if: inputs.toVersion != ''
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/edgelesssys/constellation/releases/download/${{ inputs.toVersion }}/constellation-linux-amd64 > constellation
+          chmod u+x constellation
+          echo "$(pwd)" >> $GITHUB_PATH
+          export PATH="$PATH:$(pwd)"
+          constellation version
+          # Do not spam license server from pipeline
+          sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts'
+
+      - name: Find latest nightly image
+        id: find-image
+        if: inputs.toImage == ''
+        uses: ./.github/actions/versionsapi
+        with:
+          command: latest
+          ref: main
+          stream: nightly
+
       - name: Run upgrade test
         run: |
-          go test ./e2e/internal/upgrade -v --timeout=5h30m --tags=e2eupgrade
+          go test ./e2e/internal/upgrade \
+            -v -timeout=5h30m -tags=e2eupgrade \
+            -args -to-image ${IMAGE} -to-version ${VERSION} -want-worker 2 -want-control 3
         env:
           KUBECONFIG: ${{ steps.e2e_test.outputs.kubeconfig }}
+          IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-image.outputs.image }}
+          VERSION: ${{ inputs.toVersion }}
 
       - name: Always fetch logs
         if: always()

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -105,8 +105,8 @@ jobs:
         run: |
           curl -fsSL https://github.com/edgelesssys/constellation/releases/download/${{ inputs.toVersion }}/constellation-linux-amd64 > constellation
           chmod u+x constellation
-          echo "$(pwd)" >> $GITHUB_PATH
-          export PATH="$PATH:$(pwd)"
+          "$(pwd)" >> "$GITHUB_PATH"
+          export PATH="$PATH:$PWD"
           constellation version
           # Do not spam license server from pipeline
           sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts'
@@ -124,10 +124,10 @@ jobs:
         run: |
           go test ./e2e/internal/upgrade \
             -v -timeout=5h30m -tags=e2eupgrade \
-            -args -to-image ${IMAGE} -to-version ${VERSION} -want-worker 2 -want-control 3
+            -args -to-image "${IMAGE}" -to-version "${VERSION}" -want-worker 2 -want-control 3
         env:
           KUBECONFIG: ${{ steps.e2e_test.outputs.kubeconfig }}
-          IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-image.outputs.image }}
+          IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-image.outputs.output }}
           VERSION: ${{ inputs.toVersion }}
 
       - name: Always fetch logs

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -1,9 +1,10 @@
-name: e2e test weekly
+name: e2e test upgrade
 
 on:
+  # TODO: remove push
+  push:
   workflow_dispatch:
-  schedule:
-    - cron: "0 3 * * 6" # At 03:00 on Saturday.
+  workflow_call:
 
 env:
   ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
@@ -12,82 +13,18 @@ env:
   ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
 
 jobs:
-  find-latest-image:
-    name: Find latest debug image
-    runs-on: ubuntu-22.04
-    permissions:
-      id-token: write
-      contents: read
-    outputs:
-      image: ${{ steps.find-latest-image.outputs.output }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
-
-      - name: Login to AWS
-        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
-        with:
-          role-to-assume: arn:aws:iam::795746500882:role/GithubConstellationVersionsAPIRead
-          aws-region: eu-central-1
-
-      - name: Find latest image
-        id: find-latest-image
-        uses: ./.github/actions/versionsapi
-        with:
-          command: latest
-          ref: main
-          stream: debug
-
-  e2e-weekly:
+  e2e-upgrade:
     strategy:
       fail-fast: false
-      max-parallel: 5
       matrix:
-        test:
-          ["sonobuoy full", "autoscaling", "k-bench", "lb", "verify", "recover"]
         provider: ["gcp", "azure", "aws"]
-        version: ["v1.24.9", "v1.25.6", "v1.26.1"]
-        exclude:
-          # Verify test runs only on latest version.
-          - test: "verify"
-            version: "v1.24.9"
-          - test: "verify"
-            version: "v1.25.6"
-          # Recover test runs only on latest version.
-          - test: "recover"
-            version: "v1.24.9"
-          - test: "recover"
-            version: "v1.25.6"
-          # Autoscaling test runs only on latest version.
-          - test: "autoscaling"
-            version: "v1.24.9"
-          - test: "autoscaling"
-            version: "v1.25.6"
-          # K-bench test runs only on latest version.
-          - test: "k-bench"
-            version: "v1.24.9"
-          - test: "k-bench"
-            version: "v1.25.6"
-          # lb test runs only on latest version.
-          - test: "lb"
-            version: "v1.24.9"
-          - test: "lb"
-            version: "v1.25.6"
-          # Currently not supported on AWS.
-          - test: "autoscaling"
-            provider: "aws"
-          - test: "k-bench"
-            provider: "aws"
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
       contents: read
-    needs: [find-latest-image]
     steps:
       - name: Check out repository
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
         with:
           fetch-depth: 0
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
@@ -95,7 +32,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
-          go-version: "1.19.5"
+          go-version: "1.19.4"
 
       - name: Login to Azure
         if: matrix.provider == 'azure'
@@ -104,8 +41,8 @@ jobs:
           azure_credentials: ${{ secrets.AZURE_E2E_CREDENTIALS }}
 
       - name: Create Azure resource group
-        id: az_resource_group_gen
         if: matrix.provider == 'azure'
+        id: az_resource_group_gen
         shell: bash
         run: |
           uuid=$(cat /proc/sys/kernel/random/uuid)
@@ -113,15 +50,16 @@ jobs:
           az group create --location northeurope --name "$name" --tags e2e
           echo "res_group_name=$name" >> "$GITHUB_OUTPUT"
 
-      - name: Run E2E test
+      - name: Run E2E test (nop)
         id: e2e_test
         uses: ./.github/actions/e2e_test
         with:
           workerNodesCount: "2"
           controlNodesCount: "3"
           cloudProvider: ${{ matrix.provider }}
-          osImage: ${{ needs.find-latest-image.outputs.image }}
-          kubernetesVersion: ${{ matrix.version }}
+          osImage: "v2.5.1"
+          cliVersion: "v2.5.1"
+          isDebugImage: "false"
           azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
           azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
           azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
@@ -131,7 +69,32 @@ jobs:
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcp_service_account: "constellation-e2e@constellation-331613.iam.gserviceaccount.com"
           gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
-          test: ${{ matrix.test }}
+          test: "nop"
+
+      - name: Run upgrade test
+        run: |
+          go test ./e2e/internal/upgrade -v --timeout=0 --tags=e2eupgrade
+        env:
+          KUBECONFIG: ${{ steps.e2e_test.outputs.kubeconfig }}
+
+      - name: Always fetch logs
+        if: always()
+        continue-on-error: true
+        run: |
+          kubectl logs -n kube-system -l "app.kubernetes.io/name=node-maintenance-operator" --tail=-1 > node-maintenance-operator.logs
+          kubectl get nodeversions.update.edgeless.systems constellation-version -o yaml > constellation-version.yaml
+        env:
+          KUBECONFIG: ${{ steps.e2e_test.outputs.kubeconfig }}
+
+      - name: Always upload logs
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # tag=v3.1.1
+        with:
+          name: upgrade-logs
+          path: |
+            node-maintenance-operator.logs
+            constellation-version.yaml
 
       - name: Always terminate cluster
         if: always()
@@ -141,13 +104,13 @@ jobs:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
 
       - name: Notify teams channel
-        if: failure() && github.ref == 'refs/heads/main'
+        if: ${{ failure() && github.ref == 'refs/heads/main' }}
         continue-on-error: true
         shell: bash
         working-directory: .github/actions/e2e_test
         run: |
           sudo apt-get install gettext-base -y
-          export TEAMS_JOB_NAME=${{ matrix.provider }}
+          export TEAMS_JOB_NAME="upgrade-${{ matrix.provider }}"
           export TEAMS_RUN_ID=${{ github.run_id }}
           envsubst < teams-payload.json > to-be-send.json
           curl                                          \
@@ -165,11 +128,3 @@ jobs:
             --force-deletion-types Microsoft.Compute/virtualMachines \
             --no-wait \
             --yes
-
-  e2e-upgrade:
-    name: Run upgrade tests
-    secrets: inherit
-    permissions:
-      id-token: write
-      contents: read
-    uses: ./.github/workflows/e2e-upgrade.yml

--- a/cli/internal/cmd/configfetchmeasurements.go
+++ b/cli/internal/cmd/configfetchmeasurements.go
@@ -177,19 +177,16 @@ func (f *fetchMeasurementsFlags) updateURLs(conf *config.Config) error {
 	if err != nil {
 		return fmt.Errorf("creating version from image name: %w", err)
 	}
+	measurementsURL, signatureURL, err := ver.MeasurementURL(conf.GetProvider())
+	if err != nil {
+		return err
+	}
+
 	if f.measurementsURL == nil {
-		measurementsURL, err := ver.ArtifactURL(conf.GetProvider(), constants.CDNMeasurementsFile)
-		if err != nil {
-			return err
-		}
 		f.measurementsURL = measurementsURL
 	}
 
 	if f.signatureURL == nil {
-		signatureURL, err := ver.ArtifactURL(conf.GetProvider(), constants.CDNMeasurementsSignature)
-		if err != nil {
-			return err
-		}
 		f.signatureURL = signatureURL
 	}
 	return nil

--- a/cli/internal/cmd/configfetchmeasurements_test.go
+++ b/cli/internal/cmd/configfetchmeasurements_test.go
@@ -119,8 +119,8 @@ func TestUpdateURLs(t *testing.T) {
 				},
 			},
 			flags:                  &fetchMeasurementsFlags{},
-			wantMeasurementsURL:    ver.ArtifactURL() + "/image/csp/gcp/measurements.json",
-			wantMeasurementsSigURL: ver.ArtifactURL() + "/image/csp/gcp/measurements.json.sig",
+			wantMeasurementsURL:    ver.ArtifactsURL() + "/image/csp/gcp/measurements.json",
+			wantMeasurementsSigURL: ver.ArtifactsURL() + "/image/csp/gcp/measurements.json.sig",
 		},
 		"both set by user": {
 			conf: &config.Config{},

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -470,12 +470,12 @@ func getCompatibleImageMeasurements(ctx context.Context, writer io.Writer, clien
 	for _, version := range versions {
 		log.Debugf("Fetching measurements for image: %s", version)
 		shortPath := version.ShortPath()
-		measurementsURL, err := measurementURL(csp, shortPath, "measurements.json")
+		measurementsURL, err := version.ArtifactURL(csp, constants.CDNMeasurementsFile)
 		if err != nil {
 			return nil, err
 		}
 
-		signatureURL, err := measurementURL(csp, shortPath, "measurements.json.sig")
+		signatureURL, err := version.ArtifactURL(csp, constants.CDNMeasurementsSignature)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -470,12 +470,7 @@ func getCompatibleImageMeasurements(ctx context.Context, writer io.Writer, clien
 	for _, version := range versions {
 		log.Debugf("Fetching measurements for image: %s", version)
 		shortPath := version.ShortPath()
-		measurementsURL, err := version.ArtifactURL(csp, constants.CDNMeasurementsFile)
-		if err != nil {
-			return nil, err
-		}
-
-		signatureURL, err := version.ArtifactURL(csp, constants.CDNMeasurementsSignature)
+		measurementsURL, signatureURL, err := version.MeasurementURL(csp)
 		if err != nil {
 			return nil, err
 		}

--- a/e2e/internal/upgrade/helm.go
+++ b/e2e/internal/upgrade/helm.go
@@ -1,0 +1,46 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/edgelesssys/constellation/v2/internal/constants"
+	"github.com/edgelesssys/constellation/v2/internal/logger"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/cli"
+)
+
+func servicesVersion(t *testing.T) (string, error) {
+	t.Helper()
+	log := logger.NewTest(t)
+	settings := cli.New()
+	settings.KubeConfig = "constellation-admin.conf"
+	actionConfig := &action.Configuration{}
+	if err := actionConfig.Init(settings.RESTClientGetter(), constants.HelmNamespace, "secret", log.Infof); err != nil {
+		return "", fmt.Errorf("initializing config: %w", err)
+	}
+
+	return currentVersion(actionConfig, "constellation-services")
+}
+
+func currentVersion(cfg *action.Configuration, release string) (string, error) {
+	action := action.NewList(cfg)
+	action.Filter = release
+	rel, err := action.Run()
+	if err != nil {
+		return "", err
+	}
+
+	if len(rel) == 0 {
+		return "", fmt.Errorf("release %s not found", release)
+	}
+	if len(rel) > 1 {
+		return "", fmt.Errorf("multiple releases found for %s", release)
+	}
+
+	if rel[0] == nil || rel[0].Chart == nil || rel[0].Chart.Metadata == nil {
+		return "", fmt.Errorf("received invalid release %s", release)
+	}
+
+	return rel[0].Chart.Metadata.Version, nil
+}

--- a/e2e/internal/upgrade/upgrade_test.go
+++ b/e2e/internal/upgrade/upgrade_test.go
@@ -79,7 +79,7 @@ func TestUpgrade(t *testing.T) {
 
 func writeUpgradeConfig(t *testing.T, toImage string) string {
 	fileHandler := file.NewHandler(afero.NewOsFs())
-	cfg, err := config.New(fileHandler, constants.ConfigFilename)
+	cfg, err := config.New(fileHandler, constants.ConfigFilename, true)
 	require.NoError(t, err)
 
 	info, err := fetchUpgradeInfo(cfg.GetProvider(), toImage)

--- a/e2e/internal/upgrade/upgrade_test.go
+++ b/e2e/internal/upgrade/upgrade_test.go
@@ -1,4 +1,4 @@
-// TODO //go:build e2eupgrade
+//go:build e2eupgrade
 
 /*
 Copyright (c) Edgeless Systems GmbH

--- a/e2e/internal/upgrade/upgrade_test.go
+++ b/e2e/internal/upgrade/upgrade_test.go
@@ -112,7 +112,7 @@ func testNodesEventuallyHaveImage(t *testing.T, k *kubernetes.Clientset, wantIma
 		}
 
 		allUpdated := true
-		fmt.Printf("Node status (%v):\n", time.Now())
+		t.Log(fmt.Sprintf("Node status (%v):", time.Now()))
 		for _, node := range nodes.Items {
 			for key, value := range node.Annotations {
 				if key == "constellation.edgeless.systems/node-image" {

--- a/e2e/internal/upgrade/upgrade_test.go
+++ b/e2e/internal/upgrade/upgrade_test.go
@@ -16,11 +16,9 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -276,13 +274,12 @@ func fetchUpgradeInfo(csp cloudprovider.Provider, toImage string) (upgradeInfo, 
 		return upgradeInfo{}, err
 	}
 
-	artifactURL := ver.ArtifactURL()
-	measurementsURL, err := url.JoinPath(artifactURL, "image/csp", strings.ToLower(csp.String()), "measurements.json")
+	measurementsURL, err := ver.ArtifactURL(csp, constants.CDNMeasurementsFile)
 	if err != nil {
 		return upgradeInfo{}, err
 	}
 
-	imageMeasurements, err := fetchMeasurements(measurementsURL)
+	imageMeasurements, err := fetchMeasurements(measurementsURL.String())
 	if err != nil {
 		return upgradeInfo{}, err
 	}

--- a/e2e/internal/upgrade/upgrade_test.go
+++ b/e2e/internal/upgrade/upgrade_test.go
@@ -242,6 +242,11 @@ func testNodesEventuallyAvailable(t *testing.T, k *kubernetes.Clientset, wantCon
 	}, time.Minute*30, time.Minute)
 }
 
+type Measurement struct {
+	WarnOnly bool   `json:"warnOnly"`
+	Expected string `json:"expected"`
+}
+
 type imageMeasurements struct {
 	Cmdline       string `json:"cmdline"`
 	CmdlineSHA256 string `json:"cmdline-sha256"`
@@ -249,8 +254,8 @@ type imageMeasurements struct {
 		Name   string `json:"name"`
 		SHA256 string `json:"sha256"`
 	} `json:"efistages"`
-	InitrdSHA256 string                       `json:"initrd-sha256"`
-	Measurements map[string]map[string]string `json:"measurements"`
+	InitrdSHA256 string                 `json:"initrd-sha256"`
+	Measurements map[string]Measurement `json:"measurements"`
 }
 
 type upgradeInfo struct {
@@ -272,7 +277,7 @@ func fetchUpgradeInfo(csp cloudprovider.Provider, toImage string) (upgradeInfo, 
 	}
 
 	artifactURL := ver.ArtifactURL()
-	measurementsURL, err := url.JoinPath(artifactURL, "image/csp", strings.ToLower(csp.String()), "measurements.image.json")
+	measurementsURL, err := url.JoinPath(artifactURL, "image/csp", strings.ToLower(csp.String()), "measurements.json")
 	if err != nil {
 		return upgradeInfo{}, err
 	}
@@ -287,7 +292,7 @@ func fetchUpgradeInfo(csp cloudprovider.Provider, toImage string) (upgradeInfo, 
 		if err != nil {
 			return upgradeInfo{}, err
 		}
-		info.measurements[uint32(idx)] = value["expected"]
+		info.measurements[uint32(idx)] = value.Expected
 	}
 
 	wantImage, err := fetchWantImage(versionsClient, csp, versionsapi.ImageInfo{

--- a/e2e/internal/upgrade/upgrade_test.go
+++ b/e2e/internal/upgrade/upgrade_test.go
@@ -1,0 +1,341 @@
+// TODO //go:build e2eupgrade
+
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package test
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/edgelesssys/constellation/v2/e2e/internal/kubectl"
+	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
+	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
+	"github.com/edgelesssys/constellation/v2/internal/config"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
+	"github.com/edgelesssys/constellation/v2/internal/file"
+	"github.com/edgelesssys/constellation/v2/internal/versionsapi"
+	"github.com/edgelesssys/constellation/v2/internal/versionsapi/fetcher"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	coreV1 "k8s.io/api/core/v1"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	constellationCLIVersion = "2.5.1"
+	wantWorkerNodeCount     = 2
+	wantControlNodeCount    = 3
+	wantNodeCount           = wantControlNodeCount + wantWorkerNodeCount
+)
+
+// E2E is creating cluster from root of Constellation repository, we need to
+// execute the upgrade test in that Constellation workspace.
+func TestMain(m *testing.M) {
+	if err := os.Chdir("../../.."); err != nil {
+		os.Exit(1)
+	}
+
+	os.Exit(m.Run())
+}
+
+func mustDecodeHex(s string) [32]byte {
+	val, _ := hex.DecodeString(s)
+	return *(*[32]byte)(val)
+}
+
+func TestUpgrade(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	k, err := kubectl.New()
+	require.NoError(err)
+	assert.NotNil(k)
+
+	testNodesEventuallyAvailable(t, k, wantControlNodeCount, wantWorkerNodeCount)
+	testPodsEventuallyReady(t, k, "kube-system")
+
+	testCLIHasVersion(t, constellationCLIVersion)
+	wantImage := writeUpgradeConfig(t)
+	cmd := exec.CommandContext(context.Background(), "constellation", "upgrade", "execute")
+	msg, err := cmd.CombinedOutput()
+	require.NoErrorf(err, "%s", string(msg))
+
+	testNodesEventuallyHaveImage(t, k, wantImage)
+}
+
+func writeUpgradeConfig(t *testing.T) string {
+	fileHandler := file.NewHandler(afero.NewOsFs())
+	cfg, err := config.New(fileHandler, constants.ConfigFilename)
+	require.NoError(t, err)
+
+	info, err := fetchLatestNightlyUpgradeInfo(cfg.GetProvider())
+	require.NoError(t, err)
+
+	cfg.Upgrade.Image = info.shortPath
+	cfg.Upgrade.Measurements = make(measurements.M)
+	for key, value := range info.measurements {
+		cfg.Upgrade.Measurements[key] = measurements.Measurement{
+			Expected: mustDecodeHex(value),
+			WarnOnly: false,
+		}
+	}
+	err = fileHandler.WriteYAML(constants.ConfigFilename, cfg, file.OptOverwrite)
+	require.NoError(t, err)
+
+	return info.wantImage
+}
+
+func testNodesEventuallyHaveImage(t *testing.T, k *kubernetes.Clientset, wantImage string) {
+	require.Eventually(t, func() bool {
+		nodes, err := k.CoreV1().Nodes().List(context.Background(), metaV1.ListOptions{})
+		if err != nil {
+			fmt.Println(err)
+			return false
+		}
+
+		allUpdated := true
+		fmt.Printf("Node status (%v):\n", time.Now())
+		for _, node := range nodes.Items {
+			for key, value := range node.Annotations {
+				if key == "constellation.edgeless.systems/node-image" {
+					fmt.Printf("\t%s: %s\n", node.Name, value)
+					if value != wantImage {
+						allUpdated = false
+					}
+				}
+			}
+		}
+
+		return allUpdated
+	}, time.Hour*3, time.Minute)
+}
+
+// testCLIHasVersion checks that `constellation version` states the expected version.
+func testCLIHasVersion(t *testing.T, wantVersion string) {
+	require := require.New(t)
+	cmd := exec.CommandContext(context.Background(), "constellation", "version")
+	output, err := cmd.CombinedOutput()
+	require.NoError(err)
+	require.Contains(string(output), wantVersion)
+}
+
+// testPodsEventuallyReady checks that:
+// 1) all pods are running.
+// 2) all pods have good status conditions.
+func testPodsEventuallyReady(t *testing.T, k *kubernetes.Clientset, namespace string) {
+	require.Eventually(t, func() bool {
+		pods, err := k.CoreV1().Pods(namespace).List(context.Background(), metaV1.ListOptions{})
+		if err != nil {
+			fmt.Println(err)
+			return false
+		}
+
+		for _, pod := range pods.Items {
+			if pod.Status.Phase != coreV1.PodRunning {
+				fmt.Printf("Pod %s is not running, but %s\n", pod.Name, pod.Status.Phase)
+				return false
+			}
+
+			for _, condition := range pod.Status.Conditions {
+				switch condition.Type {
+				case coreV1.ContainersReady:
+					if condition.Status != coreV1.ConditionTrue {
+						fmt.Printf("Pod %s's status %s is false\n", pod.Name, coreV1.ContainersReady)
+						return false
+					}
+				case coreV1.PodInitialized:
+					if condition.Status != coreV1.ConditionTrue {
+						fmt.Printf("Pod %s's status %s is false\n", pod.Name, coreV1.PodInitialized)
+						return false
+					}
+				case coreV1.PodReady:
+					if condition.Status != coreV1.ConditionTrue {
+						fmt.Printf("Pod %s's status %s is false\n", pod.Name, coreV1.PodReady)
+						return false
+					}
+				case coreV1.PodScheduled:
+					if condition.Status != coreV1.ConditionTrue {
+						fmt.Printf("Pod %s's status %s is false\n", pod.Name, coreV1.PodScheduled)
+						return false
+					}
+				}
+			}
+		}
+		return true
+	}, time.Minute*30, time.Minute)
+}
+
+// testNodesEventuallyAvailable checks that:
+// 1) all nodes only have good status conditions.
+// 2) the expected number of nodes have joined the cluster.
+func testNodesEventuallyAvailable(t *testing.T, k *kubernetes.Clientset, wantControlNodeCount, wantWorkerNodeCount int) {
+	require.Eventually(t, func() bool {
+		nodes, err := k.CoreV1().Nodes().List(context.Background(), metaV1.ListOptions{})
+		if err != nil {
+			fmt.Println(err)
+			return false
+		}
+
+		var controlNodeCount, workerNodeCount int
+		for _, node := range nodes.Items {
+			if _, ok := node.Labels["node-role.kubernetes.io/control-plane"]; ok {
+				controlNodeCount++
+			} else {
+				workerNodeCount++
+			}
+
+			for _, condition := range node.Status.Conditions {
+				switch condition.Type {
+				case coreV1.NodeReady:
+					if condition.Status != coreV1.ConditionTrue {
+						fmt.Printf("Status %s for node %s is %s\n", coreV1.NodeReady, node.Name, condition.Status)
+						return false
+					}
+				case coreV1.NodeMemoryPressure:
+					if condition.Status != coreV1.ConditionFalse {
+						fmt.Printf("Status %s for node %s is %s\n", coreV1.NodeMemoryPressure, node.Name, condition.Status)
+						return false
+					}
+				case coreV1.NodeDiskPressure:
+					if condition.Status != coreV1.ConditionFalse {
+						fmt.Printf("Status %s for node %s is %s\n", coreV1.NodeDiskPressure, node.Name, condition.Status)
+						return false
+					}
+				case coreV1.NodePIDPressure:
+					if condition.Status != coreV1.ConditionFalse {
+						fmt.Printf("Status %s for node %s is %s\n", coreV1.NodePIDPressure, node.Name, condition.Status)
+						return false
+					}
+				case coreV1.NodeNetworkUnavailable:
+					if condition.Status != coreV1.ConditionFalse {
+						fmt.Printf("Status %s for node %s is %s\n", coreV1.NodeNetworkUnavailable, node.Name, condition.Status)
+						return false
+					}
+				}
+			}
+		}
+
+		if controlNodeCount != wantControlNodeCount {
+			fmt.Printf("Want %d control nodes but got %d\n", wantControlNodeCount, controlNodeCount)
+			return false
+		}
+		if workerNodeCount != wantWorkerNodeCount {
+			fmt.Printf("Want %d worker nodes but got %d\n", wantWorkerNodeCount, workerNodeCount)
+			return false
+		}
+
+		return true
+	}, time.Minute*30, time.Minute)
+}
+
+type imageMeasurements struct {
+	Cmdline       string `json:"cmdline"`
+	CmdlineSHA256 string `json:"cmdline-sha256"`
+	EFIstages     []struct {
+		Name   string `json:"name"`
+		SHA256 string `json:"sha256"`
+	} `json:"efistages"`
+	InitrdSHA256 string                       `json:"initrd-sha256"`
+	Measurements map[string]map[string]string `json:"measurements"`
+}
+
+type upgradeInfo struct {
+	measurements map[uint32]string
+	shortPath    string
+	wantImage    string
+}
+
+func fetchLatestNightlyUpgradeInfo(csp cloudprovider.Provider) (upgradeInfo, error) {
+	info := upgradeInfo{
+		measurements: make(map[uint32]string),
+	}
+	versionsClient := fetcher.NewFetcher()
+
+	latest, err := versionsClient.FetchVersionLatest(context.Background(), versionsapi.Latest{
+		Ref:    "main",
+		Stream: "nightly",
+		Kind:   versionsapi.VersionKindImage,
+	})
+	if err != nil {
+		return upgradeInfo{}, err
+	}
+	info.shortPath = latest.ShortPath()
+
+	ver := versionsapi.Version{
+		Ref:     latest.Ref,
+		Stream:  latest.Stream,
+		Version: latest.Version,
+		Kind:    latest.Kind,
+	}
+	artifactURL := ver.ArtifactURL()
+
+	measurementsURL, err := url.JoinPath(artifactURL, "image/csp", strings.ToLower(csp.String()), "measurements.image.json")
+	if err != nil {
+		return upgradeInfo{}, err
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, measurementsURL, http.NoBody)
+	if err != nil {
+		return upgradeInfo{}, err
+	}
+	fmt.Printf("Fetching measurements from: %v\n", req.URL)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return upgradeInfo{}, err
+	}
+	defer resp.Body.Close()
+
+	var imageMeasurements imageMeasurements
+	err = json.NewDecoder(resp.Body).Decode(&imageMeasurements)
+	if err != nil {
+		return upgradeInfo{}, err
+	}
+
+	for key, value := range imageMeasurements.Measurements {
+		idx, err := strconv.Atoi(key)
+		if err != nil {
+			return upgradeInfo{}, err
+		}
+		info.measurements[uint32(idx)] = value["expected"]
+	}
+
+	imageInfo, err := versionsClient.FetchImageInfo(context.Background(), versionsapi.ImageInfo{
+		Ref:     latest.Ref,
+		Stream:  latest.Stream,
+		Version: latest.Version,
+	})
+	if err != nil {
+		return upgradeInfo{}, err
+	}
+
+	switch csp {
+	case cloudprovider.GCP:
+		info.wantImage = imageInfo.GCP["sev-es"]
+	case cloudprovider.Azure:
+		info.wantImage = imageInfo.Azure["cvm"]
+	case cloudprovider.AWS:
+		info.wantImage = imageInfo.AWS["eu-central-1"]
+	default:
+		return upgradeInfo{}, errors.New("finding wanted image")
+	}
+
+	return info, nil
+}

--- a/internal/attestation/measurements/measurement-generator/generate.go
+++ b/internal/attestation/measurements/measurement-generator/generate.go
@@ -143,7 +143,7 @@ func measurementURL(provider cloudprovider.Provider, image, file string) (*url.U
 	}
 
 	return url.Parse(
-		version.ArtifactURL() + path.Join("/image", "csp", strings.ToLower(provider.String()), file),
+		version.ArtifactsURL() + path.Join("/image", "csp", strings.ToLower(provider.String()), file),
 	)
 }
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -180,6 +180,10 @@ const (
 	CDNRepositoryURL = "https://cdn.confidential.cloud"
 	// CDNAPIPrefix is the prefix of the Constellation API.
 	CDNAPIPrefix = "constellation/v1"
+	// CDNMeasurementsFile is name of file containing image measurements.
+	CDNMeasurementsFile = "measurements.json"
+	// CDNMeasurementsSignature is name of file containing signature for CDNMeasurementsFile.
+	CDNMeasurementsSignature = "measurements.json.sig"
 )
 
 // VersionInfo is the version of a binary. Left as a separate variable to allow override during build.

--- a/internal/versionsapi/version.go
+++ b/internal/versionsapi/version.go
@@ -10,10 +10,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"path"
 	"regexp"
 	"strings"
 
+	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"go.uber.org/multierr"
 	"golang.org/x/mod/semver"
@@ -143,9 +145,17 @@ func (v Version) ListPath(gran Granularity) string {
 	)
 }
 
-// ArtifactURL returns the URL to the artifacts stored for this version.
+func (v Version) ArtifactURL(csp cloudprovider.Provider, file string) (*url.URL, error) {
+	path, err := url.JoinPath(v.ArtifactsURL(), "image", "csp", strings.ToLower(csp.String()), file)
+	if err != nil {
+		return &url.URL{}, err
+	}
+	return url.Parse(path)
+}
+
+// ArtifactsURL returns the URL to the artifacts stored for this version.
 // The URL points to a directory.
-func (v Version) ArtifactURL() string {
+func (v Version) ArtifactsURL() string {
 	return constants.CDNRepositoryURL + "/" + v.ArtifactPath()
 }
 

--- a/internal/versionsapi/version.go
+++ b/internal/versionsapi/version.go
@@ -145,12 +145,26 @@ func (v Version) ListPath(gran Granularity) string {
 	)
 }
 
-func (v Version) ArtifactURL(csp cloudprovider.Provider, file string) (*url.URL, error) {
-	path, err := url.JoinPath(v.ArtifactsURL(), "image", "csp", strings.ToLower(csp.String()), file)
+func (v Version) MeasurementURL(csp cloudprovider.Provider) (*url.URL, *url.URL, error) {
+	measurementPath, err := url.JoinPath(v.ArtifactsURL(), "image", "csp", strings.ToLower(csp.String()), constants.CDNMeasurementsFile)
 	if err != nil {
-		return &url.URL{}, err
+		return &url.URL{}, &url.URL{}, fmt.Errorf("joining path for measurement: %w", err)
 	}
-	return url.Parse(path)
+	signaturePath, err := url.JoinPath(v.ArtifactsURL(), "image", "csp", strings.ToLower(csp.String()), constants.CDNMeasurementsSignature)
+	if err != nil {
+		return &url.URL{}, &url.URL{}, fmt.Errorf("joining path for signature: %w", err)
+	}
+
+	measurementURL, err := url.Parse(measurementPath)
+	if err != nil {
+		return &url.URL{}, &url.URL{}, fmt.Errorf("parsing path for measurement: %w", err)
+	}
+
+	signatureURL, err := url.Parse(signaturePath)
+	if err != nil {
+		return &url.URL{}, &url.URL{}, fmt.Errorf("parsing path for signature: %w", err)
+	}
+	return measurementURL, signatureURL, nil
 }
 
 // ArtifactsURL returns the URL to the artifacts stored for this version.

--- a/internal/versionsapi/version_test.go
+++ b/internal/versionsapi/version_test.go
@@ -377,10 +377,10 @@ func TestVersionListPathURL(t *testing.T) {
 
 func TestVersionArtifactURL(t *testing.T) {
 	testCases := map[string]struct {
-		ver     Version
-		csp     cloudprovider.Provider
-		file    string
-		wantURL string
+		ver                Version
+		csp                cloudprovider.Provider
+		wantMeasurementURL string
+		wantSignatureURL   string
 	}{
 		"nightly-feature": {
 			ver: Version{
@@ -389,9 +389,9 @@ func TestVersionArtifactURL(t *testing.T) {
 				Version: "v2.6.0-pre.0.20230217095603-193dd48ca19f",
 				Kind:    VersionKindImage,
 			},
-			csp:     cloudprovider.GCP,
-			file:    "measurements.json",
-			wantURL: constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/feat-some-feature/stream/nightly/v2.6.0-pre.0.20230217095603-193dd48ca19f/image/csp/gcp/measurements.json",
+			csp:                cloudprovider.GCP,
+			wantMeasurementURL: constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/feat-some-feature/stream/nightly/v2.6.0-pre.0.20230217095603-193dd48ca19f/image/csp/gcp/measurements.json",
+			wantSignatureURL:   constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/feat-some-feature/stream/nightly/v2.6.0-pre.0.20230217095603-193dd48ca19f/image/csp/gcp/measurements.json.sig",
 		},
 	}
 
@@ -400,9 +400,10 @@ func TestVersionArtifactURL(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			artifactURL, err := tc.ver.ArtifactURL(tc.csp, tc.file)
+			measurementURL, signatureURL, err := tc.ver.MeasurementURL(tc.csp)
 			require.NoError(err)
-			assert.Equal(tc.wantURL, artifactURL.String())
+			assert.Equal(tc.wantMeasurementURL, measurementURL.String())
+			assert.Equal(tc.wantSignatureURL, signatureURL.String())
 		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Fabian Kammel <fk@edgeless.systems>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add e2e test for `constellation upgrade execute`
  - Uses the latest released version of Constellation (currently v2.5.1) and upgrades to latest nightly build on main. This image should always be available in weekly e2e test run, since we now have https://github.com/edgelesssys/constellation/blob/main/.github/workflows/build-os-image-scheduled.yml
- Pipeline run: https://github.com/edgelesssys/constellation/actions/runs/4083108093

I will remove the `push:` event once the implementation is accepted.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
