### PR TITLE
cli: add option to automatically merge kubeconfig file on init

### DIFF
--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"os"
 	"strconv"
 	"text/tabwriter"
 	"time"
@@ -37,6 +38,11 @@ import (
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	clientcodec "k8s.io/client-go/tools/clientcmd/api/latest"
+	"sigs.k8s.io/yaml"
 )
 
 // NewInitCmd returns a new cobra.Command for the init command.
@@ -51,6 +57,7 @@ func NewInitCmd() *cobra.Command {
 	}
 	cmd.Flags().String("master-secret", "", "path to base64-encoded master secret")
 	cmd.Flags().Bool("conformance", false, "enable conformance mode")
+	cmd.Flags().Bool("merge-kubeconfig", false, "merge Constellation kubeconfig file with default kubeconfig file in $HOME/.kube/config")
 	return cmd
 }
 
@@ -177,7 +184,7 @@ func (i *initCmd) initialize(cmd *cobra.Command, newDialer func(validator *cloud
 	i.log.Debugf("Initialization request succeeded")
 	i.log.Debugf("Writing Constellation ID file")
 	idFile.CloudProvider = provider
-	if err := i.writeOutput(idFile, resp, cmd.OutOrStdout(), fileHandler); err != nil {
+	if err := i.writeOutput(idFile, resp, flags.mergeConfigs, clusterName, cmd.OutOrStdout(), fileHandler); err != nil {
 		return err
 	}
 
@@ -232,7 +239,10 @@ func (d *initDoer) Do(ctx context.Context) error {
 	return nil
 }
 
-func (i *initCmd) writeOutput(idFile clusterid.File, resp *initproto.InitResponse, wr io.Writer, fileHandler file.Handler) error {
+func (i *initCmd) writeOutput(
+	idFile clusterid.File, resp *initproto.InitResponse, mergeConfig bool, clusterName string,
+	wr io.Writer, fileHandler file.Handler,
+) error {
 	fmt.Fprint(wr, "Your Constellation cluster was successfully initialized.\n\n")
 
 	ownerID := hex.EncodeToString(resp.OwnerId)
@@ -249,17 +259,72 @@ func (i *initCmd) writeOutput(idFile clusterid.File, resp *initproto.InitRespons
 	if err := fileHandler.Write(constants.AdminConfFilename, resp.Kubeconfig, file.OptNone); err != nil {
 		return fmt.Errorf("writing kubeconfig: %w", err)
 	}
-	i.log.Debugf("Wrote out kubeconfig")
+	i.log.Debugf("Wrote kubeconfig to file")
+	if mergeConfig {
+		if err := i.mergeKubeonfig(clusterName, fileHandler); err != nil {
+			return fmt.Errorf("merging kubeconfig: %w", err)
+		}
+		i.log.Debugf("Merged kubeconfig to existing file")
+		writeRow(tw, "Kubernetes configuration merged with default config", "")
+	}
 	idFile.OwnerID = ownerID
 	idFile.ClusterID = clusterID
 
 	if err := fileHandler.WriteJSON(constants.ClusterIDsFileName, idFile, file.OptOverwrite); err != nil {
-		return fmt.Errorf("writing Constellation id file: %w", err)
+		return fmt.Errorf("writing Constellation ID file: %w", err)
 	}
-	i.log.Debugf("Wrote out Constellation id file")
+	i.log.Debugf("Wrote out Constellation ID file")
 
-	fmt.Fprintln(wr, "You can now connect to your cluster by executing:")
-	fmt.Fprintf(wr, "\texport KUBECONFIG=\"$PWD/%s\"\n", constants.AdminConfFilename)
+	if !mergeConfig {
+		fmt.Fprintln(wr, "You can now connect to your cluster by executing:")
+		fmt.Fprintf(wr, "\texport KUBECONFIG=\"$PWD/%s\"\n", constants.AdminConfFilename)
+	} else {
+		fmt.Fprintln(wr, "Constellation kubeconfig merged with default config.")
+
+		if os.Getenv(clientcmd.RecommendedConfigPathEnvVar) != "" {
+			fmt.Fprintln(wr, "Warning: KUBECONFIG environment variable is set.")
+			fmt.Fprintln(wr, "You may need to unset it to use the default config and connect to your cluster.")
+		} else {
+			fmt.Fprintln(wr, "You can now connect to your cluster.")
+		}
+	}
+	return nil
+}
+
+func (i *initCmd) mergeKubeonfig(clusterName string, fileHandler file.Handler) error {
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.Precedence = []string{
+		constants.AdminConfFilename,   // load our config first so it takes precedence
+		clientcmd.RecommendedHomeFile, // then load the default config
+	}
+	i.log.Debugf("Kubeconfig file loading precedence: %v", loadingRules.Precedence)
+
+	// merge and flatten the kubeconfigs
+	cfg, err := loadingRules.Load()
+	if err != nil {
+		return fmt.Errorf("loading merged kubeconfig: %w", err)
+	}
+	if err := clientcmdapi.FlattenConfig(cfg); err != nil {
+		return fmt.Errorf("flattening merged kubeconfig: %w", err)
+	}
+
+	// Set the current context to the cluster we just created
+	cfg.CurrentContext = fmt.Sprintf("%s-admin@%s", clusterName, clusterName)
+	i.log.Debugf("Set current context to %s", cfg.CurrentContext)
+
+	json, err := runtime.Encode(clientcodec.Codec, cfg)
+	if err != nil {
+		return fmt.Errorf("encoding merged kubeconfig: %w", err)
+	}
+
+	mergedKubeconfig, err := yaml.JSONToYAML(json)
+	if err != nil {
+		return fmt.Errorf("converting merged kubeconfig to YAML: %w", err)
+	}
+
+	if err := fileHandler.Write(clientcmd.RecommendedHomeFile, mergedKubeconfig, file.OptOverwrite); err != nil {
+		return fmt.Errorf("writing merged kubeconfig to file: %w", err)
+	}
 	return nil
 }
 
@@ -285,6 +350,11 @@ func (i *initCmd) evalFlagArgs(cmd *cobra.Command) (initFlags, error) {
 		return initFlags{}, fmt.Errorf("parsing config path flag: %w", err)
 	}
 	i.log.Debugf("Configuration path flag is %q", configPath)
+	mergeConfigs, err := cmd.Flags().GetBool("merge-kubeconfig")
+	if err != nil {
+		return initFlags{}, fmt.Errorf("parsing merge-kubeconfig flag: %w", err)
+	}
+	i.log.Debugf("Merge kubeconfig flag is %t", mergeConfigs)
 
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
@@ -297,6 +367,7 @@ func (i *initCmd) evalFlagArgs(cmd *cobra.Command) (initFlags, error) {
 		conformance:      conformance,
 		masterSecretPath: masterSecretPath,
 		force:            force,
+		mergeConfigs:     mergeConfigs,
 	}, nil
 }
 
@@ -306,6 +377,7 @@ type initFlags struct {
 	masterSecretPath string
 	conformance      bool
 	force            bool
+	mergeConfigs     bool
 }
 
 // readOrGenerateMasterSecret reads a base64 encoded master secret from file or generates a new 32 byte secret.

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -222,7 +222,7 @@ func TestWriteOutput(t *testing.T) {
 		IP:  "cluster-ip",
 	}
 	i := &initCmd{log: logger.NewTest(t)}
-	err := i.writeOutput(idFile, resp, false, "", &out, fileHandler)
+	err := i.writeOutput(idFile, resp, false, &out, fileHandler)
 	assert.NoError(err)
 	// assert.Contains(out.String(), ownerID)
 	assert.Contains(out.String(), clusterID)

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -196,6 +196,7 @@ func TestInitialize(t *testing.T) {
 
 func TestWriteOutput(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 
 	resp := &initproto.InitResponse{
 		OwnerId:    []byte("ownerID"),
@@ -221,9 +222,12 @@ func TestWriteOutput(t *testing.T) {
 		UID: "test-uid",
 		IP:  "cluster-ip",
 	}
-	i := &initCmd{log: logger.NewTest(t)}
+	i := &initCmd{
+		log:    logger.NewTest(t),
+		merger: &stubMerger{},
+	}
 	err := i.writeOutput(idFile, resp, false, &out, fileHandler)
-	assert.NoError(err)
+	require.NoError(err)
 	// assert.Contains(out.String(), ownerID)
 	assert.Contains(out.String(), clusterID)
 	assert.Contains(out.String(), constants.AdminConfFilename)
@@ -239,6 +243,29 @@ func TestWriteOutput(t *testing.T) {
 	err = json.Unmarshal(idsFile, &testIDFile)
 	assert.NoError(err)
 	assert.Equal(expectedIDFile, testIDFile)
+
+	// test config merging
+	out.Reset()
+	require.NoError(afs.Remove(constants.AdminConfFilename))
+	err = i.writeOutput(idFile, resp, true, &out, fileHandler)
+	require.NoError(err)
+	// assert.Contains(out.String(), ownerID)
+	assert.Contains(out.String(), clusterID)
+	assert.Contains(out.String(), constants.AdminConfFilename)
+	assert.Contains(out.String(), "Constellation kubeconfig merged with default config")
+	assert.Contains(out.String(), "You can now connect to your cluster")
+
+	// test config merging with env vars set
+	i.merger = &stubMerger{envVar: "/some/path/to/kubeconfig"}
+	out.Reset()
+	require.NoError(afs.Remove(constants.AdminConfFilename))
+	err = i.writeOutput(idFile, resp, true, &out, fileHandler)
+	require.NoError(err)
+	// assert.Contains(out.String(), ownerID)
+	assert.Contains(out.String(), clusterID)
+	assert.Contains(out.String(), constants.AdminConfFilename)
+	assert.Contains(out.String(), "Constellation kubeconfig merged with default config")
+	assert.Contains(out.String(), "Warning: KUBECONFIG environment variable is set")
 }
 
 func TestReadOrGenerateMasterSecret(t *testing.T) {
@@ -473,6 +500,19 @@ type stubInitServer struct {
 
 func (s *stubInitServer) Init(ctx context.Context, req *initproto.InitRequest) (*initproto.InitResponse, error) {
 	return s.initResp, s.initErr
+}
+
+type stubMerger struct {
+	envVar   string
+	mergeErr error
+}
+
+func (m *stubMerger) mergeConfigs(string, file.Handler) error {
+	return m.mergeErr
+}
+
+func (m *stubMerger) kubeconfigEnvVar() string {
+	return m.envVar
 }
 
 func defaultConfigWithExpectedMeasurements(t *testing.T, conf *config.Config, csp cloudprovider.Provider) *config.Config {

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -222,7 +222,7 @@ func TestWriteOutput(t *testing.T) {
 		IP:  "cluster-ip",
 	}
 	i := &initCmd{log: logger.NewTest(t)}
-	err := i.writeOutput(idFile, resp, &out, fileHandler)
+	err := i.writeOutput(idFile, resp, false, "", &out, fileHandler)
 	assert.NoError(err)
 	// assert.Contains(out.String(), ownerID)
 	assert.Contains(out.String(), clusterID)


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
Add `--merge-kubeconfig` flag to `constellation init`.
If set, automatically merges the config generated by `init` into the default configuration in `$HOME/.kube/config` and sets it as the current context.
Users are then able to connect to the cluster without having to do any extra setup.

If the `KUBECONFIG` env variable is set, the new config is still merged into the default config, but we cant reliably tell if `kubectl` will load this config, so a warning is printed in this case telling the user they might need to unset the `KUBECONFIG` env var

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
