### PR TITLE
cli: enable jumbo frames for GCP VPCs

### DIFF
--- a/cli/internal/terraform/terraform/gcp/main.tf
+++ b/cli/internal/terraform/terraform/gcp/main.tf
@@ -60,6 +60,7 @@ resource "google_compute_network" "vpc_network" {
   name                    = local.name
   description             = "Constellation VPC network"
   auto_create_subnetworks = false
+  mtu                     = 8896
 }
 
 resource "google_compute_subnetwork" "vpc_subnetwork" {


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Raise MTU from 1460 to 8896 (jumbo frames)

This enhances general network performance inside Kubernetes with Cilium by ~4x.
(From ~1 Gbit/s to ~4 Gbit/s)

Note that Terraform's documentation on the `mtu` field is not correct that the maximum setting for MTU is 1500. I'll open a PR with them later to fix this.