### PR TITLE
cli: fix iam rollback

### DIFF
--- a/cli/internal/cloudcmd/clients.go
+++ b/cli/internal/cloudcmd/clients.go
@@ -19,7 +19,7 @@ type terraformClient interface {
 	PrepareWorkspace(path string, input terraform.Variables) error
 	CreateCluster(ctx context.Context) (terraform.CreateOutput, error)
 	CreateIAMConfig(ctx context.Context, provider cloudprovider.Provider) (terraform.IAMOutput, error)
-	DestroyResources(ctx context.Context) error
+	Destroy(ctx context.Context) error
 	CleanUpWorkspace() error
 	RemoveInstaller()
 }

--- a/cli/internal/cloudcmd/clients.go
+++ b/cli/internal/cloudcmd/clients.go
@@ -19,7 +19,7 @@ type terraformClient interface {
 	PrepareWorkspace(path string, input terraform.Variables) error
 	CreateCluster(ctx context.Context) (terraform.CreateOutput, error)
 	CreateIAMConfig(ctx context.Context, provider cloudprovider.Provider) (terraform.IAMOutput, error)
-	DestroyCluster(ctx context.Context) error
+	DestroyResources(ctx context.Context) error
 	CleanUpWorkspace() error
 	RemoveInstaller()
 }

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -32,9 +32,9 @@ type stubTerraformClient struct {
 	uid                    string
 	cleanUpWorkspaceCalled bool
 	removeInstallerCalled  bool
-	destroyClusterCalled   bool
+	destroyResourcesCalled bool
 	createClusterErr       error
-	destroyClusterErr      error
+	destroyResourcesErr    error
 	prepareWorkspaceErr    error
 	cleanUpWorkspaceErr    error
 	iamOutputErr           error
@@ -56,9 +56,9 @@ func (c *stubTerraformClient) PrepareWorkspace(path string, input terraform.Vari
 	return c.prepareWorkspaceErr
 }
 
-func (c *stubTerraformClient) DestroyCluster(ctx context.Context) error {
-	c.destroyClusterCalled = true
-	return c.destroyClusterErr
+func (c *stubTerraformClient) DestroyResources(ctx context.Context) error {
+	c.destroyResourcesCalled = true
+	return c.destroyResourcesErr
 }
 
 func (c *stubTerraformClient) CleanUpWorkspace() error {

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -32,9 +32,9 @@ type stubTerraformClient struct {
 	uid                    string
 	cleanUpWorkspaceCalled bool
 	removeInstallerCalled  bool
-	destroyResourcesCalled bool
+	destroyCalled          bool
 	createClusterErr       error
-	destroyResourcesErr    error
+	destroyErr             error
 	prepareWorkspaceErr    error
 	cleanUpWorkspaceErr    error
 	iamOutputErr           error
@@ -56,9 +56,9 @@ func (c *stubTerraformClient) PrepareWorkspace(path string, input terraform.Vari
 	return c.prepareWorkspaceErr
 }
 
-func (c *stubTerraformClient) DestroyResources(ctx context.Context) error {
-	c.destroyResourcesCalled = true
-	return c.destroyResourcesErr
+func (c *stubTerraformClient) Destroy(ctx context.Context) error {
+	c.destroyCalled = true
+	return c.destroyErr
 }
 
 func (c *stubTerraformClient) CleanUpWorkspace() error {

--- a/cli/internal/cloudcmd/create_test.go
+++ b/cli/internal/cloudcmd/create_test.go
@@ -121,7 +121,7 @@ func TestCreator(t *testing.T) {
 				if tc.wantRollback {
 					cl := tc.tfClient.(*stubTerraformClient)
 					if tc.wantTerraformRollback {
-						assert.True(cl.destroyClusterCalled)
+						assert.True(cl.destroyResourcesCalled)
 					}
 					assert.True(cl.cleanUpWorkspaceCalled)
 					if tc.provider == cloudprovider.QEMU {

--- a/cli/internal/cloudcmd/create_test.go
+++ b/cli/internal/cloudcmd/create_test.go
@@ -121,7 +121,7 @@ func TestCreator(t *testing.T) {
 				if tc.wantRollback {
 					cl := tc.tfClient.(*stubTerraformClient)
 					if tc.wantTerraformRollback {
-						assert.True(cl.destroyResourcesCalled)
+						assert.True(cl.destroyCalled)
 					}
 					assert.True(cl.cleanUpWorkspaceCalled)
 					if tc.provider == cloudprovider.QEMU {

--- a/cli/internal/cloudcmd/rollback.go
+++ b/cli/internal/cloudcmd/rollback.go
@@ -40,7 +40,7 @@ type rollbackerTerraform struct {
 
 func (r *rollbackerTerraform) rollback(ctx context.Context) error {
 	var err error
-	err = multierr.Append(err, r.client.DestroyResources(ctx))
+	err = multierr.Append(err, r.client.Destroy(ctx))
 	if err == nil {
 		err = multierr.Append(err, r.client.CleanUpWorkspace())
 	}
@@ -56,7 +56,7 @@ type rollbackerQEMU struct {
 func (r *rollbackerQEMU) rollback(ctx context.Context) error {
 	var err error
 	if r.createdWorkspace {
-		err = multierr.Append(err, r.client.DestroyResources(ctx))
+		err = multierr.Append(err, r.client.Destroy(ctx))
 	}
 	err = multierr.Append(err, r.libvirt.Stop(ctx))
 	if err == nil {

--- a/cli/internal/cloudcmd/rollback.go
+++ b/cli/internal/cloudcmd/rollback.go
@@ -40,7 +40,7 @@ type rollbackerTerraform struct {
 
 func (r *rollbackerTerraform) rollback(ctx context.Context) error {
 	var err error
-	err = multierr.Append(err, r.client.DestroyCluster(ctx))
+	err = multierr.Append(err, r.client.DestroyResources(ctx))
 	if err == nil {
 		err = multierr.Append(err, r.client.CleanUpWorkspace())
 	}
@@ -56,7 +56,7 @@ type rollbackerQEMU struct {
 func (r *rollbackerQEMU) rollback(ctx context.Context) error {
 	var err error
 	if r.createdWorkspace {
-		err = multierr.Append(err, r.client.DestroyCluster(ctx))
+		err = multierr.Append(err, r.client.DestroyResources(ctx))
 	}
 	err = multierr.Append(err, r.libvirt.Stop(ctx))
 	if err == nil {

--- a/cli/internal/cloudcmd/rollback_test.go
+++ b/cli/internal/cloudcmd/rollback_test.go
@@ -25,7 +25,7 @@ func TestRollbackTerraform(t *testing.T) {
 			tfClient: &stubTerraformClient{},
 		},
 		"destroy cluster error": {
-			tfClient: &stubTerraformClient{destroyClusterErr: someErr},
+			tfClient: &stubTerraformClient{destroyResourcesErr: someErr},
 			wantErr:  true,
 		},
 		"clean up workspace error": {
@@ -51,7 +51,7 @@ func TestRollbackTerraform(t *testing.T) {
 				return
 			}
 			assert.NoError(err)
-			assert.True(tc.tfClient.destroyClusterCalled)
+			assert.True(tc.tfClient.destroyResourcesCalled)
 			assert.True(tc.tfClient.cleanUpWorkspaceCalled)
 		})
 	}
@@ -78,7 +78,7 @@ func TestRollbackQEMU(t *testing.T) {
 		},
 		"destroy cluster error": {
 			libvirt:  &stubLibvirtRunner{stopErr: someErr},
-			tfClient: &stubTerraformClient{destroyClusterErr: someErr},
+			tfClient: &stubTerraformClient{destroyResourcesErr: someErr},
 			wantErr:  true,
 		},
 		"clean up workspace error": {
@@ -109,9 +109,9 @@ func TestRollbackQEMU(t *testing.T) {
 			assert.NoError(err)
 			assert.True(tc.libvirt.stopCalled)
 			if tc.createdWorkspace {
-				assert.True(tc.tfClient.destroyClusterCalled)
+				assert.True(tc.tfClient.destroyResourcesCalled)
 			} else {
-				assert.False(tc.tfClient.destroyClusterCalled)
+				assert.False(tc.tfClient.destroyResourcesCalled)
 			}
 			assert.True(tc.tfClient.cleanUpWorkspaceCalled)
 		})

--- a/cli/internal/cloudcmd/rollback_test.go
+++ b/cli/internal/cloudcmd/rollback_test.go
@@ -25,7 +25,7 @@ func TestRollbackTerraform(t *testing.T) {
 			tfClient: &stubTerraformClient{},
 		},
 		"destroy cluster error": {
-			tfClient: &stubTerraformClient{destroyResourcesErr: someErr},
+			tfClient: &stubTerraformClient{destroyErr: someErr},
 			wantErr:  true,
 		},
 		"clean up workspace error": {
@@ -51,7 +51,7 @@ func TestRollbackTerraform(t *testing.T) {
 				return
 			}
 			assert.NoError(err)
-			assert.True(tc.tfClient.destroyResourcesCalled)
+			assert.True(tc.tfClient.destroyCalled)
 			assert.True(tc.tfClient.cleanUpWorkspaceCalled)
 		})
 	}
@@ -78,7 +78,7 @@ func TestRollbackQEMU(t *testing.T) {
 		},
 		"destroy cluster error": {
 			libvirt:  &stubLibvirtRunner{stopErr: someErr},
-			tfClient: &stubTerraformClient{destroyResourcesErr: someErr},
+			tfClient: &stubTerraformClient{destroyErr: someErr},
 			wantErr:  true,
 		},
 		"clean up workspace error": {
@@ -109,9 +109,9 @@ func TestRollbackQEMU(t *testing.T) {
 			assert.NoError(err)
 			assert.True(tc.libvirt.stopCalled)
 			if tc.createdWorkspace {
-				assert.True(tc.tfClient.destroyResourcesCalled)
+				assert.True(tc.tfClient.destroyCalled)
 			} else {
-				assert.False(tc.tfClient.destroyResourcesCalled)
+				assert.False(tc.tfClient.destroyCalled)
 			}
 			assert.True(tc.tfClient.cleanUpWorkspaceCalled)
 		})

--- a/cli/internal/cloudcmd/terminate.go
+++ b/cli/internal/cloudcmd/terminate.go
@@ -50,7 +50,7 @@ func (t *Terminator) Terminate(ctx context.Context) (retErr error) {
 }
 
 func (t *Terminator) terminateTerraform(ctx context.Context, cl terraformClient) error {
-	if err := cl.DestroyResources(ctx); err != nil {
+	if err := cl.Destroy(ctx); err != nil {
 		return err
 	}
 	return cl.CleanUpWorkspace()

--- a/cli/internal/cloudcmd/terminate.go
+++ b/cli/internal/cloudcmd/terminate.go
@@ -50,7 +50,7 @@ func (t *Terminator) Terminate(ctx context.Context) (retErr error) {
 }
 
 func (t *Terminator) terminateTerraform(ctx context.Context, cl terraformClient) error {
-	if err := cl.DestroyCluster(ctx); err != nil {
+	if err := cl.DestroyResources(ctx); err != nil {
 		return err
 	}
 	return cl.CleanUpWorkspace()

--- a/cli/internal/cloudcmd/terminate_test.go
+++ b/cli/internal/cloudcmd/terminate_test.go
@@ -33,7 +33,7 @@ func TestTerminator(t *testing.T) {
 			wantErr:        true,
 		},
 		"destroy cluster error": {
-			tfClient: &stubTerraformClient{destroyResourcesErr: someErr},
+			tfClient: &stubTerraformClient{destroyErr: someErr},
 			libvirt:  &stubLibvirtRunner{},
 			wantErr:  true,
 		},
@@ -70,7 +70,7 @@ func TestTerminator(t *testing.T) {
 			}
 			assert.NoError(err)
 			cl := tc.tfClient.(*stubTerraformClient)
-			assert.True(cl.destroyResourcesCalled)
+			assert.True(cl.destroyCalled)
 			assert.True(cl.removeInstallerCalled)
 			assert.True(tc.libvirt.stopCalled)
 		})

--- a/cli/internal/cloudcmd/terminate_test.go
+++ b/cli/internal/cloudcmd/terminate_test.go
@@ -33,7 +33,7 @@ func TestTerminator(t *testing.T) {
 			wantErr:        true,
 		},
 		"destroy cluster error": {
-			tfClient: &stubTerraformClient{destroyClusterErr: someErr},
+			tfClient: &stubTerraformClient{destroyResourcesErr: someErr},
 			libvirt:  &stubLibvirtRunner{},
 			wantErr:  true,
 		},
@@ -70,7 +70,7 @@ func TestTerminator(t *testing.T) {
 			}
 			assert.NoError(err)
 			cl := tc.tfClient.(*stubTerraformClient)
-			assert.True(cl.destroyClusterCalled)
+			assert.True(cl.destroyResourcesCalled)
 			assert.True(cl.removeInstallerCalled)
 			assert.True(tc.libvirt.stopCalled)
 		})

--- a/cli/internal/cmd/iam.go
+++ b/cli/internal/cmd/iam.go
@@ -184,6 +184,10 @@ func (c *iamCreator) create(ctx context.Context) error {
 		return err
 	}
 
+	if err := c.checkWorkingDir(); err != nil {
+		return err
+	}
+
 	if !flags.yesFlag {
 		c.cmd.Printf("The following IAM configuration will be created:\n\n")
 		c.providerCreator.printConfirmValues(c.cmd, flags)
@@ -258,6 +262,17 @@ func (c *iamCreator) parseFlagsAndSetupConfig() (iamFlags, error) {
 	}
 
 	return flags, nil
+}
+
+// checkWorkingDir checks if the current working directory already contains a Terraform dir or a Constellation config file.
+func (c *iamCreator) checkWorkingDir() error {
+	if _, err := c.fileHandler.Stat(constants.TerraformIAMWorkingDir); err == nil {
+		return fmt.Errorf("the current working directory already contains the %s directory. Please run the command in a different directory", constants.TerraformIAMWorkingDir)
+	}
+	if _, err := c.fileHandler.Stat(constants.ConfigFilename); err == nil {
+		return fmt.Errorf("the current working directory already contains the %s file. Please run the command in a different directory", constants.ConfigFilename)
+	}
+	return nil
 }
 
 // iamFlags contains the parsed flags of the iam create command, including the parsed flags of the selected cloud provider.

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -272,8 +272,8 @@ func (c *Client) CreateIAMConfig(ctx context.Context, provider cloudprovider.Pro
 	}
 }
 
-// DestroyCluster destroys a Constellation cluster using Terraform.
-func (c *Client) DestroyCluster(ctx context.Context) error {
+// DestroyResources destroys Terraform-created cloud resources.
+func (c *Client) DestroyResources(ctx context.Context) error {
 	if err := c.tf.Init(ctx); err != nil {
 		return err
 	}

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -272,8 +272,8 @@ func (c *Client) CreateIAMConfig(ctx context.Context, provider cloudprovider.Pro
 	}
 }
 
-// DestroyResources destroys Terraform-created cloud resources.
-func (c *Client) DestroyResources(ctx context.Context) error {
+// Destroy destroys Terraform-created cloud resources.
+func (c *Client) Destroy(ctx context.Context) error {
 	if err := c.tf.Init(ctx); err != nil {
 		return err
 	}

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -660,7 +660,7 @@ func TestDestroyInstances(t *testing.T) {
 				tf: tc.tf,
 			}
 
-			err := c.DestroyResources(context.Background())
+			err := c.Destroy(context.Background())
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -660,7 +660,7 @@ func TestDestroyInstances(t *testing.T) {
 				tf: tc.tf,
 			}
 
-			err := c.DestroyCluster(context.Background())
+			err := c.DestroyResources(context.Background())
 			if tc.wantErr {
 				assert.Error(err)
 				return


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Check whether Terraform state directory already exists on the `iam create` command and if it exists, do not continue with execution
- Rename `DestroyCluster` to `DestroyResources` as it can also destroy IAM resources

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Previously, if the `iam create` command is executed twice in a row, the second execution would error because the Terraform state dir already exists. On this error, it would also rollback the existing directory which deletes the Terraform state of a previous execution of the command

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
