### PR TITLE
cli: add missing gcp values to config

### DIFF
--- a/cli/internal/cmd/iam.go
+++ b/cli/internal/cmd/iam.go
@@ -353,6 +353,7 @@ func (c *awsIAMCreator) printOutputValues(cmd *cobra.Command, flags iamFlags, ia
 	cmd.Printf("zone:\t\t\t%s\n", flags.aws.zone)
 	cmd.Printf("iamProfileControlPlane:\t%s\n", iamFile.AWSOutput.ControlPlaneInstanceProfile)
 	cmd.Printf("iamProfileWorkerNodes:\t%s\n\n", iamFile.AWSOutput.WorkerNodeInstanceProfile)
+	cmd.Println("Your IAM configuration was created successfully. Please fill the above values into your configuration file.")
 }
 
 func (c *awsIAMCreator) writeOutputValuesToConfig(conf *config.Config, flags iamFlags, iamFile iamid.File) {
@@ -493,11 +494,18 @@ func (c *gcpIAMCreator) printConfirmValues(cmd *cobra.Command, flags iamFlags) {
 }
 
 func (c *gcpIAMCreator) printOutputValues(cmd *cobra.Command, flags iamFlags, iamFile iamid.File) {
-	cmd.Println(fmt.Sprintf("serviceAccountKeyPath:\t%s\n", constants.GCPServiceAccountKeyFile))
+	cmd.Printf("projectID:\t\t%s\n", constants.GCPServiceAccountKeyFile)
+	cmd.Printf("region:\t\t\t%s\n", constants.GCPServiceAccountKeyFile)
+	cmd.Printf("zone:\t\t\t%s\n", constants.GCPServiceAccountKeyFile)
+	cmd.Printf("serviceAccountKeyPath:\t%s\n\n", constants.GCPServiceAccountKeyFile)
+	cmd.Println("Your IAM configuration was created successfully. Please fill the above values into your configuration file.")
 }
 
 func (c *gcpIAMCreator) writeOutputValuesToConfig(conf *config.Config, flags iamFlags, iamFile iamid.File) {
+	conf.Provider.GCP.Project = flags.gcp.projectID
 	conf.Provider.GCP.ServiceAccountKeyPath = constants.GCPServiceAccountKeyFile
+	conf.Provider.GCP.Region = flags.gcp.region
+	conf.Provider.GCP.Zone = flags.gcp.zone
 }
 
 func (c *gcpIAMCreator) parseAndWriteIDFile(iamFile iamid.File, fileHandler file.Handler) error {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- The `iam create` command was not adding the GCP zone, region and project id values to the configuration file or the terminal output. To create a better UX and to align with the behavior for AWS and Azure, write these values to the configuration file and print them if no config file is being generated
- Print a reminder to fill the values in the configuration file for all provide

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
