### PR TITLE
Enable cryptsetup read/write workqueue bypass

### DIFF
--- a/csi/cryptmapper/cryptmapper.go
+++ b/csi/cryptmapper/cryptmapper.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/edgelesssys/constellation/v2/internal/crypto"
+	ccryptsetup "github.com/edgelesssys/constellation/v2/internal/cryptsetup"
 	cryptsetup "github.com/martinjungblut/go-cryptsetup"
 	mount "k8s.io/mount-utils"
 	utilexec "k8s.io/utils/exec"
@@ -296,7 +297,7 @@ func openCryptDevice(ctx context.Context, device DeviceMapper, source, volumeID 
 		}
 	}
 
-	if err := device.ActivateByPassphrase(volumeID, 0, string(passphrase), 0); err != nil {
+	if err := device.ActivateByPassphrase(volumeID, 0, string(passphrase), ccryptsetup.ReadWriteQueueBypass); err != nil {
 		return "", fmt.Errorf("trying to activate dm-crypt volume: %w", err)
 	}
 
@@ -368,8 +369,8 @@ func resizeCryptDevice(ctx context.Context, device DeviceMapper, name string,
 		return fmt.Errorf("getting key: %w", err)
 	}
 
-	if err := device.ActivateByPassphrase("", 0, string(passphrase), cryptsetup.CRYPT_ACTIVATE_KEYRING_KEY); err != nil {
-		return fmt.Errorf("activating keyrung for crypt device %q with passphrase: %w", name, err)
+	if err := device.ActivateByPassphrase("", 0, string(passphrase), cryptsetup.CRYPT_ACTIVATE_KEYRING_KEY|ccryptsetup.ReadWriteQueueBypass); err != nil {
+		return fmt.Errorf("activating keyring for crypt device %q with passphrase: %w", name, err)
 	}
 
 	if err := device.Resize(name, 0); err != nil {

--- a/disk-mapper/internal/mapper/mapper.go
+++ b/disk-mapper/internal/mapper/mapper.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 	"time"
 
+	ccryptsetup "github.com/edgelesssys/constellation/v2/internal/cryptsetup"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	cryptsetup "github.com/martinjungblut/go-cryptsetup"
 	"go.uber.org/zap"
@@ -107,7 +108,7 @@ func (m *Mapper) FormatDisk(passphrase string) error {
 
 // MapDisk maps a crypt device to /dev/mapper/target using the provided passphrase.
 func (m *Mapper) MapDisk(target, passphrase string) error {
-	if err := m.device.ActivateByPassphrase(target, 0, passphrase, 0); err != nil {
+	if err := m.device.ActivateByPassphrase(target, 0, passphrase, ccryptsetup.ReadWriteQueueBypass); err != nil {
 		return fmt.Errorf("mapping disk as %q: %w", target, err)
 	}
 	return nil

--- a/internal/cryptsetup/cryptsetup.go
+++ b/internal/cryptsetup/cryptsetup.go
@@ -1,0 +1,17 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+// Package cryptsetup contains CGO bindings for cryptsetup.
+package cryptsetup
+
+// #cgo pkg-config: libcryptsetup
+// #include <libcryptsetup.h>
+import "C"
+
+const (
+	// ReadWriteQueueBypass is a flag to disable the write and read workqueues for a crypt device.
+	ReadWriteQueueBypass = C.CRYPT_ACTIVATE_NO_WRITE_WORKQUEUE | C.CRYPT_ACTIVATE_NO_READ_WORKQUEUE
+)

--- a/internal/cryptsetup/cryptsetup.go
+++ b/internal/cryptsetup/cryptsetup.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 // Package cryptsetup contains CGO bindings for cryptsetup.
 package cryptsetup
 
-// #cgo pkg-config: libcryptsetup
 // #include <libcryptsetup.h>
 import "C"
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Enable read/write workqueue bypass to potentially speed up encrypted disk usage

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
This feature should be extensively tested before we decide if we want to include it in the next release.
To achieve this I want to first run some e2e tests on this branch, and then have it in main so it gets tested by our daily and weekly e2e test, as well as developers.
As the changeset is quite small it can be easily reverted at any time

Successful run on Azure: https://github.com/edgelesssys/constellation/actions/runs/4103995386
Successful run on GCP: https://github.com/edgelesssys/constellation/actions/runs/4105197725

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
