### PR TITLE
config: fix incorrect kubernetes version validation

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -506,10 +506,6 @@ func (c *Config) Validate(force bool) error {
 		return err
 	}
 
-	if err := validate.RegisterTranslation("supported_k8s_version", trans, registerInvalidK8sVersionError, translateInvalidK8sVersionError); err != nil {
-		return err
-	}
-
 	if err := validate.RegisterValidation("no_placeholders", validateNoPlaceholder); err != nil {
 		return err
 	}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -310,7 +310,7 @@ func getPlaceholderEntries(m Measurements) []uint32 {
 }
 
 func validateK8sVersion(fl validator.FieldLevel) bool {
-	return versions.IsSupportedK8sVersion(fl.Field().String())
+	return versions.IsSupportedK8sVersion(compatibility.EnsurePrefixV(fl.Field().String()))
 }
 
 func registerVersionCompatibilityError(ut ut.Translator) error {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -66,12 +66,6 @@ func translateInvalidK8sVersionError(ut ut.Translator, fe validator.FieldError) 
 		return t
 	}
 
-	if !strings.HasPrefix(configured, "v") {
-		errorMsg = fmt.Sprintf("The configured version is missing a 'v' prefix. Supported versions: %s", strings.Join(validVersionsSorted, " "))
-		t, _ := ut.T("supported_k8s_version", fe.Field(), errorMsg)
-		return t
-	}
-
 	configured = compatibility.EnsurePrefixV(configured)
 	switch {
 	case !semver.IsValid(configured):

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -55,6 +55,10 @@ func translateInvalidK8sVersionError(ut ut.Translator, fe validator.FieldError) 
 	validVersionsSorted := semver.ByVersion(validVersions)
 	sort.Sort(validVersionsSorted)
 
+	if len(validVersionsSorted) == 0 {
+		t, _ := ut.T("supported_k8s_version", fe.Field(), "No valid versions available. This should never happen")
+		return t
+	}
 	maxVersion := validVersionsSorted[len(validVersionsSorted)-1]
 	minVersion := validVersionsSorted[0]
 

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/edgelesssys/constellation/v2/internal/compatibility"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/versions/components"
 	"golang.org/x/mod/semver"
@@ -26,7 +27,7 @@ func SupportedK8sVersions() []string {
 	validVersions := make([]string, len(VersionConfigs))
 	i := 0
 	for _, conf := range VersionConfigs {
-		validVersions[i] = conf.ClusterVersion
+		validVersions[i] = compatibility.EnsurePrefixV(conf.ClusterVersion)
 		i++
 	}
 	validVersionsSorted := semver.ByVersion(validVersions)


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix incorrect string comparison by replacing it with call to semver.Compare. Also add handling to check for missing v prefix.



### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
