### PR TITLE
image: verbose debugging options

### DIFF
--- a/disk-mapper/cmd/main.go
+++ b/disk-mapper/cmd/main.go
@@ -134,7 +134,9 @@ func main() {
 		vtpm.OpenVTPM,
 	)
 
-	setupManger.LogDevices()
+	if err := setupManger.LogDevices(); err != nil {
+		log.With(zap.Error(err)).Fatalf("Failed to log devices")
+	}
 
 	// prepare the state disk
 	if mapper.IsLUKSDevice() {

--- a/disk-mapper/cmd/main.go
+++ b/disk-mapper/cmd/main.go
@@ -134,6 +134,8 @@ func main() {
 		vtpm.OpenVTPM,
 	)
 
+	setupManger.LogDevices()
+
 	// prepare the state disk
 	if mapper.IsLUKSDevice() {
 		// set up rejoin client

--- a/disk-mapper/internal/setup/setup.go
+++ b/disk-mapper/internal/setup/setup.go
@@ -192,6 +192,7 @@ func (s *Manager) LogDevices() error {
 		dev := "/dev/" + device.Name()
 		if err := syscall.Statfs(dev, &stat); err != nil {
 			s.log.Errorf("failed to statfs %s: %v", dev, err)
+			continue
 		}
 
 		// get the raw size, in bytes

--- a/disk-mapper/internal/setup/setup.go
+++ b/disk-mapper/internal/setup/setup.go
@@ -16,6 +16,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -75,8 +76,8 @@ func New(log *logger.Logger, csp string, diskPath string, fs afero.Afero,
 // Once the disk is mapped, the function taints the node as initialized by updating it's PCRs.
 func (s *Manager) PrepareExistingDisk(recover RecoveryDoer) error {
 	s.log.Infof("Preparing existing state disk")
-	uuid := s.mapper.DiskUUID()
 
+	uuid := s.mapper.DiskUUID()
 	endpoint := net.JoinHostPort("0.0.0.0", strconv.Itoa(constants.RecoveryPort))
 
 	passphrase, measurementSecret, err := recover.Do(uuid, endpoint)
@@ -91,6 +92,7 @@ func (s *Manager) PrepareExistingDisk(recover RecoveryDoer) error {
 	if err := s.mounter.MkdirAll(stateDiskMountPath, os.ModePerm); err != nil {
 		return err
 	}
+
 	// we do not care about cleaning up the mount point on error, since any errors returned here should cause a boot failure
 	if err := s.mounter.Mount(filepath.Join("/dev/mapper/", stateDiskMappedName), stateDiskMountPath, "ext4", syscall.MS_RDONLY, ""); err != nil {
 		return err
@@ -100,6 +102,7 @@ func (s *Manager) PrepareExistingDisk(recover RecoveryDoer) error {
 	if err != nil {
 		return err
 	}
+
 	clusterID, err := attestation.DeriveClusterID(measurementSecret, measurementSalt)
 	if err != nil {
 		return err
@@ -165,6 +168,36 @@ func (s *Manager) saveConfiguration(passphrase []byte) error {
 	return s.config.Generate(stateDiskMappedName, s.diskPath, filepath.Join(keyPath, keyFile), cryptsetupOptions)
 }
 
+func (s *Manager) LogDevices() {
+	devices, err := ioutil.ReadDir("/sys/class/block")
+	if err != nil {
+		s.log.Errorf("failed to read block devices: %v", err)
+	}
+
+	s.log.Infof("List of all avaliable block devices and partitions:")
+	for _, device := range devices {
+		var stat syscall.Statfs_t
+		dev := "/dev/" + device.Name()
+		if err := syscall.Statfs(dev, &stat); err != nil {
+			s.log.Errorf("failed to statfs %s: %v", dev, err)
+		}
+
+		// get the raw size, in bytes
+		size := stat.Blocks * uint64(stat.Bsize)
+		free := stat.Bfree * uint64(stat.Bsize)
+		avail := stat.Bavail * uint64(stat.Bsize)
+
+		s.log.Infof(
+			"Name: %-15s, Size: %-10d, Mode: %s, ModTime: %s, Size = %-10d, Free = %-10d, Available = %-10d\n",
+			dev,
+			device.Size(),
+			device.Mode(),
+			device.ModTime(),
+			size,
+			free,
+			avail)
+	}
+}
 // RecoveryServer interface serves a recovery server.
 type RecoveryServer interface {
 	Serve(context.Context, net.Listener, string) (key, secret []byte, err error)
@@ -195,11 +228,13 @@ func NewNodeRecoverer(recoveryServer RecoveryServer, rejoinClient RejoinClient) 
 func (r *NodeRecoverer) Do(uuid, endpoint string) (passphrase, measurementSecret []byte, err error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	lis, err := net.Listen("tcp", endpoint)
 	if err != nil {
 		return nil, nil, err
 	}
 	defer lis.Close()
+
 
 	var once sync.Once
 	var wg sync.WaitGroup

--- a/disk-mapper/internal/setup/setup.go
+++ b/disk-mapper/internal/setup/setup.go
@@ -16,13 +16,13 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
 	"syscall"
+	"fs"
 
 	"github.com/edgelesssys/constellation/v2/disk-mapper/internal/systemd"
 	"github.com/edgelesssys/constellation/v2/internal/attestation"
@@ -169,9 +169,20 @@ func (s *Manager) saveConfiguration(passphrase []byte) error {
 }
 
 func (s *Manager) LogDevices() {
-	devices, err := ioutil.ReadDir("/sys/class/block")
+	var devices []fs.FileInfo
+	dirs, err := os.ReadDir("/sys/class/block")
+	for _, file := range dirs {
+		if file.IsDir() {
+			continue
+		}
+		fileInfo, err := file.Info()
+		if err != nil {
+			panic(err)
+		}
+		devices = append(devices, fileInfo)
+	}
 	if err != nil {
-		s.log.Errorf("failed to read block devices: %v", err)
+		panic(err)
 	}
 
 	s.log.Infof("List of all avaliable block devices and partitions:")

--- a/disk-mapper/internal/setup/setup.go
+++ b/disk-mapper/internal/setup/setup.go
@@ -191,7 +191,7 @@ func (s *Manager) LogDevices() error {
 		var stat syscall.Statfs_t
 		dev := "/dev/" + device.Name()
 		if err := syscall.Statfs(dev, &stat); err != nil {
-			s.log.Errorf("failed to statfs %s: %v", dev, err)
+			s.log.With(zap.Error(err)).Errorf("failed to statfs %s", dev)
 			continue
 		}
 
@@ -210,6 +210,7 @@ func (s *Manager) LogDevices() error {
 			free,
 			avail)
 	}
+	return nil
 }
 
 // RecoveryServer interface serves a recovery server.

--- a/image/Makefile
+++ b/image/Makefile
@@ -11,8 +11,8 @@ IMAGE_VERSION                    ?= v0.0.0
 DEBUG                            ?= false
 AUTOLOGIN                        ?= false
 AUTOLOGIN_ARGS                   := $(if $(filter true,$(AUTOLOGIN)),--autologin) # set "--autologin" if AUTOLOGIN is true
-KERNEL_DEBUG_CMDLNE				 := constellation.debug
-export INSTALL_DEBUGD			 ?= $(DEBUG)
+KERNEL_DEBUG_CMDLNE              := constellation.debug
+export INSTALL_DEBUGD            ?= $(DEBUG)
 export CONSOLE_MOTD = $(AUTOLOGIN)
 -include $(CURDIR)/config.mk
 csps := aws qemu gcp azure

--- a/image/Makefile
+++ b/image/Makefile
@@ -11,6 +11,7 @@ IMAGE_VERSION                    ?= v0.0.0
 DEBUG                            ?= false
 AUTOLOGIN                        ?= false
 AUTOLOGIN_ARGS                   := $(if $(filter true,$(AUTOLOGIN)),--autologin) # set "--autologin" if AUTOLOGIN is true
+KERNEL_DEBUG_CMDLNE				 := constellation.debug
 export INSTALL_DEBUGD			 ?= $(DEBUG)
 export CONSOLE_MOTD = $(AUTOLOGIN)
 -include $(CURDIR)/config.mk
@@ -44,6 +45,7 @@ mkosi.output.%/fedora~37/image.raw: mkosi.files/mkosi.%.conf inject-bins inject-
 		$(AUTOLOGIN_ARGS) \
 		--environment=INSTALL_DEBUGD \
 		--environment=CONSOLE_MOTD \
+		--kernel-command-line="$(KERNEL_DEBUG_CMDLNE)=$(DEBUG)" \
 		build
 	secure-boot/signed-shim.sh $@
 	@if [ -n $(SUDO_UID) ] && [ -n $(SUDO_GID) ]; then \

--- a/image/Makefile
+++ b/image/Makefile
@@ -11,7 +11,7 @@ IMAGE_VERSION                    ?= v0.0.0
 DEBUG                            ?= false
 AUTOLOGIN                        ?= false
 AUTOLOGIN_ARGS                   := $(if $(filter true,$(AUTOLOGIN)),--autologin) # set "--autologin" if AUTOLOGIN is true
-KERNEL_DEBUG_CMDLNE              := constellation.debug
+KERNEL_DEBUG_CMDLNE              := $(if $(filter true,$(DEBUG)),constellation.debug) # set "constellation.debug" if DEBUG is true
 export INSTALL_DEBUGD            ?= $(DEBUG)
 export CONSOLE_MOTD = $(AUTOLOGIN)
 -include $(CURDIR)/config.mk
@@ -45,7 +45,7 @@ mkosi.output.%/fedora~37/image.raw: mkosi.files/mkosi.%.conf inject-bins inject-
 		$(AUTOLOGIN_ARGS) \
 		--environment=INSTALL_DEBUGD \
 		--environment=CONSOLE_MOTD \
-		--kernel-command-line="$(KERNEL_DEBUG_CMDLNE)=$(DEBUG)" \
+		--kernel-command-line="$(KERNEL_DEBUG_CMDLNE)" \
 		build
 	secure-boot/signed-shim.sh $@
 	@if [ -n $(SUDO_UID) ] && [ -n $(SUDO_GID) ]; then \

--- a/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.service
+++ b/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.service
@@ -5,7 +5,6 @@ After=network-online.target nss-lookup.target configure-constel-csp.service
 Wants=network-online.target
 Requires=initrd-root-fs.target
 FailureAction=reboot-immediate
-ConditionKernelCommandLine=constellation.debug
 After=export_constellation_debug.service
 
 [Service]

--- a/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.service
+++ b/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.service
@@ -5,11 +5,13 @@ After=network-online.target nss-lookup.target configure-constel-csp.service
 Wants=network-online.target
 Requires=initrd-root-fs.target
 FailureAction=reboot-immediate
+ConditionKernelCommandLine=constellation.debug
+After=export_constellation_debug.service
 
 [Service]
 Type=oneshot
 EnvironmentFile=/run/constellation.env
-ExecStart=/bin/bash /usr/sbin/prepare-state-disk
+ExecStart=/bin/bash /usr/sbin/prepare-state-disk $CONSTELLATION_DEBUG_FLAGS
 RemainAfterExit=yes
 StandardOutput=tty
 StandardInput=tty

--- a/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.sh
+++ b/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.sh
@@ -6,12 +6,12 @@
 set -euo pipefail
 shopt -s inherit_errexit
 
-# hacky parsing of the command line arguments. check if argv[1] is --debug
+# parsing of the command line arguments. check if argv[1] is --debug
 verbosity=0
 if [[ $# -gt 0 ]]; then
   if [[ $1 == "--debug" ]]; then
     verbosity=-1
-    echo "[Constellation] Debug mode enabled"Q
+    echo "[Constellation] Debug mode enabled"
   else
     echo "[Constellation] Unknown argument: $1"
     exit 1

--- a/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.sh
+++ b/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.sh
@@ -7,16 +7,16 @@ set -euo pipefail
 shopt -s inherit_errexit
 
 # hacky parsing of the command line arguments. check if argv[1] is --debug
-VERBOSITY=0
-if [[ "$1" = "--debug" ]]; then
-  VERBOSITY=-1
+verbosity=0
+if [[ $1 == "--debug" ]]; then
+  verbosity=-1
 fi
 
 # Prepare the encrypted volume by either initializing it with a random key or by aquiring the key from another bootstrapper.
 # Store encryption key (random or recovered key) in /run/cryptsetup-keys.d/state.key
 disk-mapper \
   -csp "${CONSTEL_CSP}" \
-  -v "${VERBOSITY}"
+  -v "${verbosity}"
 
 if [[ $? -ne 0 ]]; then
   echo "Failed to prepare state disk"

--- a/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.sh
+++ b/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.sh
@@ -6,9 +6,18 @@
 set -euo pipefail
 shopt -s inherit_errexit
 
+# hacky parsing of the command line arguments. check if argv[1] is --debug
+VERBOSITY=0
+if [[ "$1" = "--debug" ]]; then
+  VERBOSITY=-1
+fi
+
 # Prepare the encrypted volume by either initializing it with a random key or by aquiring the key from another bootstrapper.
 # Store encryption key (random or recovered key) in /run/cryptsetup-keys.d/state.key
-disk-mapper -csp "${CONSTEL_CSP}"
+disk-mapper \
+  -csp "${CONSTEL_CSP}" \
+  -v "${VERBOSITY}"
+
 if [[ $? -ne 0 ]]; then
   echo "Failed to prepare state disk"
   sleep 2 # give the serial console time to print the error message

--- a/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.sh
+++ b/image/mkosi.skeleton/usr/lib/dracut/modules.d/39constellation-mount/prepare-state-disk.sh
@@ -8,8 +8,16 @@ shopt -s inherit_errexit
 
 # hacky parsing of the command line arguments. check if argv[1] is --debug
 verbosity=0
-if [[ $1 == "--debug" ]]; then
-  verbosity=-1
+if [[ $# -gt 0 ]]; then
+  if [[ $1 == "--debug" ]]; then
+    verbosity=-1
+    echo "[Constellation] Debug mode enabled"Q
+  else
+    echo "[Constellation] Unknown argument: $1"
+    exit 1
+  fi
+else
+  echo "[Constellation] Debug mode disabled"
 fi
 
 # Prepare the encrypted volume by either initializing it with a random key or by aquiring the key from another bootstrapper.

--- a/image/mkosi.skeleton/usr/lib/systemd/system-preset/30-constellation.preset
+++ b/image/mkosi.skeleton/usr/lib/systemd/system-preset/30-constellation.preset
@@ -5,3 +5,4 @@ enable containerd.service
 enable kubelet.service
 enable systemd-networkd.service
 enable tpm-pcrs.service
+enable export_constellation_debug.service

--- a/image/mkosi.skeleton/usr/lib/systemd/system/constellation-bootstrapper.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/constellation-bootstrapper.service
@@ -2,7 +2,6 @@
 Description=Constellation Bootstrapper
 Wants=network-online.target
 After=network-online.target configure-constel-csp.service
-ConditionKernelCommandLine=constellation.debug
 After=export_constellation_debug.service
 
 [Service]

--- a/image/mkosi.skeleton/usr/lib/systemd/system/constellation-bootstrapper.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/constellation-bootstrapper.service
@@ -3,6 +3,7 @@ Description=Constellation Bootstrapper
 Wants=network-online.target
 After=network-online.target configure-constel-csp.service
 ConditionKernelCommandLine=constellation.debug
+After=export_constellation_debug.service
 
 [Service]
 Type=simple
@@ -10,7 +11,7 @@ RemainAfterExit=yes
 Restart=on-failure
 EnvironmentFile=/run/constellation.env
 Environment=PATH=/run/state/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-ExecStart=/usr/bin/bootstrapper
+ExecStart=/usr/bin/bootstrapper $CONSTELLATION_DEBUG_FLAGS
 
 [Install]
 WantedBy=multi-user.target

--- a/image/mkosi.skeleton/usr/lib/systemd/system/constellation-bootstrapper.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/constellation-bootstrapper.service
@@ -2,6 +2,7 @@
 Description=Constellation Bootstrapper
 Wants=network-online.target
 After=network-online.target configure-constel-csp.service
+ConditionKernelCommandLine=constellation.debug
 
 [Service]
 Type=simple

--- a/image/mkosi.skeleton/usr/lib/systemd/system/constellation-upgrade-agent.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/constellation-upgrade-agent.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Constellation Upgrade Agent
-ConditionKernelCommandLine=constellation.debug
 After=export_constellation_debug.service
 
 [Service]

--- a/image/mkosi.skeleton/usr/lib/systemd/system/constellation-upgrade-agent.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/constellation-upgrade-agent.service
@@ -1,13 +1,15 @@
 [Unit]
 Description=Constellation Upgrade Agent
 ConditionKernelCommandLine=constellation.debug
+After=export_constellation_debug.service
 
 [Service]
 Type=simple
 RemainAfterExit=yes
 Restart=on-failure
+EnvironmentFile=/run/constellation.env
 Environment=PATH=/run/state/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-ExecStart=/usr/bin/upgrade-agent
+ExecStart=/usr/bin/upgrade-agent $CONSTELLATION_DEBUG_FLAGS
 
 [Install]
 WantedBy=multi-user.target

--- a/image/mkosi.skeleton/usr/lib/systemd/system/constellation-upgrade-agent.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/constellation-upgrade-agent.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Constellation Upgrade Agent
+ConditionKernelCommandLine=constellation.debug
 
 [Service]
 Type=simple

--- a/image/mkosi.skeleton/usr/lib/systemd/system/export_constellation_debug.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/export_constellation_debug.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Export Constellation Debug Level to Environment
+ConditionKernelCommandLine=constellation.debug
+
+[Service]
+Type=simple
+ExecStart=/bin/bash -c "DEBUG=$(< /proc/cmdline tr  ' ' '\n' | grep constellation.debug | sed 's/constellation.debug=//'); echo CONSTELLATION_DEBUG_FLAGS=$DEBUG >> /run/constellation.env"
+
+[Install]
+WantedBy=multi-user.target

--- a/image/mkosi.skeleton/usr/lib/systemd/system/export_constellation_debug.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/export_constellation_debug.service
@@ -4,7 +4,7 @@ ConditionKernelCommandLine=constellation.debug
 
 [Service]
 Type=simple
-ExecStart=/bin/bash -c "DEBUG=$(< /proc/cmdline tr  ' ' '\n' | grep constellation.debug | sed 's/constellation.debug=//'); echo CONSTELLATION_DEBUG_FLAGS=$DEBUG >> /run/constellation.env"
+ExecStart=/bin/bash -c "DEBUG=$(< /proc/cmdline tr  ' ' '\n' | grep constellation.debug | sed 's/constellation.debug=//'); [ $DEBUG = 'true' ] && echo CONSTELLATION_DEBUG_FLAGS=--debug >> /run/constellation.env"
 
 [Install]
 WantedBy=multi-user.target

--- a/image/mkosi.skeleton/usr/lib/systemd/system/export_constellation_debug.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/export_constellation_debug.service
@@ -2,8 +2,9 @@
 Description=Export Constellation Debug Level to Environment
 
 [Service]
-Type=simple
+Type=oneshot
 ExecStart=/bin/bash -c "tr ' ' '\n' < /proc/cmdline | grep -q 'constellation.debug' && echo CONSTELLATION_DEBUG_FLAGS=--debug >> /run/constellation.env"
+RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/image/mkosi.skeleton/usr/lib/systemd/system/export_constellation_debug.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/export_constellation_debug.service
@@ -1,10 +1,9 @@
 [Unit]
 Description=Export Constellation Debug Level to Environment
-ConditionKernelCommandLine=constellation.debug
 
 [Service]
 Type=simple
-ExecStart=/bin/bash -c "DEBUG=$(< /proc/cmdline tr  ' ' '\n' | grep constellation.debug | sed 's/constellation.debug=//'); [ $DEBUG = 'true' ] && echo CONSTELLATION_DEBUG_FLAGS=--debug >> /run/constellation.env"
+ExecStart=/bin/bash -c "tr ' ' '\n' < /proc/cmdline | grep -q 'constellation.debug' && echo CONSTELLATION_DEBUG_FLAGS=--debug >> /run/constellation.env"
 
 [Install]
 WantedBy=multi-user.target

--- a/image/mkosi.skeleton/usr/lib/systemd/system/tpm-pcrs.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/tpm-pcrs.service
@@ -2,6 +2,7 @@
 Description=Print PCR state on startup
 Before=constellation-bootstrapper.service
 ConditionKernelCommandLine=constellation.debug
+After=export_constellation_debug.service
 
 [Service]
 Type=oneshot

--- a/image/mkosi.skeleton/usr/lib/systemd/system/tpm-pcrs.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/tpm-pcrs.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Print PCR state on startup
 Before=constellation-bootstrapper.service
+ConditionKernelCommandLine=constellation.debug
 
 [Service]
 Type=oneshot

--- a/image/mkosi.skeleton/usr/lib/systemd/system/tpm-pcrs.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/tpm-pcrs.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=Print PCR state on startup
 Before=constellation-bootstrapper.service
-ConditionKernelCommandLine=constellation.debug
-After=export_constellation_debug.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
1. Add new `systemd` unit that checks if the kernel command line option `constellation.debug` is set. If it is `true`, the following services are started with the `--debug` flag via their respective systemd unit file
- [x] `bootstrapper`
- [x] `upgrade-agent`
- [x] `disk-mapper`

2. Add `lsblk` like log that shows the information for all available block devices

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone

### E22 [![Build and Upload OS image](https://github.com/edgelesssys/constellation/actions/workflows/build-os-image.yml/badge.svg?branch=main&event=workflow_dispatch)](https://github.com/edgelesssys/constellation/actions/workflows/build-os-image.yml)
