### PR TITLE
ci: fix k8s version format in e2e tests

### DIFF
--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -42,7 +42,7 @@ on:
         required: true
       kubernetesVersion:
         description: "Kubernetes version to create the cluster from."
-        default: "1.25"
+        default: "1.25.6"
         required: true
       keepMeasurements:
         description: "Keep measurements embedded in the CLI."

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -48,33 +48,33 @@ jobs:
         test:
           ["sonobuoy full", "autoscaling", "k-bench", "lb", "verify", "recover"]
         provider: ["gcp", "azure", "aws"]
-        version: ["1.24", "1.25", "1.26"]
+        version: ["v1.24.9", "v1.25.6", "v1.26.1"]
         exclude:
           # Verify test runs only on latest version.
           - test: "verify"
-            version: "1.24"
+            version: "v1.24.9"
           - test: "verify"
-            version: "1.25"
+            version: "v1.25.6"
           # Recover test runs only on latest version.
           - test: "recover"
-            version: "1.24"
+            version: "v1.24.9"
           - test: "recover"
-            version: "1.25"
+            version: "v1.25.6"
           # Autoscaling test runs only on latest version.
           - test: "autoscaling"
-            version: "1.24"
+            version: "v1.24.9"
           - test: "autoscaling"
-            version: "1.25"
+            version: "v1.25.6"
           # K-bench test runs only on latest version.
           - test: "k-bench"
-            version: "1.24"
+            version: "v1.24.9"
           - test: "k-bench"
-            version: "1.25"
+            version: "v1.25.6"
           # lb test runs only on latest version.
           - test: "lb"
-            version: "1.24"
+            version: "v1.24.9"
           - test: "lb"
-            version: "1.25"
+            version: "v1.25.6"
           # Currently not supported on AWS.
           - test: "autoscaling"
             provider: "aws"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -311,7 +311,7 @@ jobs:
       cloudProvider: ${{ matrix.csp }}
       runner: ${{ matrix.runner }}
       test: "sonobuoy full"
-      kubernetesVersion: "1.25"
+      kubernetesVersion: "v1.25.6"
       keepMeasurements: true
       osImage: ${{ inputs.version }}
       machineType: "default"


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Adapt the pipelines to use the new version format for k8s versions. This would have been fixed by #1157 but #1157 will not be merged before the weekly pipeline runs. Therefore this PR only brings in the new versions.
- The missing v in one version can be ignored as the code handles both formats transparently. 

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
