### PR TITLE
cli: adapt "upgrade check" reference to conventions

### DIFF
--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -47,7 +47,7 @@ func NewRootCmd() *cobra.Command {
 	must(rootCmd.MarkPersistentFlagFilename("config", "yaml"))
 
 	rootCmd.PersistentFlags().Bool("debug", false, "enable debug logging")
-	rootCmd.PersistentFlags().Bool("force", false, "disables version validation errors - might result in corrupted clusters")
+	rootCmd.PersistentFlags().Bool("force", false, "disable version compatibility checks - might result in corrupted clusters")
 
 	rootCmd.AddCommand(cmd.NewConfigCmd())
 	rootCmd.AddCommand(cmd.NewCreateCmd())

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -39,15 +39,15 @@ import (
 func newUpgradeCheckCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check",
-		Short: "Check for possible upgrades.",
+		Short: "Check for possible upgrades",
 		Long:  "Check which upgrades can be applied to your Constellation Cluster.",
 		Args:  cobra.NoArgs,
 		RunE:  runUpgradeCheck,
 	}
 
-	cmd.Flags().BoolP("write-config", "w", false, "Update the specified config file with the suggested versions")
-	cmd.Flags().String("ref", versionsapi.ReleaseRef, "Specify the reference used when querying the versionsapi for new versions.")
-	cmd.Flags().String("stream", "stable", "Specify the stream used when querying the versionsapi for new versions.")
+	cmd.Flags().BoolP("write-config", "w", false, "update the specified config file with the suggested versions")
+	cmd.Flags().String("ref", versionsapi.ReleaseRef, "the reference to use for querying new versions")
+	cmd.Flags().String("stream", "stable", "the stream to use for querying new versions")
 
 	return cmd
 }


### PR DESCRIPTION
Adapt the command reference to our conventions and also simplify/clarify.