### PR TITLE
ci: update vale action

### DIFF
--- a/.github/workflows/docs-vale.yml
+++ b/.github/workflows/docs-vale.yml
@@ -21,8 +21,9 @@ jobs:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
       - name: Vale
-        uses: errata-ai/vale-action@753427452ff1d6cf7a7b76a552aa0cbee3971551 # tag=v1.5.0
+        uses: errata-ai/vale-action@c4213d4de3d5f718b8497bd86161531c78992084 # tag=v2.0.1
         with:
+          version: 2.17.0
           files: docs/docs
         env:
           # Required, set by GitHub actions automatically:


### PR DESCRIPTION
Old version of the action doesn't work anymore. Use new version of the action with older version of vale. (Newer versions of vale introduce false positives.)