### PR TITLE
ci: fix yq command for new k8s version format

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -100,7 +100,7 @@ runs:
           constellation-conf.yaml
 
         if [[ ${{ inputs.kubernetesVersion != '' }} = true ]]; then
-          yq eval -i "(.kubernetesVersion) = ${{ inputs.kubernetesVersion }}" constellation-conf.yaml
+          yq eval -i "(.kubernetesVersion) = \"${{ inputs.kubernetesVersion }}\"" constellation-conf.yaml
         fi
 
     - name: Remove embedded measurements


### PR DESCRIPTION


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add quotes to the version to ensure it’s treated as a string. The MAJOR.MINOR format was treated as a float and therefore worked without quotes. Test run: https://github.com/edgelesssys/constellation/actions/runs/4160988930

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
