### PR TITLE
cli: fix init with k8s version without v prefix

### DIFF
--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -18,6 +18,8 @@ import (
 	"text/tabwriter"
 	"time"
 
+	"github.com/edgelesssys/constellation/v2/internal/compatibility"
+
 	"github.com/edgelesssys/constellation/v2/bootstrapper/initproto"
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
 	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
@@ -112,7 +114,7 @@ func (i *initCmd) initialize(cmd *cobra.Command, newDialer func(validator *cloud
 		return fmt.Errorf("reading cluster ID file: %w", err)
 	}
 
-	k8sVersion, err := versions.NewValidK8sVersion(conf.KubernetesVersion)
+	k8sVersion, err := versions.NewValidK8sVersion(compatibility.EnsurePrefixV(conf.KubernetesVersion))
 	if err != nil {
 		return fmt.Errorf("validating kubernetes version: %w", err)
 	}

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	kmssetup "github.com/edgelesssys/constellation/v2/internal/kms/setup"
+	"github.com/edgelesssys/constellation/v2/internal/versions"
 
 	"github.com/edgelesssys/constellation/v2/bootstrapper/initproto"
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
@@ -115,6 +116,12 @@ func TestInitialize(t *testing.T) {
 			initServerAPI: &stubInitServer{initErr: someErr},
 			retriable:     true,
 			wantErr:       true,
+		},
+		"k8s version without v works": {
+			provider:      cloudprovider.Azure,
+			idFile:        &clusterid.File{IP: "192.0.2.1"},
+			initServerAPI: &stubInitServer{initResp: testInitResp},
+			configMutator: func(c *config.Config) { c.KubernetesVersion = strings.TrimPrefix(string(versions.Default), "v") },
 		},
 	}
 


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- The config validation generally allows users to specify versions without "v" prefix, even though internally we need all version strings to have that prefix. As init validates the k8s version without ensuring a "v" prefix it broke for version strings that are normally accepted. 

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
