### PR TITLE
rfc: specify cli version api

### DIFF
--- a/rfc/apis.md
+++ b/rfc/apis.md
@@ -57,7 +57,7 @@ and [pseudo-versions](https://go.dev/ref/mod#pseudo-versions).
 
 The [pesudo-version tool](../hack/pseudo-version) can generate a valid pseudo-version for your current head.
 
-### Consisten API path prefix of `ref` and `stream`
+### Consistent API path prefix of `ref` and `stream`
 
 For API calls, paths will always start with `ref` and `stream`:
 

--- a/rfc/apis.md
+++ b/rfc/apis.md
@@ -32,6 +32,7 @@ There may be more API groups in the future (e.g. `cli`)
 - [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/csp/<csp>/measurements.json`](image-api.md)
 - [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/csp/<csp>/measurements.json.sig`](image-api.md)
 - [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/csp/<csp>/image.raw`](image-api.md)
+- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/cli/info.json`](cli-api.md#cli-lookup-table)
 
 ## API path identifiers  `ref`, `stream` and `version`
 

--- a/rfc/cli-api.md
+++ b/rfc/cli-api.md
@@ -4,17 +4,17 @@ The CLI API provides information about the compatibility of the Constellation CL
 
 ## CLI API Endpoints
 
-The build pipeline produces lookup tables for compatibility information that are uploaded to S3 and can be accessed via HTTP.
-The lookup tables are organized in a directory structure that allows to look up the compatibility for a given Constellation version.
+The build pipeline produces artifacts for compatibility information that are uploaded to S3 and can be accessed via HTTP.
+The artifacts are organized in a directory structure that allows to look up the compatibility for a given Constellation version.
 
 The following HTTP endpoints are available:
 
 - `GET /constellation/v1/ref/<REF>/stream/<STREAM>/<VERSION>/cli/`
-  - [`info.json` returns the CLI compatibility lookup table for the given Constellation version.](#cli-lookup-table)
+  - [`info.json` returns the CLI compatibility information artifact for the given Constellation version.](#cli-lookup-table)
 
-## CLI lookup table
+## CLI information artifact
 
-The CLI compatibility lookup table is a JSON file that maps the image name consisting of `ref`, `stream` and `version` to the corresponding CLI version and it's compatibility information:
+The CLI compatibility information artifact is a JSON file that maps the image name consisting of `ref`, `stream` and `version` to the corresponding CLI version and it's compatibility information:
 
 ```
 /constellation/v1/ref/<REF>/stream/<STREAM>/<VERSION>/cli/info.json
@@ -25,9 +25,8 @@ The CLI compatibility lookup table is a JSON file that maps the image name consi
   "version": "<VERSION>",
   "ref": "<REF>",
   "stream": "<STREAM>",
-  "cli": "v1.2.3",
   "kubernetes": ["v1.1.23", "v1.1.24", "v1.1.25"]
 }
 ```
 
-This shows that the Constellation CLI version `v1.2.3` is compatible with Kubernetes versions `v1.1.23`, `v1.1.24` and `v1.1.25`.
+This shows that the Constellation CLI version `<VERSION>` is compatible with Kubernetes versions `v1.1.23`, `v1.1.24` and `v1.1.25`.

--- a/rfc/cli-api.md
+++ b/rfc/cli-api.md
@@ -1,0 +1,33 @@
+# CLI compatibility information
+
+The CLI API provides information about the compatibility of the Constellation CLI and other components of the Constellation ecosystem such as Kubernetes versions.
+
+## CLI API Endpoints
+
+The build pipeline produces lookup tables for compatibility information that are uploaded to S3 and can be accessed via HTTP.
+The lookup tables are organized in a directory structure that allows to look up the compatibility for a given Constellation version.
+
+The following HTTP endpoints are available:
+
+- `GET /constellation/v1/ref/<REF>/stream/<STREAM>/<VERSION>/cli/`
+  - [`info.json` returns the CLI compatibility lookup table for the given Constellation version.](#cli-lookup-table)
+
+## CLI lookup table
+
+The CLI compatibility lookup table is a JSON file that maps the image name consisting of `ref`, `stream` and `version` to the corresponding CLI version and it's compatibility information:
+
+```
+/constellation/v1/ref/<REF>/stream/<STREAM>/<VERSION>/cli/info.json
+```
+
+```json
+{
+  "version": "<VERSION>",
+  "ref": "<REF>",
+  "stream": "<STREAM>",
+  "cli": "v1.2.3",
+  "kubernetes": ["v1.1.23", "v1.1.24", "v1.1.25"]
+}
+```
+
+This shows that the Constellation CLI version `v1.2.3` is compatible with Kubernetes versions `v1.1.23`, `v1.1.24` and `v1.1.25`.

--- a/rfc/image-api.md
+++ b/rfc/image-api.md
@@ -1,6 +1,6 @@
 # OS image & measurement discovery
 
-The Constellation OS image build pipeline generates a set of images using a chosen commit of the Constellation monorepo and and a desired release version number.
+The Constellation OS image build pipeline generates a set of images using a chosen commit of the Constellation monorepo and a desired release version number.
 
 ```mermaid
 graph LR


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add specification for the CLI version compatibility API
  - The API should be exposed via the [version API](https://github.com/edgelesssys/constellation/tree/main/internal/versionsapi) and provide information on compatibility between a specific CLI version of a Constellation version and Kubernetes versions.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
