### PR TITLE
cli: add name of build type to version cmd output

### DIFF
--- a/cli/internal/cmd/version.go
+++ b/cli/internal/cmd/version.go
@@ -34,7 +34,7 @@ func runVersion(cmd *cobra.Command, args []string) {
 
 	commit, state, date, goVersion, compiler, platform := parseBuildInfo(buildInfo)
 
-	cmd.Printf("Version:\t%s\n", constants.VersionInfo)
+	cmd.Printf("Version:\t%s (%s)\n", constants.VersionInfo, constants.VersionBuild)
 	cmd.Printf("GitCommit:\t%s\n", commit)
 	cmd.Printf("GitTreeState:\t%s\n", state)
 	cmd.Printf("BuildDate:\t%s\n", date)

--- a/internal/constants/enterprise.go
+++ b/internal/constants/enterprise.go
@@ -14,3 +14,6 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEf8F1hpmwE+YCFXzjGtaQcrL6XZVT
 JmEe5iSLvG1SyQSAew7WdMKF6o9t8e2TFuCkzlOhhlws2OHWbiFZnFWCFw==
 -----END PUBLIC KEY-----
 `
+
+// VersionBuild is the category of the current build.
+const VersionBuild = "Enterprise build; see documentation for license agreement"

--- a/internal/constants/oss.go
+++ b/internal/constants/oss.go
@@ -14,3 +14,6 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELcPl4Ik+qZuH4K049wksoXK/Os3Z
 b92PDCpM7FZAINQF88s1TZS/HmRXYk62UJ4eqPduvUnJmXhNikhLbMi6fw==
 -----END PUBLIC KEY-----
 `
+
+// VersionBuild is the category of the current build.
+const VersionBuild = "Open-source software build; AGPL-3.0-only applies"


### PR DESCRIPTION
Signed-off-by: Paul Meyer <49727155+katexochen@users.noreply.github.com>

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

Looks like:

```
❯ ./constellation version
Version:        2.5.0 (Open-source software build; AGPL-3.0-only applies)
GitCommit:      b053f4e837af063bcc495e0ac442412b5a9ced53
GitTreeState:   dirty
BuildDate:      2023-02-13T17:35:30Z
GoVersion:      go1.19.5
Compiler:       gc
Platform:       linux/amd64
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
