### PR TITLE
ci: add force flag to remaining constellation cmds

### DIFF
--- a/.github/actions/e2e_recover/action.yml
+++ b/.github/actions/e2e_recover/action.yml
@@ -40,7 +40,7 @@ runs:
         start_time=$(date +%s)
         recovered=0
         while true; do
-            output=$(constellation recover --master-secret=${{ inputs.masterSecret }})
+            output=$(constellation recover --master-secret=${{ inputs.masterSecret }} --force)
             if echo "$output" | grep -q "Pushed recovery key."; then
                 echo "$output"
                 i=$(echo "$output" | grep -o "Pushed recovery key." | wc -l | sed 's/ //g')

--- a/.github/actions/e2e_verify/action.yml
+++ b/.github/actions/e2e_verify/action.yml
@@ -31,4 +31,4 @@ runs:
 
     - name: Constellation verify
       shell: bash
-      run: constellation verify --cluster-id $(jq -r ".clusterID" constellation-id.json)
+      run: constellation verify --cluster-id $(jq -r ".clusterID" constellation-id.json) --force

--- a/.github/actions/e2e_verify/action.yml
+++ b/.github/actions/e2e_verify/action.yml
@@ -24,7 +24,6 @@ runs:
         for key in $(echo $MEASUREMENTS | jq 'keys[]' -r); do
             echo Updating $key to $(echo $MEASUREMENTS | jq ".\"$key\"" -r)
             yq -i ".provider.${{ inputs.cloudProvider }}.measurements.[$key] = $(echo $MEASUREMENTS | jq ".\"$key\"")" constellation-conf.yaml
-            yq -i ".provider.${{ inputs.cloudProvider }}.measurements.[$key].warnOnly = false" constellation-conf.yaml
         done
         yq -i '.provider.${{ inputs.cloudProvider }}.measurements |= array_to_map' constellation-conf.yaml
         cat constellation-conf.yaml


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- In the CI most configs use prerelease images. Config validation prevents this. Therefore we need to use the force flag for now.
- Discussion on UX of the flag is ongoing. Adding this to fix the pipeline for the time being.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
