### PR TITLE
image: upgrade to Linux 6.1.12 for Azure

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -17,7 +17,7 @@ export CONSOLE_MOTD = $(AUTOLOGIN)
 csps := aws qemu gcp azure
 certs := $(PKI)/PK.cer $(PKI)/KEK.cer $(PKI)/db.cer
 
-AZURE_FIXED_KERNEL_RPMS := kernel-6.1.11-200.fc37.x86_64.rpm kernel-core-6.1.11-200.fc37.x86_64.rpm kernel-modules-6.1.11-200.fc37.x86_64.rpm
+AZURE_FIXED_KERNEL_RPMS := kernel-6.1.12-200.fc37.x86_64.rpm kernel-core-6.1.12-200.fc37.x86_64.rpm kernel-modules-6.1.12-200.fc37.x86_64.rpm
 GCP_FIXED_KERNEL_RPMS := kernel-5.19.17-300.fc37.x86_64.rpm kernel-core-5.19.17-300.fc37.x86_64.rpm kernel-modules-5.19.17-300.fc37.x86_64.rpm
 PREBUILT_RPMS_AZURE := $(addprefix prebuilt/rpms/azure/,$(AZURE_FIXED_KERNEL_RPMS))
 PREBUILT_RPMS_GCP := $(addprefix prebuilt/rpms/gcp/,$(GCP_FIXED_KERNEL_RPMS))
@@ -36,7 +36,7 @@ prebuilt/rpms/gcp/%.rpm:
 prebuilt/rpms/azure/%.rpm:
 	@echo "Downloading $*"
 	@mkdir -p $(@D)
-	@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/6.1.11/200.fc37/x86_64/$*.rpm
+	@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/6.1.12/200.fc37/x86_64/$*.rpm
 
 mkosi.output.%/fedora~37/image.raw: mkosi.files/mkosi.%.conf inject-bins inject-certs
 	mkosi --config mkosi.files/mkosi.$*.conf \

--- a/image/Makefile
+++ b/image/Makefile
@@ -17,7 +17,7 @@ export CONSOLE_MOTD = $(AUTOLOGIN)
 csps := aws qemu gcp azure
 certs := $(PKI)/PK.cer $(PKI)/KEK.cer $(PKI)/db.cer
 
-AZURE_FIXED_KERNEL_RPMS := kernel-6.1.7-200.fc37.x86_64.rpm kernel-core-6.1.7-200.fc37.x86_64.rpm kernel-modules-6.1.7-200.fc37.x86_64.rpm
+AZURE_FIXED_KERNEL_RPMS := kernel-6.1.11-200.fc37.x86_64.rpm kernel-core-6.1.11-200.fc37.x86_64.rpm kernel-modules-6.1.11-200.fc37.x86_64.rpm
 GCP_FIXED_KERNEL_RPMS := kernel-5.19.17-300.fc37.x86_64.rpm kernel-core-5.19.17-300.fc37.x86_64.rpm kernel-modules-5.19.17-300.fc37.x86_64.rpm
 PREBUILT_RPMS_AZURE := $(addprefix prebuilt/rpms/azure/,$(AZURE_FIXED_KERNEL_RPMS))
 PREBUILT_RPMS_GCP := $(addprefix prebuilt/rpms/gcp/,$(GCP_FIXED_KERNEL_RPMS))
@@ -36,7 +36,7 @@ prebuilt/rpms/gcp/%.rpm:
 prebuilt/rpms/azure/%.rpm:
 	@echo "Downloading $*"
 	@mkdir -p $(@D)
-	@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/6.1.7/200.fc37/x86_64/$*.rpm
+	@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/6.1.11/200.fc37/x86_64/$*.rpm
 
 mkosi.output.%/fedora~37/image.raw: mkosi.files/mkosi.%.conf inject-bins inject-certs
 	mkosi --config mkosi.files/mkosi.$*.conf \

--- a/image/mkosi.files/mkosi.azure.conf
+++ b/image/mkosi.files/mkosi.azure.conf
@@ -8,6 +8,6 @@ BasePackages=conditional
 Packages=systemd
          util-linux
          dracut
-         prebuilt/rpms/azure/kernel-6.1.11-200.fc37.x86_64.rpm
-         prebuilt/rpms/azure/kernel-core-6.1.11-200.fc37.x86_64.rpm
-         prebuilt/rpms/azure/kernel-modules-6.1.11-200.fc37.x86_64.rpm
+         prebuilt/rpms/azure/kernel-6.1.12-200.fc37.x86_64.rpm
+         prebuilt/rpms/azure/kernel-core-6.1.12-200.fc37.x86_64.rpm
+         prebuilt/rpms/azure/kernel-modules-6.1.12-200.fc37.x86_64.rpm

--- a/image/mkosi.files/mkosi.azure.conf
+++ b/image/mkosi.files/mkosi.azure.conf
@@ -8,6 +8,6 @@ BasePackages=conditional
 Packages=systemd
          util-linux
          dracut
-         prebuilt/rpms/azure/kernel-6.1.7-200.fc37.x86_64.rpm
-         prebuilt/rpms/azure/kernel-core-6.1.7-200.fc37.x86_64.rpm
-         prebuilt/rpms/azure/kernel-modules-6.1.7-200.fc37.x86_64.rpm
+         prebuilt/rpms/azure/kernel-6.1.11-200.fc37.x86_64.rpm
+         prebuilt/rpms/azure/kernel-core-6.1.11-200.fc37.x86_64.rpm
+         prebuilt/rpms/azure/kernel-modules-6.1.11-200.fc37.x86_64.rpm


### PR DESCRIPTION
### Proposed change(s)
- Upgrade to Linux kernel 6.1.11 for Azure

This includes the important network patches for netvsc for Azure.

Guess this will be the golden kernel for a while upstream figures out what to do with the slow disk issues / MTRR story.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
