### PR TITLE
cli: load helm values during upgrade

### DIFF
--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -171,7 +171,7 @@ func (c *Client) upgradeRelease(
 	return nil
 }
 
-// prepareCertManagerValues returns a values map as required for helm-upgrade.
+// prepareValues returns a values map as required for helm-upgrade.
 // It imitates the behaviour of helm's reuse-values flag by fetching the current values from the cluster
 // and merging the fetched values with the locally found values.
 // This is done to ensure that new values (from upgrades of the local files) end up in the cluster.

--- a/cli/internal/helm/client_test.go
+++ b/cli/internal/helm/client_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/stretchr/testify/assert"
 	"helm.sh/helm/v3/pkg/chart"
@@ -102,7 +103,7 @@ func TestUpgradeRelease(t *testing.T) {
 			assert := assert.New(t)
 
 			client := Client{kubectl: nil, actions: &stubActionWrapper{}, log: logger.NewTest(t)}
-			err := client.upgradeRelease(context.Background(), 0, certManagerPath, certManagerReleaseName, false, tc.allowDestructive)
+			err := client.upgradeRelease(context.Background(), 0, config.Default(), certManagerPath, certManagerReleaseName, false, tc.allowDestructive)
 			if tc.wantError {
 				assert.ErrorIs(err, ErrConfirmationMissing)
 				return

--- a/cli/internal/helm/loader_test.go
+++ b/cli/internal/helm/loader_test.go
@@ -35,8 +35,8 @@ func TestLoad(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	chartLoader := ChartLoader{}
 	config := &config.Config{Provider: config.ProviderConfig{GCP: &config.GCPConfig{}}}
+	chartLoader := ChartLoader{csp: config.GetProvider()}
 	release, err := chartLoader.Load(config, true, []byte("secret"), []byte("salt"))
 	require.NoError(err)
 
@@ -89,6 +89,7 @@ func TestConstellationServices(t *testing.T) {
 			require := require.New(t)
 
 			chartLoader := ChartLoader{
+				csp:                      tc.config.GetProvider(),
 				joinServiceImage:         "joinServiceImage",
 				keyServiceImage:          "keyServiceImage",
 				ccmImage:                 tc.ccmImage,
@@ -100,7 +101,7 @@ func TestConstellationServices(t *testing.T) {
 			}
 			chart, err := loadChartsDir(helmFS, conServicesPath)
 			require.NoError(err)
-			values, err := chartLoader.loadConstellationServicesValues(tc.config.GetProvider())
+			values, err := chartLoader.loadConstellationServicesValues()
 			require.NoError(err)
 			err = extendConstellationServicesValues(values, tc.config, []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
 			require.NoError(err)
@@ -160,6 +161,7 @@ func TestOperators(t *testing.T) {
 			require := require.New(t)
 
 			chartLoader := ChartLoader{
+				csp:                          tc.csp,
 				joinServiceImage:             "joinServiceImage",
 				keyServiceImage:              "keyServiceImage",
 				ccmImage:                     "ccmImage",
@@ -170,7 +172,7 @@ func TestOperators(t *testing.T) {
 			}
 			chart, err := loadChartsDir(helmFS, conOperatorsPath)
 			require.NoError(err)
-			vals, err := chartLoader.loadOperatorsValues(tc.csp)
+			vals, err := chartLoader.loadOperatorsValues()
 			require.NoError(err)
 
 			options := chartutil.ReleaseOptions{

--- a/cli/internal/helm/loader_test.go
+++ b/cli/internal/helm/loader_test.go
@@ -100,7 +100,9 @@ func TestConstellationServices(t *testing.T) {
 			}
 			chart, err := loadChartsDir(helmFS, conServicesPath)
 			require.NoError(err)
-			values, err := chartLoader.loadConstellationServicesValues(tc.config, []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
+			values, err := chartLoader.loadConstellationServicesValues(tc.config.GetProvider())
+			require.NoError(err)
+			err = extendConstellationServicesValues(values, tc.config, []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))
 			require.NoError(err)
 
 			options := chartutil.ReleaseOptions{

--- a/internal/compatibility/compatibility.go
+++ b/internal/compatibility/compatibility.go
@@ -45,7 +45,7 @@ func IsValidUpgrade(a, b string) error {
 	}
 
 	if semver.Compare(a, b) >= 0 {
-		return errors.New("current version newer than new version")
+		return errors.New("current version newer than or equal to new version")
 	}
 
 	aMajor, aMinor, err := parseCanonicalSemver(a)


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- This fixes multiple bugs where upgrades did not change resources in the cluster as expected. These bugs stem from the fact that the existing upgrade code did not load values locally and therefore did not render the templates correctly in some cases.
- Solve by letting go code load helm values also during upgrade. While we still want to reuse values from the cluster we need to set others. Like the images. This change therefore loads all values during an upgrade that do not depend on user input. If a value depends on user input it will not be set. Because the value is not set, the existing value from the cluster is reused.
- [Azure, 1.25, 1+2](https://github.com/edgelesssys/constellation/actions/runs/4181302080). Check that init still works as expected.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
