### PR TITLE
config: only print upgrade deprecation msg if key is set

### DIFF
--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -365,7 +365,16 @@ func returnsTrue(fl validator.FieldLevel) bool {
 
 // validateUpgradeConfig prints a warning to STDERR and validates the field successfully.
 func validateUpgradeConfig(sl validator.StructLevel) {
-	fmt.Printf("WARNING: the config key `upgrade` will be deprecated in an upcoming version. Please check the documentation for more information.\n")
+	config, ok := sl.Current().Interface().(UpgradeConfig)
+	if !ok {
+		sl.ReportError(config, "upgrade", "UpgradeConfig", "malformed_upgrade_config", "")
+	}
+	// A valid `upgrade` section will always have a non-nil Measurements map.
+	// Only print a warning if the user actually specified an upgrade section.
+	if config.Image == "" && config.CSP == cloudprovider.Unknown && config.Measurements == nil {
+		return
+	}
+	fmt.Println("WARNING: the config key `upgrade` will be deprecated in an upcoming version. Please check the documentation for more information.")
 }
 
 func registerValidateNameError(ut ut.Translator) error {


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Previously the deprecation warning was printed all the time. Now the validator checks if the key is defined. I could not find a more direct way of checking existence of the key, but this seems like and equivalent to me.
- The logs of the following run should not show the deprecation warning. Previous runs did. [Azure, 1.25.6, 1+2](https://github.com/edgelesssys/constellation/actions/runs/4181576538).

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
