### PR TITLE
compatibility: various bug fixes

### DIFF
--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -81,7 +81,7 @@ func runUpgradeCheck(cmd *cobra.Command, args []string) error {
 			client:         http.DefaultClient,
 			rekor:          rekor,
 			flags:          flags,
-			cliVersion:     constants.VersionInfo,
+			cliVersion:     compatibility.EnsurePrefixV(constants.VersionInfo),
 			log:            log,
 		},
 		log: log,

--- a/internal/compatibility/compatibility.go
+++ b/internal/compatibility/compatibility.go
@@ -90,7 +90,8 @@ func BinaryWith(target string) error {
 	if cliMajor != targetMajor {
 		return ErrMajorMismatch
 	}
-	if semver.Compare(binaryVersion, target) == -1 {
+	// For images we allow newer patch versions, therefore this only checks the minor version.
+	if semver.Compare(semver.MajorMinor(binaryVersion), semver.MajorMinor(target)) == -1 {
 		return ErrOutdatedCLI
 	}
 	// Abort if minor version drift between CLI and versionA value is greater than 1.

--- a/internal/compatibility/compatibility.go
+++ b/internal/compatibility/compatibility.go
@@ -22,9 +22,11 @@ var (
 	// ErrMajorMismatch signals that the major version of two compared versions don't match.
 	ErrMajorMismatch = errors.New("missmatching major version")
 	// ErrMinorDrift signals that the minor version of two compared versions are further apart than one.
-	ErrMinorDrift = errors.New("target version needs to be equal or up to one minor version higher")
+	ErrMinorDrift = errors.New("version difference larger than one minor version")
 	// ErrSemVer signals that a given version does not adhere to the Semver syntax.
 	ErrSemVer = errors.New("invalid semantic version")
+	// ErrOutdatedCLI signals that the configured version is newer than the CLI. This is not allowed.
+	ErrOutdatedCLI = errors.New("target version newer than cli version")
 )
 
 // EnsurePrefixV returns the input string prefixed with the letter "v", if the string doesn't already start with that letter.
@@ -89,7 +91,7 @@ func BinaryWith(target string) error {
 		return ErrMajorMismatch
 	}
 	if semver.Compare(binaryVersion, target) == -1 {
-		return ErrMinorDrift
+		return ErrOutdatedCLI
 	}
 	// Abort if minor version drift between CLI and versionA value is greater than 1.
 	if cliMinor-targetMinor > 1 {

--- a/internal/compatibility/compatibility_test.go
+++ b/internal/compatibility/compatibility_test.go
@@ -87,7 +87,7 @@ func TestNextMinorVersion(t *testing.T) {
 	}
 }
 
-func TestCLIWith(t *testing.T) {
+func TestBinaryWith(t *testing.T) {
 	testCases := map[string]struct {
 		cli       string
 		target    string
@@ -107,7 +107,7 @@ func TestCLIWith(t *testing.T) {
 			target:    "v1.2",
 			wantError: true,
 		},
-		"a has to be the newer version": {
+		"cli has to be the newer version": {
 			cli:       "v2.4.0",
 			target:    "v2.5.0",
 			wantError: true,
@@ -116,7 +116,7 @@ func TestCLIWith(t *testing.T) {
 			cli:    "v2.5.0-pre",
 			target: "v2.4.0",
 		},
-		"pre prelease version ordering is correct #2": {
+		"pre prelease versions are not forward compatible": {
 			cli:       "v2.4.0",
 			target:    "v2.5.0-pre",
 			wantError: true,
@@ -125,10 +125,18 @@ func TestCLIWith(t *testing.T) {
 			cli:    "v2.6.0-pre",
 			target: "v2.6.0-pre",
 		},
-		"pseudo version is newer than first pre release": {
-			cli:       "v2.6.0-pre",
+		"patch versions are forward compatible": {
+			cli:    "v2.6.0",
+			target: "v2.6.1",
+		},
+		"pseudo versions are not forward compatible": {
+			cli:       "v2.5.0",
 			target:    "v2.6.0-pre.0.20230125085856-aaaaaaaaaaaa",
 			wantError: true,
+		},
+		"pseudo version is newer than first pre release": {
+			cli:    "v2.6.0-pre",
+			target: "v2.6.0-pre.0.20230125085856-aaaaaaaaaaaa",
 		},
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -341,7 +341,9 @@ func New(fileHandler file.Handler, name string, force bool) (*Config, error) {
 
 	// Backwards compatibility: configs without the field `microserviceVersion` are valid in version 2.6.
 	// In case the field is not set in an old config we prefil it with the default value.
-	c.MicroserviceVersion = Default().MicroserviceVersion
+	if c.MicroserviceVersion == "" {
+		c.MicroserviceVersion = Default().MicroserviceVersion
+	}
 
 	return c, c.Validate(force)
 }

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -328,7 +328,9 @@ func translateVersionCompatibilityError(ut ut.Translator, fe validator.FieldErro
 	case errors.Is(err, compatibility.ErrMajorMismatch):
 		msg = fmt.Sprintf("the CLI's major version (%s) has to match your configured major version (%s)", constants.VersionInfo, fe.Value().(string))
 	case errors.Is(err, compatibility.ErrMinorDrift):
-		msg = fmt.Sprintf("only the CLI (%s) can be up to one minor version newer than the configured version (%s)", constants.VersionInfo, fe.Value().(string))
+		msg = fmt.Sprintf("the CLI's minor version (%s) and the configured version (%s) are more than one minor version apart", constants.VersionInfo, fe.Value().(string))
+	case errors.Is(err, compatibility.ErrOutdatedCLI):
+		msg = fmt.Sprintf("the CLI's version (%s) is older than the configured version (%s)", constants.VersionInfo, fe.Value().(string))
 	default:
 		msg = err.Error()
 	}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -358,6 +358,14 @@ func validateVersionCompatibilityHelper(fieldName string, configuredVersion stri
 		configuredVersion = imageVersion.Version
 	}
 
+	if fieldName == "MicroserviceVersion" {
+		cliVersion := compatibility.EnsurePrefixV(constants.VersionInfo)
+		serviceVersion := compatibility.EnsurePrefixV(configuredVersion)
+		if semver.Compare(cliVersion, serviceVersion) == -1 {
+			return fmt.Errorf("the CLI's version (%s) is older than the configured version (%s)", cliVersion, serviceVersion)
+		}
+	}
+
 	return compatibility.BinaryWith(configuredVersion)
 }
 


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Improve error messages for situtation where the CLI is too old for the configured versions
- Allow newer patch versions for images. This was the intended behavior from the beginning.
- Fix a bug where the `microserviceVersion` value is always overwritten with the default during `config.New()`
- Fix a bug where `upgrade check` does not find new images because the CLI version is not correctly set in `versionCollector`

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
