### PR TITLE
hack: add api module to container during build

### DIFF
--- a/hack/qemu-metadata-api/Dockerfile
+++ b/hack/qemu-metadata-api/Dockerfile
@@ -11,6 +11,9 @@ RUN wget -q https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz && \
 ENV PATH ${PATH}:/usr/local/go/bin
 
 WORKDIR /qemu-metadata-api
+# Necessary to make `go mod download all` work while having a local replace rule in the root-go.mod.
+COPY operators/constellation-node-operator/api/go.mod ./operators/constellation-node-operator/api/go.mod
+COPY operators/constellation-node-operator/api/go.sum ./operators/constellation-node-operator/api/go.sum
 COPY go.mod ./
 COPY go.sum ./
 RUN go mod download all


### PR DESCRIPTION
Oversaw that this is necessary when making the operator's api a submodule. Similar change is in the root's Dockerfile.build.

[Workflow run](https://github.com/edgelesssys/constellation/actions/runs/4192532685)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
