### PR TITLE
deps: update rules_proto to v5.3.0

### DIFF
--- a/toolchains/proto_deps.bzl
+++ b/toolchains/proto_deps.bzl
@@ -5,10 +5,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def proto_deps():
     http_archive(
         name = "rules_proto",
-        sha256 = "bc12122a5ae4b517fa423ea03a8d82ea6352d5127ea48cb54bc324e8ab78493c",
-        strip_prefix = "rules_proto-af6481970a34554c6942d993e194a9aed7987780",
+        sha256 = "dc3fb206a2cb3441b485eb1e423165b231235a1ea9b031b4433cf7bc1fa460dd",
+        strip_prefix = "rules_proto-5.3.0-21.7",
         urls = [
-            "https://github.com/bazelbuild/rules_proto/archive/af6481970a34554c6942d993e194a9aed7987780.tar.gz",
-            "https://storage.googleapis.com/builddeps/bc12122a5ae4b517fa423ea03a8d82ea6352d5127ea48cb54bc324e8ab78493c",
+            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/5.3.0-21.7.tar.gz",
         ],
     )


### PR DESCRIPTION
Upstream release: https://github.com/bazelbuild/rules_proto/releases/tag/5.3.0-21.7

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- update rules_proto to v5.3.0

### Related issue

- [Upstream PR to use hermetic / statically linked protoc](https://github.com/bazelbuild/rules_proto/pull/168)

### Additional info
- Breaks build on NixOS since protoc is not hermetic.
- We should not merge this and instead upgrade to the next release with static protoc.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
