### PR TITLE
cli: refer to --force and --config flags

### DIFF
--- a/cli/internal/cmd/miniup.go
+++ b/cli/internal/cmd/miniup.go
@@ -202,11 +202,12 @@ func (m *miniUpCmd) prepareConfig(cmd *cobra.Command, fileHandler file.Handler) 
 	_, err = fileHandler.Stat(constants.ConfigFilename)
 	if err == nil {
 		// config already exists, prompt user to overwrite
-		cmd.PrintErrln("A config file already exists in the current workspace.")
+		cmd.PrintErrln("A config file already exists in the current workspace. If you know what you are doing, you can use the --config flag to use your own config.")
 		ok, err := askToConfirm(cmd, "Do you want to overwrite it?")
 		if err != nil {
 			return nil, err
 		}
+
 		if !ok {
 			return nil, errors.New("not overwriting existing config")
 		}

--- a/cli/internal/cmd/miniup.go
+++ b/cli/internal/cmd/miniup.go
@@ -202,7 +202,7 @@ func (m *miniUpCmd) prepareConfig(cmd *cobra.Command, fileHandler file.Handler) 
 	_, err = fileHandler.Stat(constants.ConfigFilename)
 	if err == nil {
 		// config already exists, prompt user to overwrite
-		cmd.PrintErrln("A config file already exists in the current workspace. If you know what you are doing, you can use the --config flag to use your own config.")
+		cmd.PrintErrln("A config file already exists in the current workspace. Use --config to use an existing config file.")
 		ok, err := askToConfirm(cmd, "Do you want to overwrite it?")
 		if err != nil {
 			return nil, err

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -326,11 +326,11 @@ func translateVersionCompatibilityError(ut ut.Translator, fe validator.FieldErro
 	case errors.Is(err, compatibility.ErrSemVer):
 		msg = fmt.Sprintf("configured version (%s) does not adhere to SemVer syntax", fe.Value().(string))
 	case errors.Is(err, compatibility.ErrMajorMismatch):
-		msg = fmt.Sprintf("the CLI's major version (%s) has to match your configured major version (%s). If you know what you are doing, you can use the --force flag to ignore this version mismatch.", constants.VersionInfo, fe.Value().(string))
+		msg = fmt.Sprintf("the CLI's major version (%s) has to match your configured major version (%s). Use --force to ignore the version mismatch.", constants.VersionInfo, fe.Value().(string))
 	case errors.Is(err, compatibility.ErrMinorDrift):
-		msg = fmt.Sprintf("the CLI's minor version (%s) and the configured version (%s) are more than one minor version apart", constants.VersionInfo, fe.Value().(string))
+		msg = fmt.Sprintf("the CLI's minor version (%s) and the configured version (%s) are more than one minor version apart. Use --force to ignore the version mismatch.", constants.VersionInfo, fe.Value().(string))
 	case errors.Is(err, compatibility.ErrOutdatedCLI):
-		msg = fmt.Sprintf("the CLI's version (%s) is older than the configured version (%s)", constants.VersionInfo, fe.Value().(string))
+		msg = fmt.Sprintf("the CLI's version (%s) is older than the configured version (%s). Use --force to ignore the version mismatch.", constants.VersionInfo, fe.Value().(string))
 	default:
 		msg = err.Error()
 	}

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -326,7 +326,7 @@ func translateVersionCompatibilityError(ut ut.Translator, fe validator.FieldErro
 	case errors.Is(err, compatibility.ErrSemVer):
 		msg = fmt.Sprintf("configured version (%s) does not adhere to SemVer syntax", fe.Value().(string))
 	case errors.Is(err, compatibility.ErrMajorMismatch):
-		msg = fmt.Sprintf("the CLI's major version (%s) has to match your configured major version (%s)", constants.VersionInfo, fe.Value().(string))
+		msg = fmt.Sprintf("the CLI's major version (%s) has to match your configured major version (%s). If you know what you are doing, you can use the --force flag to ignore this version mismatch.", constants.VersionInfo, fe.Value().(string))
 	case errors.Is(err, compatibility.ErrMinorDrift):
 		msg = fmt.Sprintf("the CLI's minor version (%s) and the configured version (%s) are more than one minor version apart", constants.VersionInfo, fe.Value().(string))
 	case errors.Is(err, compatibility.ErrOutdatedCLI):


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- If there is a version mismatch in the config file, refer to the `--force` flag to ignore this behavior. 
- If there is already a `constellation-conf.yaml` in the current working directory, refer to the `--config` option to ignore this behavior.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
