### PR TITLE
cli: option to disable spinner via environment variable

### DIFF
--- a/cli/internal/cmd/spinner.go
+++ b/cli/internal/cmd/spinner.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 	tty "github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
 )
@@ -45,10 +46,11 @@ type spinner struct {
 
 func newSpinnerOrStderr(cmd *cobra.Command) (spinnerInterf, error) {
 	debug, err := cmd.Flags().GetBool("debug")
+	noSpinner := os.Getenv(constants.EnvVarNoSpinner)
 	if err != nil {
 		return nil, err
 	}
-	if debug {
+	if debug || noSpinner != "" {
 		return &nopSpinner{cmd.ErrOrStderr()}, nil
 	}
 	return newSpinner(cmd.ErrOrStderr()), nil

--- a/cli/internal/cmd/terminate.go
+++ b/cli/internal/cmd/terminate.go
@@ -37,7 +37,10 @@ func NewTerminateCmd() *cobra.Command {
 // runTerminate runs the terminate command.
 func runTerminate(cmd *cobra.Command, args []string) error {
 	fileHandler := file.NewHandler(afero.NewOsFs())
-	spinner := newSpinner(cmd.ErrOrStderr())
+	spinner, err := newSpinnerOrStderr(cmd)
+	if err != nil {
+		return fmt.Errorf("creating spinner: %w", err)
+	}
 	defer spinner.Stop()
 	terminator := cloudcmd.NewTerminator()
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -145,6 +145,10 @@ const (
 	// EnvVarAzureClientSecretValue is environment variable to overwrite
 	// provider.azure.clientSecretValue .
 	EnvVarAzureClientSecretValue = EnvVarPrefix + "AZURE_CLIENT_SECRET_VALUE"
+	// EnvVarNoSpinner is environment variable used to disable the loading indicator (spinner)
+	// displayed in Constellation CLI. Any non-empty value, e.g., CONSTELL_NO_SPINNER=1,
+	// can be used to disable the spinner.
+	EnvVarNoSpinner = EnvVarPrefix + "NO_SPINNER"
 	// MiniConstellationUID is a sentinel value for the UID of a mini constellation.
 	MiniConstellationUID = "mini"
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Option to disable spinner via `CONSTELL_NO_SPINNER` environment variable. Main motivation is to automatically skip waiting times in asciinema recordings 
- Fix `constellation terminate` spinner to honor `debug` flag and new `CONSTELL_NO_SPINNER` environment variable

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
