### PR TITLE
Allow unset 'name' key but print warning if unset

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,8 @@ type Digests = idkeydigest.IDKeyDigests
 const (
 	// Version2 is the second version number for Constellation config file.
 	Version2 = "v2"
+
+	defaultName = "constell"
 )
 
 // Config defines configuration used by CLI.
@@ -62,7 +64,7 @@ type Config struct {
 	Image string `yaml:"image" validate:"required,version_compatibility"`
 	// description: |
 	//   Name of the cluster.
-	Name string `yaml:"name" validate:"required,valid_name"`
+	Name string `yaml:"name" validate:"valid_name"` // TODO: v2.7: Use "required" validation for name
 	// description: |
 	//   Size (in GB) of a node's disk to store the non-volatile state.
 	StateDiskSizeGB int `yaml:"stateDiskSizeGB" validate:"min=0"`
@@ -255,7 +257,7 @@ func Default() *Config {
 	return &Config{
 		Version:             Version2,
 		Image:               defaultImage,
-		Name:                "constell",
+		Name:                defaultName,
 		MicroserviceVersion: compatibility.EnsurePrefixV(constants.VersionInfo),
 		KubernetesVersion:   string(versions.Default),
 		StateDiskSizeGB:     30,

--- a/internal/config/config_doc.go
+++ b/internal/config/config_doc.go
@@ -37,7 +37,7 @@ func init() {
 	ConfigDoc.Fields[1].Comments[encoder.LineComment] = "Machine image version used to create Constellation nodes."
 	ConfigDoc.Fields[2].Name = "name"
 	ConfigDoc.Fields[2].Type = "string"
-	ConfigDoc.Fields[2].Note = ""
+	ConfigDoc.Fields[2].Note = "TODO: v2.7: Use \"required\" validation for name\n"
 	ConfigDoc.Fields[2].Description = "Name of the cluster."
 	ConfigDoc.Fields[2].Comments[encoder.LineComment] = "Name of the cluster."
 	ConfigDoc.Fields[3].Name = "stateDiskSizeGB"

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -384,7 +385,7 @@ func validateUpgradeConfig(sl validator.StructLevel) {
 	if config.Image == "" && config.CSP == cloudprovider.Unknown && config.Measurements == nil {
 		return
 	}
-	fmt.Println("WARNING: the config key `upgrade` will be deprecated in an upcoming version. Please check the documentation for more information.")
+	fmt.Fprintln(os.Stderr, "WARNING: the config key `upgrade` will be deprecated in an upcoming version. Please check the documentation for more information.")
 }
 
 func registerValidateNameError(ut ut.Translator) error {
@@ -406,6 +407,12 @@ func (c *Config) translateValidateNameError(ut ut.Translator, fe validator.Field
 // Since this value may differ between providers, we can't simply use built-in validation.
 // This also allows us to eventually add more validation rules for constellation names if necessary.
 func (c *Config) validateName(fl validator.FieldLevel) bool {
+	// TODO: v2.7: remove fallback to defaultName and make name a required field
+	if c.Name == "" {
+		fmt.Fprintln(os.Stderr, "WARNING: the config key `name` is not set. This key will be required in the next version. Falling back to default name.")
+		c.Name = defaultName
+	}
+
 	if c.Provider.AWS != nil {
 		return len(fl.Field().String()) <= constants.AWSConstellationNameLength
 	}


### PR DESCRIPTION
* Print deprecation warnings to `os.Stderr`
* Allow unset `name` key in config, but fallback to default name and print a warning if it does not show up