### PR TITLE
cli: fix incorrect output for single worker/control-plane clusters

### DIFF
--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -125,8 +125,8 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 	if !flags.yes {
 		// Ask user to confirm action.
 		cmd.Printf("The following Constellation cluster will be created:\n")
-		cmd.Printf("%d control-planes nodes of type %s will be created.\n", flags.controllerCount, instanceType)
-		cmd.Printf("%d worker nodes of type %s will be created.\n", flags.workerCount, instanceType)
+		cmd.Printf("%d control-plane node%s of type %s will be created.\n", flags.controllerCount, isPlural(flags.controllerCount), instanceType)
+		cmd.Printf("%d worker node%s of type %s will be created.\n", flags.workerCount, isPlural(flags.workerCount), instanceType)
 		ok, err := askToConfirm(cmd, "Do you want to create this cluster?")
 		if err != nil {
 			return err
@@ -246,6 +246,13 @@ func translateCreateErrors(cmd *cobra.Command, err error) error {
 	default:
 		return err
 	}
+}
+
+func isPlural(count int) string {
+	if count == 1 {
+		return ""
+	}
+	return "s"
 }
 
 func must(err error) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix incorrect pluralization of nodes during the `constellation create` command when creating clusters with only 1 control-plane/worker node
- Fix incorrect `control-planes` string to `control-plane`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
