### PR TITLE
config: allow k8s version MAJOR.MINOR  for v2.6

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -70,7 +70,7 @@ type Config struct {
 	StateDiskSizeGB int `yaml:"stateDiskSizeGB" validate:"min=0"`
 	// description: |
 	//   Kubernetes version to be installed into the cluster.
-	KubernetesVersion string `yaml:"kubernetesVersion" validate:"supported_k8s_version"`
+	KubernetesVersion string `yaml:"kubernetesVersion" validate:"required,supported_k8s_version"`
 	// description: |
 	//   Microservice version to be installed into the cluster. Setting this value is optional until v2.7. Defaults to the version of the CLI.
 	MicroserviceVersion string `yaml:"microserviceVersion" validate:"omitempty,version_compatibility"`
@@ -526,7 +526,7 @@ func (c *Config) Validate(force bool) error {
 	}
 
 	// register custom validator with label supported_k8s_version to validate version based on available versionConfigs.
-	if err := validate.RegisterValidation("supported_k8s_version", validateK8sVersion); err != nil {
+	if err := validate.RegisterValidation("supported_k8s_version", c.validateK8sVersion); err != nil {
 		return err
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -273,6 +273,26 @@ func TestValidate(t *testing.T) {
 				return cnf
 			}(),
 		},
+		// TODO: v2.7: remove this test as it should start breaking after v2.6 is released.
+		"k8s vMAJOR.MINOR is valid in v2.7": {
+			cnf: func() *Config {
+				cnf := Default()
+				cnf.KubernetesVersion = "v1.25"
+				return cnf
+			}(),
+			wantErr:      true,
+			wantErrCount: defaultErrCount,
+		},
+		// TODO: v2.7: remove this test as it should start breaking after v2.6 is released.
+		"k8s MAJOR.MINOR is valid in v2.7": {
+			cnf: func() *Config {
+				cnf := Default()
+				cnf.KubernetesVersion = "1.25"
+				return cnf
+			}(),
+			wantErr:      true,
+			wantErrCount: defaultErrCount,
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- To adhere to our compatibility goal of not breaking old configs within one version, the kubernetes patch version is automatically extended for configs in the transistional version v2.6.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
