### PR TITLE
cli: upgrade apply uses correct measurements key

### DIFF
--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -149,7 +149,7 @@ func (u *upgradeApplyCmd) handleImageUpgrade(ctx context.Context, conf *config.C
 		return fmt.Errorf("parsing version from image short path: %w", err)
 	}
 
-	err = u.upgrader.UpgradeImage(ctx, imageReference, imageVersion.Version, conf.Upgrade.Measurements)
+	err = u.upgrader.UpgradeImage(ctx, imageReference, imageVersion.Version, conf.GetMeasurements())
 	if err != nil {
 		return fmt.Errorf("upgrading image: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -436,6 +436,23 @@ func (c *Config) GetProvider() cloudprovider.Provider {
 	return cloudprovider.Unknown
 }
 
+// GetMeasurements returns the configured measurements or nil if no provder is set.
+func (c *Config) GetMeasurements() measurements.M {
+	if c.Provider.AWS != nil {
+		return c.Provider.AWS.Measurements
+	}
+	if c.Provider.Azure != nil {
+		return c.Provider.Azure.Measurements
+	}
+	if c.Provider.GCP != nil {
+		return c.Provider.GCP.Measurements
+	}
+	if c.Provider.QEMU != nil {
+		return c.Provider.QEMU.Measurements
+	}
+	return nil
+}
+
 // EnforcesIDKeyDigest checks whether ID Key Digest should be enforced for respective cloud provider.
 func (c *Config) EnforcesIDKeyDigest() bool {
 	return c.Provider.Azure != nil && c.Provider.Azure.EnforceIDKeyDigest != nil && *c.Provider.Azure.EnforceIDKeyDigest


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Apply still used the obsolete upgrade key's measurements. The new, desired behavior is to use the Provider's measurements key

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
