### PR TITLE
cli: add `config kubernetes-versions` subcommand

### DIFF
--- a/cli/internal/cmd/config.go
+++ b/cli/internal/cmd/config.go
@@ -23,6 +23,7 @@ func NewConfigCmd() *cobra.Command {
 	cmd.AddCommand(newConfigGenerateCmd())
 	cmd.AddCommand(newConfigFetchMeasurementsCmd())
 	cmd.AddCommand(newConfigInstanceTypesCmd())
+	cmd.AddCommand(newConfigKubernetesVersionsCmd())
 
 	return cmd
 }

--- a/cli/internal/cmd/configkubernetesversions.go
+++ b/cli/internal/cmd/configkubernetesversions.go
@@ -1,0 +1,34 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package cmd
+
+import (
+	"strings"
+
+	"github.com/edgelesssys/constellation/v2/internal/versions"
+	"github.com/spf13/cobra"
+)
+
+func newConfigKubernetesVersionsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "kubernetes-versions",
+		Short: "Print the Kubernetes versions supported by this CLI",
+		Long:  "Print the Kubernetes versions supported by this CLI.",
+		Args:  cobra.ArbitraryArgs,
+		Run:   printSupportedKubernetesVersions,
+	}
+
+	return cmd
+}
+
+func printSupportedKubernetesVersions(cmd *cobra.Command, args []string) {
+	cmd.Printf("Supported Kubernetes Versions:\n\t%s\n", formatKubernetesVersions())
+}
+
+func formatKubernetesVersions() string {
+	return strings.Join(versions.SupportedK8sVersions(), "\n\t")
+}

--- a/docs/docs/architecture/versions.md
+++ b/docs/docs/architecture/versions.md
@@ -10,3 +10,6 @@ New releases are published on [GitHub](https://github.com/edgelesssys/constellat
 ### Kubernetes support policy
 
 Constellation is aligned to the [version support policy of Kubernetes](https://kubernetes.io/releases/version-skew-policy/#supported-versions), and therefore supports the most recent three minor versions.
+When a new minor version is released upstream, the next Constellation release will include four supported Kubernetes versions.
+The fourth version being the newly released Kubernetes version.
+Then, the next Constellation release after that will drop the oldest supported Kubernetes version.

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -36,7 +36,7 @@ This creates the file `constellation-conf.yaml` in the current directory.
 You can also automatically generate a configuration file by adding the `--generate-config` flag to the `constellation iam create` command when [creating an IAM configuration](#creating-an-iam-configuration).
 :::
 
-## Choosing VM types
+## Choosing a VM type
 
 Constellation supports the following VM types:
 <tabs groupId="csp">
@@ -60,6 +60,11 @@ By default, Constellation uses `m6a.xlarge` VMs (4 vCPUs, 16 GB RAM) to create y
 </tabs>
 
 Fill the desired VM type into the **instanceType** field in the `constellation-conf.yml` file.
+
+## Choosing a Kubernetes version
+
+To learn which Kubernetes versions can be installed with your current CLI you can run `constellation config kubernetes-versions`.
+Our support policy for Kubernetes versions is described in [Kubernetes support policy](../architecture/versions.md#kubernetes-support-policy).
 
 ## Creating an IAM configuration
 

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -49,16 +49,12 @@ func NewValidK8sVersion(k8sVersion string) (ValidK8sVersion, error) {
 
 // IsSupportedK8sVersion checks if a given Kubernetes version is supported by Constellation.
 func IsSupportedK8sVersion(version string) bool {
-	switch version {
-	case string(V1_24):
-		return true
-	case string(V1_25):
-		return true
-	case string(V1_26):
-		return true
-	default:
-		return false
+	for _, valid := range SupportedK8sVersions() {
+		if valid == version {
+			return true
+		}
 	}
+	return false
 }
 
 // IsPreviewK8sVersion checks if a given Kubernetes version is still in preview and not fully supported.


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Allows users to learn which k8s versions are supported by the current CLI. This can be helpful when creating new cluster, applying upgrades or understanding the output of `upgrade check`.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
