### PR TITLE
cli: add `--kubernetes` flag to `config generate`

### DIFF
--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -319,19 +319,35 @@ func (c *Config) validateK8sVersion(fl validator.FieldLevel) bool {
 	if !semver.IsValid(configVersion) {
 		return false
 	}
-	var extendedVersion string
-	switch semver.MajorMinor(configVersion) {
-	case semver.MajorMinor(string(versions.V1_24)):
-		extendedVersion = string(versions.V1_24)
-	case semver.MajorMinor(string(versions.V1_25)):
-		extendedVersion = string(versions.V1_25)
-	case semver.MajorMinor(string(versions.V1_26)):
-		extendedVersion = string(versions.V1_26)
-	default:
+
+	extendedVersion := K8sVersionFromMajorMinor(semver.MajorMinor(configVersion))
+	if extendedVersion == "" {
 		return false
 	}
+
+	valid := versions.IsSupportedK8sVersion(extendedVersion)
+	if !valid {
+		return false
+	}
+
 	c.KubernetesVersion = extendedVersion
-	return versions.IsSupportedK8sVersion(extendedVersion)
+	return true
+}
+
+// K8sVersionFromMajorMinor takes a semver in format MAJOR.MINOR
+// and returns the version in format MAJOR.MINOR.PATCH with the
+// supported patch version as PATCH.
+func K8sVersionFromMajorMinor(version string) string {
+	switch version {
+	case semver.MajorMinor(string(versions.V1_24)):
+		return string(versions.V1_24)
+	case semver.MajorMinor(string(versions.V1_25)):
+		return string(versions.V1_25)
+	case semver.MajorMinor(string(versions.V1_26)):
+		return string(versions.V1_26)
+	default:
+		return ""
+	}
 }
 
 func registerVersionCompatibilityError(ut ut.Translator) error {


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- This flag can be used to specify a Kubernetes version in format MAJOR.MINOR and let the CLI extend the
value with the patch version.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
