### PR TITLE
bazel: update Perl for macOS & Linux arm64

### DIFF
--- a/3rdparty/bazel/org_openssl/openssl_repositories.bzl
+++ b/3rdparty/bazel/org_openssl/openssl_repositories.bzl
@@ -31,9 +31,9 @@ def openssl_repositories():
     maybe(
         http_archive,
         name = "rules_perl",
-        sha256 = "765e6a282cc38b197a6408c625bd3fc28f3f2d44353fb4615490a6eb0b8f420c",
-        strip_prefix = "rules_perl-e3ed0f1727d15db6c5ff84f64454b9a4926cc591",
+        sha256 = "391edb08802860ba733d402c6376cfe1002b598b90d2240d9d302ecce2289a64",
+        strip_prefix = "rules_perl-7f10dada09fcba1dc79a6a91da2facc25e72bd7d",
         urls = [
-            "https://github.com/bazelbuild/rules_perl/archive/e3ed0f1727d15db6c5ff84f64454b9a4926cc591.tar.gz",
+            "https://github.com/bazelbuild/rules_perl/archive/7f10dada09fcba1dc79a6a91da2facc25e72bd7d.tar.gz",
         ],
     )


### PR DESCRIPTION
(This PR merges into the Bazel branch, not main)
### Proposed change(s)
- Update Perl for macOS & Linux arm64

Compared to yesterday's use of release version, I bumped it to the latest main so it also has support for Linux arm64 building (which I haven't tried yet at all - I trust them on this).

Still the remaining issues seem to be OpenSSL complaining about wrong ARM architecture and the Go race detector complaining about missing tsan definitions since we cross-compile tests. We can also handle this as a "add macOS / Linux arm64" support PR if you like a larger PR.

