### PR TITLE
iam: assign uami role to base resource group

### DIFF
--- a/cli/internal/terraform/terraform/iam/azure/main.tf
+++ b/cli/internal/terraform/terraform/iam/azure/main.tf
@@ -73,7 +73,7 @@ resource "azuread_service_principal" "application_principal" {
 
 # Set identity as base resource group owner
 resource "azurerm_role_assignment" "owner_role" {
-  scope                = azurerm_resource_group.identity_resource_group.id
+  scope                = azurerm_resource_group.base_resource_group.id
   role_definition_name = "Owner"
   principal_id         = azuread_service_principal.application_principal.object_id
 }

--- a/cli/internal/terraform/terraform/iam/azure/main.tf
+++ b/cli/internal/terraform/terraform/iam/azure/main.tf
@@ -48,13 +48,13 @@ resource "azurerm_user_assigned_identity" "identity_uami" {
 
 # Assign roles to managed identity
 resource "azurerm_role_assignment" "virtual_machine_contributor_role" {
-  scope                = azurerm_resource_group.identity_resource_group.id
+  scope                = azurerm_resource_group.base_resource_group.id
   role_definition_name = "Virtual Machine Contributor"
   principal_id         = azurerm_user_assigned_identity.identity_uami.principal_id
 }
 
 resource "azurerm_role_assignment" "application_insights_component_contributor_role" {
-  scope                = azurerm_resource_group.identity_resource_group.id
+  scope                = azurerm_resource_group.base_resource_group.id
   role_definition_name = "Application Insights Component Contributor"
   principal_id         = azurerm_user_assigned_identity.identity_uami.principal_id
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Assign role at the base resource group and not the iam resource group

This bug was introduced in https://github.com/edgelesssys/constellation/commit/b8648261e3a89c69c46ec313fda6bfd16db1e415

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
