### PR TITLE
ci: fix release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
     needs: verify-inputs
     permissions:
       contents: write
+      pull-requests: write
     env:
       VERSION: ${{ inputs.version }}
       MAJOR_MINOR: ${{ needs.verify-inputs.outputs.MAJOR_MINOR }}
@@ -118,6 +119,9 @@ jobs:
     name: Build micro services
     runs-on: ubuntu-22.04
     needs: [verify-inputs, prepare-release-branch]
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         koTarget:
@@ -169,6 +173,11 @@ jobs:
           - appName: libvirt
             dockerfile: ./cli/internal/libvirt/Dockerfile
     steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ needs.verify-inputs.outputs.RELEASE_BRANCH }}
+
       - name: Build docker image
         uses: ./.github/actions/build_micro_service
         with:
@@ -187,6 +196,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: write
+      packages: read
     env:
       VERSION: ${{ inputs.version }}
       WITHOUT_V: ${{ needs.verify-inputs.outputs.WITHOUT_V }}
@@ -261,7 +271,7 @@ jobs:
 
   update-hardcoded-measurements:
     name: Update hardcoded measurements (in the CLI)
-    needs: [verify-inputs]
+    needs: [verify-inputs, os-image]
     permissions:
       contents: write
     runs-on: ubuntu-22.04


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- While running the release pipeline to see if my changes to `CMakeLists.txt` work I encountered multiple errors. I fixed the errors on the branch `feat/cli-pseudoversion` and ran the pipeline [here](https://github.com/edgelesssys/constellation/actions/runs/4240682413). This PR includes only the pipeline fixes and I plan to remove those fixes from `feat/cli-pseudoversion` once this PR is merged. 
- Intentionally not setting "needs-backport" as the offending commits that made these fixes necessary are not on `release/v2.5`.
- New run with AWS fixes from main included: https://github.com/edgelesssys/constellation/actions/runs/4243719447

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
