### PR TITLE
ci: specify URL predicate because shortnames are unreliable

### DIFF
--- a/.github/actions/container_sbom/action.yml
+++ b/.github/actions/container_sbom/action.yml
@@ -34,9 +34,9 @@ runs:
       run: |
         set -ex
         syft packages ${{ inputs.containerReference }} -o cyclonedx-json > container-image-predicate.json
-        cosign attest ${{ inputs.containerReference }} --key env://COSIGN_PRIVATE_KEY --predicate container-image-predicate.json --type cyclonedx > container-image.att.json
+        cosign attest ${{ inputs.containerReference }} --key env://COSIGN_PRIVATE_KEY --predicate container-image-predicate.json --type "https://cyclonedx.org/bom" > container-image.att.json
         cosign attach attestation ${{ inputs.containerReference }} --attestation container-image.att.json
         # TODO: type should be auto-discovered after issue is resolved:
         # https://github.com/sigstore/cosign/issues/2264
-        cosign verify-attestation ${{ inputs.containerReference }} --type 'https://cyclonedx.org/bom' --key env://COSIGN_PUBLIC_KEY
+        cosign verify-attestation ${{ inputs.containerReference }} --type "https://cyclonedx.org/bom" --key env://COSIGN_PUBLIC_KEY
         grype ${{ inputs.containerReference }} --fail-on high --only-fixed --add-cpes-if-none


### PR DESCRIPTION
### Proposed change(s)
- specify CycloneDX spec via URL rather than using a shortname

See: https://github.com/sigstore/cosign/issues/2596
Apparently, Syft and Cosign have different specs for CycloneDX. Cosign wants to update them in v2, but on the current release, you end up with stuff that is _slightly_ incompatible if you use attestation with these two tools.

Granted, this happened because the verification already used the "new" URL while the attestation didn't. Not sure if this is also related to the update or not... could be. Let's just use the new version.

And hopefully I won't have to deal with this again because this in-toto stuff is so early days it makes my head hurt dealing with these minor issues over multiple PRs now.

This is truly a mess, I hate it.

