### PR TITLE
cli: handle invalid upgrades for microservice consistently

### DIFF
--- a/cli/internal/cloudcmd/upgrade_test.go
+++ b/cli/internal/cloudcmd/upgrade_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
+	"github.com/edgelesssys/constellation/v2/internal/compatibility"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/internal/versions/components"
@@ -48,7 +49,7 @@ func TestUpgradeK8s(t *testing.T) {
 			newClusterVersion:     "v1.2.3",
 			wantErr:               true,
 			assertCorrectError: func(t *testing.T, err error) bool {
-				target := &InvalidUpgradeError{}
+				target := &compatibility.InvalidUpgradeError{}
 				return assert.ErrorAs(t, err, &target)
 			},
 		},
@@ -57,7 +58,7 @@ func TestUpgradeK8s(t *testing.T) {
 			newClusterVersion:     "v1.2.2",
 			wantErr:               true,
 			assertCorrectError: func(t *testing.T, err error) bool {
-				target := &InvalidUpgradeError{}
+				target := &compatibility.InvalidUpgradeError{}
 				return assert.ErrorAs(t, err, &target)
 			},
 		},
@@ -156,7 +157,7 @@ func TestUpgradeImage(t *testing.T) {
 			newImageVersion:     "v1.2.2",
 			wantErr:             true,
 			assertCorrectError: func(t *testing.T, err error) bool {
-				target := &InvalidUpgradeError{}
+				target := &compatibility.InvalidUpgradeError{}
 				return assert.ErrorAs(t, err, &target)
 			},
 		},
@@ -165,7 +166,7 @@ func TestUpgradeImage(t *testing.T) {
 			newImageVersion:     "v1.2.1",
 			wantErr:             true,
 			assertCorrectError: func(t *testing.T, err error) bool {
-				target := &InvalidUpgradeError{}
+				target := &compatibility.InvalidUpgradeError{}
 				return assert.ErrorAs(t, err, &target)
 			},
 		},

--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -20,7 +20,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/versions"
 	"github.com/pkg/errors"
 	"github.com/spf13/afero"
-	"golang.org/x/mod/semver"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/cli"
@@ -166,12 +165,10 @@ func (c *Client) upgradeRelease(
 	c.log.Debugf("Current %s version: %s", releaseName, currentVersion)
 	c.log.Debugf("New %s version: %s", releaseName, chart.Metadata.Version)
 
-	if !isUpgrade(currentVersion, chart.Metadata.Version) {
-		c.log.Debugf(
-			"Skipping upgrade of %s: new version (%s) is not an upgrade for current version (%s)",
-			releaseName, chart.Metadata.Version, currentVersion,
-		)
-		return nil
+	// This may break for cert-manager or cilium if we decide to upgrade more than one minor version at a time.
+	// Leaving it as is since it is not clear to me what kind of sanity check we could do.
+	if err := compatibility.IsValidUpgrade(currentVersion, chart.Metadata.Version); err != nil {
+		return err
 	}
 
 	if releaseName == certManagerReleaseName && !allowDestructive {
@@ -243,29 +240,6 @@ func (c *Client) updateCRDs(ctx context.Context, chart *chart.Chart) error {
 		}
 	}
 	return nil
-}
-
-// isUpgrade returns true if the new version is greater than the current version.
-// Versions should adhere to the semver spec, but this function will prefix the versions with 'v' if they don't.
-func isUpgrade(currentVersion, newVersion string) bool {
-	if !strings.HasPrefix(currentVersion, "v") {
-		currentVersion = "v" + currentVersion
-	}
-	if !strings.HasPrefix(newVersion, "v") {
-		newVersion = "v" + newVersion
-	}
-
-	// If the current version is not a valid semver,
-	// we cant compare it to the new version.
-	// -> We can't upgrade.
-	if !semver.IsValid(currentVersion) {
-		return false
-	}
-
-	if semver.Compare(currentVersion, newVersion) < 0 {
-		return true
-	}
-	return false
 }
 
 type debugLog interface {

--- a/cli/internal/helm/client_test.go
+++ b/cli/internal/helm/client_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/edgelesssys/constellation/v2/internal/compatibility"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/stretchr/testify/assert"
@@ -18,83 +19,33 @@ import (
 	"helm.sh/helm/v3/pkg/release"
 )
 
-func TestIsUpgrade(t *testing.T) {
-	testCases := map[string]struct {
-		currentVersion string
-		newVersion     string
-		wantUpgrade    bool
-	}{
-		"upgrade": {
-			currentVersion: "0.1.0",
-			newVersion:     "0.2.0",
-			wantUpgrade:    true,
-		},
-		"downgrade": {
-			currentVersion: "0.2.0",
-			newVersion:     "0.1.0",
-			wantUpgrade:    false,
-		},
-		"equal": {
-			currentVersion: "0.1.0",
-			newVersion:     "0.1.0",
-			wantUpgrade:    false,
-		},
-		"invalid current version": {
-			currentVersion: "asdf",
-			newVersion:     "0.1.0",
-			wantUpgrade:    false,
-		},
-		"invalid new version": {
-			currentVersion: "0.1.0",
-			newVersion:     "asdf",
-			wantUpgrade:    false,
-		},
-		"patch version": {
-			currentVersion: "0.1.0",
-			newVersion:     "0.1.1",
-			wantUpgrade:    true,
-		},
-		"pre-release version": {
-			currentVersion: "0.1.0",
-			newVersion:     "0.1.1-rc1",
-			wantUpgrade:    true,
-		},
-		"pre-release version downgrade": {
-			currentVersion: "0.1.1-rc1",
-			newVersion:     "0.1.0",
-			wantUpgrade:    false,
-		},
-		"pre-release of same version": {
-			currentVersion: "0.1.0",
-			newVersion:     "0.1.0-rc1",
-			wantUpgrade:    false,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			assert := assert.New(t)
-
-			upgrade := isUpgrade(tc.currentVersion, tc.newVersion)
-			assert.Equal(tc.wantUpgrade, upgrade)
-
-			upgrade = isUpgrade("v"+tc.currentVersion, "v"+tc.newVersion)
-			assert.Equal(tc.wantUpgrade, upgrade)
-		})
-	}
-}
-
 func TestUpgradeRelease(t *testing.T) {
 	testCases := map[string]struct {
-		allowDestructive bool
-		wantError        bool
+		allowDestructive   bool
+		version            string
+		assertCorrectError func(t *testing.T, err error) bool
+		wantError          bool
 	}{
 		"allow": {
 			allowDestructive: true,
+			version:          "1.9.0",
+		},
+		"not a valid upgrade": {
+			allowDestructive: true,
+			version:          "1.0.0",
+			assertCorrectError: func(t *testing.T, err error) bool {
+				target := &compatibility.InvalidUpgradeError{}
+				return assert.ErrorAs(t, err, &target)
+			},
+			wantError: true,
 		},
 		"deny": {
 			allowDestructive: false,
-			wantError:        true,
+			version:          "1.9.0",
+			assertCorrectError: func(t *testing.T, err error) bool {
+				return assert.ErrorIs(t, err, ErrConfirmationMissing)
+			},
+			wantError: true,
 		},
 	}
 
@@ -102,10 +53,10 @@ func TestUpgradeRelease(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			client := Client{kubectl: nil, actions: &stubActionWrapper{}, log: logger.NewTest(t)}
+			client := Client{kubectl: nil, actions: &stubActionWrapper{version: tc.version}, log: logger.NewTest(t)}
 			err := client.upgradeRelease(context.Background(), 0, config.Default(), certManagerPath, certManagerReleaseName, false, tc.allowDestructive)
 			if tc.wantError {
-				assert.ErrorIs(err, ErrConfirmationMissing)
+				tc.assertCorrectError(t, err)
 				return
 			}
 			assert.NoError(err)
@@ -113,11 +64,13 @@ func TestUpgradeRelease(t *testing.T) {
 	}
 }
 
-type stubActionWrapper struct{}
+type stubActionWrapper struct {
+	version string
+}
 
 // listAction returns a list of len 1 with a release that has only it's version set.
 func (a *stubActionWrapper) listAction(_ string) ([]*release.Release, error) {
-	return []*release.Release{{Chart: &chart.Chart{Metadata: &chart.Metadata{Version: "1.0.0"}}}}, nil
+	return []*release.Release{{Chart: &chart.Chart{Metadata: &chart.Metadata{Version: a.version}}}}, nil
 }
 
 func (a *stubActionWrapper) getValues(release string) (map[string]any, error) {


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Handle invalid upgrade errors similarly as for images and k8s.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
