### PR TITLE
docs: add docs on general Terraform usage

### DIFF
--- a/docs/docs/architecture/orchestration.md
+++ b/docs/docs/architecture/orchestration.md
@@ -23,10 +23,10 @@ Altogether, the following files are generated during the creation of a Constella
 * a configuration file
 * an ID file
 * a Base64-encoded master secret
-* Terraform artifacts such as `terraform.tfstate`
+* Terraform artifacts such as `terraform.tfstate`, stored in the `constellation-terraform` subdirectory
 * a Kubernetes `kubeconfig` file.
 
-Constellation uses Terraform for infrastructure management. No setup of Terraform is needed. The CLI automatically fetches a copy of Terraform when required.
+Constellation uses Terraform for infrastructure management. No setup of Terraform is needed. The CLI automatically fetches a copy of Terraform when required. The policy on usage of Terraform by Constellation can be found [here](../reference/terraform.md).
 
 After the creation of your cluster, the CLI will provide you with a Kubernetes `kubeconfig` file.
 This file grants you access to your Kubernetes cluster and configures the [kubectl](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) tool.
@@ -51,7 +51,7 @@ Post-installation the CLI provides a configuration for [accessing the cluster us
 The `kubeconfig` file provides the credentials and configuration for connecting and authenticating to the API server.
 Once configured, orchestrate the Kubernetes cluster via `kubectl`.
 
-Make sure to keep the state files such as `terraform.tfstate` in the workspace directory to be able to manage your cluster later on.
+Make sure to keep the Terraform subdirectory such as `constellation-terraform` in the workspace directory to be able to manage your cluster later on.
 Without it, you won't be able to modify or terminate your cluster.
 
 After the initialization, the CLI will present you with a couple of tokens:

--- a/docs/docs/architecture/orchestration.md
+++ b/docs/docs/architecture/orchestration.md
@@ -23,10 +23,8 @@ Altogether, the following files are generated during the creation of a Constella
 * a configuration file
 * an ID file
 * a Base64-encoded master secret
-* Terraform artifacts such as `terraform.tfstate`, stored in the `constellation-terraform` subdirectory
+* [Terraform artifacts](../reference/terraform.md), stored in the `constellation-terraform` subdirectory
 * a Kubernetes `kubeconfig` file.
-
-Constellation uses Terraform for infrastructure management. No setup of Terraform is needed. The CLI automatically fetches a copy of Terraform when required. The policy on usage of Terraform by Constellation can be found [here](../reference/terraform.md).
 
 After the creation of your cluster, the CLI will provide you with a Kubernetes `kubeconfig` file.
 This file grants you access to your Kubernetes cluster and configures the [kubectl](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) tool.

--- a/docs/docs/architecture/orchestration.md
+++ b/docs/docs/architecture/orchestration.md
@@ -23,7 +23,7 @@ Altogether, the following files are generated during the creation of a Constella
 * a configuration file
 * an ID file
 * a Base64-encoded master secret
-* [Terraform artifacts](../reference/terraform.md), stored in the `constellation-terraform` subdirectory
+* [Terraform artifacts](../reference/terraform.md), stored in the `constellation-terraform` and `constellation-iam-terraform` subdirectories
 * a Kubernetes `kubeconfig` file.
 
 After the creation of your cluster, the CLI will provide you with a Kubernetes `kubeconfig` file.

--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -76,7 +76,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
 -->
 
 2. Create the cluster with one control-plane node and two worker nodes. `constellation create` uses options set in `constellation-conf.yaml`.
-    If you want to use Terraform for managing the cloud resources instead, follow the corresponding instructions in the [Create workflow](../workflows/create.md).
+    If you want to manually use Terraform for managing the cloud resources instead, follow the corresponding instructions in the [Create workflow](../workflows/create.md).
 
     :::tip
 
@@ -151,7 +151,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
 
 ## Terminate your cluster
 
-Use the CLI to terminate your cluster. If you used Terraform to manage your cloud resources, follow the corresponding instructions in the [Terminate workflow](../workflows/terminate.md).
+Use the CLI to terminate your cluster. If you manually used Terraform to manage your cloud resources, follow the corresponding instructions in the [Terminate workflow](../workflows/terminate.md).
 
 ```bash
 constellation terminate

--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -76,7 +76,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
 -->
 
 2. Create the cluster with one control-plane node and two worker nodes. `constellation create` uses options set in `constellation-conf.yaml`.
-    If you want to manually use Terraform for managing the cloud resources instead, follow the corresponding instructions in the [Create workflow](../workflows/create.md).
+    If you want to manually use [Terraform](../reference/terraform.md) for managing the cloud resources instead, follow the corresponding instructions in the [Create workflow](../workflows/create.md).
 
     :::tip
 
@@ -151,7 +151,7 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
 
 ## Terminate your cluster
 
-Use the CLI to terminate your cluster. If you manually used Terraform to manage your cloud resources, follow the corresponding instructions in the [Terminate workflow](../workflows/terminate.md).
+Use the CLI to terminate your cluster. If you manually used [Terraform](../reference/terraform.md) to manage your cloud resources, follow the corresponding instructions in the [Terminate workflow](../workflows/terminate.md).
 
 ```bash
 constellation terminate

--- a/docs/docs/reference/terraform.md
+++ b/docs/docs/reference/terraform.md
@@ -3,7 +3,7 @@
 [Terraform](https://www.terraform.io/) is an open-source Infrastructure as Code (IaC) framework which is being used by multiple Constellation components to manage cloud resources. This page describes our policy on using Terraform in Constellation.
 
 :::info
-This page assumes basic familiarity with Terraform. The Terraform documentation can be found [here](https://developer.hashicorp.com/terraform/docs).
+This page assumes basic familiarity with Terraform. Refer to the [Terraform documentation](https://developer.hashicorp.com/terraform/docs) for an introduction.
 :::
 
 ## Interacting with Terraform manually

--- a/docs/docs/reference/terraform.md
+++ b/docs/docs/reference/terraform.md
@@ -19,4 +19,4 @@ Currently, these subdirectories are:
 * `constellation-terraform` - Terraform state files for the resources used for the Constellation cluster
 * `constellation-iam-terraform` - Terraform state files for IAM configuration
 
-When working with either of the files, i.e. when running `constellation terminate` to [terminate a cluster](../workflows/terminate.md) (and delete it's cloud resources), the `constellation terraform` subdirectory needs to be in the current working directory. The same applies to the `constellation-iam-terraform` subdirectory when working with IAM configuration. The state directories should not be deleted manually.
+When working with either of the files, i.e. when running `constellation terminate` to [terminate a cluster](../workflows/terminate.md) (and delete it's cloud resources), the `constellation terraform` subdirectory needs to be in the current working directory. The same applies to the `constellation-iam-terraform` subdirectory when working with IAM configuration. The state directories shouldn't be deleted manually.

--- a/docs/docs/reference/terraform.md
+++ b/docs/docs/reference/terraform.md
@@ -1,0 +1,22 @@
+# Terraform Usage
+
+[Terraform](https://www.terraform.io/) is an open-source Infrastructure as Code (IaC) framework which is being used by multiple Constellation components to manage cloud resources. This page describes our policy on using Terraform in Constellation.
+
+:::info
+This page assumes basic familiarity with Terraform. The Terraform documentation can be found [here](https://developer.hashicorp.com/terraform/docs).
+:::
+
+## Interacting with Terraform manually
+
+Manual interaction with Terraform state created by Constellation should only be performed by experienced users and only if absolutely necessary, as it may lead to unrecoverable loss of cloud resources. For the vast majority of users and use-cases, the interaction done by the [Constellation CLI](cli.md) is sufficient.
+
+## Terraform state files
+
+Constellation keeps Terraform state files in subdirectories together with the corresponding Terraform configuration files and metadata. When first performing an action in the Constellation CLI which uses Terraform internally, the needed subdirectory will be created.
+
+Currently, these subdirectories are:
+
+* `constellation-terraform` - Terraform state files for the resources used for the Constellation cluster
+* `constellation-iam-terraform` - Terraform state files for IAM configuration
+
+When working with either of the files, i.e. when running `constellation terminate` to [terminate a cluster](../workflows/terminate.md) (and delete it's cloud resources), the `constellation terraform` subdirectory needs to be in the current working directory. The same applies to the `constellation-iam-terraform` subdirectory when working with IAM configuration.

--- a/docs/docs/reference/terraform.md
+++ b/docs/docs/reference/terraform.md
@@ -3,7 +3,7 @@
 [Terraform](https://www.terraform.io/) is an open-source Infrastructure as Code (IaC) framework which is being used by multiple Constellation components to manage cloud resources. This page describes our policy on using Terraform in Constellation.
 
 :::info
-This page assumes basic familiarity with Terraform. Refer to the [Terraform documentation](https://developer.hashicorp.com/terraform/docs) for an introduction.
+This page assumes familiarity with Terraform. Refer to the [Terraform documentation](https://developer.hashicorp.com/terraform/docs) for an introduction.
 :::
 
 ## Interacting with Terraform manually

--- a/docs/docs/reference/terraform.md
+++ b/docs/docs/reference/terraform.md
@@ -8,7 +8,7 @@ This page assumes basic familiarity with Terraform. The Terraform documentation 
 
 ## Interacting with Terraform manually
 
-Manual interaction with Terraform state created by Constellation should only be performed by experienced users and only if absolutely necessary, as it may lead to unrecoverable loss of cloud resources. For the vast majority of users and use-cases, the interaction done by the [Constellation CLI](cli.md) is sufficient.
+Manual interaction with Terraform state created by Constellation (i.e. via the Terraform CLI) should only be performed by experienced users and only if absolutely necessary, as it may lead to unrecoverable loss of cloud resources. For the vast majority of users and use-cases, the interaction done by the [Constellation CLI](cli.md) is sufficient.
 
 ## Terraform state files
 
@@ -19,4 +19,4 @@ Currently, these subdirectories are:
 * `constellation-terraform` - Terraform state files for the resources used for the Constellation cluster
 * `constellation-iam-terraform` - Terraform state files for IAM configuration
 
-When working with either of the files, i.e. when running `constellation terminate` to [terminate a cluster](../workflows/terminate.md) (and delete it's cloud resources), the `constellation terraform` subdirectory needs to be in the current working directory. The same applies to the `constellation-iam-terraform` subdirectory when working with IAM configuration.
+When working with either of the files, i.e. when running `constellation terminate` to [terminate a cluster](../workflows/terminate.md) (and delete it's cloud resources), the `constellation terraform` subdirectory needs to be in the current working directory. The same applies to the `constellation-iam-terraform` subdirectory when working with IAM configuration. The state directories should not be deleted manually.

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -231,13 +231,13 @@ The following describes the configuration fields and how you obtain the required
 
 * **iamProfileControlPlane**: The name of an IAM instance profile attached to all control-plane nodes.
 
-  The resource can be created with [Terraform](../reference/terraform.md). For that, use the [provided Terraform script](https://github.com/edgelesssys/constellation/tree/release/v2.2/hack/terraform/aws/iam) to generate the necessary profile. The profile name will be provided as Terraform output value: `control_plane_instance_profile`.
+  The resource can be created with [Terraform](https://www.terraform.io/). For that, use the [provided Terraform script](https://github.com/edgelesssys/constellation/tree/release/v2.2/hack/terraform/aws/iam) to generate the necessary profile. The profile name will be provided as Terraform output value: `control_plane_instance_profile`.
 
   Alternatively, you can create the AWS profile with a tool of your choice. Use the JSON policy in [main.tf](https://github.com/edgelesssys/constellation/tree/release/v2.2/hack/terraform/aws/iam/main.tf) in the resource `aws_iam_policy.control_plane_policy`.
 
 * **iamProfileWorkerNodes**: The name of an IAM instance profile attached to all worker nodes.
 
-  The resource can be created with [Terraform](../reference/terraform.md). For that, use the [provided Terraform script](https://github.com/edgelesssys/constellation/tree/release/v2.2/hack/terraform/aws/iam) to generate the necessary profile. The profile name will be provided as Terraform output value: `worker_nodes_instance_profile`.
+  The resource can be created with [Terraform](https://www.terraform.io/). For that, use the [provided Terraform script](https://github.com/edgelesssys/constellation/tree/release/v2.2/hack/terraform/aws/iam) to generate the necessary profile. The profile name will be provided as Terraform output value: `worker_nodes_instance_profile`.
 
   Alternatively, you can create the AWS profile with a tool of your choice. Use the JSON policy in [main.tf](https://github.com/edgelesssys/constellation/tree/release/v2.2/hack/terraform/aws/iam/main.tf) in the resource `aws_iam_policy.worker_node_policy`.
 

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -254,7 +254,7 @@ You can keep created IAM configurations and reuse them for new clusters. Alterna
 
 **Prerequisites:**
 * [Terraform](https://developer.hashicorp.com/terraform/downloads) is installed on your machine.
-* Access to the `terraform.tfstate` file created by the `constellation iam create` command.
+* Access to the `constellation-iam-terraform` directory created by the `constellation iam create` command.
 
 You can delete the IAM configuration using the following commands:
 ```bash

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -231,13 +231,13 @@ The following describes the configuration fields and how you obtain the required
 
 * **iamProfileControlPlane**: The name of an IAM instance profile attached to all control-plane nodes.
 
-  Use the [provided Terraform script](https://github.com/edgelesssys/constellation/tree/release/v2.2/hack/terraform/aws/iam) to generate the necessary profile. The profile name will be provided as Terraform output value: `control_plane_instance_profile`.
+  The resource can be created with [Terraform](../reference/terraform.md). For that, use the [provided Terraform script](https://github.com/edgelesssys/constellation/tree/release/v2.2/hack/terraform/aws/iam) to generate the necessary profile. The profile name will be provided as Terraform output value: `control_plane_instance_profile`.
 
   Alternatively, you can create the AWS profile with a tool of your choice. Use the JSON policy in [main.tf](https://github.com/edgelesssys/constellation/tree/release/v2.2/hack/terraform/aws/iam/main.tf) in the resource `aws_iam_policy.control_plane_policy`.
 
 * **iamProfileWorkerNodes**: The name of an IAM instance profile attached to all worker nodes.
 
-  Use the [provided Terraform script](https://github.com/edgelesssys/constellation/tree/release/v2.2/hack/terraform/aws/iam) to generate the necessary profile. The profile name will be provided as Terraform output value: `worker_nodes_instance_profile`.
+  The resource can be created with [Terraform](../reference/terraform.md). For that, use the [provided Terraform script](https://github.com/edgelesssys/constellation/tree/release/v2.2/hack/terraform/aws/iam) to generate the necessary profile. The profile name will be provided as Terraform output value: `worker_nodes_instance_profile`.
 
   Alternatively, you can create the AWS profile with a tool of your choice. Use the JSON policy in [main.tf](https://github.com/edgelesssys/constellation/tree/release/v2.2/hack/terraform/aws/iam/main.tf) in the resource `aws_iam_policy.worker_node_policy`.
 
@@ -254,7 +254,7 @@ You can keep created IAM configurations and reuse them for new clusters. Alterna
 
 **Prerequisites:**
 * [Terraform](https://developer.hashicorp.com/terraform/downloads) is installed on your machine.
-* Access to the `constellation-iam-terraform` directory created by the `constellation iam create` command.
+* Access to the [`constellation-iam-terraform`](../reference/terraform.md) directory created by the `constellation iam create` command.
 
 You can delete the IAM configuration using the following commands:
 ```bash

--- a/docs/docs/workflows/create.md
+++ b/docs/docs/workflows/create.md
@@ -18,10 +18,6 @@ Before you create the cluster, make sure to have a [valid configuration file](./
 
 ### Create
 
-:::info
-Familiarize with the [Terraform usage policy](../reference/terraform.md) before manually interacting with Terraform to create a cluster.
-:::
-
 <tabs groupId="provider">
 <tabItem value="cli" label="CLI">
 
@@ -39,9 +35,13 @@ For details on the flags, consult the command help via `constellation create -h`
 </tabItem>
 <tabItem value="terraform" label="Terraform">
 
-Constellation supports managing the infrastructure via Terraform. This allows for an easier GitOps integration as well as meeting regulatory requirements.
+Terraform allows for an easier GitOps integration as well as meeting regulatory requirements.
 Since the Constellation CLI also uses Terraform under the hood, you can reuse the same Terraform files.
-For now, please refrain from changing the Terraform resource definitions, as Constellation is tightly coupled to them.
+
+:::info
+Familiarize with the [Terraform usage policy](../reference/terraform.md) before manually interacting with Terraform to create a cluster.
+Please also refrain from changing the Terraform resource definitions, as Constellation is tightly coupled to them.
+:::
 
 Download the Terraform files for the selected CSP from the [GitHub repository](https://github.com/edgelesssys/constellation/tree/main/cli/internal/terraform/terraform).
 

--- a/docs/docs/workflows/create.md
+++ b/docs/docs/workflows/create.md
@@ -18,6 +18,10 @@ Before you create the cluster, make sure to have a [valid configuration file](./
 
 ### Create
 
+:::info
+Familiarize with the [Terraform usage policy](../reference/terraform.md) before manually interacting with Terraform to create a cluster.
+:::
+
 <tabs groupId="provider">
 <tabItem value="cli" label="CLI">
 
@@ -30,7 +34,7 @@ constellation create --control-plane-nodes 1 --worker-nodes 2
 
 For details on the flags, consult the command help via `constellation create -h`.
 
-*create* stores your cluster's state into a [`terraform.tfstate`](../architecture/orchestration.md#cluster-creation-process) file in your workspace.
+*create* stores your cluster's state in a [`constellation-terraform`](../architecture/orchestration.md#cluster-creation-process) directory in your workspace.
 
 </tabItem>
 <tabItem value="terraform" label="Terraform">

--- a/docs/docs/workflows/terminate.md
+++ b/docs/docs/workflows/terminate.md
@@ -1,6 +1,6 @@
 # Terminate your cluster
 
-You can terminate your cluster using the CLI. For this, you need the Terraform state directory named `constellation-terraform` in the current directory.
+You can terminate your cluster using the CLI. For this, you need the Terraform state directory named [`constellation-terraform`](../reference/terraform.md) in the current directory.
 
 :::danger
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -261,6 +261,11 @@ const sidebars = {
           label: 'SLSA adoption',
           id: 'reference/slsa',
         },
+        {
+          type: 'doc',
+          label: 'Terraform Usage',
+          id: 'reference/terraform',
+        },
       ],
     },
   ],


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Our docs featured multiple references to Terraform state files, using Terraform, etc. This PR should add a general documentation page on how Terraform is being used by Constellation to manage cloud resources as stated [here](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/2935/). This includes:
- Instructions on interacting with Terraform state manually 
- Instructions on how and where to keep Terraform state files

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
