### PR TITLE
versions: use renovate to update valid k8s versions

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -75,7 +75,11 @@ runs:
       shell: bash
       if: inputs.existingConfig != 'true'
       run: |
-        constellation config generate ${{ inputs.cloudProvider }}
+        if [[ ${{ inputs.kubernetesVersion != '' }} == true ]]; then
+          constellation config generate ${{ inputs.cloudProvider }} --kubernetes="${{ inputs.kubernetesVersion }}"
+        else
+          constellation config generate ${{ inputs.cloudProvider }}
+        fi
 
         yq eval -i "(.name) = \"e2e-test\"" constellation-conf.yaml
 
@@ -102,13 +106,6 @@ runs:
             (.provider | select(. | has(\"aws\")).aws.iamProfileControlPlane) = \"e2e_test_control_plane_instance_profile\" |
             (.provider | select(. | has(\"aws\")).aws.iamProfileWorkerNodes) = \"e2e_test_worker_node_instance_profile\"" \
           constellation-conf.yaml
-
-    - name: Update config
-      shell: bash
-      run: |
-        if [[ ${{ inputs.kubernetesVersion != '' }} = true ]]; then
-          yq eval -i "(.kubernetesVersion) = \"${{ inputs.kubernetesVersion }}\"" constellation-conf.yaml
-        fi
 
     - name: Remove embedded measurements
       if: inputs.keepMeasurements == 'false'

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -43,7 +43,7 @@ on:
         required: true
       kubernetesVersion:
         description: "Kubernetes version to create the cluster from."
-        default: "1.25.6"
+        default: "1.25"
         required: true
       keepMeasurements:
         description: "Keep measurements embedded in the CLI."

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -48,38 +48,38 @@ jobs:
         test:
           ["sonobuoy full", "autoscaling", "k-bench", "lb", "verify", "recover", "iamcreate"]
         provider: ["gcp", "azure", "aws"]
-        version: ["v1.24.9", "v1.25.6", "v1.26.1"]
+        version: ["v1.24", "v1.25", "v1.26"]
         exclude:
           # IAM create test runs only on latest version.
           - test: "iamcreate"
-            version: "v1.24.9"
+            version: "v1.24"
           - test: "iamcreate"
-            version: "v1.25.6"
+            version: "v1.25"
           # Verify test runs only on latest version.
           - test: "verify"
-            version: "v1.24.9"
+            version: "v1.24"
           - test: "verify"
-            version: "v1.25.6"
+            version: "v1.25"
           # Recover test runs only on latest version.
           - test: "recover"
-            version: "v1.24.9"
+            version: "v1.24"
           - test: "recover"
-            version: "v1.25.6"
+            version: "v1.25"
           # Autoscaling test runs only on latest version.
           - test: "autoscaling"
-            version: "v1.24.9"
+            version: "v1.24"
           - test: "autoscaling"
-            version: "v1.25.6"
+            version: "v1.25"
           # K-bench test runs only on latest version.
           - test: "k-bench"
-            version: "v1.24.9"
+            version: "v1.24"
           - test: "k-bench"
-            version: "v1.25.6"
+            version: "v1.25"
           # lb test runs only on latest version.
           - test: "lb"
-            version: "v1.24.9"
+            version: "v1.24"
           - test: "lb"
-            version: "v1.25.6"
+            version: "v1.25"
           # Currently not supported on AWS.
           - test: "autoscaling"
             provider: "aws"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,7 +315,7 @@ jobs:
       cloudProvider: ${{ matrix.csp }}
       runner: ${{ matrix.runner }}
       test: "sonobuoy full"
-      kubernetesVersion: "v1.25.6"
+      kubernetesVersion: "v1.25"
       keepMeasurements: true
       osImage: ${{ inputs.version }}
       machineType: "default"

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -98,11 +98,11 @@ const (
 
 	// currently supported versions.
 	//nolint:revive
-	V1_24 ValidK8sVersion = "v1.24.9"
+	V1_24 ValidK8sVersion = "v1.24.10" // renovate:kubernetes-release
 	//nolint:revive
-	V1_25 ValidK8sVersion = "v1.25.6"
+	V1_25 ValidK8sVersion = "v1.25.6" // renovate:kubernetes-release
 	//nolint:revive
-	V1_26 ValidK8sVersion = "v1.26.1"
+	V1_26 ValidK8sVersion = "v1.26.1" // renovate:kubernetes-release
 
 	// Default k8s version deployed by Constellation.
 	Default ValidK8sVersion = V1_25


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- use renovate to update valid k8s versions. not sure if this will work. I copied the comment from the `ClusterVersion` field.
- go back to using MAJOR.MINOR format when specifying k8s version for CI jobs by utilizing `--kubernetes` flag

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info
- Old: [702](https://github.com/edgelesssys/constellation/actions/runs/4280805120): specified "1.25" as workflow input. shows "1.25" in config. CLI automatically extends patch version as a compatibility feature for v2.6.
- [704](https://github.com/edgelesssys/constellation/actions/runs/4281000433/jobs/7454445191): specified "1.24" as workflow input. shows "1.24.10" in config, since `--kubernetes` was used to automatically extend patch version.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
