### PR TITLE
cli: use pseudoversion and forward it into helm charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,6 +378,12 @@ jobs:
           git config --global user.email "release[bot]@users.noreply.github.com"
           git fetch
           git checkout -b "${NEW_BRANCH}"
+
+      - name: Update CMakeLists.txt
+        run: |
+          sed -i "s/project(constellation LANGUAGES C VERSION [0-9]\+\.[0-9]\+\.[0-9]\+)/project(constellation LANGUAGES C VERSION 0.0.0)/" CMakeLists.txt
+          git add CMakeLists.txt
+          git commit -m "deps: set PROJECT_VERSION to prerelease"
           git push --set-upstream origin "${NEW_BRANCH}"
 
       - name: Create PR

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,25 +219,6 @@ jobs:
           sed -i "s/project(constellation LANGUAGES C VERSION [0-9]\+\.[0-9]\+\.[0-9]\+)/project(constellation LANGUAGES C VERSION ${WITHOUT_V})/" CMakeLists.txt
           git add CMakeLists.txt
 
-      - name: Update Helm Charts
-        run: |
-          yq eval -i ".version = \"${WITHOUT_V}\"" cli/internal/helm/charts/edgeless/constellation-services/Chart.yaml
-          for service in key-service join-service ccm cnm autoscaler verification-service konnectivity gcp-guest-agent; do
-            yq eval -i "(.dependencies[] | select(.name == \"${service}\")).version = \"${WITHOUT_V}\"" cli/internal/helm/charts/edgeless/constellation-services/Chart.yaml
-            yq eval -i ".version = \"${WITHOUT_V}\"" "cli/internal/helm/charts/edgeless/constellation-services/charts/${service}/Chart.yaml"
-            git add "cli/internal/helm/charts/edgeless/constellation-services/charts/${service}/Chart.yaml"
-          done
-
-          git add cli/internal/helm/charts/edgeless/constellation-services/Chart.yaml
-
-          yq eval -i ".version = \"${WITHOUT_V}\"" cli/internal/helm/charts/edgeless/operators/Chart.yaml
-          for service in node-maintenance-operator constellation-operator; do
-            yq eval -i "(.dependencies[] | select(.name == \"${service}\")).version = \"${WITHOUT_V}\"" cli/internal/helm/charts/edgeless/operators/Chart.yaml
-            yq eval -i ".version = \"${WITHOUT_V}\"" "cli/internal/helm/charts/edgeless/operators/charts/${service}/Chart.yaml"
-            git add "cli/internal/helm/charts/edgeless/operators/charts/${service}/Chart.yaml"
-          done
-          git add cli/internal/helm/charts/edgeless/operators/Chart.yaml
-
       - name: Update micro service versions
         run: |
           for service in node-operator join-service key-service verification-service qemu-metadata-api; do

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,16 @@
 cmake_minimum_required(VERSION 3.11)
-project(constellation LANGUAGES C VERSION 2.5.0)
+
+# WARNING: This is only executed when running `cmake`.
+# Therefore, to update the version number, one needs to run `cmake` first.
+execute_process(COMMAND bash -c "go run ${CMAKE_SOURCE_DIR}/hack/pseudo-version/. | tr -d '\n'"
+    OUTPUT_VARIABLE PSEUDO_VERSION)
+
+project(constellation LANGUAGES C VERSION 0.0.0)
+
+if (${PROJECT_VERSION} STREQUAL "0.0.0")
+  set(PROJECT_VERSION ${PSEUDO_VERSION})
+endif()
+
 set(CLI_BUILD_TAGS "" CACHE STRING "Tags passed to go build of Constellation CLI.")
 
 enable_testing()
@@ -8,7 +19,7 @@ enable_testing()
 # core-os disk-mapper
 #
 add_custom_target(disk-mapper ALL
-  DOCKER_BUILDKIT=1 docker build -o ${CMAKE_BINARY_DIR} --build-arg PROJECT_VERSION=${PROJECT_VERSION} -f Dockerfile.build --target disk-mapper .
+  DOCKER_BUILDKIT=1 docker build -o ${CMAKE_BINARY_DIR} --build-arg PROJECT_VERSION="${PROJECT_VERSION}" -f Dockerfile.build --target disk-mapper .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   BYPRODUCTS disk-mapper
 )
@@ -17,7 +28,7 @@ add_custom_target(disk-mapper ALL
 # bootstrapper
 #
 add_custom_target(bootstrapper ALL
-  DOCKER_BUILDKIT=1 docker build -o ${CMAKE_BINARY_DIR} --build-arg PROJECT_VERSION=${PROJECT_VERSION} -f Dockerfile.build --target bootstrapper .
+  DOCKER_BUILDKIT=1 docker build -o ${CMAKE_BINARY_DIR} --build-arg PROJECT_VERSION="${PROJECT_VERSION}" -f Dockerfile.build --target bootstrapper .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   BYPRODUCTS bootstrapper
 )
@@ -26,7 +37,7 @@ add_custom_target(bootstrapper ALL
 # upgrade-agent
 #
 add_custom_target(upgrade-agent ALL
-  DOCKER_BUILDKIT=1 docker build -o ${CMAKE_BINARY_DIR} --build-arg PROJECT_VERSION=${PROJECT_VERSION} -f Dockerfile.build --target upgrade-agent .
+  DOCKER_BUILDKIT=1 docker build -o ${CMAKE_BINARY_DIR} --build-arg PROJECT_VERSION="${PROJECT_VERSION}" -f Dockerfile.build --target upgrade-agent .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   BYPRODUCTS upgrade-agent
 )

--- a/cli/internal/helm/charts/edgeless/constellation-services/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/Chart.yaml
@@ -2,54 +2,54 @@ apiVersion: v2
 name: constellation-services
 description: A chart to deploy all microservices that are part of a valid constellation cluster
 type: application
-version: 2.5.0
+version: 0.0.0
 dependencies:
   - name: key-service
-    version: 2.5.0
+    version: 0.0.0
     tags:
       - Azure
       - GCP
       - AWS
       - QEMU
   - name: join-service
-    version: 2.5.0
+    version: 0.0.0
     tags:
       - Azure
       - GCP
       - AWS
       - QEMU
   - name: ccm
-    version: 2.5.0
+    version: 0.0.0
     tags:
       - Azure
       - GCP
       - AWS
   - name: cnm
-    version: 2.5.0
+    version: 0.0.0
     tags:
       - Azure
   - name: autoscaler
-    version: 2.5.0
+    version: 0.0.0
     tags:
       - Azure
       - GCP
       - AWS
   - name: verification-service
-    version: 2.5.0
+    version: 0.0.0
     tags:
       - Azure
       - GCP
       - AWS
       - QEMU
   - name: konnectivity
-    version: 2.5.0
+    version: 0.0.0
     tags:
       - Azure
       - GCP
       - AWS
       - QEMU
   - name: gcp-guest-agent
-    version: 2.5.0
+    version: 0.0.0
     tags:
       - GCP
   - name: gcp-compute-persistent-disk-csi-driver

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/autoscaler/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/autoscaler/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: autoscaler
 description: A Helm chart to deploy the cluster autoscaler.
 type: application
-version: 2.5.0
+version: 0.0.0

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/ccm/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/ccm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: ccm
 description: A Helm chart to deploy the cloud controller manager.
 type: application
-version: 2.5.0
+version: 0.0.0

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/cnm/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/cnm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: cnm
 description: A chart to deploy cloud node manager for constellation
 type: application
-version: 2.5.0
+version: 0.0.0

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-guest-agent/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-guest-agent/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: gcp-guest-agent
 description: A chart to deploy the GCP guest agent for Constellation
 type: application
-version: 2.5.0
+version: 0.0.0

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/join-service/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/join-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: join-service
 description: A chart to deploy the Constellation join-service
 type: application
-version: 2.5.0
+version: 0.0.0

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/key-service/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/key-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: key-service
 description: A Helm chart to deploy the Constellation KeyService
 type: application
-version: 2.5.0
+version: 0.0.0

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/konnectivity/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/konnectivity/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: konnectivity
 description: A chart to deploy konnectivity for Constellation
 type: application
-version: 2.5.0
+version: 0.0.0

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/verification-service/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/verification-service/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: verification-service
 description: A Helm chart for Kubernetes
 type: application
-version: 2.5.0
+version: 0.0.0

--- a/cli/internal/helm/charts/edgeless/operators/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/operators/Chart.yaml
@@ -2,17 +2,17 @@ apiVersion: v2
 name: constellation-operators
 description: A Helm chart for Kubernetes
 type: application
-version: 2.5.0
+version: 0.0.0
 dependencies:
   - name: node-maintenance-operator
-    version: 2.5.0
+    version: 0.0.0
     tags:
       - Azure
       - GCP
       - AWS
       - QEMU
   - name: constellation-operator
-    version: 2.5.0
+    version: 0.0.0
     tags:
       - Azure
       - GCP

--- a/cli/internal/helm/charts/edgeless/operators/charts/constellation-operator/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/operators/charts/constellation-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: constellation-operator
 description: A Helm chart for Kubernetes
 type: application
-version: 2.5.0
+version: 0.0.0

--- a/cli/internal/helm/charts/edgeless/operators/charts/node-maintenance-operator/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/operators/charts/node-maintenance-operator/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: node-maintenance-operator
 description: A Helm chart for Kubernetes
 type: application
-version: 2.5.0
+version: 0.0.0

--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -149,8 +149,12 @@ func (c *Client) upgradeRelease(
 	case certManagerReleaseName:
 		values = loader.loadCertManagerValues()
 	case conOperatorsReleaseName:
+		// ensure that the operator chart has the same version as the CLI
+		updateVersions(chart, compatibility.EnsurePrefixV(constants.VersionInfo))
 		values, err = loader.loadOperatorsValues()
 	case conServicesReleaseName:
+		// ensure that the services chart has the same version as the CLI
+		updateVersions(chart, compatibility.EnsurePrefixV(constants.VersionInfo))
 		values, err = loader.loadConstellationServicesValues()
 	default:
 		return fmt.Errorf("invalid release name: %s", releaseName)

--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -282,6 +282,9 @@ func (i *ChartLoader) loadOperators() (helm.Release, error) {
 	if err != nil {
 		return helm.Release{}, fmt.Errorf("loading operators chart: %w", err)
 	}
+
+	updateVersions(chart, compatibility.EnsurePrefixV(constants.VersionInfo))
+
 	values, err := i.loadOperatorsValues()
 	if err != nil {
 		return helm.Release{}, err
@@ -366,6 +369,9 @@ func (i *ChartLoader) loadConstellationServices() (helm.Release, error) {
 	if err != nil {
 		return helm.Release{}, fmt.Errorf("loading constellation-services chart: %w", err)
 	}
+
+	updateVersions(chart, compatibility.EnsurePrefixV(constants.VersionInfo))
+
 	values, err := i.loadConstellationServicesValues()
 	if err != nil {
 		return helm.Release{}, err
@@ -511,6 +517,24 @@ func extendConstellationServicesValues(in map[string]any, config *config.Config,
 	}
 
 	return nil
+}
+
+// updateVersions changes all versions of direct dependencies that are set to "0.0.0" to newVersion.
+func updateVersions(chart *chart.Chart, newVersion string) {
+	chart.Metadata.Version = newVersion
+	selectedDeps := chart.Metadata.Dependencies
+	for i := range selectedDeps {
+		if selectedDeps[i].Version == "0.0.0" {
+			selectedDeps[i].Version = newVersion
+		}
+	}
+
+	deps := chart.Dependencies()
+	for i := range deps {
+		if deps[i].Metadata.Version == "0.0.0" {
+			deps[i].Metadata.Version = newVersion
+		}
+	}
 }
 
 // marshalChart takes a Chart object, packages it to a temporary file and returns the content of that file.

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-controller-manager
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -16,7 +16,7 @@ metadata:
   namespace: testNamespace
   labels:
     control-plane: controller-manager
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/leader-election-rbac.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/leader-election-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-leader-election-role
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -47,7 +47,7 @@ metadata:
   name: constellation-operator-leader-election-rolebinding
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/manager-config.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/manager-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-manager-config
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-manager-role
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -208,7 +208,7 @@ metadata:
   name: constellation-operator-manager-rolebinding
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/metrics-reader-rbac.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/metrics-reader-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-metrics-reader
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/metrics-service.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     control-plane: controller-manager
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/proxy-rbac.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/proxy-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-proxy-role
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ metadata:
   name: constellation-operator-proxy-rolebinding
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -18,7 +18,7 @@ metadata:
   labels:
     control-plane: controller-manager
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/leader-election-rbac.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/leader-election-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -49,7 +49,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/metrics-reader-rbac.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/metrics-reader-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/metrics-service.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/metrics-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     control-plane: controller-manager
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/proxy-rbac.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/proxy-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/selfsigned-issuer.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/selfsigned-issuer.yaml
@@ -4,7 +4,7 @@ metadata:
   name: node-maintenance-operator-selfsigned-issuer
   namespace: testNamespace
   labels:
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/serving-cert.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/serving-cert.yaml
@@ -4,7 +4,7 @@ metadata:
   name: node-maintenance-operator-serving-cert
   namespace: testNamespace
   labels:
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/validating-webhook-configuration.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/validating-webhook-configuration.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: testNamespace/node-maintenance-operator-serving-cert
   labels:
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/webhook-service.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/webhook-service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-controller-manager
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -16,7 +16,7 @@ metadata:
   namespace: testNamespace
   labels:
     control-plane: controller-manager
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/leader-election-rbac.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/leader-election-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-leader-election-role
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -47,7 +47,7 @@ metadata:
   name: constellation-operator-leader-election-rolebinding
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/manager-config.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/manager-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-manager-config
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-manager-role
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -208,7 +208,7 @@ metadata:
   name: constellation-operator-manager-rolebinding
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/metrics-reader-rbac.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/metrics-reader-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-metrics-reader
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/metrics-service.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     control-plane: controller-manager
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/proxy-rbac.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/proxy-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-proxy-role
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ metadata:
   name: constellation-operator-proxy-rolebinding
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -18,7 +18,7 @@ metadata:
   labels:
     control-plane: controller-manager
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/leader-election-rbac.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/leader-election-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -49,7 +49,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/metrics-reader-rbac.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/metrics-reader-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/metrics-service.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/metrics-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     control-plane: controller-manager
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/proxy-rbac.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/proxy-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/selfsigned-issuer.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/selfsigned-issuer.yaml
@@ -4,7 +4,7 @@ metadata:
   name: node-maintenance-operator-selfsigned-issuer
   namespace: testNamespace
   labels:
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/serving-cert.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/serving-cert.yaml
@@ -4,7 +4,7 @@ metadata:
   name: node-maintenance-operator-serving-cert
   namespace: testNamespace
   labels:
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/validating-webhook-configuration.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/validating-webhook-configuration.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: testNamespace/node-maintenance-operator-serving-cert
   labels:
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/webhook-service.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/webhook-service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-controller-manager
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -16,7 +16,7 @@ metadata:
   namespace: testNamespace
   labels:
     control-plane: controller-manager
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/leader-election-rbac.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/leader-election-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-leader-election-role
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -47,7 +47,7 @@ metadata:
   name: constellation-operator-leader-election-rolebinding
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/manager-config.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/manager-config.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-manager-config
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-manager-role
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -208,7 +208,7 @@ metadata:
   name: constellation-operator-manager-rolebinding
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/metrics-reader-rbac.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/metrics-reader-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-metrics-reader
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/metrics-service.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/metrics-service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     control-plane: controller-manager
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/proxy-rbac.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/proxy-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: constellation-operator-proxy-role
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -28,7 +28,7 @@ metadata:
   name: constellation-operator-proxy-rolebinding
   namespace: testNamespace
   labels:
-    helm.sh/chart: constellation-operator-2.5.0
+    helm.sh/chart: constellation-operator-0.0.0
     app.kubernetes.io/name: constellation-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/deployment.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -18,7 +18,7 @@ metadata:
   labels:
     control-plane: controller-manager
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/leader-election-rbac.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/leader-election-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -49,7 +49,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -117,7 +117,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/metrics-reader-rbac.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/metrics-reader-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/metrics-service.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/metrics-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     control-plane: controller-manager
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/proxy-rbac.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/proxy-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm
@@ -30,7 +30,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/selfsigned-issuer.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/selfsigned-issuer.yaml
@@ -4,7 +4,7 @@ metadata:
   name: node-maintenance-operator-selfsigned-issuer
   namespace: testNamespace
   labels:
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/serving-cert.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/serving-cert.yaml
@@ -4,7 +4,7 @@ metadata:
   name: node-maintenance-operator-serving-cert
   namespace: testNamespace
   labels:
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/validating-webhook-configuration.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/validating-webhook-configuration.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     cert-manager.io/inject-ca-from: testNamespace/node-maintenance-operator-serving-cert
   labels:
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm

--- a/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/webhook-service.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/webhook-service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: testNamespace
   labels:
     node-maintenance-operator: ""
-    helm.sh/chart: node-maintenance-operator-2.5.0
+    helm.sh/chart: node-maintenance-operator-0.0.0
     app.kubernetes.io/name: node-maintenance-operator
     app.kubernetes.io/instance: testRelease
     app.kubernetes.io/managed-by: Helm


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Cmake produces a new pseudoversion whenever `cmake` is run. This version is used to set `PROJECT_VERSION`, unless `PROJECT_VERSION` is set to a version other than `0.0.0`. The release pipeline already overwrites `PROJECT_VERSION`, thus this change does not interfere with the pipeline. Another commit is created when merging changes from a release branch to main that resets `PROJECT_VERSION` to `0.0.0`.
- Use the CLI's current version to set the helm chart versions. This allows us to test upgrades to an arbitrary development build more easily. And we don't have to update chart versions manually. Since we currently don't publish the charts standalone it does not make sense to version them independently from the CLI imo.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
