### PR TITLE
cli: allow existing config for IAM creation without --generate-config

### DIFF
--- a/cli/internal/cmd/iamcreate.go
+++ b/cli/internal/cmd/iamcreate.go
@@ -198,7 +198,7 @@ func (c *iamCreator) create(ctx context.Context) error {
 	}
 	c.log.Debugf("Using flags: %+v", flags)
 
-	if err := c.checkWorkingDir(); err != nil {
+	if err := c.checkWorkingDir(flags); err != nil {
 		return err
 	}
 
@@ -281,12 +281,14 @@ func (c *iamCreator) parseFlagsAndSetupConfig() (iamFlags, error) {
 }
 
 // checkWorkingDir checks if the current working directory already contains a Terraform dir or a Constellation config file.
-func (c *iamCreator) checkWorkingDir() error {
+func (c *iamCreator) checkWorkingDir(flags iamFlags) error {
 	if _, err := c.fileHandler.Stat(constants.TerraformIAMWorkingDir); err == nil {
-		return fmt.Errorf("the current working directory already contains the %s directory. Please run the command in a different directory", constants.TerraformIAMWorkingDir)
+		return fmt.Errorf("the current working directory already contains the Terraform workspace directory %q. Please run the command in a different directory or destroy the existing workspace", constants.TerraformIAMWorkingDir)
 	}
-	if _, err := c.fileHandler.Stat(constants.ConfigFilename); err == nil {
-		return fmt.Errorf("the current working directory already contains the %s file. Please run the command in a different directory", constants.ConfigFilename)
+	if flags.generateConfig {
+		if _, err := c.fileHandler.Stat(flags.configPath); err == nil {
+			return fmt.Errorf("the flag --generate-config is set, but %q already exists. Please either run the command in a different directory, define another config path, or delete or move the existing configuration", flags.configPath)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Allow constellation-conf.yaml to exist when --generate-config is not set
- Fix the check itself: the stat check checks against the _constant_, but the config path is a possibly dynamic flag

Technically Go error strings are also kinda inconvenient to give actionable advice (due to capitalitation rules and the rule that they are not supposed to end with punctation), but let's not change this as part of this PR since there are also other parts in the code where we already do this.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
