### PR TITLE
image: update to Linux 6.1.14 for Azure

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -18,7 +18,7 @@ export CONSOLE_MOTD = $(AUTOLOGIN)
 csps := aws qemu gcp azure
 certs := $(PKI)/PK.cer $(PKI)/KEK.cer $(PKI)/db.cer
 
-AZURE_FIXED_KERNEL_RPMS := kernel-6.1.12-200.fc37.x86_64.rpm kernel-core-6.1.12-200.fc37.x86_64.rpm kernel-modules-6.1.12-200.fc37.x86_64.rpm
+AZURE_FIXED_KERNEL_RPMS := kernel-6.1.14-200.fc37.x86_64.rpm kernel-core-6.1.14-200.fc37.x86_64.rpm kernel-modules-6.1.14-200.fc37.x86_64.rpm
 GCP_FIXED_KERNEL_RPMS := kernel-5.19.17-300.fc37.x86_64.rpm kernel-core-5.19.17-300.fc37.x86_64.rpm kernel-modules-5.19.17-300.fc37.x86_64.rpm
 PREBUILT_RPMS_AZURE := $(addprefix prebuilt/rpms/azure/,$(AZURE_FIXED_KERNEL_RPMS))
 PREBUILT_RPMS_GCP := $(addprefix prebuilt/rpms/gcp/,$(GCP_FIXED_KERNEL_RPMS))
@@ -37,7 +37,7 @@ prebuilt/rpms/gcp/%.rpm:
 prebuilt/rpms/azure/%.rpm:
 	@echo "Downloading $*"
 	@mkdir -p $(@D)
-	@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/6.1.12/200.fc37/x86_64/$*.rpm
+	@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/6.1.14/200.fc37/x86_64/$*.rpm
 
 mkosi.output.%/fedora~37/image.raw: mkosi.files/mkosi.%.conf inject-bins inject-certs
 	mkosi --config mkosi.files/mkosi.$*.conf \

--- a/image/mkosi.files/mkosi.azure.conf
+++ b/image/mkosi.files/mkosi.azure.conf
@@ -8,6 +8,6 @@ BasePackages=conditional
 Packages=systemd
          util-linux
          dracut
-         prebuilt/rpms/azure/kernel-6.1.12-200.fc37.x86_64.rpm
-         prebuilt/rpms/azure/kernel-core-6.1.12-200.fc37.x86_64.rpm
-         prebuilt/rpms/azure/kernel-modules-6.1.12-200.fc37.x86_64.rpm
+         prebuilt/rpms/azure/kernel-6.1.14-200.fc37.x86_64.rpm
+         prebuilt/rpms/azure/kernel-core-6.1.14-200.fc37.x86_64.rpm
+         prebuilt/rpms/azure/kernel-modules-6.1.14-200.fc37.x86_64.rpm


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use Linux 6.1.14 for Azure
Still doesn't contain a backported version of the MTRR revert commit included with 6.2.0, so we can still take "the latest and greatest" patch release in before the upcoming release.