### PR TITLE
cli: set constellation uid and role as instance metadata of OpenStack  instances

### DIFF
--- a/cli/internal/terraform/terraform/openstack/main.tf
+++ b/cli/internal/terraform/terraform/openstack/main.tf
@@ -135,6 +135,7 @@ module "instance_group_control_plane" {
     openstack_compute_secgroup_v2.vpc_secgroup.id,
   ]
   tags              = local.tags
+  uid               = local.uid
   disk_size         = var.state_disk_size
   availability_zone = var.availability_zone
   network_id        = openstack_networking_network_v2.vpc_network.id
@@ -149,6 +150,7 @@ module "instance_group_worker" {
   image_id       = openstack_images_image_v2.constellation_os_image.image_id
   flavor_id      = var.flavor_id
   tags           = local.tags
+  uid            = local.uid
   security_groups = [
     openstack_compute_secgroup_v2.vpc_secgroup.id,
   ]

--- a/cli/internal/terraform/terraform/openstack/modules/instance_group/main.tf
+++ b/cli/internal/terraform/terraform/openstack/modules/instance_group/main.tf
@@ -48,6 +48,8 @@ resource "openstack_compute_instance_v2" "instance_group_member" {
     delete_on_termination = true
   }
   metadata = {
+    constellation-role             = local.role_dashed
+    constellation-uid              = var.uid
     constellation-init-secret-hash = var.init_secret_hash
   }
   availability_zone_hints = var.availability_zone

--- a/cli/internal/terraform/terraform/openstack/modules/instance_group/variables.tf
+++ b/cli/internal/terraform/terraform/openstack/modules/instance_group/variables.tf
@@ -3,6 +3,11 @@ variable "name" {
   description = "Base name of the instance group."
 }
 
+variable "uid" {
+  type        = string
+  description = "Unique ID of the Constellation."
+}
+
 variable "role" {
   type        = string
   description = "The role of the instance group."


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: set constellation uid and role as instance metadata of OpenStack  instances

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
