### PR TITLE
constants: make VersionInfo readonly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ add_custom_target(upgrade-agent ALL
 # cli
 #
 add_custom_target(cli ALL
-  CGO_ENABLED=0 go build -o ${CMAKE_BINARY_DIR}/constellation -tags='${CLI_BUILD_TAGS}' -ldflags "-buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}"
+  CGO_ENABLED=0 go build -o ${CMAKE_BINARY_DIR}/constellation -tags='${CLI_BUILD_TAGS}' -ldflags "-buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.versionInfo=${PROJECT_VERSION}"
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/cli
   BYPRODUCTS constellation
 )
@@ -73,7 +73,7 @@ add_custom_target(debugd ALL
 # cdbg
 #
 add_custom_target(cdbg ALL
-  CGO_ENABLED=0 go build -o ${CMAKE_BINARY_DIR}/cdbg -buildvcs=false -ldflags "-buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}"
+  CGO_ENABLED=0 go build -o ${CMAKE_BINARY_DIR}/cdbg -buildvcs=false -ldflags "-buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.versionInfo=${PROJECT_VERSION}"
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/debugd/cmd/cdbg
   BYPRODUCTS cdbg
 )

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -28,19 +28,19 @@ FROM build AS build-bootstrapper
 WORKDIR /constellation/bootstrapper/
 
 ARG PROJECT_VERSION
-RUN --mount=type=cache,target=/root/.cache/go-build go build -o bootstrapper -tags=disable_tpm_simulator -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/bootstrapper/
+RUN --mount=type=cache,target=/root/.cache/go-build go build -o bootstrapper -tags=disable_tpm_simulator -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.versionInfo=${PROJECT_VERSION}" ./cmd/bootstrapper/
 
 FROM build AS build-disk-mapper
 WORKDIR /constellation/disk-mapper/
 
 ARG PROJECT_VERSION
-RUN --mount=type=cache,target=/root/.cache/go-build go build -o disk-mapper -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/
+RUN --mount=type=cache,target=/root/.cache/go-build go build -o disk-mapper -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.versionInfo=${PROJECT_VERSION}" ./cmd/
 
 FROM build AS build-upgrade-agent
 WORKDIR /constellation/upgrade-agent/
 
 ARG PROJECT_VERSION
-RUN --mount=type=cache,target=/root/.cache/go-build go build -o upgrade-agent -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/
+RUN --mount=type=cache,target=/root/.cache/go-build go build -o upgrade-agent -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.versionInfo=${PROJECT_VERSION}" ./cmd/
 
 FROM scratch AS bootstrapper
 COPY --from=build-bootstrapper /constellation/bootstrapper/bootstrapper /

--- a/bootstrapper/cmd/bootstrapper/run.go
+++ b/bootstrapper/cmd/bootstrapper/run.go
@@ -32,7 +32,7 @@ func run(issuer atls.Issuer, tpm vtpm.TPMOpenFunc, fileHandler file.Handler,
 ) {
 	defer cloudLogger.Close()
 
-	log.With(zap.String("version", constants.VersionInfo)).Infof("Starting bootstrapper")
+	log.With(zap.String("version", constants.VersionInfo())).Infof("Starting bootstrapper")
 	cloudLogger.Disclose("bootstrapper started running...")
 
 	uuid, err := getDiskUUID()

--- a/cli/internal/cmd/configfetchmeasurements_test.go
+++ b/cli/internal/cmd/configfetchmeasurements_test.go
@@ -250,7 +250,6 @@ func TestConfigFetchMeasurements(t *testing.T) {
 
 			gcpConfig := defaultConfigWithExpectedMeasurements(t, config.Default(), cloudprovider.GCP)
 			gcpConfig.Image = "v999.999.999"
-			constants.VersionInfo = "v999.999.999"
 
 			err := fileHandler.WriteYAML(constants.ConfigFilename, gcpConfig, file.OptMkdirAll)
 			require.NoError(err)

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -79,7 +79,7 @@ func runUpgradeCheck(cmd *cobra.Command, args []string) error {
 			client:         http.DefaultClient,
 			rekor:          rekor,
 			flags:          flags,
-			cliVersion:     compatibility.EnsurePrefixV(constants.VersionInfo),
+			cliVersion:     compatibility.EnsurePrefixV(constants.VersionInfo()),
 			log:            log,
 		},
 		log: log,

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -233,7 +233,6 @@ func TestUpgradeCheck(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			constants.VersionInfo = "v0.0.0"
 			fileHandler := file.NewHandler(afero.NewMemMapFs())
 			cfg := defaultConfigWithExpectedMeasurements(t, config.Default(), tc.csp)
 			require.NoError(fileHandler.WriteYAML(tc.flags.configPath, cfg))

--- a/cli/internal/cmd/version.go
+++ b/cli/internal/cmd/version.go
@@ -34,7 +34,7 @@ func runVersion(cmd *cobra.Command, args []string) {
 
 	commit, state, date, goVersion, compiler, platform := parseBuildInfo(buildInfo)
 
-	cmd.Printf("Version:\t%s (%s)\n", constants.VersionInfo, constants.VersionBuild)
+	cmd.Printf("Version:\t%s (%s)\n", constants.VersionInfo(), constants.VersionBuild)
 	cmd.Printf("GitCommit:\t%s\n", commit)
 	cmd.Printf("GitTreeState:\t%s\n", state)
 	cmd.Printf("BuildDate:\t%s\n", date)

--- a/cli/internal/cmd/version_test.go
+++ b/cli/internal/cmd/version_test.go
@@ -28,7 +28,7 @@ func TestVersionCmd(t *testing.T) {
 
 	s, err := io.ReadAll(b)
 	assert.NoError(err)
-	assert.Contains(string(s), constants.VersionInfo)
+	assert.Contains(string(s), constants.VersionInfo())
 }
 
 func TestParseBuildInfo(t *testing.T) {

--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -149,11 +149,11 @@ func (c *Client) upgradeRelease(
 		values = loader.loadCertManagerValues()
 	case conOperatorsReleaseName:
 		// ensure that the operator chart has the same version as the CLI
-		updateVersions(chart, compatibility.EnsurePrefixV(constants.VersionInfo))
+		updateVersions(chart, compatibility.EnsurePrefixV(constants.VersionInfo()))
 		values, err = loader.loadOperatorsValues()
 	case conServicesReleaseName:
 		// ensure that the services chart has the same version as the CLI
-		updateVersions(chart, compatibility.EnsurePrefixV(constants.VersionInfo))
+		updateVersions(chart, compatibility.EnsurePrefixV(constants.VersionInfo()))
 		values, err = loader.loadConstellationServicesValues()
 	default:
 		return fmt.Errorf("invalid release name: %s", releaseName)

--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -283,7 +283,7 @@ func (i *ChartLoader) loadOperators() (helm.Release, error) {
 		return helm.Release{}, fmt.Errorf("loading operators chart: %w", err)
 	}
 
-	updateVersions(chart, compatibility.EnsurePrefixV(constants.VersionInfo))
+	updateVersions(chart, compatibility.EnsurePrefixV(constants.VersionInfo()))
 
 	values, err := i.loadOperatorsValues()
 	if err != nil {
@@ -370,7 +370,7 @@ func (i *ChartLoader) loadConstellationServices() (helm.Release, error) {
 		return helm.Release{}, fmt.Errorf("loading constellation-services chart: %w", err)
 	}
 
-	updateVersions(chart, compatibility.EnsurePrefixV(constants.VersionInfo))
+	updateVersions(chart, compatibility.EnsurePrefixV(constants.VersionInfo()))
 
 	values, err := i.loadConstellationServicesValues()
 	if err != nil {

--- a/disk-mapper/cmd/main.go
+++ b/disk-mapper/cmd/main.go
@@ -57,7 +57,7 @@ func main() {
 
 	flag.Parse()
 	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity))
-	log.With(zap.String("version", constants.VersionInfo), zap.String("cloudProvider", *csp)).
+	log.With(zap.String("version", constants.VersionInfo()), zap.String("cloudProvider", *csp)).
 		Infof("Starting disk-mapper")
 
 	// set up metadata API and quote issuer for aTLS connections

--- a/internal/compatibility/compatibility.go
+++ b/internal/compatibility/compatibility.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"golang.org/x/mod/semver"
 )
 
@@ -93,8 +92,8 @@ func IsValidUpgrade(a, b string) error {
 }
 
 // BinaryWith tests that this binarie's version is greater or equal than some target version, but not further away than one minor version.
-func BinaryWith(target string) error {
-	binaryVersion := EnsurePrefixV(constants.VersionInfo)
+func BinaryWith(binaryVersion, target string) error {
+	binaryVersion = EnsurePrefixV(binaryVersion)
 	target = EnsurePrefixV(target)
 	if !semver.IsValid(binaryVersion) || !semver.IsValid(target) {
 		return ErrSemVer

--- a/internal/compatibility/compatibility_test.go
+++ b/internal/compatibility/compatibility_test.go
@@ -9,7 +9,6 @@ package compatibility
 import (
 	"testing"
 
-	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -144,8 +143,7 @@ func TestBinaryWith(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			constants.VersionInfo = tc.cli
-			err := BinaryWith(tc.target)
+			err := BinaryWith(tc.cli, tc.target)
 			if tc.wantError {
 				assert.Error(err)
 				return

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -279,7 +279,7 @@ func Default() *Config {
 		Version:             Version2,
 		Image:               defaultImage,
 		Name:                defaultName,
-		MicroserviceVersion: compatibility.EnsurePrefixV(constants.VersionInfo),
+		MicroserviceVersion: compatibility.EnsurePrefixV(constants.VersionInfo()),
 		KubernetesVersion:   string(versions.Default),
 		StateDiskSizeGB:     30,
 		DebugCluster:        toPtr(false),

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -9,7 +9,6 @@ package config
 import (
 	"testing"
 
-	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -39,8 +38,7 @@ func TestValidateVersionCompatibilityHelper(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			constants.VersionInfo = tc.cli
-			err := validateVersionCompatibilityHelper("Image", tc.target)
+			err := validateVersionCompatibilityHelper(tc.cli, "Image", tc.target)
 			if tc.wantError {
 				assert.Error(err)
 				return

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -182,5 +182,10 @@ const (
 	CDNAPIPrefix = "constellation/v1"
 )
 
-// VersionInfo is the version of a binary. Left as a separate variable to allow override during build.
-var VersionInfo = "0.0.0"
+// VersionInfo returns the version of a binary.
+func VersionInfo() string {
+	return versionInfo
+}
+
+// versionInfo is the version of a binary. Left as a separate variable to allow override during build.
+var versionInfo = "0.0.0"

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -70,7 +70,7 @@ func (v Semver) IsUpgradeTo(other Semver) bool {
 // CompatibleWithBinary returns if a version is compatible version of the current built binary.
 // It checks if the version of the binary is equal or greater than the current version and allows a drift of at most one minor version.
 func (v Semver) CompatibleWithBinary() bool {
-	binaryVersion, err := NewSemver(constants.VersionInfo)
+	binaryVersion, err := NewSemver(constants.VersionInfo())
 	if err != nil {
 		return false
 	}

--- a/joinservice/Dockerfile
+++ b/joinservice/Dockerfile
@@ -23,7 +23,7 @@ RUN rm -rf ./hack/
 
 WORKDIR /constellation/joinservice
 ARG PROJECT_VERSION=0.0.0
-RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -o join-service -trimpath -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -o join-service -trimpath -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.versionInfo=${PROJECT_VERSION}" ./cmd/
 
 # Use gcr.io/distroless/static here since we need CA certificates to be installed for aTLS operations on GCP.
 FROM gcr.io/distroless/static@sha256:5b2fa762fb6ebf66ff88ae1db2dc4ad8fc6ddf1164477297dfac1a09f20e7339 as release

--- a/joinservice/cmd/main.go
+++ b/joinservice/cmd/main.go
@@ -45,7 +45,7 @@ func main() {
 	flag.Parse()
 
 	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity))
-	log.With(zap.String("version", constants.VersionInfo), zap.String("cloudProvider", *provider)).
+	log.With(zap.String("version", constants.VersionInfo()), zap.String("cloudProvider", *provider)).
 		Infof("Constellation Node Join Service")
 
 	handler := file.NewHandler(afero.NewOsFs())

--- a/keyservice/Dockerfile
+++ b/keyservice/Dockerfile
@@ -24,7 +24,7 @@ RUN rm -rf ./hack/
 RUN mkdir -p /constellation/build
 WORKDIR /constellation/keyservice/cmd
 ARG PROJECT_VERSION=0.0.0
-RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -o /constellation/build/keyservice -trimpath -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}"
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -o /constellation/build/keyservice -trimpath -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.versionInfo=${PROJECT_VERSION}"
 
 FROM gcr.io/distroless/static:nonroot@sha256:9ec950c09380320e203369982691eb821df6a6974edf9f4bb8e661d4b77b9d99 as release
 COPY --from=build /constellation/build/keyservice /keyservice

--- a/keyservice/cmd/main.go
+++ b/keyservice/cmd/main.go
@@ -33,7 +33,7 @@ func main() {
 	flag.Parse()
 	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity))
 
-	log.With(zap.String("version", constants.VersionInfo)).
+	log.With(zap.String("version", constants.VersionInfo())).
 		Infof("Constellation Key Management Service")
 
 	// read master secret and salt

--- a/verify/Dockerfile
+++ b/verify/Dockerfile
@@ -23,7 +23,7 @@ RUN rm -rf ./hack/
 
 WORKDIR /constellation/verify
 ARG PROJECT_VERSION=0.0.0
-RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -o verify-service -trimpath -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.VersionInfo=${PROJECT_VERSION}" ./cmd/
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 go build -o verify-service -trimpath -buildvcs=false -ldflags "-s -w -buildid='' -X github.com/edgelesssys/constellation/v2/internal/constants.versionInfo=${PROJECT_VERSION}" ./cmd/
 
 FROM scratch AS release
 COPY --from=build /constellation/verify/verify-service /verify

--- a/verify/cmd/main.go
+++ b/verify/cmd/main.go
@@ -29,7 +29,7 @@ func main() {
 	flag.Parse()
 	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity))
 
-	log.With(zap.String("version", constants.VersionInfo), zap.String("cloudProvider", *provider)).
+	log.With(zap.String("version", constants.VersionInfo()), zap.String("cloudProvider", *provider)).
 		Infof("Constellation Verification Service")
 
 	var issuer server.AttestationIssuer


### PR DESCRIPTION
The variable VersionInfo is supposed to be set by `go build -X ...` during link time but should not be modified at runtime. This change ensures the underlying var is private and can only be accessed by a public getter.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- constants: make VersionInfo readonly

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
