### PR TITLE
cli: restructure `upgrade apply` to change NodeVersion in one request

### DIFF
--- a/cli/internal/cloudcmd/clients.go
+++ b/cli/internal/cloudcmd/clients.go
@@ -16,6 +16,11 @@ import (
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
+// imageFetcher gets an image reference from the versionsapi.
+type imageFetcher interface {
+	FetchReference(ctx context.Context, config *config.Config) (string, error)
+}
+
 type terraformClient interface {
 	PrepareWorkspace(path string, input terraform.Variables) error
 	CreateCluster(ctx context.Context) (terraform.CreateOutput, error)
@@ -29,10 +34,6 @@ type terraformClient interface {
 type libvirtRunner interface {
 	Start(ctx context.Context, containerName, imageName string) error
 	Stop(ctx context.Context) error
-}
-
-type imageFetcher interface {
-	FetchReference(ctx context.Context, config *config.Config) (string, error)
 }
 
 type rawDownloader interface {

--- a/internal/compatibility/compatibility.go
+++ b/internal/compatibility/compatibility.go
@@ -41,12 +41,12 @@ func NewInvalidUpgradeError(from string, to string, innerErr error) *InvalidUpgr
 }
 
 // Unwrap returns the inner error, which is nil in this case.
-func (e *InvalidUpgradeError) Unwrap() error {
+func (e InvalidUpgradeError) Unwrap() error {
 	return e.innerErr
 }
 
 // Error returns the String representation of this error.
-func (e *InvalidUpgradeError) Error() string {
+func (e InvalidUpgradeError) Error() string {
 	return fmt.Sprintf("upgrading from %s to %s is not a valid upgrade: %s", e.from, e.to, e.innerErr)
 }
 


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Applies the updated NodeVersion object with one request instead of two. This makes sure that the first request does not accidentially put the cluster into a "updgrade in progress" status. Which would lead users to having to run apply twice.
- Testing manually

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
