### PR TITLE
oid: add alternative string representations for attestation variants

### DIFF
--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -400,14 +400,14 @@ func TestAttestation(t *testing.T) {
 	netDialer := testdialer.NewBufconnDialer()
 	newDialer := func(v *cloudcmd.Validator) *dialer.Dialer {
 		validator := &testValidator{
-			Getter: oid.QEMU{},
+			Getter: oid.QEMUVTPM{},
 			pcrs:   v.PCRS(),
 		}
 		return dialer.New(nil, validator, netDialer)
 	}
 
 	issuer := &testIssuer{
-		Getter: oid.QEMU{},
+		Getter: oid.QEMUVTPM{},
 		pcrs: map[uint32][]byte{
 			0: bytes.Repeat([]byte{0xFF}, 32),
 			1: bytes.Repeat([]byte{0xFF}, 32),

--- a/internal/attestation/aws/issuer.go
+++ b/internal/attestation/aws/issuer.go
@@ -23,7 +23,7 @@ import (
 
 // Issuer for AWS TPM attestation.
 type Issuer struct {
-	oid.AWS
+	oid.AWSNitroTPM
 	*vtpm.Issuer
 }
 

--- a/internal/attestation/aws/validator.go
+++ b/internal/attestation/aws/validator.go
@@ -23,7 +23,7 @@ import (
 
 // Validator for AWS TPM attestation.
 type Validator struct {
-	oid.AWS
+	oid.AWSNitroTPM
 	*vtpm.Validator
 	getDescribeClient func(context.Context, string) (awsMetadataAPI, error)
 }

--- a/internal/attestation/azure/snp/issuer.go
+++ b/internal/attestation/azure/snp/issuer.go
@@ -51,7 +51,7 @@ func GetIDKeyDigest(open vtpm.TPMOpenFunc) ([]byte, error) {
 
 // Issuer for Azure TPM attestation.
 type Issuer struct {
-	oid.AzureSNP
+	oid.AzureSEVSNP
 	*vtpm.Issuer
 }
 

--- a/internal/attestation/azure/snp/validator.go
+++ b/internal/attestation/azure/snp/validator.go
@@ -38,7 +38,7 @@ const (
 
 // Validator for Azure confidential VM attestation.
 type Validator struct {
-	oid.AzureSNP
+	oid.AzureSEVSNP
 	*vtpm.Validator
 }
 

--- a/internal/attestation/gcp/issuer.go
+++ b/internal/attestation/gcp/issuer.go
@@ -20,7 +20,7 @@ import (
 
 // Issuer for GCP confidential VM attestation.
 type Issuer struct {
-	oid.GCP
+	oid.GCPSEVES
 	*vtpm.Issuer
 }
 

--- a/internal/attestation/gcp/validator.go
+++ b/internal/attestation/gcp/validator.go
@@ -30,7 +30,7 @@ import (
 
 // Validator for GCP confidential VM attestation.
 type Validator struct {
-	oid.GCP
+	oid.GCPSEVES
 	*vtpm.Validator
 }
 

--- a/internal/attestation/qemu/issuer.go
+++ b/internal/attestation/qemu/issuer.go
@@ -16,7 +16,7 @@ import (
 
 // Issuer for qemu TPM attestation.
 type Issuer struct {
-	oid.QEMU
+	oid.QEMUVTPM
 	*vtpm.Issuer
 }
 

--- a/internal/attestation/qemu/validator.go
+++ b/internal/attestation/qemu/validator.go
@@ -17,7 +17,7 @@ import (
 
 // Validator for QEMU VM attestation.
 type Validator struct {
-	oid.QEMU
+	oid.QEMUVTPM
 	*vtpm.Validator
 }
 

--- a/internal/oid/oid.go
+++ b/internal/oid/oid.go
@@ -25,11 +25,31 @@ package oid
 
 import (
 	"encoding/asn1"
+	"errors"
 )
 
 // Getter returns an ASN.1 Object Identifier.
 type Getter interface {
 	OID() asn1.ObjectIdentifier
+}
+
+// FromString returns the OID for the given string.
+func FromString(oid string) (Getter, error) {
+	switch oid {
+	case dummy:
+		return Dummy{}, nil
+	case awsNitroTPM:
+		return AWS{}, nil
+	case gcpSEVES:
+		return GCP{}, nil
+	case azureSEVSNP:
+		return AzureSNP{}, nil
+	case azureTL:
+		return AzureTrustedLaunch{}, nil
+	case qemuVTPM:
+		return QEMU{}, nil
+	}
+	return nil, errors.New("unknown OID")
 }
 
 // Dummy OID for testing.
@@ -40,12 +60,22 @@ func (Dummy) OID() asn1.ObjectIdentifier {
 	return asn1.ObjectIdentifier{1, 3, 9900, 1, 1}
 }
 
+// String returns the string representation of the OID.
+func (Dummy) String() string {
+	return dummy
+}
+
 // AWS holds the AWS OID.
 type AWS struct{}
 
 // OID returns the struct's object identifier.
 func (AWS) OID() asn1.ObjectIdentifier {
 	return asn1.ObjectIdentifier{1, 3, 9900, 2, 1}
+}
+
+// String returns the string representation of the OID.
+func (AWS) String() string {
+	return awsNitroTPM
 }
 
 // GCP holds the GCP OID.
@@ -56,12 +86,22 @@ func (GCP) OID() asn1.ObjectIdentifier {
 	return asn1.ObjectIdentifier{1, 3, 9900, 3, 1}
 }
 
+// String returns the string representation of the OID.
+func (GCP) String() string {
+	return gcpSEVES
+}
+
 // AzureSNP holds the OID for Azure SNP CVMs.
 type AzureSNP struct{}
 
 // OID returns the struct's object identifier.
 func (AzureSNP) OID() asn1.ObjectIdentifier {
 	return asn1.ObjectIdentifier{1, 3, 9900, 4, 1}
+}
+
+// String returns the string representation of the OID.
+func (AzureSNP) String() string {
+	return azureSEVSNP
 }
 
 // AzureTrustedLaunch holds the OID for Azure TrustedLaunch VMs.
@@ -72,6 +112,11 @@ func (AzureTrustedLaunch) OID() asn1.ObjectIdentifier {
 	return asn1.ObjectIdentifier{1, 3, 9900, 4, 2}
 }
 
+// String returns the string representation of the OID.
+func (AzureTrustedLaunch) String() string {
+	return azureTL
+}
+
 // QEMU holds the QEMU OID.
 type QEMU struct{}
 
@@ -79,3 +124,17 @@ type QEMU struct{}
 func (QEMU) OID() asn1.ObjectIdentifier {
 	return asn1.ObjectIdentifier{1, 3, 9900, 5, 1}
 }
+
+// String returns the string representation of the OID.
+func (QEMU) String() string {
+	return qemuVTPM
+}
+
+const (
+	dummy       = "dummy"
+	awsNitroTPM = "aws-nitrotpm"
+	gcpSEVES    = "gcp-seves"
+	azureSEVSNP = "azure-sevsnp"
+	azureTL     = "azure-trustedlaunch"
+	qemuVTPM    = "qemu-vtpm"
+)

--- a/internal/oid/oid.go
+++ b/internal/oid/oid.go
@@ -39,15 +39,15 @@ func FromString(oid string) (Getter, error) {
 	case dummy:
 		return Dummy{}, nil
 	case awsNitroTPM:
-		return AWS{}, nil
+		return AWSNitroTPM{}, nil
 	case gcpSEVES:
-		return GCP{}, nil
+		return GCPSEVES{}, nil
 	case azureSEVSNP:
-		return AzureSNP{}, nil
-	case azureTL:
+		return AzureSEVSNP{}, nil
+	case azureTrustedLaunch:
 		return AzureTrustedLaunch{}, nil
 	case qemuVTPM:
-		return QEMU{}, nil
+		return QEMUVTPM{}, nil
 	}
 	return nil, errors.New("unknown OID")
 }
@@ -65,42 +65,42 @@ func (Dummy) String() string {
 	return dummy
 }
 
-// AWS holds the AWS OID.
-type AWS struct{}
+// AWSNitroTPM holds the AWS nitro TPM OID.
+type AWSNitroTPM struct{}
 
 // OID returns the struct's object identifier.
-func (AWS) OID() asn1.ObjectIdentifier {
+func (AWSNitroTPM) OID() asn1.ObjectIdentifier {
 	return asn1.ObjectIdentifier{1, 3, 9900, 2, 1}
 }
 
 // String returns the string representation of the OID.
-func (AWS) String() string {
+func (AWSNitroTPM) String() string {
 	return awsNitroTPM
 }
 
-// GCP holds the GCP OID.
-type GCP struct{}
+// GCPSEVES holds the GCP SEV-ES OID.
+type GCPSEVES struct{}
 
 // OID returns the struct's object identifier.
-func (GCP) OID() asn1.ObjectIdentifier {
+func (GCPSEVES) OID() asn1.ObjectIdentifier {
 	return asn1.ObjectIdentifier{1, 3, 9900, 3, 1}
 }
 
 // String returns the string representation of the OID.
-func (GCP) String() string {
+func (GCPSEVES) String() string {
 	return gcpSEVES
 }
 
-// AzureSNP holds the OID for Azure SNP CVMs.
-type AzureSNP struct{}
+// AzureSEVSNP holds the OID for Azure SNP CVMs.
+type AzureSEVSNP struct{}
 
 // OID returns the struct's object identifier.
-func (AzureSNP) OID() asn1.ObjectIdentifier {
+func (AzureSEVSNP) OID() asn1.ObjectIdentifier {
 	return asn1.ObjectIdentifier{1, 3, 9900, 4, 1}
 }
 
 // String returns the string representation of the OID.
-func (AzureSNP) String() string {
+func (AzureSEVSNP) String() string {
 	return azureSEVSNP
 }
 
@@ -114,27 +114,27 @@ func (AzureTrustedLaunch) OID() asn1.ObjectIdentifier {
 
 // String returns the string representation of the OID.
 func (AzureTrustedLaunch) String() string {
-	return azureTL
+	return azureTrustedLaunch
 }
 
-// QEMU holds the QEMU OID.
-type QEMU struct{}
+// QEMUVTPM holds the QEMUVTPM OID.
+type QEMUVTPM struct{}
 
 // OID returns the struct's object identifier.
-func (QEMU) OID() asn1.ObjectIdentifier {
+func (QEMUVTPM) OID() asn1.ObjectIdentifier {
 	return asn1.ObjectIdentifier{1, 3, 9900, 5, 1}
 }
 
 // String returns the string representation of the OID.
-func (QEMU) String() string {
+func (QEMUVTPM) String() string {
 	return qemuVTPM
 }
 
 const (
-	dummy       = "dummy"
-	awsNitroTPM = "aws-nitrotpm"
-	gcpSEVES    = "gcp-seves"
-	azureSEVSNP = "azure-sevsnp"
-	azureTL     = "azure-trustedlaunch"
-	qemuVTPM    = "qemu-vtpm"
+	dummy              = "dummy"
+	awsNitroTPM        = "aws-nitro-tpm"
+	gcpSEVES           = "gcp-sev-es"
+	azureSEVSNP        = "azure-sev-snp"
+	azureTrustedLaunch = "azure-trustedlaunch"
+	qemuVTPM           = "qemu-vtpm"
 )


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- oid: add alternative string representations for attestation variants

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

This is the first part of a small refactor. aTLS Issuers/Validators should be selectable on a finer level than just the CSP. Adding this now simplifies adoption of more attestation variants in the future.
Next step is adding a kernel cmdline parameter indicating the wanted attestation variant using one of the string constants added here.


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
