### PR TITLE
image: set attestation variant on kernel cmdline

### DIFF
--- a/image/mkosi.files/mkosi.aws.conf
+++ b/image/mkosi.files/mkosi.aws.conf
@@ -1,3 +1,3 @@
 [Output]
-KernelCommandLine=constel.csp=aws
+KernelCommandLine=constel.csp=aws constel.attestation-variant=aws-nitro-tpm
 OutputDirectory=mkosi.output.aws

--- a/image/mkosi.files/mkosi.azure.conf
+++ b/image/mkosi.files/mkosi.azure.conf
@@ -1,5 +1,5 @@
 [Output]
-KernelCommandLine=constel.csp=azure
+KernelCommandLine=constel.csp=azure constel.attestation-variant=azure-sev-snp
 OutputDirectory=mkosi.output.azure
 
 # replace kernel

--- a/image/mkosi.files/mkosi.gcp.conf
+++ b/image/mkosi.files/mkosi.gcp.conf
@@ -1,5 +1,5 @@
 [Output]
-KernelCommandLine=constel.csp=gcp
+KernelCommandLine=constel.csp=gcp constel.attestation-variant=gcp-sev-es
 OutputDirectory=mkosi.output.gcp
 
 # replace kernel

--- a/image/mkosi.files/mkosi.openstack.conf
+++ b/image/mkosi.files/mkosi.openstack.conf
@@ -1,5 +1,5 @@
 [Output]
-KernelCommandLine=constel.csp=openstack mem_encrypt=on kvm_amd.sev=1 module_blacklist=qemu_fw_cfg console=tty0 console=ttyS0
+KernelCommandLine=constel.csp=openstack constel.attestation-variant=qemu-vtpm mem_encrypt=on kvm_amd.sev=1 module_blacklist=qemu_fw_cfg console=tty0 console=ttyS0
 OutputDirectory=mkosi.output.openstack
 
 [Content]

--- a/image/mkosi.files/mkosi.qemu.conf
+++ b/image/mkosi.files/mkosi.qemu.conf
@@ -1,5 +1,5 @@
 [Output]
-KernelCommandLine=constel.csp=qemu
+KernelCommandLine=constel.csp=qemu constel.attestation-variant=qemu-vtpm
 OutputDirectory=mkosi.output.qemu
 
 [Content]

--- a/image/mkosi.skeleton/usr/lib/systemd/system/configure-constel-csp.service
+++ b/image/mkosi.skeleton/usr/lib/systemd/system/configure-constel-csp.service
@@ -4,6 +4,7 @@ Description=Configures constellation cloud service provider environment variable
 [Service]
 Type=oneshot
 ExecStart=/bin/bash -c "CSP=$(< /proc/cmdline tr  ' ' '\n' | grep constel.csp | sed 's/constel.csp=//'); echo CONSTEL_CSP=$CSP >> /run/constellation.env"
+ExecStart=/bin/bash -c "ATTESTATION=$(< /proc/cmdline tr  ' ' '\n' | grep constel.attestation-variant | sed 's/constel.attestation-variant=//'); echo CONSTEL_ATTESTATION_VARIANT=$ATTESTATION >> /run/constellation.env"
 RemainAfterExit=yes
 
 [Install]


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- image: set attestation variant on kernel cmdline

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info

Follow up for #1322. OS images should pass the desired attestation variant via the kernel cmdline. This is measured at boot and can be used in the future to select the aTLS Issuer/Validator.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)