### PR TITLE
cli: log grpc connection state for init call

### DIFF
--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -15,6 +15,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"sync"
 	"text/tabwriter"
 	"time"
 
@@ -237,7 +238,15 @@ func (d *initDoer) Do(ctx context.Context) error {
 		return fmt.Errorf("dialing init server: %w", err)
 	}
 	defer conn.Close()
-	d.logGRPCStateChanges(ctx, conn)
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	grpcStateLogCtx, grpcStateLogCancel := context.WithCancel(ctx)
+	defer grpcStateLogCancel()
+	wg.Add(1)
+	d.logGRPCStateChanges(grpcStateLogCtx, &wg, conn)
+
 	protoClient := initproto.NewAPIClient(conn)
 	d.log.Debugf("Created protoClient")
 	resp, err := protoClient.Init(ctx, d.req)
@@ -248,8 +257,9 @@ func (d *initDoer) Do(ctx context.Context) error {
 	return nil
 }
 
-func (d *initDoer) logGRPCStateChanges(ctx context.Context, conn *grpc.ClientConn) {
+func (d *initDoer) logGRPCStateChanges(ctx context.Context, wg *sync.WaitGroup, conn *grpc.ClientConn) {
 	go func() {
+		defer wg.Done()
 		state := conn.GetState()
 		d.log.Debugf("Connection state started as %s", state)
 		for ; state != connectivity.Ready && conn.WaitForStateChange(ctx, state); state = conn.GetState() {


### PR DESCRIPTION
This is a measure to detect cases where an aTLS handshake is performed but the long running call is interrupted, leading to a retry of the init call. Whenever the grpc connection state reaches ready, we know that the aTLS handshake has succeeded:

> READY: The channel has successfully established a connection all the way through TLS handshake (or equivalent) and protocol-level (HTTP/2, etc) handshaking, and all subsequent attempt to communicate have succeeded (or are pending without any known failure).

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: log grpc connection state for init call

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

Logs look like this:

```
[...]
2023-03-02T12:27:18+01:00       DEBUG   cmd/init.go:181 Sending initialization request
2023-03-02T12:27:18+01:00       DEBUG   cmd/init.go:217 Making initialization call, doer is &{dialer:0xc0012e09c0 endpoint:10.42.1.100:9000 req:0xc0006b3e00 resp:<nil> log:0xc00081c0f8}
2023-03-02T12:27:18+01:00       DEBUG   cmd/init.go:242 Created protoClient
2023-03-02T12:27:18+01:00       DEBUG   cmd/init.go:254 Connection state started as CONNECTING
2023-03-02T12:27:19+01:00       DEBUG   cmd/init.go:256 Connection state changed to CONNECTING
2023-03-02T12:27:19+01:00       DEBUG   cmd/init.go:259 Connection ready
2023-03-02T12:29:36+01:00       DEBUG   cmd/init.go:192 Initialization request succeeded
2023-03-02T12:29:36+01:00       DEBUG   cmd/init.go:193 Writing Constellation ID file
Your Constellation cluster was successfully initialized.
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
