### PR TITLE
cli: add `--kubernetes` flag to `iam create` (when used with `--create-config`)

### DIFF
--- a/cli/internal/cmd/iamcreate.go
+++ b/cli/internal/cmd/iamcreate.go
@@ -59,7 +59,7 @@ func newIAMCreateCmd() *cobra.Command {
 
 	cmd.PersistentFlags().Bool("yes", false, "create the IAM configuration without further confirmation")
 	cmd.PersistentFlags().Bool("generate-config", false, "automatically generate a configuration file and fill in the required fields")
-	cmd.PersistentFlags().StringP("kubernetes", "k", semver.MajorMinor(config.Default().KubernetesVersion), "Kubernetes version to use in format MAJOR.MINOR, only usable in combination with --generate-config")
+	cmd.PersistentFlags().StringP("kubernetes", "k", semver.MajorMinor(config.Default().KubernetesVersion), "Kubernetes version to use in format MAJOR.MINOR - only usable in combination with --generate-config")
 
 	cmd.AddCommand(newIAMCreateAWSCmd())
 	cmd.AddCommand(newIAMCreateAzureCmd())


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Put K8s version parsing logic into an own function in configgenerate.go
- Add `--kubernetes` as a separate flag for IAM create using the new function (only respected when `--generate-config` is set)

This is mainly here to get both "config generate" and "iam create --generate-config" on feature parity. After v2.6.0, I hope we can refactor this a bit more to unify both config generation functions.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
