### PR TITLE
ci: set timestamp format correctly for opensearch

### DIFF
--- a/.github/actions/e2e_benchmark/evaluate/parse.py
+++ b/.github/actions/e2e_benchmark/evaluate/parse.py
@@ -68,13 +68,17 @@ def main() -> None:
     knb_results = knb.evaluate(knb_path)
     fio_results = fio.evaluate(fio_path)
 
+    # Get timestamp
+    now = datetime.now()
+    timestamp = now.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
     combined_results = {'metadata': {
                             'github.sha': commit_hash,
                             'github.ref-name': commit_ref,
                             'github.actor': actor,
                             'github.workflow': workflow,
-                            'created': str(datetime.now()),
                         },
+                        '@timestamp': str(timestamp),
                         'provider': ext_provider_name,
                         'fio': {}, 
                         'knb': {}}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Change the timestamp format in the benchmark results sent to opensearch
- Allows Open search to parse and display the value correctly

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
