### PR TITLE
cli: upgrade libtpms in libvirt container

### DIFF
--- a/cli/internal/libvirt/Dockerfile
+++ b/cli/internal/libvirt/Dockerfile
@@ -7,8 +7,10 @@ RUN dnf -y update && \
     swtpm \
     swtpm-tools \
     libvirt-client && \
+    dnf upgrade --enablerepo=updates-testing --refresh --advisory=FEDORA-2023-c487bde4b4 -y && \
     dnf remove -y python-setuptools && \
     dnf clean all
+# TODO(malt3): remove advisory FEDORA-2023-c487bde4b4 upgrade for libtpms to libtpms-0.9.6-1.fc37.x86_64 once it is in stable
 
 # Prevent cgroup issues on Fedora and configure libvirt
 RUN echo "cgroup_controllers = []" >> /etc/libvirt/qemu.conf && \


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: upgrade libtpms in libvirt container

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

I tested this locally and it works (mini constellation still works and the container includes a fixed version of libtpms).
We also need to rebuild and bump the image in versions.go before the release @derpsteb 

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
