### PR TITLE
deps: manually upgrade libvirt container for upcoming release

### DIFF
--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -89,7 +89,7 @@ const (
 	// QEMUMetadataImage image of QEMU metadata api service.
 	QEMUMetadataImage = "ghcr.io/edgelesssys/constellation/qemu-metadata-api:v2.6.0-pre.0.20230228093604-90ed4701788f@sha256:db97a869391567415c436581345696fdbde572caee385a1b7fea40ced5c00528" // renovate:container
 	// LibvirtImage image that provides libvirt.
-	LibvirtImage = "ghcr.io/edgelesssys/constellation/libvirt:v2.2.0@sha256:81ddc30cd679a95379e94e2f154861d9112bcabfffa96330c09a4917693f7cce" // renovate:container
+	LibvirtImage = "ghcr.io/edgelesssys/constellation/libvirt:v2.6.0@sha256:4e221138b1747ce367d4332d2d191def9a49069317fdde569a82b414ef66f95e" // renovate:container
 
 	// LogstashImage is the container image of logstash, used for log collection by debugd.
 	LogstashImage = "ghcr.io/edgelesssys/constellation/logstash-debugd:v2.5.0-pre.0.20230120132332-a31d79e9cb71@sha256:17f8555581d8916d8121c6ce00f85974e62df55898a890c9855e830856c8cdf7" // renovate:container


### PR DESCRIPTION
The libvirt container is currently not automatically upgraded (it still had version v2.2.0 before this change). To ensure we update libvirt for this release, we manually upgrade the libvirt container image.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- deps: manually upgrade libvirt container for upcoming release

### Related issue
- #1338
- https://kb.cert.org/vuls/id/782720


### Additional info

We can either merge this into main before creating the release branch or cherry pick this into the release branch.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
