### PR TITLE
ci: store additional data in bench results

### DIFF
--- a/.github/actions/e2e_benchmark/evaluate/evaluators/fio.py
+++ b/.github/actions/e2e_benchmark/evaluate/evaluators/fio.py
@@ -33,4 +33,6 @@ def evaluate(log_path) -> Dict[str, Dict[str, float]]:
             raise Exception(
                 f"Error: Unexpected fio test: {test['jobname']}"
             )
+    # Get volume size. Format is 400Gi.
+    result['volumesize'] = int(fio[0]['Raw']['size'][:-2])
     return result

--- a/.github/actions/e2e_benchmark/evaluate/evaluators/knb.py
+++ b/.github/actions/e2e_benchmark/evaluate/evaluators/knb.py
@@ -18,8 +18,9 @@ def evaluate(log_path) -> Dict[str, Dict[str, float]]:
     data = knb['data']
     result = {'pod2pod': {}, 'pod2svc': {}}
     result['pod2pod']['tcp_bw_mbit'] = float(data['pod2pod']['tcp']['bandwidth'])
-    result['pod2pod']['upd_bw_mbit'] = float(data['pod2pod']['udp']['bandwidth'])
+    result['pod2pod']['udp_bw_mbit'] = float(data['pod2pod']['udp']['bandwidth'])
     result['pod2svc']['tcp_bw_mbit'] = float(data['pod2svc']['tcp']['bandwidth'])
-    result['pod2svc']['upd_bw_mbit'] = float(data['pod2svc']['udp']['bandwidth'])
+    result['pod2svc']['udp_bw_mbit'] = float(data['pod2svc']['udp']['bandwidth'])
+    result['mtu'] = int(data['mtu'])
 
     return result


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Store MTU and volume size as part of the benchmark results
- Fix typo in udp fields

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
