### PR TITLE
ci: move aws iam create test to less utilized zone

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -170,7 +170,7 @@ runs:
       uses: ./.github/actions/constellation_iam_create
       with:
         cloudProvider: ${{ inputs.cloudProvider }}
-        awsZone: eu-central-1a
+        awsZone: eu-central-1c
         awsPrefix: e2e_${{ github.run_id }}_${{ github.run_attempt }}
         azureRegion: northeurope
         azureResourceGroup: e2e_${{ github.run_id }}_${{ github.run_attempt }}_rg


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: move aws iam create test to less utilized zone


### Related issue
- https://github.com/edgelesssys/constellation/actions/runs/4345520863/jobs/7602473882

### Additional info

The zone `eu-central-1a` is often at capacity when it comes to our requested instance type. To reduce the failure rate of e2e tests, move tests to a different zone instead.

Error from terraform:

```
Error: waiting for Auto Scaling Group (constell-e5aec073-worker) capacity satisfied: 1 error occurred:
	* Scaling activity (f8e61aea-c168-31a4-af97-3460028473c3): Failed: We currently do not have sufficient m6a.xlarge capacity in the Availability Zone you requested (eu-central-1a). Our system will be working on provisioning additional capacity. You can currently get m6a.xlarge capacity by not specifying an Availability Zone in your request or choosing eu-central-1b, eu-central-1c. Launching EC2 instance failed.
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
