### PR TITLE
image: add systemd-boot as explicit dependency

### DIFF
--- a/image/mkosi.conf.d/secure-boot-tpm.conf
+++ b/image/mkosi.conf.d/secure-boot-tpm.conf
@@ -5,4 +5,5 @@ Packages=
            sbsigntools,
            efitools,
            mokutil,
-           tpm2-tools
+           tpm2-tools,
+           systemd-boot-unsigned,


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- image: add systemd-boot as explicit dependency

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

Fedora's systemd package now does not bundle systemd-boot anymore, so we have to install it explicitly: https://bodhi.fedoraproject.org/updates/FEDORA-2023-f72fbc711a.

[Testrun](https://github.com/edgelesssys/constellation/actions/runs/4352383126)

Otherwise, `bootctl install` will fail:

```
  ‣    Installing boot loader…
  Failed to open "/usr/lib/systemd/boot/efi": No such file or directory
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
