### PR TITLE
attestation: create issuer based on kernel cmd line

### DIFF
--- a/internal/attestation/azure/azure.go
+++ b/internal/attestation/azure/azure.go
@@ -18,19 +18,3 @@ Constellation supports multiple attestation technologies on Azure.
     Basic TPM attestation.
 */
 package azure
-
-import (
-	"github.com/edgelesssys/constellation/v2/internal/atls"
-	"github.com/edgelesssys/constellation/v2/internal/attestation/azure/snp"
-	"github.com/edgelesssys/constellation/v2/internal/attestation/azure/trustedlaunch"
-	"github.com/edgelesssys/constellation/v2/internal/attestation/vtpm"
-)
-
-// NewIssuer returns an SNP issuer if it can successfully read the idkeydigest from the TPM.
-// Otherwise returns a Trusted Launch issuer.
-func NewIssuer(log vtpm.AttestationLogger) atls.Issuer {
-	if _, err := snp.GetIDKeyDigest(vtpm.OpenVTPM); err == nil {
-		return snp.NewIssuer(log)
-	}
-	return trustedlaunch.NewIssuer(log)
-}

--- a/internal/attestation/choose/choose.go
+++ b/internal/attestation/choose/choose.go
@@ -36,7 +36,6 @@ func Issuer(variant oid.Getter, log vtpm.AttestationLogger) (atls.Issuer, error)
 		return qemu.NewIssuer(log), nil
 	case oid.Dummy{}:
 		return atls.NewFakeIssuer(oid.Dummy{}), nil
-	// TODO(malt3): Add Openstack Issuer
 	default:
 		return nil, fmt.Errorf("unknown attestation variant: %s", variant)
 	}
@@ -61,7 +60,6 @@ func Validator(
 		return qemu.NewValidator(measurements, log), nil
 	case oid.Dummy{}:
 		return atls.NewFakeValidator(oid.Dummy{}), nil
-	// TODO(malt3): Add Openstack Validator
 	default:
 		return nil, fmt.Errorf("unknown attestation variant: %s", variant)
 	}

--- a/internal/attestation/choose/choose.go
+++ b/internal/attestation/choose/choose.go
@@ -17,12 +17,12 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/attestation/idkeydigest"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/qemu"
-	"github.com/edgelesssys/constellation/v2/internal/logger"
+	"github.com/edgelesssys/constellation/v2/internal/attestation/vtpm"
 	"github.com/edgelesssys/constellation/v2/internal/oid"
 )
 
 // Issuer returns the issuer for the given variant.
-func Issuer(variant oid.Getter, log *logger.Logger) (atls.Issuer, error) {
+func Issuer(variant oid.Getter, log vtpm.AttestationLogger) (atls.Issuer, error) {
 	switch variant {
 	case oid.AWSNitroTPM{}:
 		return aws.NewIssuer(log), nil
@@ -46,7 +46,7 @@ func Issuer(variant oid.Getter, log *logger.Logger) (atls.Issuer, error) {
 func Validator(
 	variant oid.Getter, measurements measurements.M,
 	idKeyDigest idkeydigest.IDKeyDigests, enfoceIDKeyDigest bool,
-	log *logger.Logger,
+	log vtpm.AttestationLogger,
 ) (atls.Validator, error) {
 	switch variant {
 	case oid.AWSNitroTPM{}:

--- a/internal/attestation/choose/choose.go
+++ b/internal/attestation/choose/choose.go
@@ -1,0 +1,68 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package choose
+
+import (
+	"fmt"
+
+	"github.com/edgelesssys/constellation/v2/internal/atls"
+	"github.com/edgelesssys/constellation/v2/internal/attestation/aws"
+	"github.com/edgelesssys/constellation/v2/internal/attestation/azure/snp"
+	"github.com/edgelesssys/constellation/v2/internal/attestation/azure/trustedlaunch"
+	"github.com/edgelesssys/constellation/v2/internal/attestation/gcp"
+	"github.com/edgelesssys/constellation/v2/internal/attestation/idkeydigest"
+	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
+	"github.com/edgelesssys/constellation/v2/internal/attestation/qemu"
+	"github.com/edgelesssys/constellation/v2/internal/logger"
+	"github.com/edgelesssys/constellation/v2/internal/oid"
+)
+
+// Issuer returns the issuer for the given variant.
+func Issuer(variant oid.Getter, log *logger.Logger) (atls.Issuer, error) {
+	switch variant {
+	case oid.AWSNitroTPM{}:
+		return aws.NewIssuer(log), nil
+	case oid.AzureTrustedLaunch{}:
+		return snp.NewIssuer(log), nil
+	case oid.AzureSEVSNP{}:
+		return trustedlaunch.NewIssuer(log), nil
+	case oid.GCPSEVES{}:
+		return gcp.NewIssuer(log), nil
+	case oid.QEMUVTPM{}:
+		return qemu.NewIssuer(log), nil
+	case oid.Dummy{}:
+		return atls.NewFakeIssuer(oid.Dummy{}), nil
+	// TODO(malt3): Add Openstack Issuer
+	default:
+		return nil, fmt.Errorf("unknown attestation variant: %s", variant)
+	}
+}
+
+// Validator returns the validator for the given variant.
+func Validator(
+	variant oid.Getter, measurements measurements.M,
+	idKeyDigest idkeydigest.IDKeyDigests, enfoceIDKeyDigest bool,
+	log *logger.Logger,
+) (atls.Validator, error) {
+	switch variant {
+	case oid.AWSNitroTPM{}:
+		return aws.NewValidator(measurements, log), nil
+	case oid.AzureSEVSNP{}:
+		return snp.NewValidator(measurements, idKeyDigest, enfoceIDKeyDigest, log), nil
+	case oid.AzureTrustedLaunch{}:
+		return trustedlaunch.NewValidator(measurements, log), nil
+	case oid.GCPSEVES{}:
+		return gcp.NewValidator(measurements, log), nil
+	case oid.QEMUVTPM{}:
+		return qemu.NewValidator(measurements, log), nil
+	case oid.Dummy{}:
+		return atls.NewFakeValidator(oid.Dummy{}), nil
+	// TODO(malt3): Add Openstack Validator
+	default:
+		return nil, fmt.Errorf("unknown attestation variant: %s", variant)
+	}
+}

--- a/internal/attestation/choose/choose.go
+++ b/internal/attestation/choose/choose.go
@@ -27,9 +27,9 @@ func Issuer(variant oid.Getter, log *logger.Logger) (atls.Issuer, error) {
 	case oid.AWSNitroTPM{}:
 		return aws.NewIssuer(log), nil
 	case oid.AzureTrustedLaunch{}:
-		return snp.NewIssuer(log), nil
-	case oid.AzureSEVSNP{}:
 		return trustedlaunch.NewIssuer(log), nil
+	case oid.AzureSEVSNP{}:
+		return snp.NewIssuer(log), nil
 	case oid.GCPSEVES{}:
 		return gcp.NewIssuer(log), nil
 	case oid.QEMUVTPM{}:
@@ -51,10 +51,10 @@ func Validator(
 	switch variant {
 	case oid.AWSNitroTPM{}:
 		return aws.NewValidator(measurements, log), nil
-	case oid.AzureSEVSNP{}:
-		return snp.NewValidator(measurements, idKeyDigest, enfoceIDKeyDigest, log), nil
 	case oid.AzureTrustedLaunch{}:
 		return trustedlaunch.NewValidator(measurements, log), nil
+	case oid.AzureSEVSNP{}:
+		return snp.NewValidator(measurements, idKeyDigest, enfoceIDKeyDigest, log), nil
 	case oid.GCPSEVES{}:
 		return gcp.NewValidator(measurements, log), nil
 	case oid.QEMUVTPM{}:

--- a/internal/attestation/choose/choose_test.go
+++ b/internal/attestation/choose/choose_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package choose
+
+import (
+	"encoding/asn1"
+	"testing"
+
+	"github.com/edgelesssys/constellation/v2/internal/oid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIssuer(t *testing.T) {
+	testCases := map[string]struct {
+		variant oid.Getter
+		wantErr bool
+	}{
+		"aws-nitro-tpm": {
+			variant: oid.AWSNitroTPM{},
+		},
+		"azure-sev-snp": {
+			variant: oid.AzureSEVSNP{},
+		},
+		"azure-trusted-launch": {
+			variant: oid.AzureTrustedLaunch{},
+		},
+		"gcp-sev-es": {
+			variant: oid.GCPSEVES{},
+		},
+		"qemu-vtpm": {
+			variant: oid.QEMUVTPM{},
+		},
+		"dummy": {
+			variant: oid.Dummy{},
+		},
+		"unknown": {
+			variant: unknownVariant{},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			issuer, err := Issuer(tc.variant, nil)
+
+			if tc.wantErr {
+				assert.Error(err)
+				return
+			}
+			require.NoError(err)
+			assert.True(issuer.OID().Equal(tc.variant.OID()))
+		})
+	}
+}
+
+func TestValidator(t *testing.T) {
+	testCases := map[string]struct {
+		variant oid.Getter
+		wantErr bool
+	}{
+		"aws-nitro-tpm": {
+			variant: oid.AWSNitroTPM{},
+		},
+		"azure-sev-snp": {
+			variant: oid.AzureSEVSNP{},
+		},
+		"azure-trusted-launch": {
+			variant: oid.AzureTrustedLaunch{},
+		},
+		"gcp-sev-es": {
+			variant: oid.GCPSEVES{},
+		},
+		"qemu-vtpm": {
+			variant: oid.QEMUVTPM{},
+		},
+		"dummy": {
+			variant: oid.Dummy{},
+		},
+		"unknown": {
+			variant: unknownVariant{},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			validator, err := Validator(tc.variant, nil, nil, false, nil)
+
+			if tc.wantErr {
+				assert.Error(err)
+				return
+			}
+			require.NoError(err)
+			assert.True(validator.OID().Equal(tc.variant.OID()))
+		})
+	}
+}
+
+type unknownVariant struct{}
+
+func (unknownVariant) OID() asn1.ObjectIdentifier {
+	return asn1.ObjectIdentifier{1, 3, 9900, 9999, 9999}
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -31,6 +31,8 @@ const (
 	ConstellationSaltKey = "salt"
 	// ConstellationVerifyServiceUserData is the user data that the verification service includes in the attestation.
 	ConstellationVerifyServiceUserData = "VerifyService"
+	// AttestationVariant is the name of the environment variable that contains the attestation variant.
+	AttestationVariant = "CONSTEL_ATTESTATION_VARIANT"
 
 	//
 	// Ports.

--- a/verify/cmd/main.go
+++ b/verify/cmd/main.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 
 	"github.com/edgelesssys/constellation/v2/internal/attestation/aws"
-	"github.com/edgelesssys/constellation/v2/internal/attestation/azure"
+	"github.com/edgelesssys/constellation/v2/internal/attestation/azure/snp"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/gcp"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/qemu"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
@@ -39,7 +39,7 @@ func main() {
 	case cloudprovider.GCP:
 		issuer = gcp.NewIssuer(log)
 	case cloudprovider.Azure:
-		issuer = azure.NewIssuer(log)
+		issuer = snp.NewIssuer(log) // TODO: dynamic selection
 	case cloudprovider.QEMU:
 		issuer = qemu.NewIssuer(log)
 	default:


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Instead of relying on just the Cloud Provider to identify what Attestation Issuer we need to set up, we now use information from the Kernel command line to do so
- Add `choose.Issuer()` and `choose.Validator()` utility functions to create Issuer or Validator from a given oid

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Set up of Issuer for the VerifyService will be handled in a different PR
- Dynamic creation of Validators using `choose.Validator()` will be handled in a different PR

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
