### PR TITLE
cli: use registry.k8s.io instead of k8s.gcr.io (GCP CSI driver)

### DIFF
--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/values.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/values.yaml
@@ -1,22 +1,22 @@
 image:
   csiProvisioner:
-    repo: k8s.gcr.io/sig-storage/csi-provisioner
+    repo: registry.k8s.io/sig-storage/csi-provisioner
     tag: "v3.1.1"
     pullPolicy: IfNotPresent
   csiAttacher:
-    repo: k8s.gcr.io/sig-storage/csi-attacher
+    repo: registry.k8s.io/sig-storage/csi-attacher
     tag: "v3.5.0"
     pullPolicy: IfNotPresent
   csiResizer:
-    repo: k8s.gcr.io/sig-storage/csi-resizer
+    repo: registry.k8s.io/sig-storage/csi-resizer
     tag: "v1.5.0"
     pullPolicy: IfNotPresent
   csiSnapshotter:
-    repo: k8s.gcr.io/sig-storage/csi-snapshotter
+    repo: registry.k8s.io/sig-storage/csi-snapshotter
     tag: "v6.0.1"
     pullPolicy: IfNotPresent
   csiNodeRegistrar:
-    repo: k8s.gcr.io/sig-storage/csi-node-driver-registrar
+    repo: registry.k8s.io/sig-storage/csi-node-driver-registrar
     tag: "v2.5.1"
     pullPolicy: IfNotPresent
   gcepdDriver:


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: use registry.k8s.io instead of k8s.gcr.io
See: https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/

This shouldn't break any existing CLI release as long as the K8s team really only freezes the repository (versus actually shutting it down). But since it might trigger one of these fancy scanning tools on GCP that an outdated repository is used, let's update here.

@daniel-weisse Is it possible to also update the external CSI images without the driver breaking? I don't think these are tracked by Renovate, so we might also bump them is this wouldn't break anything.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
