### PR TITLE
bootstrapper: override Cilium MTU auto-detection on GCP (requires Cilium 1.13.0)

### DIFF
--- a/bootstrapper/internal/helm/helm.go
+++ b/bootstrapper/internal/helm/helm.go
@@ -179,9 +179,9 @@ func (h *Client) installCiliumGCP(ctx context.Context, kubectl k8sapi.Client, re
 	// But not sure if this will blow up in the future, so let's better ask the operating system instead of doing tricks.
 	hostMTU, err := getHostMTU(nodeIP, h.log)
 	if err != nil {
-		h.log.Warnf("Failed to determine MTU from host network interface, falling back to Cilium's auto-detection", zap.Error(err))
+		h.log.With(zap.Error(err)).Warnf("Failed to determine MTU from host network interface, falling back to Cilium's auto-detection")
 	} else {
-		h.log.Infof("Detected host MTU for Cilium", zap.Int("mtu", hostMTU))
+		h.log.With(zap.Int("mtu", hostMTU)).Infof("Detected host MTU for Cilium")
 	}
 
 	// configure pod network CIDR
@@ -274,7 +274,7 @@ func getHostMTU(nodeIP string, log *logger.Logger) (int, error) {
 
 		addrs, err := i.Addrs()
 		if err != nil {
-			log.Warnf("Failed to retrieve interface addresses", zap.String("interface", i.Name))
+			log.With(zap.String("interface", i.Name)).Warnf("Failed to retrieve interface addresses")
 			continue
 		}
 		for _, addr := range addrs {

--- a/bootstrapper/internal/helm/helm.go
+++ b/bootstrapper/internal/helm/helm.go
@@ -274,7 +274,7 @@ func getHostMTU(nodeIP string, log *logger.Logger) (int, error) {
 
 		addrs, err := i.Addrs()
 		if err != nil {
-			log.Warnf("Failed to retrieve interface address", zap.String("interface", i.Name))
+			log.Warnf("Failed to retrieve interface addresses", zap.String("interface", i.Name))
 			continue
 		}
 		for _, addr := range addrs {

--- a/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
@@ -240,6 +240,7 @@ func (k *KubernetesUtil) prepareControlPlaneForKonnectivity(ctx context.Context,
 type SetupPodNetworkInput struct {
 	CloudProvider        string
 	NodeName             string
+	NodeIP               string
 	FirstNodePodCIDR     string
 	SubnetworkPodCIDR    string
 	LoadBalancerEndpoint string

--- a/bootstrapper/internal/kubernetes/kubernetes.go
+++ b/bootstrapper/internal/kubernetes/kubernetes.go
@@ -175,6 +175,7 @@ func (k *KubeWrapper) InitCluster(
 	setupPodNetworkInput := k8sapi.SetupPodNetworkInput{
 		CloudProvider:        k.cloudProvider,
 		NodeName:             nodeName,
+		NodeIP:               nodeIP,
 		FirstNodePodCIDR:     nodePodCIDR,
 		SubnetworkPodCIDR:    subnetworkPodCIDR,
 		LoadBalancerEndpoint: controlPlaneEndpoint,


### PR DESCRIPTION
### Proposed change(s)
- override Cilium MTU auto-detection on GCP

This should fix the issues with benchmarking in the CI, where Cilium picks up the MTU from Podman.
On normal deployments this should not be an issue so far.

This requires Cilium 1.13.0 as the MTU value does not exist in Helm before, see: https://github.com/cilium/cilium/pull/20639

This workaround could be way easier by hardcoding the network interface to `ens3`. However, not sure if Google will ever change that in the future, so let's just to it the tedious way I presume. 

Draft for now since we need to upgrade to Cilium 1.13.0 first.

### Related issue
- Cilium's auto detection picks up the wrong device: https://github.com/cilium/cilium/issues/14339

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
