### PR TITLE
image: downgrade systemd to 251.11-2

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -18,8 +18,10 @@ export CONSOLE_MOTD = $(AUTOLOGIN)
 csps := aws azure gcp openstack qemu
 certs := $(PKI)/PK.cer $(PKI)/KEK.cer $(PKI)/db.cer
 
+SYSTEMD_FIXED_RPMS := systemd-251.11-2.fc37.x86_64.rpm systemd-libs-251.11-2.fc37.x86_64.rpm systemd-networkd-251.11-2.fc37.x86_64.rpm systemd-pam-251.11-2.fc37.x86_64.rpm systemd-resolved-251.11-2.fc37.x86_64.rpm systemd-udev-251.11-2.fc37.x86_64.rpm
 AZURE_FIXED_KERNEL_RPMS := kernel-6.1.14-200.fc37.x86_64.rpm kernel-core-6.1.14-200.fc37.x86_64.rpm kernel-modules-6.1.14-200.fc37.x86_64.rpm
 GCP_FIXED_KERNEL_RPMS := kernel-5.19.17-300.fc37.x86_64.rpm kernel-core-5.19.17-300.fc37.x86_64.rpm kernel-modules-5.19.17-300.fc37.x86_64.rpm
+PREBUILD_RPMS_SYSTEMD := $(addprefix prebuilt/rpms/systemd/,$(SYSTEMD_FIXED_RPMS))
 PREBUILT_RPMS_AZURE := $(addprefix prebuilt/rpms/azure/,$(AZURE_FIXED_KERNEL_RPMS))
 PREBUILT_RPMS_GCP := $(addprefix prebuilt/rpms/gcp/,$(GCP_FIXED_KERNEL_RPMS))
 
@@ -28,6 +30,11 @@ PREBUILT_RPMS_GCP := $(addprefix prebuilt/rpms/gcp/,$(GCP_FIXED_KERNEL_RPMS))
 all: $(csps)
 
 $(csps): %: mkosi.output.%/fedora~37/image.raw
+
+prebuilt/rpms/systemd/%.rpm:
+	@echo "Downloading $*"
+	@mkdir -p $(@D)
+	@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/systemd/251.11/2.fc37/x86_64/$*.rpm
 
 prebuilt/rpms/gcp/%.rpm:
 	@echo "Downloading $*"
@@ -53,7 +60,7 @@ mkosi.output.%/fedora~37/image.raw: mkosi.files/mkosi.%.conf inject-bins inject-
 	fi
 	@echo "Image is ready: $@"
 
-inject-bins: $(PREBUILT_RPMS_AZURE) $(PREBUILT_RPMS_GCP)
+inject-bins: $(PREBUILD_RPMS_SYSTEMD) $(PREBUILT_RPMS_AZURE) $(PREBUILT_RPMS_GCP)
 	mkdir -p $(MKOSI_EXTRA)/usr/bin
 	mkdir -p $(MKOSI_EXTRA)/usr/sbin
 	cp $(UPGRADE_AGENT_BINARY) $(MKOSI_EXTRA)/usr/bin/upgrade-agent

--- a/image/mkosi.conf.d/mkosi.conf
+++ b/image/mkosi.conf.d/mkosi.conf
@@ -20,5 +20,16 @@ SecureBootCertificate=pki/db.crt
 ImageId=constellation
 Output=image.raw
 
+[Content]
+BasePackages=conditional
+Packages=prebuilt/rpms/systemd/systemd-251.11-2.fc37.x86_64.rpm
+         prebuilt/rpms/systemd/systemd-libs-251.11-2.fc37.x86_64.rpm
+         prebuilt/rpms/systemd/systemd-networkd-251.11-2.fc37.x86_64.rpm
+         prebuilt/rpms/systemd/systemd-pam-251.11-2.fc37.x86_64.rpm
+         prebuilt/rpms/systemd/systemd-resolved-251.11-2.fc37.x86_64.rpm
+         prebuilt/rpms/systemd/systemd-udev-251.11-2.fc37.x86_64.rpm
+         util-linux
+         dracut
+
 [Host]
 QemuHeadless=yes

--- a/image/mkosi.conf.d/secure-boot-tpm.conf
+++ b/image/mkosi.conf.d/secure-boot-tpm.conf
@@ -6,4 +6,3 @@ Packages=
            efitools,
            mokutil,
            tpm2-tools,
-           systemd-boot-unsigned,

--- a/image/mkosi.files/mkosi.aws.conf
+++ b/image/mkosi.files/mkosi.aws.conf
@@ -1,3 +1,9 @@
 [Output]
 KernelCommandLine=constel.csp=aws constel.attestation-variant=aws-nitro-tpm
 OutputDirectory=mkosi.output.aws
+
+[Content]
+BasePackages=conditional
+Packages=kernel
+         kernel-core
+         kernel-modules

--- a/image/mkosi.files/mkosi.azure.conf
+++ b/image/mkosi.files/mkosi.azure.conf
@@ -5,9 +5,6 @@ OutputDirectory=mkosi.output.azure
 # replace kernel
 [Content]
 BasePackages=conditional
-Packages=systemd
-         util-linux
-         dracut
-         prebuilt/rpms/azure/kernel-6.1.14-200.fc37.x86_64.rpm
+Packages=prebuilt/rpms/azure/kernel-6.1.14-200.fc37.x86_64.rpm
          prebuilt/rpms/azure/kernel-core-6.1.14-200.fc37.x86_64.rpm
          prebuilt/rpms/azure/kernel-modules-6.1.14-200.fc37.x86_64.rpm

--- a/image/mkosi.files/mkosi.gcp.conf
+++ b/image/mkosi.files/mkosi.gcp.conf
@@ -5,9 +5,6 @@ OutputDirectory=mkosi.output.gcp
 # replace kernel
 [Content]
 BasePackages=conditional
-Packages=systemd
-         util-linux
-         dracut
-         prebuilt/rpms/gcp/kernel-5.19.17-300.fc37.x86_64.rpm
+Packages=prebuilt/rpms/gcp/kernel-5.19.17-300.fc37.x86_64.rpm
          prebuilt/rpms/gcp/kernel-core-5.19.17-300.fc37.x86_64.rpm
          prebuilt/rpms/gcp/kernel-modules-5.19.17-300.fc37.x86_64.rpm

--- a/image/mkosi.files/mkosi.openstack.conf
+++ b/image/mkosi.files/mkosi.openstack.conf
@@ -5,3 +5,7 @@ OutputDirectory=mkosi.output.openstack
 [Content]
 Autologin=yes
 Environment=CONSOLE_MOTD=true
+BasePackages=conditional
+Packages=kernel
+         kernel-core
+         kernel-modules

--- a/image/mkosi.files/mkosi.qemu.conf
+++ b/image/mkosi.files/mkosi.qemu.conf
@@ -5,3 +5,7 @@ OutputDirectory=mkosi.output.qemu
 [Content]
 Autologin=yes
 Environment=CONSOLE_MOTD=true
+BasePackages=conditional
+Packages=kernel
+         kernel-core
+         kernel-modules


### PR DESCRIPTION
We are noticing issues with dns on systemd 251.13. Downgrading systemd for now.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- image: downgrade systemd to 251.11-2

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info
- [Build pipeline](https://github.com/edgelesssys/constellation/actions/runs/4362258906)
- [e2e on azure](https://github.com/edgelesssys/constellation/actions/runs/4362759101)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
