### PR TITLE
image: print RTMR state upon boot (TDX)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -404,8 +404,6 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
-github.com/edgelesssys/go-tdx-qpl v0.0.0-20230223132449-90301bfa9f9f h1:btpBA17fEd3s24F4yzPUDMk714ANfmJr6O967P7hDaI=
-github.com/edgelesssys/go-tdx-qpl v0.0.0-20230223132449-90301bfa9f9f/go.mod h1:IC72qyykUIWl0ZmSk53L4xbLCFDBEGZVaujUmPQOEyw=
 github.com/edgelesssys/go-tdx-qpl v0.0.0-20230307140231-bb361f158928 h1:uQMmc/B1RGE2VeSsh/NqjRgEheqp1cjy8ELIDTFpaUw=
 github.com/edgelesssys/go-tdx-qpl v0.0.0-20230307140231-bb361f158928/go.mod h1:IC72qyykUIWl0ZmSk53L4xbLCFDBEGZVaujUmPQOEyw=
 github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaBNrHW5M=

--- a/hack/go.sum
+++ b/hack/go.sum
@@ -2123,8 +2123,8 @@ k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 h1:+70TFaan3hfJzs+7VK2o+O
 k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280/go.mod h1:+Axhij7bCpeqhklhUTe3xmOn6bWxolyZEeyaFpjGtl4=
 k8s.io/kubectl v0.26.0 h1:xmrzoKR9CyNdzxBmXV7jW9Ln8WMrwRK6hGbbf69o4T0=
 k8s.io/kubectl v0.26.0/go.mod h1:eInP0b+U9XUJWSYeU9XZnTA+cVYuWyl3iYPGtru0qhQ=
-k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5 h1:kmDqav+P+/5e1i9tFfHq1qcF3sOrDp+YEkVDAHu7Jwk=
-k8s.io/utils v0.0.0-20230220204549-a5ecb0141aa5/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20230209194617-a36077c30491 h1:r0BAOLElQnnFhE/ApUsg3iHdVYYPBjNSSOMowRZxxsY=
+k8s.io/utils v0.0.0-20230209194617-a36077c30491/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 libvirt.org/go/libvirt v1.8010.0 h1:q4UeuyzSp7GiYUB5T3ytzeXh41hp9JqNQu150NkO+7A=
 libvirt.org/go/libvirt v1.8010.0/go.mod h1:1WiFE8EjZfq+FCVog+rvr1yatKbKZ9FaFMZgEqxEJqQ=
 libvirt.org/go/libvirtxml v1.8009.0 h1:29wyVe4m08S3JBSJnMJ/0WCWWcq8Xl5zF5NIa2RtXdI=

--- a/hack/rtmr-reader/main.go
+++ b/hack/rtmr-reader/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"os"
+
+	"github.com/edgelesssys/go-tdx-qpl/tdx"
+)
+
+func main() {
+	tdxDevice, err := os.Open(tdx.GuestDevice)
+	if err != nil {
+		fmt.Println("error: cannot open TDX device:", err)
+		os.Exit(1)
+	}
+
+	measurements, err := tdx.ReadMeasurements(tdxDevice)
+	if err != nil {
+		fmt.Println("error: cannot read TDX measurements", err)
+		os.Exit(1)
+	}
+
+	// The intent is to make the output look the same as form tpm2_pcrread
+	// %8s = space padding (2 spaces for sha384, 4 spaces for MRTD/RTMR[i])
+	// %3s = alignment for "MRTD" to have the same length as "RTMR[i]"
+	fmt.Printf("%8s:\n", "sha384")
+	fmt.Printf("%8s%3s: 0x%s\n", "MRTD", "", hex.EncodeToString(measurements[0][:]))
+	for i := 0; i <= 3; i++ {
+		fmt.Printf("%8s[%d]: 0x%s\n", "RTMR", i, hex.EncodeToString(measurements[i+1][:]))
+	}
+}

--- a/image/Makefile
+++ b/image/Makefile
@@ -5,6 +5,7 @@ BOOTSTRAPPER_BINARY              ?= $(BASE_PATH)/../build/bootstrapper
 DISK_MAPPER_BINARY               ?= $(BASE_PATH)/../build/disk-mapper
 UPGRADE_AGENT_BINARY             ?= $(BASE_PATH)/../build/upgrade-agent
 DEBUGD_BINARY                    ?= $(BASE_PATH)/../build/debugd
+RTMR_READER_BINARY               ?= $(BASE_PATH)/../build/rtmr-reader
 PKI                              ?= $(BASE_PATH)/pki
 MKOSI_EXTRA                      ?= $(BASE_PATH)/mkosi.extra
 IMAGE_VERSION                    ?= v0.0.0
@@ -61,6 +62,7 @@ mkosi.output.%/fedora~37/image.raw: mkosi.files/mkosi.%.conf inject-bins inject-
 inject-bins: $(PREBUILT_RPMS_AZURE) $(PREBUILT_RPMS_GCP) $(PREBUILT_RPMS_QEMU)
 	mkdir -p $(MKOSI_EXTRA)/usr/bin
 	mkdir -p $(MKOSI_EXTRA)/usr/sbin
+	cp $(RTMR_READER_BINARY) $(MKOSI_EXTRA)/usr/bin/rtmr-reader
 	cp $(UPGRADE_AGENT_BINARY) $(MKOSI_EXTRA)/usr/bin/upgrade-agent
 	cp $(DISK_MAPPER_BINARY) $(MKOSI_EXTRA)/usr/sbin/disk-mapper
 	if [ "$(DEBUG)" = "true" ]; then \

--- a/image/mkosi.skeleton/usr/libexec/constellation-pcrs
+++ b/image/mkosi.skeleton/usr/libexec/constellation-pcrs
@@ -7,8 +7,10 @@
 # of the system and prints the message to the serial console
 
 main() {
-  pcr_state="$(tpm2_pcrread sha256)"
-  echo -e "PCR state:\n${pcr_state}\n" > /run/issue.d/35_constellation_pcrs.issue
+  if [ -e /dev/tpm0 ] || [ -e /dev/tpmrm0 ]; then
+    pcr_state="$(tpm2_pcrread sha256)"
+    echo -e "PCR state:\n${pcr_state}\n" > /run/issue.d/35_constellation_pcrs.issue
+  fi
   if [ -e /dev/tdx-guest ]; then
     rtmr_state="$(rtmr-reader)"
     echo -e "RTMR state:\n${rtmr_state}\n" >> /run/issue.d/35_constellation_pcrs.issue

--- a/image/mkosi.skeleton/usr/libexec/constellation-pcrs
+++ b/image/mkosi.skeleton/usr/libexec/constellation-pcrs
@@ -3,12 +3,16 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
-# This script reads the PCR state of the system
-# and prints the message to the serial console
+# This script reads the PCR and RTMR (Intel TDX) state
+# of the system and prints the message to the serial console
 
 main() {
   pcr_state="$(tpm2_pcrread sha256)"
   echo -e "PCR state:\n${pcr_state}\n" > /run/issue.d/35_constellation_pcrs.issue
+  if [ -e /dev/tdx-guest ]; then
+    rtmr_state="$(rtmr-reader)"
+    echo -e "RTMR state:\n${rtmr_state}\n" >> /run/issue.d/35_constellation_pcrs.issue
+  fi
 }
 
 main


### PR DESCRIPTION
### Proposed change(s)
- Create a new tool called rtmr-reader which prints the MRTD/initial RTMR state upon boot
- Only print PCRs when a TPM is present 

The format strings are weird because the output is supposed to mimic tpm2_tools (since they don't seem to use \t?).
Maybe could be simplified by just using spaces in strings.

Maybe later we can also only print either PCRs or RTMRs depending on what is set on the kernel command line.

Still misses CI integration to build the tool (due to GOPRIVATE). Draft for now?