### PR TITLE
deps: fix dependabot's security warnings

### DIFF
--- a/hack/go.mod
+++ b/hack/go.mod
@@ -37,7 +37,7 @@ replace (
 )
 
 require (
-	github.com/edgelesssys/constellation/v2 v2.5.2
+	github.com/edgelesssys/constellation/v2 v2.6.0
 	github.com/go-git/go-git/v5 v5.5.2
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2

--- a/operators/constellation-node-operator/go.mod
+++ b/operators/constellation-node-operator/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.1
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4 v4.1.0
-	github.com/edgelesssys/constellation/v2 v2.5.2
+	github.com/edgelesssys/constellation/v2 v2.6.0
 	github.com/edgelesssys/constellation/v2/3rdparty/node-maintenance-operator v0.0.0-00010101000000-000000000000
 	github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/api v0.0.0
 	github.com/googleapis/gax-go/v2 v2.7.0


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fixes Github's security warnings. Creating an updated in the dependabot interface failed for some reason.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
