### PR TITLE
cli: show available cli upgrades on upgrade check command

### DIFF
--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -64,6 +64,7 @@ go_library(
         "//internal/license",
         "//internal/logger",
         "//internal/retry",
+        "//internal/semver",
         "//internal/sigstore",
         "//internal/variant",
         "//internal/versions",

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -81,7 +81,7 @@ func runUpgradeCheck(cmd *cobra.Command, _ []string) error {
 			flags:          flags,
 			cliVersion:     compatibility.EnsurePrefixV(constants.VersionInfo()),
 			log:            log,
-			verFetcher:     fetcher.NewFetcher(),
+			versionsapi:    fetcher.NewFetcher(),
 		},
 		log: log,
 	}
@@ -251,7 +251,7 @@ type versionCollector struct {
 	client         *http.Client
 	rekor          rekorVerifier
 	flags          upgradeCheckFlags
-	verFetcher     versionFetcher
+	versionsapi    versionFetcher
 	cliVersion     string
 	log            debugLog
 }
@@ -453,7 +453,7 @@ func (v *versionUpgrade) buildString() (string, error) {
 		return result.String(), nil
 	}
 
-	result.WriteString("No upgrades available with this CLI.\nNewer versions may be available at: https://github.com/edgelesssys/constellation/releases\n")
+	result.WriteString("No upgrades available with this CLI.\n")
 
 	return result.String(), nil
 }
@@ -567,7 +567,7 @@ func (v *versionCollector) newCompatibleCLIVersions(ctx context.Context, current
 		Base:        "v2",
 		Kind:        versionsapi.VersionKindCLI,
 	}
-	minorList, err := v.verFetcher.FetchVersionList(ctx, list)
+	minorList, err := v.versionsapi.FetchVersionList(ctx, list)
 	if err != nil {
 		return nil, fmt.Errorf("listing minor versions: %w", err)
 	}
@@ -585,7 +585,7 @@ func (v *versionCollector) newCompatibleCLIVersions(ctx context.Context, current
 			Base:        version,
 			Kind:        versionsapi.VersionKindCLI,
 		}
-		patchList, err := v.verFetcher.FetchVersionList(ctx, list)
+		patchList, err := v.versionsapi.FetchVersionList(ctx, list)
 		if err != nil {
 			return nil, fmt.Errorf("listing minor versions: %w", err)
 		}
@@ -604,7 +604,7 @@ func (v *versionCollector) newCompatibleCLIVersions(ctx context.Context, current
 			Stream:  v.flags.stream,
 			Version: version,
 		}
-		info, err := v.verFetcher.FetchCLIInfo(ctx, req)
+		info, err := v.versionsapi.FetchCLIInfo(ctx, req)
 		if err != nil {
 			return nil, fmt.Errorf("fetching CLI info: %w", err)
 		}

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -145,7 +145,7 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 		return err
 	}
 
-	supported, err := u.collect.supportedVersions(cmd.Context(), csp, current.image, current.k8s)
+	supported, err := u.collect.supportedVersions(cmd.Context(), current.image, current.k8s)
 	if err != nil {
 		return err
 	}
@@ -236,10 +236,10 @@ func filterK8sUpgrades(currentVersion string, newVersions []string) []string {
 
 type collector interface {
 	currentVersions(ctx context.Context) (currentVersionInfo, error)
-	supportedVersions(ctx context.Context, csp cloudprovider.Provider, version, currentK8sVersion string) (supportedVersionInfo, error)
-	newImages(ctx context.Context, version string, csp cloudprovider.Provider) ([]versionsapi.Version, error)
+	supportedVersions(ctx context.Context, version, currentK8sVersion string) (supportedVersionInfo, error)
+	newImages(ctx context.Context, version string) ([]versionsapi.Version, error)
 	newMeasurements(ctx context.Context, csp cloudprovider.Provider, images []versionsapi.Version) (map[string]measurements.M, error)
-	newerVersions(ctx context.Context, currentVersion string, allowedVersions []string) ([]versionsapi.Version, error)
+	newerVersions(ctx context.Context, allowedVersions []string) ([]versionsapi.Version, error)
 	newCompatibleCLIVersions(ctx context.Context, currentKubernetesVersion string) ([]string, error)
 }
 
@@ -311,13 +311,13 @@ type supportedVersionInfo struct {
 }
 
 // supportedVersions returns slices of supported versions.
-func (v *versionCollector) supportedVersions(ctx context.Context, csp cloudprovider.Provider, version, currentK8sVersion string) (supportedVersionInfo, error) {
+func (v *versionCollector) supportedVersions(ctx context.Context, version, currentK8sVersion string) (supportedVersionInfo, error) {
 	k8sVersions := versions.SupportedK8sVersions()
 	serviceVersion, err := helm.AvailableServiceVersions()
 	if err != nil {
 		return supportedVersionInfo{}, fmt.Errorf("loading service versions: %w", err)
 	}
-	imageVersions, err := v.newImages(ctx, version, csp)
+	imageVersions, err := v.newImages(ctx, version)
 	if err != nil {
 		return supportedVersionInfo{}, fmt.Errorf("loading image versions: %w", err)
 	}

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -586,7 +586,7 @@ func (v *versionCollector) newCLIVersions(ctx context.Context, currentKubernetes
 	}
 	minorList, err := v.versionsapi.FetchVersionList(ctx, list)
 	if err != nil {
-		return nil, fmt.Errorf("listing minor versions: %w", err)
+		return nil, fmt.Errorf("listing major versions: %w", err)
 	}
 
 	var patchVersions []string

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -576,12 +576,16 @@ type versionFetcher interface {
 }
 
 // newCLIVersions returns a list of versions of the CLI which are a valid upgrade.
-func (v *versionCollector) newCLIVersions(ctx context.Context, currentKubernetesVersion string) ([]string, error) {
+func (v *versionCollector) newCLIVersions(ctx context.Context) ([]string, error) {
+	cliVersion, err := conSemver.New(constants.VersionInfo())
+	if err != nil {
+		return nil, fmt.Errorf("parsing current CLI version: %w", err)
+	}
 	list := versionsapi.List{
 		Ref:         v.flags.ref,
 		Stream:      v.flags.stream,
 		Granularity: versionsapi.GranularityMajor,
-		Base:        "v2",
+		Base:        fmt.Sprintf("v%d", cliVersion.Major),
 		Kind:        versionsapi.VersionKindCLI,
 	}
 	minorList, err := v.versionsapi.FetchVersionList(ctx, list)

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -162,7 +162,7 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 	}
 
 	newKubernetes := filterK8sUpgrades(current.k8s, supported.k8s)
-	sort.Strings(newKubernetes)
+	semver.Sort(newKubernetes)
 
 	supported.image = filterImageUpgrades(current.image, supported.image)
 	newImages, err := u.collect.newMeasurements(cmd.Context(), csp, supported.image)
@@ -609,6 +609,8 @@ func (v *versionCollector) newCompatibleCLIVersions(ctx context.Context, current
 			}
 		}
 	}
+
+	semver.Sort(compatibleVersions)
 
 	return compatibleVersions, nil
 }

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -239,6 +239,7 @@ type collector interface {
 	newImages(ctx context.Context, version string, csp cloudprovider.Provider) ([]versionsapi.Version, error)
 	newMeasurements(ctx context.Context, csp cloudprovider.Provider, images []versionsapi.Version) (map[string]measurements.M, error)
 	newerVersions(ctx context.Context, currentVersion string, allowedVersions []string) ([]versionsapi.Version, error)
+	newCompatibleCLIVersions(ctx context.Context, currentKubernetesVersion string) ([]string, error)
 }
 
 type versionCollector struct {

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -604,7 +604,7 @@ func (v *versionCollector) newCLIVersions(ctx context.Context, currentKubernetes
 		}
 		patchList, err := v.versionsapi.FetchVersionList(ctx, list)
 		if err != nil {
-			return nil, fmt.Errorf("listing minor versions: %w", err)
+			return nil, fmt.Errorf("listing minor versions for major version %s: %w", version, err)
 		}
 		patchVersions = append(patchVersions, patchList.Versions...)
 	}

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -24,6 +24,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/kubernetes/kubectl"
+	conSemver "github.com/edgelesssys/constellation/v2/internal/semver"
 	"github.com/edgelesssys/constellation/v2/internal/sigstore"
 	"github.com/edgelesssys/constellation/v2/internal/versions"
 	"github.com/edgelesssys/constellation/v2/internal/versionsapi"
@@ -241,7 +242,7 @@ type collector interface {
 	newImages(ctx context.Context, version string) ([]versionsapi.Version, error)
 	newMeasurements(ctx context.Context, csp cloudprovider.Provider, images []versionsapi.Version) (map[string]measurements.M, error)
 	newerVersions(ctx context.Context, allowedVersions []string) ([]versionsapi.Version, error)
-	newCLIVersions(ctx context.Context, currentKubernetesVersion string) ([]string, error)
+	newCLIVersions(ctx context.Context) ([]string, error)
 	filterCompatibleCLIVersions(ctx context.Context, cliPatchVersions []string, currentK8sVersion string) ([]string, error)
 }
 
@@ -326,7 +327,7 @@ func (v *versionCollector) supportedVersions(ctx context.Context, version, curre
 	if err != nil {
 		return supportedVersionInfo{}, fmt.Errorf("loading image versions: %w", err)
 	}
-	cliVersions, err := v.newCLIVersions(ctx, currentK8sVersion)
+	cliVersions, err := v.newCLIVersions(ctx)
 	if err != nil {
 		return supportedVersionInfo{}, fmt.Errorf("loading cli versions: %w", err)
 	}

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -259,24 +259,36 @@ type stubVersionCollector struct {
 	supportedImages           []versionsapi.Version
 	supportedImageVersions    map[string]measurements.M
 	supportedK8sVersions      []string
+	supportedCLIVersions      []string
 	currentServicesVersions   string
 	currentImageVersion       string
 	currentK8sVersion         string
+	currentCLIVersion         string
 	images                    []versionsapi.Version
 	newCLIVersions            []string
 	someErr                   error
 }
 
-func (s *stubVersionCollector) newMeasurementes(_ context.Context, _ cloudprovider.Provider, _ []versionsapi.Version) (map[string]measurements.M, error) {
+func (s *stubVersionCollector) newMeasurements(ctx context.Context, csp cloudprovider.Provider, images []versionsapi.Version) (map[string]measurements.M, error) {
 	return s.supportedImageVersions, nil
 }
 
-func (s *stubVersionCollector) currentVersions(_ context.Context) (serviceVersions string, imageVersion string, k8sVersion string, err error) {
-	return s.currentServicesVersions, s.currentImageVersion, s.currentK8sVersion, s.someErr
+func (s *stubVersionCollector) currentVersions(ctx context.Context) (currentVersionInfo, error) {
+	return currentVersionInfo{
+		service: s.currentServicesVersions,
+		image:   s.currentImageVersion,
+		k8s:     s.currentK8sVersion,
+		cli:     s.currentCLIVersion,
+	}, s.someErr
 }
 
-func (s *stubVersionCollector) supportedVersions(_ context.Context, _ string) (serviceVersions string, imageVersions []versionsapi.Version, k8sVersions []string, err error) {
-	return s.supportedServicesVersions, s.supportedImages, s.supportedK8sVersions, s.someErr
+func (s *stubVersionCollector) supportedVersions(ctx context.Context, csp cloudprovider.Provider, version, currentK8sVersion string) (supportedVersionInfo, error) {
+	return supportedVersionInfo{
+		service: s.supportedServicesVersions,
+		image:   s.supportedImages,
+		k8s:     s.supportedK8sVersions,
+		cli:     s.supportedCLIVersions,
+	}, s.someErr
 }
 
 func (s *stubVersionCollector) newImages(_ context.Context, _ string) ([]versionsapi.Version, error) {

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -42,20 +42,24 @@ func TestBuildString(t *testing.T) {
 					"v2.5.0": measurements.DefaultsFor(cloudprovider.QEMU),
 				},
 				newKubernetes:     []string{"v1.24.12", "v1.25.6"},
+				newCLI:            []string{"v2.5.0", "v2.6.0"},
 				currentServices:   "v2.4.0",
 				currentImage:      "v2.4.0",
 				currentKubernetes: "v1.24.5",
+				currentCLI:        "v2.4.0",
 			},
-			expected: "The following updates are available with this CLI:\n  Kubernetes: v1.24.5 --> v1.24.12 v1.25.6\n  Images:\n    v2.4.0 --> v2.5.0\n      Includes these measurements:\n      4:\n          expected: \"1234123412341234123412341234123412341234123412341234123412341234\"\n          warnOnly: false\n      8:\n          expected: \"0000000000000000000000000000000000000000000000000000000000000000\"\n          warnOnly: false\n      9:\n          expected: \"1234123412341234123412341234123412341234123412341234123412341234\"\n          warnOnly: false\n      11:\n          expected: \"0000000000000000000000000000000000000000000000000000000000000000\"\n          warnOnly: false\n      12:\n          expected: \"1234123412341234123412341234123412341234123412341234123412341234\"\n          warnOnly: false\n      13:\n          expected: \"0000000000000000000000000000000000000000000000000000000000000000\"\n          warnOnly: false\n      15:\n          expected: \"0000000000000000000000000000000000000000000000000000000000000000\"\n          warnOnly: false\n      \n  Services: v2.4.0 --> v2.5.0\n",
+			expected: "The following updates are available with this CLI:\n  Kubernetes: v1.24.5 --> v1.24.12 v1.25.6\n  CLI: v2.4.0 --> v2.5.0 v2.6.0\n  Images:\n    v2.4.0 --> v2.5.0\n      Includes these measurements:\n      4:\n          expected: \"1234123412341234123412341234123412341234123412341234123412341234\"\n          warnOnly: false\n      8:\n          expected: \"0000000000000000000000000000000000000000000000000000000000000000\"\n          warnOnly: false\n      9:\n          expected: \"1234123412341234123412341234123412341234123412341234123412341234\"\n          warnOnly: false\n      11:\n          expected: \"0000000000000000000000000000000000000000000000000000000000000000\"\n          warnOnly: false\n      12:\n          expected: \"1234123412341234123412341234123412341234123412341234123412341234\"\n          warnOnly: false\n      13:\n          expected: \"0000000000000000000000000000000000000000000000000000000000000000\"\n          warnOnly: false\n      15:\n          expected: \"0000000000000000000000000000000000000000000000000000000000000000\"\n          warnOnly: false\n      \n  Services: v2.4.0 --> v2.5.0\n",
 		},
 		"no upgrades": {
 			upgrade: versionUpgrade{
 				newServices:       "",
 				newImages:         map[string]measurements.M{},
 				newKubernetes:     []string{},
+				newCLI:            []string{},
 				currentServices:   "v2.5.0",
 				currentImage:      "v2.5.0",
 				currentKubernetes: "v1.25.6",
+				currentCLI:        "v2.5.0",
 			},
 			expected: "No upgrades available with this CLI.\nNewer versions may be available at: https://github.com/edgelesssys/constellation/releases\n",
 		},
@@ -217,6 +221,7 @@ func TestUpgradeCheck(t *testing.T) {
 				currentServicesVersions: "v2.4.0",
 				currentImageVersion:     "v2.4.0",
 				currentK8sVersion:       "v1.24.5",
+				currentCLIVersion:       "v2.4.0",
 				images:                  []versionsapi.Version{v2_5},
 				newCLIVersions:          []string{"v2.5.0", "v2.6.0"},
 			},
@@ -297,6 +302,10 @@ func (s *stubVersionCollector) newImages(_ context.Context, _ string) ([]version
 
 func (s *stubVersionCollector) newerVersions(_ context.Context, _ []string) ([]versionsapi.Version, error) {
 	return s.images, nil
+}
+
+func (s *stubVersionCollector) newCompatibleCLIVersions(ctx context.Context, currentKubernetesVersion string) ([]string, error) {
+	return s.newCLIVersions, nil
 }
 
 type stubUpgradeChecker struct {

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -326,7 +326,7 @@ func (s *stubVersionCollector) newerVersions(_ context.Context, _ []string) ([]v
 	return s.images, nil
 }
 
-func (s *stubVersionCollector) newCLIVersions(ctx context.Context, currentKubernetesVersion string) ([]string, error) {
+func (s *stubVersionCollector) newCLIVersions(ctx context.Context) ([]string, error) {
 	return s.newCLIVersionsList, nil
 }
 
@@ -394,7 +394,7 @@ func TestNewCLIVersions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 
-			_, err := tc.verCollector.newCLIVersions(context.Background(), "v1.24.5")
+			_, err := tc.verCollector.newCLIVersions(context.Background())
 			if tc.wantErr {
 				require.Error(err)
 				return

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -301,7 +301,7 @@ func (s *stubVersionCollector) currentVersions(ctx context.Context) (currentVers
 	}, s.someErr
 }
 
-func (s *stubVersionCollector) supportedVersions(ctx context.Context, csp cloudprovider.Provider, version, currentK8sVersion string) (supportedVersionInfo, error) {
+func (s *stubVersionCollector) supportedVersions(ctx context.Context, version, currentK8sVersion string) (supportedVersionInfo, error) {
 	return supportedVersionInfo{
 		service: s.supportedServicesVersions,
 		image:   s.supportedImages,

--- a/hack/clidocgen/BUILD.bazel
+++ b/hack/clidocgen/BUILD.bazel
@@ -16,4 +16,6 @@ go_binary(
     name = "clidocgen",
     embed = [":clidocgen_lib"],
     visibility = ["//visibility:public"],
+    # keep
+    pure = "on",
 )

--- a/hack/clidocgen/BUILD.bazel
+++ b/hack/clidocgen/BUILD.bazel
@@ -15,7 +15,7 @@ go_library(
 go_binary(
     name = "clidocgen",
     embed = [":clidocgen_lib"],
-    visibility = ["//visibility:public"],
     # keep
     pure = "on",
+    visibility = ["//visibility:public"],
 )

--- a/internal/versionsapi/cliinfo.go
+++ b/internal/versionsapi/cliinfo.go
@@ -18,11 +18,11 @@ import (
 
 // CLIInfo contains information about a specific CLI version (i.e. it's compatibility with Kubernetes versions).
 type CLIInfo struct {
-	// Ref is the reference name of the image.
+	// Ref is the reference name of the CLI.
 	Ref string `json:"ref,omitempty"`
-	// Stream is the stream name of the image.
+	// Stream is the stream name of the CLI.
 	Stream string `json:"stream,omitempty"`
-	// Version is the version of the image.
+	// Version is the version of the CLI.
 	Version string `json:"version,omitempty"`
 	// Kubernetes contains all compatible Kubernetes versions.
 	Kubernetes []string `json:"kubernetes,omitempty"`


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add listing of valid CLI version upgrades with the `upgrade check` command
  -  Upgrade is considered valid if 1) compatible with current K8s version and 2) semver is greater and has at most 1 minor version drift
- Uploading of CLI version lists and compatibility information was done in #1218 & #1377 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Possible follow-ups
  - Upgrade check command is in (urgent) need of a refactoring. Files are very large. See [this AB ticket.](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/2957/)
  - Custom version type should be used eventually. See [this AB ticket](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/2956/).

Output of `constellation upgrade check` looks like:
```
The following updates are available with this CLI:
  Kubernetes: v1.25.7 --> v1.26.2
  CLI: v2.5.0 --> v2.6.0-pre.0.20230308113257-643afd38b347 v2.6.0-pre.0.20230309101241-15faa64ef6cc
  ```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
