### PR TITLE
deps: upgrade rules_oci to v0.3.3

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -120,11 +120,11 @@ load("//bazel/toolchains:oci_deps.bzl", "oci_deps")
 
 oci_deps()
 
-load("@contrib_rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
+load("@rules_oci//oci:dependencies.bzl", "rules_oci_dependencies")
 
 rules_oci_dependencies()
 
-load("@contrib_rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "LATEST_ZOT_VERSION", "oci_register_toolchains")
+load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "LATEST_ZOT_VERSION", "oci_register_toolchains")
 
 oci_register_toolchains(
     name = "oci",

--- a/bazel/toolchains/oci_deps.bzl
+++ b/bazel/toolchains/oci_deps.bzl
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def oci_deps():
     http_archive(
-        name = "contrib_rules_oci",
-        sha256 = "4ba3022f6475df4dbd1b21142f7bcb9bfaf2689a74687536837e1827b6aaddbf",
-        strip_prefix = "rules_oci-0.2.0",
-        url = "https://github.com/bazel-contrib/rules_oci/archive/v0.2.0.tar.gz",
+        name = "rules_oci",
+        sha256 = "4f119dc9e08319a3262c04b334bda54ba0484ca34f8ead706dd2397fc11816f7",
+        strip_prefix = "rules_oci-0.3.3",
+        url = "https://github.com/bazel-contrib/rules_oci/releases/download/v0.3.3/rules_oci-v0.3.3.tar.gz",
     )


### PR DESCRIPTION
Release: https://github.com/bazel-contrib/rules_oci/releases/tag/v0.3.3

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)

- deps: upgrade rules_oci to v0.3.3


### Checklist

- [x] Add labels (e.g., for changelog category)
