### PR TITLE
bootstrapper: try to mitigate timeout issues

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -194,6 +194,7 @@ runs:
         echo "KUBECONFIG=$(pwd)/constellation-admin.conf" >> $GITHUB_OUTPUT
         echo "MASTERSECRET=$(pwd)/constellation-mastersecret.json" >> $GITHUB_OUTPUT
 
+    # TODO(nirusu): Temporarily increase kubectl wait timeout here - might be related to all the Cilium / cert-manager issues?
     - name: Wait for nodes to join and become ready
       shell: bash
       env:
@@ -214,7 +215,13 @@ runs:
             exit 1
         fi
         echo "$(kubectl get nodes -o json | jq '.items | length')/"${NODES_COUNT}" nodes have joined"
-        kubectl wait --for=condition=ready --all nodes --timeout=10m
+        kubectl wait --for=condition=ready --all nodes --timeout=20m
+        kubectlErrorCode=$?
+        if [[ "${kubectlErrorCode}" -ne 0 ]]; then
+          kubectl get pods -n kube-system
+          kubectl get events -n kube-system
+          exit "${kubectlErrorCode}"
+        fi
         echo "::endgroup::"
 
     - name: Download boot logs

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -215,12 +215,12 @@ runs:
             exit 1
         fi
         echo "$(kubectl get nodes -o json | jq '.items | length')/"${NODES_COUNT}" nodes have joined"
-        kubectl wait --for=condition=ready --all nodes --timeout=20m
-        kubectlErrorCode=$?
-        if [[ "${kubectlErrorCode}" -ne 0 ]]; then
+        if ! kubectl wait --for=condition=ready --all nodes --timeout=20m; then
           kubectl get pods -n kube-system
           kubectl get events -n kube-system
-          exit "${kubectlErrorCode}"
+          echo "::error::kubectl wait timed out before all nodes became ready"
+          echo "::endgroup::"
+          exit 1
         fi
         echo "::endgroup::"
 

--- a/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
@@ -247,23 +247,19 @@ type SetupPodNetworkInput struct {
 	LoadBalancerEndpoint string
 }
 
-// FixCilium fixes https://github.com/cilium/cilium/issues/19958 but instead of a rollout restart of
-// the cilium daemonset, it only restarts the local cilium pod.
-func (k *KubernetesUtil) FixCilium(log *logger.Logger) {
-	ctx := context.Background()
-
+// WaitForCilium waits until Cilium reports a healthy status over its /healthz endpoint.
+func (k *KubernetesUtil) WaitForCilium(ctx context.Context, log *logger.Logger) error {
 	// wait for cilium pod to be healthy
 	client := http.Client{}
 	for {
 		time.Sleep(5 * time.Second)
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://127.0.0.1:9879/healthz", http.NoBody)
 		if err != nil {
-			log.With(zap.Error(err)).Errorf("Unable to create request")
-			continue
+			return fmt.Errorf("unable to create request: %w", err)
 		}
 		resp, err := client.Do(req)
 		if err != nil {
-			log.With(zap.Error(err)).Warnf("Waiting for local cilium daemonset pod not healthy")
+			log.With(zap.Error(err)).Infof("Waiting for local Cilium DaemonSet - Pod not healthy yet")
 			continue
 		}
 		resp.Body.Close()
@@ -272,42 +268,45 @@ func (k *KubernetesUtil) FixCilium(log *logger.Logger) {
 		}
 	}
 
+	return nil
+}
+
+// FixCilium fixes https://github.com/cilium/cilium/issues/19958
+// Instead of a rollout restart of the Cilium DaemonSet, it only restarts the local Cilium Pod.
+func (k *KubernetesUtil) FixCilium(ctx context.Context) error {
 	// get cilium container id
 	out, err := exec.CommandContext(ctx, "/run/state/bin/crictl", "ps", "--name", "cilium-agent", "-q").CombinedOutput()
 	if err != nil {
-		log.With(zap.Error(err)).Errorf("Getting cilium container id failed: %s", out)
-		return
+		return fmt.Errorf("getting cilium container id failed: %s", out)
 	}
 	outLines := strings.Split(string(out), "\n")
 	if len(outLines) < 2 {
-		log.Errorf("Getting cilium container id returned invalid output: %s", out)
-		return
+		return fmt.Errorf("getting cilium container id returned invalid output: %s", out)
 	}
 	containerID := outLines[len(outLines)-2]
 
 	// get cilium pod id
 	out, err = exec.CommandContext(ctx, "/run/state/bin/crictl", "inspect", "-o", "go-template", "--template", "{{ .info.sandboxID }}", containerID).CombinedOutput()
 	if err != nil {
-		log.With(zap.Error(err)).Errorf("Getting cilium pod id failed: %s", out)
-		return
+		return fmt.Errorf("getting Cilium Pod ID failed: %s", out)
 	}
 	outLines = strings.Split(string(out), "\n")
 	if len(outLines) < 2 {
-		log.Errorf("Getting cilium pod id returned invalid output: %s", out)
-		return
+		return fmt.Errorf("getting Cilium Pod ID returned invalid output: %s", out)
 	}
 	podID := outLines[len(outLines)-2]
 
 	// stop and delete pod
 	out, err = exec.CommandContext(ctx, "/run/state/bin/crictl", "stopp", podID).CombinedOutput()
 	if err != nil {
-		log.With(zap.Error(err)).Errorf("Stopping cilium agent pod failed: %s", out)
-		return
+		return fmt.Errorf("stopping Cilium agent Pod failed: %s", out)
 	}
 	out, err = exec.CommandContext(ctx, "/run/state/bin/crictl", "rmp", podID).CombinedOutput()
 	if err != nil {
-		log.With(zap.Error(err)).Errorf("Removing cilium agent pod failed: %s", out)
+		return fmt.Errorf("removing Cilium agent Pod failed: %s", out)
 	}
+
+	return nil
 }
 
 // JoinCluster joins existing Kubernetes cluster using kubeadm join.

--- a/bootstrapper/internal/kubernetes/k8sutil.go
+++ b/bootstrapper/internal/kubernetes/k8sutil.go
@@ -21,7 +21,8 @@ type clusterUtil interface {
 	InstallComponents(ctx context.Context, kubernetesComponents components.Components) error
 	InitCluster(ctx context.Context, initConfig []byte, nodeName, clusterName string, ips []net.IP, controlPlaneEndpoint string, conformanceMode bool, log *logger.Logger) ([]byte, error)
 	JoinCluster(ctx context.Context, joinConfig []byte, peerRole role.Role, controlPlaneEndpoint string, log *logger.Logger) error
-	FixCilium(log *logger.Logger)
+	WaitForCilium(ctx context.Context, log *logger.Logger) error
+	FixCilium(ctx context.Context) error
 	StartKubelet() error
 }
 

--- a/bootstrapper/internal/kubernetes/kubernetes.go
+++ b/bootstrapper/internal/kubernetes/kubernetes.go
@@ -248,12 +248,10 @@ func (k *KubeWrapper) InitCluster(
 
 	// cert-manager is necessary for our operator deployments.
 	log.Infof("Installing cert-manager")
-	timeToStartWaiting = time.Now()
 	if err = k.helmClient.InstallCertManager(ctx, helmReleases.CertManager); err != nil {
 		return nil, fmt.Errorf("installing cert-manager: %w", err)
 	}
-	timeUntilFinishedWaiting = time.Since(timeToStartWaiting)
-	log.With(zap.Duration("duration", timeUntilFinishedWaiting)).Infof("cert-manager installation finished")
+
 	operatorVals, err := k.setupOperatorVals(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("setting up operator vals: %w", err)

--- a/bootstrapper/internal/kubernetes/kubernetes.go
+++ b/bootstrapper/internal/kubernetes/kubernetes.go
@@ -200,7 +200,7 @@ func (k *KubeWrapper) InitCluster(
 		return nil, fmt.Errorf("waiting for Cilium to become healthy: %w", err)
 	}
 	timeUntilFinishedWaiting := time.Since(timeToStartWaiting)
-	log.Infof("Cilium took %s to become healthy", timeUntilFinishedWaiting.Round(time.Second).String())
+	log.With(zap.Duration("duration", timeUntilFinishedWaiting)).Infof("Cilium became healthy")
 
 	log.Infof("Restart Cilium")
 	if err := k.clusterUtil.FixCilium(ctx); err != nil {
@@ -253,8 +253,7 @@ func (k *KubeWrapper) InitCluster(
 		return nil, fmt.Errorf("installing cert-manager: %w", err)
 	}
 	timeUntilFinishedWaiting = time.Since(timeToStartWaiting)
-	log.Infof("cert-manager took %s to be fully installed", timeUntilFinishedWaiting.Round(time.Second).String())
-
+	log.With(zap.Duration("duration", timeUntilFinishedWaiting)).Infof("cert-manager installation finished")
 	operatorVals, err := k.setupOperatorVals(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("setting up operator vals: %w", err)

--- a/bootstrapper/internal/kubernetes/kubernetes.go
+++ b/bootstrapper/internal/kubernetes/kubernetes.go
@@ -185,12 +185,11 @@ func (k *KubeWrapper) InitCluster(
 		return nil, fmt.Errorf("unmarshalling helm releases: %w", err)
 	}
 
+	log.Infof("Installing Cilium")
 	if err = k.helmClient.InstallCilium(ctx, k.client, helmReleases.Cilium, setupPodNetworkInput); err != nil {
 		return nil, fmt.Errorf("installing pod network: %w", err)
 	}
 
-	// TODO: The timeout here is high as ghcr.io can be slow sometimes. Reduce this later when we move the repository.
-	// Also remove the logging later.
 	log.Infof("Waiting for Cilium to become healthy")
 	timeToStartWaiting := time.Now()
 	// TODO(Nirusu): Reduce the timeout when we switched the package repository - this is only this high because I once
@@ -237,24 +236,31 @@ func (k *KubeWrapper) InitCluster(
 		return nil, fmt.Errorf("setting up extraVals: %w", err)
 	}
 
+	log.Infof("Installing Constellation microservices")
 	if err = k.helmClient.InstallConstellationServices(ctx, helmReleases.ConstellationServices, extraVals); err != nil {
 		return nil, fmt.Errorf("installing constellation-services: %w", err)
 	}
 
+	log.Infof("Setting up internal-config ConfigMap")
 	if err := k.setupInternalConfigMap(ctx); err != nil {
 		return nil, fmt.Errorf("failed to setup internal ConfigMap: %w", err)
 	}
 
 	// cert-manager is necessary for our operator deployments.
+	log.Infof("Installing cert-manager")
+	timeToStartWaiting = time.Now()
 	if err = k.helmClient.InstallCertManager(ctx, helmReleases.CertManager); err != nil {
 		return nil, fmt.Errorf("installing cert-manager: %w", err)
 	}
+	timeUntilFinishedWaiting = time.Since(timeToStartWaiting)
+	log.Infof("cert-manager took %s to be fully installed", timeUntilFinishedWaiting.Round(time.Second).String())
 
 	operatorVals, err := k.setupOperatorVals(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("setting up operator vals: %w", err)
 	}
 
+	log.Infof("Installing operators")
 	if err = k.helmClient.InstallOperators(ctx, helmReleases.Operators, operatorVals); err != nil {
 		return nil, fmt.Errorf("installing operators: %w", err)
 	}

--- a/bootstrapper/internal/kubernetes/kubernetes_test.go
+++ b/bootstrapper/internal/kubernetes/kubernetes_test.go
@@ -510,7 +510,12 @@ func (s *stubClusterUtil) StartKubelet() error {
 	return s.startKubeletErr
 }
 
-func (s *stubClusterUtil) FixCilium(log *logger.Logger) {
+func (s *stubClusterUtil) WaitForCilium(ctx context.Context, log *logger.Logger) error {
+	return nil
+}
+
+func (s *stubClusterUtil) FixCilium(ctx context.Context) error {
+	return nil
 }
 
 type stubConfigProvider struct {


### PR DESCRIPTION
### Proposed change(s)
- Split FixCilium into WaitForCilium and FixCilium
- Put both directly after Cilium installation so we have a distinct error when Cilium doesn't come up instead of having the same cert-manager context deadline exceeded error
- Set a timeout for 20 minutes for WaitForCilium (pulling can sometimes be slow with ghcr.io - in local testing the worst case was ~16 minutes occasionally) -> This should likely be reduced after the next Cilium update when/if we switch repositories that have more consistent performance.
- Set a timeout for 10 minutes for Helm install instead of 5 minutes (cert-manager can sometimes take longer)
- Track duration of Cilium and cert-manager install (since both can stall)
- Minor fixes

Generally, the issue is the following:
- We try to install too many things at once almost immediately the cluster is up, so when "cert-manager" fails, we have ~10 Pods that need to be created, need to pull images, scheduled etc.
- The node can still be tainted as uninitialized for a bit when the cluster recently came up
- Repositories can be slow sometimes (e.g. hit a bad PoP from a CDN - definitely happens with ghcr.io)
- Sometimes Kubernetes takes time to schedule things

Often it's not things being completely broken - they are just occasionally slow. Given that we depend on external resources, this is not too unsurprising (though certainly annoying).

I hope we can use OpenSearch to maybe capture the duration of successful installs and derive good timeouts from them. 

I choose a middle ground with 20 minutes and 10 minutes. We could also set them higher in case they still make trouble and/or we want to run more statistics on them. 20 minutes for Cilium is already graceful (only doing this because of the ghcr.io issue), 10 minutes for Helm might still be a little bit too short for worst-case scenarios.

In the later run though, however, I wish we can refactor the bootstrapper to handle the Helm installations after we return the kubeconfig to the client. Often things just take longer. Or they can be fixed manually.

Maybe we can also disable the cert-manager API health check? Not sure how that works though with the dependencies on the operator. Maybe @derpsteb can comment on that?
