### PR TITLE
cli: split spinner into "Connecting" and "Initializing cluster" state for init (and prevent double initialization cases when an error is mistakenly retried)

### DIFF
--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -173,8 +173,8 @@ func TestInitialize(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
 			defer cancel()
 			cmd.SetContext(ctx)
-			i := &initCmd{log: logger.NewTest(t)}
-			err := i.initialize(cmd, newDialer, fileHandler, &stubLicenseClient{}, &nopSpinner{})
+			i := &initCmd{log: logger.NewTest(t), spinner: &nopSpinner{}}
+			err := i.initialize(cmd, newDialer, fileHandler, &stubLicenseClient{})
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -452,8 +452,8 @@ func TestAttestation(t *testing.T) {
 	defer cancel()
 	cmd.SetContext(ctx)
 
-	i := &initCmd{log: logger.NewTest(t)}
-	err := i.initialize(cmd, newDialer, fileHandler, &stubLicenseClient{}, &nopSpinner{})
+	i := &initCmd{log: logger.NewTest(t), spinner: &nopSpinner{}}
+	err := i.initialize(cmd, newDialer, fileHandler, &stubLicenseClient{})
 	assert.Error(err)
 	// make sure the error is actually a TLS handshake error
 	assert.Contains(err.Error(), "transport: authentication handshake failed")

--- a/cli/internal/cmd/miniup.go
+++ b/cli/internal/cmd/miniup.go
@@ -265,8 +265,8 @@ func (m *miniUpCmd) initializeMiniCluster(cmd *cobra.Command, fileHandler file.H
 	}
 	m.log.Debugf("Created new logger")
 	defer log.Sync()
-	i := &initCmd{log: log, merger: &kubeconfigMerger{log: log}}
-	if err := i.initialize(cmd, newDialer, fileHandler, license.NewClient(), spinner); err != nil {
+	i := &initCmd{log: log, merger: &kubeconfigMerger{log: log}, spinner: spinner}
+	if err := i.initialize(cmd, newDialer, fileHandler, license.NewClient()); err != nil {
 		return err
 	}
 	m.log.Debugf("Initialized mini cluster")


### PR DESCRIPTION
### Proposed change(s)
- Add "Connecting" spinner state for "constellation init"
- Show "Initializing cluster" only when our gRPC connection was successful 

This is based on @malt3 gRPC debug logging functions.
I figured we can also just use them for the normal user output :) 
Not sure if this is the best place to put it there, though since I am not sure if the state can theoretically change multiple times to READY. 
Hope I can get some feedback on that? Not super familiar with gRPC connection states and how this works in our init.
Otherwise it might make sense to make this a channel and let the caller handle this.

Second commit also adds a note that it can take a few minutes.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
