### PR TITLE
image: update Azure and GCP to kernel 6.1.18

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -20,8 +20,8 @@ csps := aws azure gcp openstack qemu
 certs := $(PKI)/PK.cer $(PKI)/KEK.cer $(PKI)/db.cer
 
 SYSTEMD_FIXED_RPMS := systemd-251.11-2.fc37.x86_64.rpm systemd-libs-251.11-2.fc37.x86_64.rpm systemd-networkd-251.11-2.fc37.x86_64.rpm systemd-pam-251.11-2.fc37.x86_64.rpm systemd-resolved-251.11-2.fc37.x86_64.rpm systemd-udev-251.11-2.fc37.x86_64.rpm
-AZURE_FIXED_KERNEL_RPMS := kernel-6.1.14-200.fc37.x86_64.rpm kernel-core-6.1.14-200.fc37.x86_64.rpm kernel-modules-6.1.14-200.fc37.x86_64.rpm
-GCP_FIXED_KERNEL_RPMS := kernel-5.19.17-300.fc37.x86_64.rpm kernel-core-5.19.17-300.fc37.x86_64.rpm kernel-modules-5.19.17-300.fc37.x86_64.rpm
+AZURE_FIXED_KERNEL_RPMS := kernel-6.1.18-200.fc37.x86_64.rpm kernel-core-6.1.18-200.fc37.x86_64.rpm kernel-modules-6.1.18-200.fc37.x86_64.rpm
+GCP_FIXED_KERNEL_RPMS := kernel-6.1.18-200.fc37.x86_64.rpm kernel-core-6.1.18-200.fc37.x86_64.rpm kernel-modules-6.1.18-200.fc37.x86_64.rpm
 PREBUILD_RPMS_SYSTEMD := $(addprefix prebuilt/rpms/systemd/,$(SYSTEMD_FIXED_RPMS))
 PREBUILT_RPMS_AZURE := $(addprefix prebuilt/rpms/azure/,$(AZURE_FIXED_KERNEL_RPMS))
 PREBUILT_RPMS_GCP := $(addprefix prebuilt/rpms/gcp/,$(GCP_FIXED_KERNEL_RPMS))
@@ -37,15 +37,18 @@ prebuilt/rpms/systemd/%.rpm:
 	@mkdir -p $(@D)
 	@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/systemd/251.11/2.fc37/x86_64/$*.rpm
 
-prebuilt/rpms/gcp/%.rpm:
-	@echo "Downloading $*"
-	@mkdir -p $(@D)
-	@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/5.19.17/300.fc37/x86_64/$*.rpm
+# Currently, Azure and GCP use the same fixed kernels.
+# They will likely derive soon again, but for now we can just copy the file from Azure to save traffic.
+prebuilt/rpms/gcp/%.rpm: prebuilt/rpms/azure/%.rpm
+	#@echo "Downloading $*"
+	#@mkdir -p $(@D)
+	#@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/6.1.18/200.fc37/x86_64/$*.rpm
+	cp prebuilt/rpms/azure/%.rpm prebuilt/rpms/gcp/%.rpm
 
 prebuilt/rpms/azure/%.rpm:
 	@echo "Downloading $*"
 	@mkdir -p $(@D)
-	@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/6.1.14/200.fc37/x86_64/$*.rpm
+	@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/6.1.18/200.fc37/x86_64/$*.rpm
 
 mkosi.output.%/fedora~37/image.raw: mkosi.files/mkosi.%.conf inject-bins inject-certs
 	mkosi --config mkosi.files/mkosi.$*.conf \

--- a/image/Makefile
+++ b/image/Makefile
@@ -40,7 +40,10 @@ prebuilt/rpms/systemd/%.rpm:
 # Currently, Azure and GCP use the same fixed kernels.
 # They will likely derive soon again, but for now we can just copy the file from Azure to save traffic.
 prebuilt/rpms/gcp/%.rpm: prebuilt/rpms/azure/%.rpm
-	cp prebuilt/rpms/azure/%.rpm prebuilt/rpms/gcp/%.rpm
+	# @echo "Downloading $*"
+	# @mkdir -p $(@D)
+	# @curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/6.1.18/200.fc37/x86_64/$*.rpm
+	cp prebuilt/rpms/azure/$*.rpm prebuilt/rpms/gcp/$*.rpm
 
 prebuilt/rpms/azure/%.rpm:
 	@echo "Downloading $*"

--- a/image/Makefile
+++ b/image/Makefile
@@ -40,9 +40,6 @@ prebuilt/rpms/systemd/%.rpm:
 # Currently, Azure and GCP use the same fixed kernels.
 # They will likely derive soon again, but for now we can just copy the file from Azure to save traffic.
 prebuilt/rpms/gcp/%.rpm: prebuilt/rpms/azure/%.rpm
-	#@echo "Downloading $*"
-	#@mkdir -p $(@D)
-	#@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/6.1.18/200.fc37/x86_64/$*.rpm
 	cp prebuilt/rpms/azure/%.rpm prebuilt/rpms/gcp/%.rpm
 
 prebuilt/rpms/azure/%.rpm:

--- a/image/Makefile
+++ b/image/Makefile
@@ -40,8 +40,8 @@ prebuilt/rpms/systemd/%.rpm:
 # Currently, Azure and GCP use the same fixed kernels.
 # They will likely derive soon again, but for now we can just copy the file from Azure to save traffic.
 prebuilt/rpms/gcp/%.rpm: prebuilt/rpms/azure/%.rpm
-	# @echo "Downloading $*"
-	# @mkdir -p $(@D)
+	@echo "Downloading $*"
+	@mkdir -p $(@D)
 	# @curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/kernel/6.1.18/200.fc37/x86_64/$*.rpm
 	cp prebuilt/rpms/azure/$*.rpm prebuilt/rpms/gcp/$*.rpm
 

--- a/image/mkosi.files/mkosi.azure.conf
+++ b/image/mkosi.files/mkosi.azure.conf
@@ -5,6 +5,6 @@ OutputDirectory=mkosi.output.azure
 # replace kernel
 [Content]
 BasePackages=conditional
-Packages=prebuilt/rpms/azure/kernel-6.1.14-200.fc37.x86_64.rpm
-         prebuilt/rpms/azure/kernel-core-6.1.14-200.fc37.x86_64.rpm
-         prebuilt/rpms/azure/kernel-modules-6.1.14-200.fc37.x86_64.rpm
+Packages=prebuilt/rpms/azure/kernel-6.1.18-200.fc37.x86_64.rpm
+         prebuilt/rpms/azure/kernel-core-6.1.18-200.fc37.x86_64.rpm
+         prebuilt/rpms/azure/kernel-modules-6.1.18-200.fc37.x86_64.rpm

--- a/image/mkosi.files/mkosi.gcp.conf
+++ b/image/mkosi.files/mkosi.gcp.conf
@@ -5,6 +5,6 @@ OutputDirectory=mkosi.output.gcp
 # replace kernel
 [Content]
 BasePackages=conditional
-Packages=prebuilt/rpms/gcp/kernel-5.19.17-300.fc37.x86_64.rpm
-         prebuilt/rpms/gcp/kernel-core-5.19.17-300.fc37.x86_64.rpm
-         prebuilt/rpms/gcp/kernel-modules-5.19.17-300.fc37.x86_64.rpm
+Packages=prebuilt/rpms/gcp/kernel-6.1.18-200.fc37.x86_64.rpm
+         prebuilt/rpms/gcp/kernel-core-6.1.18-200.fc37.x86_64.rpm
+         prebuilt/rpms/gcp/kernel-modules-6.1.18-200.fc37.x86_64.rpm


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Update Azure & GCP kernel to 6.1.18

6.1.18 contains the [backport for the GCP disk fix](https://lore.kernel.org/all/20230310133720.407990040@linuxfoundation.org/) we reported, so we can finally get away from EOL 5.19.
The kernel also does not contain yet the backport of the MTRR fix revert that breaks Azure disks again. Wonder if this will ever happen with kernel 6.1, but 6.2 will be broken again I presume.

