### PR TITLE
debugd: Enable ordered logs in Logstash (+ update Filebeat/Logstash)

### DIFF
--- a/debugd/internal/debugd/logcollector/filebeat/Dockerfile
+++ b/debugd/internal/debugd/logcollector/filebeat/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:37@sha256:a9fed38b343ea8a2722c78d5ad97d691421bf46f20f20076d34dd6948a2a792d AS release
 
-RUN dnf install -y https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-8.5.0-x86_64.rpm
+RUN dnf install -y https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-8.6.2-x86_64.rpm
 
 COPY debugd/internal/debugd/logcollector/filebeat/filebeat.yml /usr/share/filebeat/filebeat.yml
 

--- a/debugd/internal/debugd/logcollector/logstash/Dockerfile
+++ b/debugd/internal/debugd/logcollector/logstash/Dockerfile
@@ -1,6 +1,6 @@
 FROM fedora:37@sha256:a9fed38b343ea8a2722c78d5ad97d691421bf46f20f20076d34dd6948a2a792d AS build
 
-ARG LOGSTASH_VER=8.4.0
+ARG LOGSTASH_VER=8.6.1
 
 RUN curl -fsSLO https://artifacts.opensearch.org/logstash/logstash-oss-with-opensearch-output-plugin-$LOGSTASH_VER-linux-x64.tar.gz
 RUN tar -zxvf logstash-oss-with-opensearch-output-plugin-$LOGSTASH_VER-linux-x64.tar.gz

--- a/debugd/internal/debugd/logcollector/logstash/config/logstash.yml
+++ b/debugd/internal/debugd/logcollector/logstash/config/logstash.yml
@@ -1,2 +1,5 @@
 log.level: warn
 config.reload.automatic: true
+pipeline:
+  workers: 1
+  ordered: true


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Enable ordered logs in Logstash
Currently, our log output in OpenSearch is not ordered even when ordered by timestamp. This makes browsing through the logs a bit tiresome and confusing as it makes it sometimes difficult to see on a glance what happened in our cluster.
This is theoretically a performance bottleneck since we need to downgrade to single-threaded log processing to use this: https://www.elastic.co/guide/en/logstash/8.6/processing.html#order-setting
However, given that each node has its own Logstash instance, I think this should be fine.

- Update Filebeat to 8.6.2
- Update Logstash to 8.6.1 (yes, not 8.6.2 because OpenSearch does not seem to ship their bundle with 8.6.2 for whatever reason).

