### PR TITLE
bazel: command to prepare development workspace

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -16,6 +16,11 @@ alias(
     actual = "//bazel/ci:check",
 )
 
+alias(
+    name = "devbuild",
+    actual = "//bazel/devbuild:devbuild",
+)
+
 # These magic Gazelle commands need to be in the top-level BUILD file.
 # gazelle:map_kind go_test go_test //bazel/go:go_test.bzl
 # gazelle:prefix github.com/edgelesssys/constellation/v2

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,7 @@
 /.github @katexochen
 /3rdparty/gcp-guest-agent @malt3
 /apko @katexochen
+/bazel @malt3
 /bootstrapper @3u13r
 /cli @katexochen
 /cli/internal/helm @derpsteb

--- a/bazel/ci/BUILD.bazel
+++ b/bazel/ci/BUILD.bazel
@@ -47,6 +47,7 @@ sh_library(
     srcs = [
         "lib.bash",
     ],
+    visibility = ["//visibility:public"],
 )
 
 sh_template(

--- a/bazel/devbuild/BUILD.bazel
+++ b/bazel/devbuild/BUILD.bazel
@@ -1,0 +1,21 @@
+load("//bazel/ci:def.bzl", "sh_template")
+
+sh_template(
+    name = "devbuild",
+    data = [
+        "//bazel/ci:base_lib",
+        "//bootstrapper/cmd/bootstrapper",
+        "//cli:cli_oss_host",
+        "//debugd/cmd/cdbg:cdbg_host",
+        "//upgrade-agent/cmd",
+    ],
+    substitutions = {
+        "@@BASE_LIB@@": "$(rootpath //bazel/ci:base_lib)",
+        "@@BOOTSTRAPPER@@": "$(rootpath //bootstrapper/cmd/bootstrapper)",
+        "@@CLI@@": "$(rootpath //cli:cli_oss_host)",
+        "@@CDBG@@": "$(rootpath //debugd/cmd/cdbg:cdbg_host)",
+        "@@UPGRADE_AGENT@@": "$(rootpath //upgrade-agent/cmd)",
+    },
+    template = "prepare_developer_workspace.sh.in",
+    visibility = ["//visibility:public"],
+)

--- a/bazel/devbuild/prepare_developer_workspace.sh.in
+++ b/bazel/devbuild/prepare_developer_workspace.sh.in
@@ -3,11 +3,11 @@
 # This script is run from the user's Constellation workspace (BUILD_WORKING_DIRECTORY).
 # It prepares the workspace by symlinking all required binaries into folder.
 
-lib=$(realpath @@BASE_LIB@@)
-bootstrapper=$(realpath @@BOOTSTRAPPER@@)
-upgrade_agent=$(realpath @@UPGRADE_AGENT@@)
-cli=$(realpath @@CLI@@)
-cdbg=$(realpath @@CDBG@@)
+lib=$(realpath @@BASE_LIB@@) || exit 1
+bootstrapper=$(realpath @@BOOTSTRAPPER@@) || exit 1
+upgrade_agent=$(realpath @@UPGRADE_AGENT@@) || exit 1
+cli=$(realpath @@CLI@@) || exit 1
+cdbg=$(realpath @@CDBG@@) || exit 1
 
 # shellcheck source=../ci/lib.bash
 if ! source "${lib}"; then

--- a/bazel/devbuild/prepare_developer_workspace.sh.in
+++ b/bazel/devbuild/prepare_developer_workspace.sh.in
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# This script is run from the user's Constellation workspace (BUILD_WORKING_DIRECTORY).
+# It prepares the workspace by symlinking all required binaries into folder.
+
+lib=$(realpath @@BASE_LIB@@)
+bootstrapper=$(realpath @@BOOTSTRAPPER@@)
+upgrade_agent=$(realpath @@UPGRADE_AGENT@@)
+cli=$(realpath @@CLI@@)
+cdbg=$(realpath @@CDBG@@)
+
+# shellcheck source=../ci/lib.bash
+if ! source "${lib}"; then
+  echo "Error: could not find import"
+  exit 1
+fi
+
+cd "${BUILD_WORKING_DIRECTORY}" || exit 1
+
+if [[ $# -eq 0 ]] ; then
+    workdir="."
+else
+    workdir="$1"
+fi
+
+ln -sf "${bootstrapper}" "${workdir}/bootstrapper"
+ln -sf "${upgrade_agent}" "${workdir}/upgrade-agent"
+ln -sf "${cli}" "${workdir}/constellation"
+ln -sf "${cdbg}" "${workdir}/cdbg"

--- a/cli/BUILD.bazel
+++ b/cli/BUILD.bazel
@@ -43,3 +43,16 @@ go_binary(
         "enterprise",
     ]
 ]
+
+[
+    go_cross_binary(
+        name = "cli_%s_host" % edition,
+        platform = "@local_config_platform//:host",
+        target = ":cli_%s" % edition,
+        visibility = ["//visibility:public"],
+    )
+    for edition in [
+        "oss",
+        "enterprise",
+    ]
+]

--- a/debugd/cmd/cdbg/BUILD.bazel
+++ b/debugd/cmd/cdbg/BUILD.bazel
@@ -30,3 +30,10 @@ go_binary(
         "linux_arm64",
     ]
 ]
+
+go_cross_binary(
+    name = "cdbg_host",
+    platform = "@local_config_platform//:host",
+    target = ":cdbg",
+    visibility = ["//visibility:public"],
+)

--- a/dev-docs/workflows/build-test-run.md
+++ b/dev-docs/workflows/build-test-run.md
@@ -21,13 +21,19 @@ Prerequisites:
   sudo dnf install @development-tools pkg-config cmake openssl-devel cryptsetup-libs cryptsetup-devel
   ```
 
-CMake wrapper:
+Developer workspace:
 
 ```sh
 mkdir build
 cd build
-cmake ..
-make
+# build required binaries for a dev build
+# and symlink them into the current directory
+bazel run //:devbuild
+./constellation ...
+# modify code
+# rerun to ensure that all binaries are up to date
+bazel run //:devbuild
+./constellation ...
 ```
 
 Bazel build:


### PR DESCRIPTION
This command symlinks all binaries into the current working directory (or the path specified by the first argument).
You can run this command repeatedly to ensure the symlinks point to up-to-date binaries.
This should simplify the development workflow!
I'm not sure about the name `devbuild`. Feel free to suggest other names.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bazel: command to prepare development workspace

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

Usage:

```shell-session
mkdir my-constellation-workspace && cd my-constellation-workspace
bazel run //:devbuild
./constellation create ......
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
