### PR TITLE
fix: use TDX device to mark node as initialized

### DIFF
--- a/disk-mapper/internal/setup/setup.go
+++ b/disk-mapper/internal/setup/setup.go
@@ -48,29 +48,29 @@ const (
 
 // Manager handles formatting, mapping, mounting and unmounting of state disks.
 type Manager struct {
-	log      *logger.Logger
-	csp      string
-	diskPath string
-	fs       afero.Afero
-	mapper   DeviceMapper
-	mounter  Mounter
-	config   ConfigurationGenerator
-	openTPM  vtpm.TPMOpenFunc
+	log        *logger.Logger
+	csp        string
+	diskPath   string
+	fs         afero.Afero
+	mapper     DeviceMapper
+	mounter    Mounter
+	config     ConfigurationGenerator
+	openDevice vtpm.TPMOpenFunc
 }
 
 // New initializes a SetupManager with the given parameters.
 func New(log *logger.Logger, csp string, diskPath string, fs afero.Afero,
-	mapper DeviceMapper, mounter Mounter, openTPM vtpm.TPMOpenFunc,
+	mapper DeviceMapper, mounter Mounter, openDevice vtpm.TPMOpenFunc,
 ) *Manager {
 	return &Manager{
-		log:      log,
-		csp:      csp,
-		diskPath: diskPath,
-		fs:       fs,
-		mapper:   mapper,
-		mounter:  mounter,
-		config:   systemd.New(fs),
-		openTPM:  openTPM,
+		log:        log,
+		csp:        csp,
+		diskPath:   diskPath,
+		fs:         fs,
+		mapper:     mapper,
+		mounter:    mounter,
+		config:     systemd.New(fs),
+		openDevice: openDevice,
 	}
 }
 
@@ -110,7 +110,7 @@ func (s *Manager) PrepareExistingDisk(recover RecoveryDoer) error {
 	}
 
 	// taint the node as initialized
-	if err := initialize.MarkNodeAsBootstrapped(s.openTPM, clusterID); err != nil {
+	if err := initialize.MarkNodeAsBootstrapped(s.openDevice, clusterID); err != nil {
 		return err
 	}
 

--- a/disk-mapper/internal/setup/setup_test.go
+++ b/disk-mapper/internal/setup/setup_test.go
@@ -43,7 +43,7 @@ func TestPrepareExistingDisk(t *testing.T) {
 		mapper          *stubMapper
 		mounter         *stubMounter
 		configGenerator *stubConfigurationGenerator
-		openTPM         vtpm.TPMOpenFunc
+		openDevice      vtpm.TPMOpenFunc
 		missingState    bool
 		wantErr         bool
 	}{
@@ -52,14 +52,14 @@ func TestPrepareExistingDisk(t *testing.T) {
 			mapper:          &stubMapper{uuid: "test"},
 			mounter:         &stubMounter{},
 			configGenerator: &stubConfigurationGenerator{},
-			openTPM:         vtpm.OpenNOPTPM,
+			openDevice:      vtpm.OpenNOPTPM,
 		},
 		"WaitForDecryptionKey fails": {
 			recoveryDoer:    &stubRecoveryDoer{recoveryErr: someErr},
 			mapper:          &stubMapper{uuid: "test"},
 			mounter:         &stubMounter{},
 			configGenerator: &stubConfigurationGenerator{},
-			openTPM:         vtpm.OpenNOPTPM,
+			openDevice:      vtpm.OpenNOPTPM,
 			wantErr:         true,
 		},
 		"MapDisk fails": {
@@ -70,7 +70,7 @@ func TestPrepareExistingDisk(t *testing.T) {
 			},
 			mounter:         &stubMounter{},
 			configGenerator: &stubConfigurationGenerator{},
-			openTPM:         vtpm.OpenNOPTPM,
+			openDevice:      vtpm.OpenNOPTPM,
 			wantErr:         true,
 		},
 		"MkdirAll fails": {
@@ -78,7 +78,7 @@ func TestPrepareExistingDisk(t *testing.T) {
 			mapper:          &stubMapper{uuid: "test"},
 			mounter:         &stubMounter{mkdirAllErr: someErr},
 			configGenerator: &stubConfigurationGenerator{},
-			openTPM:         vtpm.OpenNOPTPM,
+			openDevice:      vtpm.OpenNOPTPM,
 			wantErr:         true,
 		},
 		"Mount fails": {
@@ -86,7 +86,7 @@ func TestPrepareExistingDisk(t *testing.T) {
 			mapper:          &stubMapper{uuid: "test"},
 			mounter:         &stubMounter{mountErr: someErr},
 			configGenerator: &stubConfigurationGenerator{},
-			openTPM:         vtpm.OpenNOPTPM,
+			openDevice:      vtpm.OpenNOPTPM,
 			wantErr:         true,
 		},
 		"Unmount fails": {
@@ -94,7 +94,7 @@ func TestPrepareExistingDisk(t *testing.T) {
 			mapper:          &stubMapper{uuid: "test"},
 			mounter:         &stubMounter{unmountErr: someErr},
 			configGenerator: &stubConfigurationGenerator{},
-			openTPM:         vtpm.OpenNOPTPM,
+			openDevice:      vtpm.OpenNOPTPM,
 			wantErr:         true,
 		},
 		"MarkNodeAsBootstrapped fails": {
@@ -102,7 +102,7 @@ func TestPrepareExistingDisk(t *testing.T) {
 			mapper:          &stubMapper{uuid: "test"},
 			mounter:         &stubMounter{unmountErr: someErr},
 			configGenerator: &stubConfigurationGenerator{},
-			openTPM:         failOpener,
+			openDevice:      failOpener,
 			wantErr:         true,
 		},
 		"Generating config fails": {
@@ -110,7 +110,7 @@ func TestPrepareExistingDisk(t *testing.T) {
 			mapper:          &stubMapper{uuid: "test"},
 			mounter:         &stubMounter{},
 			configGenerator: &stubConfigurationGenerator{generateErr: someErr},
-			openTPM:         failOpener,
+			openDevice:      failOpener,
 			wantErr:         true,
 		},
 		"no state file": {
@@ -118,7 +118,7 @@ func TestPrepareExistingDisk(t *testing.T) {
 			mapper:          &stubMapper{uuid: "test"},
 			mounter:         &stubMounter{},
 			configGenerator: &stubConfigurationGenerator{},
-			openTPM:         vtpm.OpenNOPTPM,
+			openDevice:      vtpm.OpenNOPTPM,
 			missingState:    true,
 			wantErr:         true,
 		},
@@ -136,14 +136,14 @@ func TestPrepareExistingDisk(t *testing.T) {
 			}
 
 			setupManager := &Manager{
-				log:      logger.NewTest(t),
-				csp:      "test",
-				diskPath: "disk-path",
-				fs:       fs,
-				mapper:   tc.mapper,
-				mounter:  tc.mounter,
-				config:   tc.configGenerator,
-				openTPM:  tc.openTPM,
+				log:        logger.NewTest(t),
+				csp:        "test",
+				diskPath:   "disk-path",
+				fs:         fs,
+				mapper:     tc.mapper,
+				mounter:    tc.mounter,
+				config:     tc.configGenerator,
+				openDevice: tc.openDevice,
 			}
 
 			err := setupManager.PrepareExistingDisk(tc.recoveryDoer)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix disk-mapper rejoining by using TDX device instead of trying to mark node using TPM

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->