### PR TITLE
bazel: use host platform by default

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,9 +20,6 @@ build --strip=always
 # set build mode to opt by default (better reproducibility and performance)
 build --compilation_mode=opt
 
-# compile for linux_amd64 by default (this is the target for any binaries that go into the cluster)
-build --platforms @zig_sdk//libc_aware/platform:linux_amd64_gnu.2.34
-
 # enable tpm simulator for tests
 test --//bazel/settings:tpm_simulator
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,8 @@ enable_testing()
 # disk-mapper
 #
 add_custom_target(disk-mapper ALL
-  COMMAND ${BAZEL} build //disk-mapper/cmd:cmd
-  COMMAND cp \$$\(${BAZEL} cquery --output=files //disk-mapper/cmd:cmd\) ${CMAKE_BINARY_DIR}/disk-mapper
+  COMMAND ${BAZEL} build //disk-mapper/cmd:disk-mapper_linux_amd64
+  COMMAND cp \$$\(${BAZEL} cquery --output=files //disk-mapper/cmd:disk-mapper_linux_amd64\) ${CMAKE_BINARY_DIR}/disk-mapper
   COMMAND chmod +w ${CMAKE_BINARY_DIR}/disk-mapper
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   BYPRODUCTS disk-mapper
@@ -20,8 +20,8 @@ add_custom_target(disk-mapper ALL
 # measurement-reader
 #
 add_custom_target(measurement-reader ALL
-  COMMAND ${BAZEL} build //measurement-reader/cmd:cmd
-  COMMAND cp \$$\(${BAZEL} cquery --output=files //measurement-reader/cmd:cmd\) ${CMAKE_BINARY_DIR}/measurement-reader
+  COMMAND ${BAZEL} build //measurement-reader/cmd:measurement-reader_linux_amd64
+  COMMAND cp \$$\(${BAZEL} cquery --output=files //measurement-reader/cmd:measurement-reader_linux_amd64\) ${CMAKE_BINARY_DIR}/measurement-reader
   COMMAND chmod +w ${CMAKE_BINARY_DIR}/measurement-reader
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   BYPRODUCTS measurement-reader
@@ -31,8 +31,8 @@ add_custom_target(measurement-reader ALL
 # bootstrapper
 #
 add_custom_target(bootstrapper ALL
-  COMMAND ${BAZEL} build //bootstrapper/cmd/bootstrapper:bootstrapper
-  COMMAND cp \$$\(${BAZEL} cquery --output=files //bootstrapper/cmd/bootstrapper:bootstrapper\) ${CMAKE_BINARY_DIR}/bootstrapper
+  COMMAND ${BAZEL} build //bootstrapper/cmd/bootstrapper:bootstrapper_linux_amd64
+  COMMAND cp \$$\(${BAZEL} cquery --output=files //bootstrapper/cmd/bootstrapper:bootstrapper_linux_amd64\) ${CMAKE_BINARY_DIR}/bootstrapper
   COMMAND chmod +w ${CMAKE_BINARY_DIR}/bootstrapper
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   BYPRODUCTS bootstrapper
@@ -42,8 +42,8 @@ add_custom_target(bootstrapper ALL
 # upgrade-agent
 #
 add_custom_target(upgrade-agent ALL
-  COMMAND ${BAZEL} build //upgrade-agent/cmd:cmd
-  COMMAND cp \$$\(${BAZEL} cquery --output=files //upgrade-agent/cmd:cmd\) ${CMAKE_BINARY_DIR}/upgrade-agent
+  COMMAND ${BAZEL} build //upgrade-agent/cmd:upgrade_agent_linux_amd64
+  COMMAND cp \$$\(${BAZEL} cquery --output=files //upgrade-agent/cmd:upgrade_agent_linux_amd64\) ${CMAKE_BINARY_DIR}/upgrade-agent
   COMMAND chmod +w ${CMAKE_BINARY_DIR}/upgrade-agent
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   BYPRODUCTS upgrade-agent
@@ -53,8 +53,8 @@ add_custom_target(upgrade-agent ALL
 # cli
 #
 add_custom_target(cli ALL
-  COMMAND ${BAZEL} build --@io_bazel_rules_go//go/config:tags='${CLI_BUILD_TAGS}' --platforms=@local_config_platform//:host //cli:cli_oss
-  COMMAND cp \$$\(${BAZEL} cquery --@io_bazel_rules_go//go/config:tags='${CLI_BUILD_TAGS}' --platforms=@local_config_platform//:host --output=files //cli:cli_oss\) ${CMAKE_BINARY_DIR}/constellation
+  COMMAND ${BAZEL} build --@io_bazel_rules_go//go/config:tags='${CLI_BUILD_TAGS}' //cli:cli_oss_host
+  COMMAND cp \$$\(${BAZEL} cquery --@io_bazel_rules_go//go/config:tags='${CLI_BUILD_TAGS}' --output=files //cli:cli_oss_host\) ${CMAKE_BINARY_DIR}/constellation
   COMMAND chmod +w ${CMAKE_BINARY_DIR}/constellation
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   BYPRODUCTS constellation
@@ -64,8 +64,8 @@ add_custom_target(cli ALL
 # debugd
 #
 add_custom_target(debugd ALL
-  COMMAND ${BAZEL} build //debugd/cmd/debugd:debugd
-  COMMAND cp \$$\(${BAZEL} cquery --output=files //debugd/cmd/debugd:debugd\) ${CMAKE_BINARY_DIR}/debugd
+  COMMAND ${BAZEL} build //debugd/cmd/debugd:debugd_linux_amd64
+  COMMAND cp \$$\(${BAZEL} cquery --output=files //debugd/cmd/debugd:debugd_linux_amd64\) ${CMAKE_BINARY_DIR}/debugd
   COMMAND chmod +w ${CMAKE_BINARY_DIR}/debugd
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   BYPRODUCTS debugd
@@ -75,8 +75,8 @@ add_custom_target(debugd ALL
 # cdbg
 #
 add_custom_target(cdbg ALL
-  COMMAND ${BAZEL} build --platforms=@local_config_platform//:host //debugd/cmd/cdbg:cdbg
-  COMMAND cp \$$\(${BAZEL} cquery --platforms=@local_config_platform//:host --output=files //debugd/cmd/cdbg:cdbg\) ${CMAKE_BINARY_DIR}/cdbg
+  COMMAND ${BAZEL} build //debugd/cmd/cdbg:cdbg_host
+  COMMAND cp \$$\(${BAZEL} cquery --output=files //debugd/cmd/cdbg:cdbg_host\) ${CMAKE_BINARY_DIR}/cdbg
   COMMAND chmod +w ${CMAKE_BINARY_DIR}/cdbg
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   BYPRODUCTS cdbg

--- a/bazel/devbuild/BUILD.bazel
+++ b/bazel/devbuild/BUILD.bazel
@@ -3,16 +3,16 @@ load("//bazel/sh:def.bzl", "sh_template")
 sh_template(
     name = "devbuild",
     data = [
-        "//bootstrapper/cmd/bootstrapper",
+        "//bootstrapper/cmd/bootstrapper:bootstrapper_linux_amd64",
         "//cli:cli_oss_host",
         "//debugd/cmd/cdbg:cdbg_host",
-        "//upgrade-agent/cmd",
+        "//upgrade-agent/cmd:upgrade_agent_linux_amd64",
     ],
     substitutions = {
-        "@@BOOTSTRAPPER@@": "$(rootpath //bootstrapper/cmd/bootstrapper)",
+        "@@BOOTSTRAPPER@@": "$(rootpath //bootstrapper/cmd/bootstrapper:bootstrapper_linux_amd64)",
         "@@CDBG@@": "$(rootpath //debugd/cmd/cdbg:cdbg_host)",
         "@@CLI@@": "$(rootpath //cli:cli_oss_host)",
-        "@@UPGRADE_AGENT@@": "$(rootpath //upgrade-agent/cmd)",
+        "@@UPGRADE_AGENT@@": "$(rootpath //upgrade-agent/cmd:upgrade_agent_linux_amd64)",
     },
     template = "prepare_developer_workspace.sh.in",
     visibility = ["//visibility:public"],

--- a/bazel/go/platform.bzl
+++ b/bazel/go/platform.bzl
@@ -1,0 +1,49 @@
+"""A rule to build a single executable for a specific platform."""
+
+def _platform_transition_impl(settings, attr):
+    _ignore = settings  # @unused
+    return {
+        "//command_line_option:platforms": "{}".format(attr.platform),
+    }
+
+_platform_transition = transition(
+    implementation = _platform_transition_impl,
+    inputs = [],
+    outputs = [
+        "//command_line_option:platforms",
+    ],
+)
+
+def _platform_binary_impl(ctx):
+    out = ctx.actions.declare_file("{}_{}".format(ctx.file.target_file.basename, ctx.attr.platform))
+    ctx.actions.symlink(output = out, target_file = ctx.file.target_file)
+
+    return [
+        DefaultInfo(
+            executable = out,
+            files = depset([out]),
+            runfiles = ctx.runfiles(files = ctx.files.target_file),
+        ),
+    ]
+
+_attrs = {
+    "platform": attr.string(
+        doc = "The platform to build the target for.",
+    ),
+    "target_file": attr.label(
+        allow_single_file = True,
+        mandatory = True,
+        doc = "Target to build.",
+    ),
+    "_allowlist_function_transition": attr.label(
+        default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+    ),
+}
+
+# wrap a single exectable and build it for the specified platform.
+platform_binary = rule(
+    implementation = _platform_binary_impl,
+    cfg = _platform_transition,
+    attrs = _attrs,
+    executable = True,
+)

--- a/bootstrapper/cmd/bootstrapper/BUILD.bazel
+++ b/bootstrapper/cmd/bootstrapper/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//bazel/go:platform.bzl", "platform_binary")
 
 go_library(
     name = "bootstrapper_lib",
@@ -52,5 +53,12 @@ go_binary(
         "//bazel/settings:tpm_simulator_enabled": [],
         "//conditions:default": ["disable_tpm_simulator"],
     }),
+    visibility = ["//visibility:public"],
+)
+
+platform_binary(
+    name = "bootstrapper_linux_amd64",
+    platform = "@zig_sdk//libc_aware/platform:linux_amd64_gnu.2.34",
+    target_file = ":bootstrapper",
     visibility = ["//visibility:public"],
 )

--- a/debugd/cmd/debugd/BUILD.bazel
+++ b/debugd/cmd/debugd/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//bazel/go:platform.bzl", "platform_binary")
 
 go_library(
     name = "debugd_lib",
@@ -31,5 +32,12 @@ go_binary(
     embed = [":debugd_lib"],
     # keep
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+platform_binary(
+    name = "debugd_linux_amd64",
+    platform = "@zig_sdk//libc_aware/platform:linux_amd64_gnu.2.34",
+    target_file = ":debugd",
     visibility = ["//visibility:public"],
 )

--- a/disk-mapper/cmd/BUILD.bazel
+++ b/disk-mapper/cmd/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//bazel/go:platform.bzl", "platform_binary")
 
 go_library(
     name = "cmd_lib",
@@ -33,5 +34,12 @@ go_library(
 go_binary(
     name = "cmd",
     embed = [":cmd_lib"],
+    visibility = ["//visibility:public"],
+)
+
+platform_binary(
+    name = "disk-mapper_linux_amd64",
+    platform = "@zig_sdk//libc_aware/platform:linux_amd64_gnu.2.34",
+    target_file = ":cmd",
     visibility = ["//visibility:public"],
 )

--- a/measurement-reader/cmd/BUILD.bazel
+++ b/measurement-reader/cmd/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//bazel/go:platform.bzl", "platform_binary")
 
 go_library(
     name = "cmd_lib",
@@ -19,5 +20,12 @@ go_library(
 go_binary(
     name = "cmd",
     embed = [":cmd_lib"],
+    visibility = ["//visibility:public"],
+)
+
+platform_binary(
+    name = "measurement-reader_linux_amd64",
+    platform = "@zig_sdk//libc_aware/platform:linux_amd64_gnu.2.34",
+    target_file = ":cmd",
     visibility = ["//visibility:public"],
 )

--- a/upgrade-agent/cmd/BUILD.bazel
+++ b/upgrade-agent/cmd/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("//bazel/go:platform.bzl", "platform_binary")
 
 go_library(
     name = "cmd_lib",
@@ -20,5 +21,12 @@ go_binary(
     embed = [":cmd_lib"],
     # keep
     pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+platform_binary(
+    name = "upgrade_agent_linux_amd64",
+    platform = "@zig_sdk//libc_aware/platform:linux_amd64_gnu.2.34",
+    target_file = ":cmd",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bazel: use host platform by default

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

When using `bazel run` on hosts that are not linux amd64, we would select tools that are incompatible to the host arch / host os.
Now we don't set a static target platform anymore. Instead, we add targets to build some go binaries explicitly for linux amd64.


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
