### PR TITLE
ci: disable upload of Azure TrustedLaunch image

### DIFF
--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -371,9 +371,9 @@ jobs:
       matrix:
         csp: [aws, azure, gcp, openstack, qemu]
         upload-variant: [""]
-        include:
-          - csp: azure
-            upload-variant: TrustedLaunch
+        # include:
+        #   - csp: azure
+        #     upload-variant: TrustedLaunch
     steps:
       - name: Checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: disable upload of Azure TrustedLaunch image

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [image build](https://github.com/edgelesssys/constellation/actions/runs/4445324692)
- TrustedLaunch image upload fails. This is probably due to a change in the API on Azure's side

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
