### PR TITLE
ci: use github actions cache to speedup bazel builds

### DIFF
--- a/.github/actions/setup_bazel/action.yml
+++ b/.github/actions/setup_bazel/action.yml
@@ -26,6 +26,7 @@ runs:
           exit 1
         fi
         echo "::endgroup::"
+
     - name: Bazel repository cache (Linux)
       uses: actions/cache/restore@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
       if: runner.os == 'Linux' && (inputs.useCache == 'true' || inputs.useCache == 'readonly')
@@ -37,6 +38,7 @@ runs:
           /home/runner/.cache/shared_bazel_action_cache
           /tmp/bazel-zig-cc
         key: bazel
+
     - name: Configure Bazel
       shell: bash
       if: inputs.useCache == 'true' || inputs.useCache == 'readonly'
@@ -54,6 +56,7 @@ runs:
         build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_ORG_API_KEY}
         EOF
         echo "::endgroup::"
+
     - name: Configure Bazel (readonly)
       shell: bash
       if: inputs.useCache == 'readonly'
@@ -61,6 +64,7 @@ runs:
         echo "::group::Configure Bazel (readonly)"
         echo "build --remote_upload_local_results=false" >> ~/.bazelrc
         echo "::endgroup::"
+
     - name: Check bazel version
       shell: bash
       run: bazel version

--- a/.github/actions/setup_bazel/action.yml
+++ b/.github/actions/setup_bazel/action.yml
@@ -26,6 +26,17 @@ runs:
           exit 1
         fi
         echo "::endgroup::"
+    - name: Bazel repository cache (Linux)
+      uses: actions/cache/restore@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
+      if: runner.os == 'Linux' && (inputs.useCache == 'true' || inputs.useCache == 'readonly')
+      with:
+        path: |
+          ${{ github.workspace }}/tools/pseudo-version
+          /home/runner/.cache/bazel
+          /home/runner/.cache/shared_bazel_repository_cache
+          /home/runner/.cache/shared_bazel_action_cache
+          /tmp/bazel-zig-cc
+        key: bazel
     - name: Configure Bazel
       shell: bash
       if: inputs.useCache == 'true' || inputs.useCache == 'readonly'

--- a/.github/workflows/warm-bazel-cache.yml
+++ b/.github/workflows/warm-bazel-cache.yml
@@ -1,0 +1,53 @@
+name: Warm bazel cache
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "5 6 * * *" # At 06:05 every day.
+
+env:
+  CACHE_KEY: bazel
+
+permissions:
+  actions: write
+
+jobs:
+  warm-bazel-cache:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
+
+      - name: Build common targets
+        run: |
+          bazel build \
+            //bootstrapper/cmd/bootstrapper:bootstrapper_linux_amd64 \
+            //cli:cli_oss_linux_amd64 \
+            //cli:cli_oss_darwin_amd64 \
+            //debugd/cmd/cdbg:cdbg_linux_amd64 \
+            //debugd/cmd/cdbg:cdbg_darwin_amd64 \
+            //disk-mapper/cmd:disk-mapper_linux_amd64 \
+            //measurement-reader/cmd:measurement-reader_linux_amd64 \
+            //upgrade-agent/cmd:upgrade_agent_linux_amd64
+
+      - name: clear
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh extension install actions/gh-actions-cache || true
+          gh actions-cache delete "${CACHE_KEY}" --confirm || true
+        continue-on-error: true
+
+      - name: save
+        uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        with:
+          path: |
+            ${{ github.workspace }}/tools/pseudo-version
+            /home/runner/.cache/bazel
+            /home/runner/.cache/shared_bazel_repository_cache
+            /home/runner/.cache/shared_bazel_action_cache
+            /tmp/bazel-zig-cc
+          key: ${{ env.CACHE_KEY }}

--- a/.github/workflows/warm-bazel-cache.yml
+++ b/.github/workflows/warm-bazel-cache.yml
@@ -33,13 +33,13 @@ jobs:
             //upgrade-agent/cmd:upgrade_agent_linux_amd64
 
       - name: clear
+        continue-on-error: true
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh extension install actions/gh-actions-cache || true
           gh actions-cache delete "${CACHE_KEY}" --confirm || true
-        continue-on-error: true
 
       - name: save
         uses: actions/cache/save@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: use github actions cache to speedup bazel build

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info
- [run with empty cache](https://github.com/edgelesssys/constellation/actions/runs/4446625524) 11m15s
- [run with repo cache (but without remote cache)](https://github.com/edgelesssys/constellation/actions/runs/4446715094) 7m36s
- [run with repo cache and remote cache](https://github.com/edgelesssys/constellation/actions/runs/4468366094) 3m20s
- <strike>The github actions cache alone is a smaller improvement than I was hoping for. GitHub only allows uploading things to the cache if the cache key doesn't exist yet. We would want to merge the existing cache with new builds to get amazing speedups. See also: https://github.com/actions/cache/issues/342</strike>
- Combining caches and using a separate workflow to warm up the cache did the trick

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
