### PR TITLE
e2e: Remove Ubuntu builder for debug artifacts required for macOS runner

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -111,34 +111,14 @@ runs:
         targetArch: ${{ steps.determine-build-target.outputs.hostArch }}
         enterpriseCLI: ${{ inputs.keepMeasurements }}
 
-    # macOS runners don't have Docker preinstalled, so they cannot build the bootstrapper.
-    # But we can use a Linux runner to build it and store/retrieve it from the action cache.
-    - name: Download the bootstrapper from cache
-      id: download-bootstrapper-cache
-      if: inputs.isDebugImage == 'true' && runner.os == 'macOS'
-      uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
-      with:
-        key: bootstrapper-${{ github.sha }}
-        path: "build/bootstrapper"
-
     - name: Build the bootstrapper
       id: build-bootstrapper
-      if: inputs.isDebugImage == 'true' && runner.os != 'macOS'
+      if: inputs.isDebugImage == 'true'
       uses: ./.github/actions/build_bootstrapper
-
-    # macOS runners don't have Docker preinstalled, so they cannot build the upgrade-agent.
-    # But we can use a Linux runner to build it and store/retrieve it from the action cache.
-    - name: Download the upgrade-agent from cache
-      id: download-upgrade-agent-cache
-      if: inputs.isDebugImage == 'true' && runner.os == 'macOS'
-      uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
-      with:
-        key: upgrade-agent-${{ github.sha }}
-        path: "build/upgrade-agent"
 
     - name: Build the upgrade-agent
       id: build-upgrade-agent
-      if: inputs.isDebugImage == 'true' && runner.os != 'macOS'
+      if: inputs.isDebugImage == 'true'
       uses: ./.github/actions/build_upgrade_agent
 
     - name: Build cdbg

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -189,9 +189,7 @@ jobs:
       id-token: write
       contents: read
     needs: [find-latest-image]
-    if: |
-      always() &&
-      !cancelled()
+    if: always() && !cancelled()
     steps:
       - name: Install basic tools (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -183,62 +183,15 @@ jobs:
               ;;
           esac
 
-  build-bootstrapper:
-    name: "Build bootstrapper for macOS runner"
-    runs-on: ubuntu-22.04
-    if: inputs.runner == 'macos-12' && needs.find-latest-image.outputs.isDebugImage == 'true'
-    needs: [find-latest-image]
-    steps:
-      - name: Setup Go environment
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
-        with:
-          go-version: "1.20.2"
-
-      - name: Checkout head
-        if: inputs.git-ref == 'head'
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
-
-      - name: Checkout ref
-        if: inputs.git-ref != 'head'
-        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
-        with:
-          ref: ${{ inputs.git-ref }}
-
-      - name: Build bootstrapper
-        uses: ./.github/actions/build_bootstrapper
-
-      - name: Build upgrade-agent
-        uses: ./.github/actions/build_upgrade_agent
-        with:
-          outputPath: ${{ github.workspace }}/build/upgrade-agent
-
-      - name: Upload bootstrapper to cache
-        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
-        with:
-          key: bootstrapper-${{ github.sha }}
-          path: "build/bootstrapper"
-
-      - name: Upload upgrade-agent to cache
-        uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0 # v3.2.6
-        with:
-          key: upgrade-agent-${{ github.sha }}
-          path: "build/upgrade-agent"
-
   e2e-test-manual:
     runs-on: ${{ inputs.runner }}
     permissions:
       id-token: write
       contents: read
-    needs: [find-latest-image, build-bootstrapper]
+    needs: [find-latest-image]
     if: |
       always() &&
-      !cancelled() &&
-      (
-        needs.build-bootstrapper.result == 'success' ||
-        needs.build-bootstrapper.result == 'skipped'
-      )
+      !cancelled()
     steps:
       - name: Install the basics tools (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -193,7 +193,7 @@ jobs:
       always() &&
       !cancelled()
     steps:
-      - name: Install the basics tools (macOS)
+      - name: Install basic tools (macOS)
         if: runner.os == 'macOS'
         shell: bash
         run: brew install coreutils kubectl bash


### PR DESCRIPTION
### Proposed change(s)
- Remove Ubuntu + cache build steps for macOS e2e test

Shouldn't be required anymore as we use Bazel and we can now cross-compile correctly.
