### PR TITLE
cli: remove ctx parameter from rollbackOnError to prevent wrong use

### DIFF
--- a/cli/internal/cloudcmd/create.go
+++ b/cli/internal/cloudcmd/create.go
@@ -130,7 +130,7 @@ func (c *Creator) createAWS(ctx context.Context, cl terraformClient, config *con
 		return clusterid.File{}, err
 	}
 
-	defer rollbackOnError(context.Background(), c.out, &retErr, &rollbackerTerraform{client: cl})
+	defer rollbackOnError(c.out, &retErr, &rollbackerTerraform{client: cl})
 	tfOutput, err := cl.CreateCluster(ctx)
 	if err != nil {
 		return clusterid.File{}, err
@@ -168,7 +168,7 @@ func (c *Creator) createGCP(ctx context.Context, cl terraformClient, config *con
 		return clusterid.File{}, err
 	}
 
-	defer rollbackOnError(context.Background(), c.out, &retErr, &rollbackerTerraform{client: cl})
+	defer rollbackOnError(c.out, &retErr, &rollbackerTerraform{client: cl})
 	tfOutput, err := cl.CreateCluster(ctx)
 	if err != nil {
 		return clusterid.File{}, err
@@ -209,7 +209,7 @@ func (c *Creator) createAzure(ctx context.Context, cl terraformClient, config *c
 		return clusterid.File{}, err
 	}
 
-	defer rollbackOnError(context.Background(), c.out, &retErr, &rollbackerTerraform{client: cl})
+	defer rollbackOnError(c.out, &retErr, &rollbackerTerraform{client: cl})
 	tfOutput, err := cl.CreateCluster(ctx)
 	if err != nil {
 		return clusterid.File{}, err
@@ -288,7 +288,7 @@ func (c *Creator) createOpenStack(ctx context.Context, cl terraformClient, confi
 		return clusterid.File{}, err
 	}
 
-	defer rollbackOnError(context.Background(), c.out, &retErr, &rollbackerTerraform{client: cl})
+	defer rollbackOnError(c.out, &retErr, &rollbackerTerraform{client: cl})
 	tfOutput, err := cl.CreateCluster(ctx)
 	if err != nil {
 		return clusterid.File{}, err
@@ -306,7 +306,7 @@ func (c *Creator) createQEMU(ctx context.Context, cl terraformClient, lv libvirt
 	controlPlaneCount, workerCount int, source string,
 ) (idFile clusterid.File, retErr error) {
 	qemuRollbacker := &rollbackerQEMU{client: cl, libvirt: lv, createdWorkspace: false}
-	defer rollbackOnError(context.Background(), c.out, &retErr, qemuRollbacker)
+	defer rollbackOnError(c.out, &retErr, qemuRollbacker)
 
 	// TODO: render progress bar
 	downloader := c.newRawDownloader()

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -152,7 +152,7 @@ func (c *IAMCreator) Create(ctx context.Context, provider cloudprovider.Provider
 
 // createGCP creates the IAM configuration on GCP.
 func (c *IAMCreator) createGCP(ctx context.Context, cl terraformClient, iamConfig *IAMConfig) (retFile iamid.File, retErr error) {
-	defer rollbackOnError(context.Background(), c.out, &retErr, &rollbackerTerraform{client: cl})
+	defer rollbackOnError(c.out, &retErr, &rollbackerTerraform{client: cl})
 
 	vars := terraform.GCPIAMVariables{
 		ServiceAccountID: iamConfig.GCP.ServiceAccountID,
@@ -180,7 +180,7 @@ func (c *IAMCreator) createGCP(ctx context.Context, cl terraformClient, iamConfi
 
 // createAzure creates the IAM configuration on Azure.
 func (c *IAMCreator) createAzure(ctx context.Context, cl terraformClient, iamConfig *IAMConfig) (retFile iamid.File, retErr error) {
-	defer rollbackOnError(context.Background(), c.out, &retErr, &rollbackerTerraform{client: cl})
+	defer rollbackOnError(c.out, &retErr, &rollbackerTerraform{client: cl})
 
 	vars := terraform.AzureIAMVariables{
 		Region:           iamConfig.Azure.Region,
@@ -211,7 +211,7 @@ func (c *IAMCreator) createAzure(ctx context.Context, cl terraformClient, iamCon
 
 // createAWS creates the IAM configuration on AWS.
 func (c *IAMCreator) createAWS(ctx context.Context, cl terraformClient, iamConfig *IAMConfig) (retFile iamid.File, retErr error) {
-	defer rollbackOnError(context.Background(), c.out, &retErr, &rollbackerTerraform{client: cl})
+	defer rollbackOnError(c.out, &retErr, &rollbackerTerraform{client: cl})
 
 	vars := terraform.AWSIAMVariables{
 		Region: iamConfig.AWS.Region,

--- a/cli/internal/cloudcmd/rollback.go
+++ b/cli/internal/cloudcmd/rollback.go
@@ -20,13 +20,13 @@ type rollbacker interface {
 
 // rollbackOnError calls rollback on the rollbacker if the handed error is not nil,
 // and writes logs to the writer w.
-func rollbackOnError(ctx context.Context, w io.Writer, onErr *error, roll rollbacker) {
+func rollbackOnError(w io.Writer, onErr *error, roll rollbacker) {
 	if *onErr == nil {
 		return
 	}
 	fmt.Fprintf(w, "An error occurred: %s\n", *onErr)
 	fmt.Fprintln(w, "Attempting to roll back.")
-	if err := roll.rollback(ctx); err != nil {
+	if err := roll.rollback(context.Background()); err != nil {
 		*onErr = errors.Join(*onErr, fmt.Errorf("on rollback: %w", err)) // TODO: print the error, or return it?
 		return
 	}


### PR DESCRIPTION
rollbackOnError must not be called with the ctx of the to-be-rollbacked action, so we shouldn't allow to pass a (wrong) context in.