### PR TITLE
debugd: Use very basic JSON regex filter before JSON filter

### DIFF
--- a/debugd/internal/debugd/logcollector/logstash/templates/pipeline.conf
+++ b/debugd/internal/debugd/logcollector/logstash/templates/pipeline.conf
@@ -28,25 +28,31 @@ filter {
 
     # Parse structured logs for following systemd units.
     if [systemd][unit] in ["bootstrapper.service", "constellation-bootstrapper.service"] {
-        json {
-            source => "message"
-            target => "logs"
-            skip_on_invalid_json => true
-        }
-        date {
-            match => [ "[logs][ts]", "ISO8601" ]
-        }
-        mutate {
-            replace => {
-                "message" => "%{[logs][msg]}"
+        # skip_on_invalid_json below does not skip the whole filter, so let's use a cheap workaround here.
+        # See:
+        # https://discuss.elastic.co/t/skip-on-invalid-json-skipping-all-filters/215195
+        # https://discuss.elastic.co/t/looking-for-a-way-to-detect-json/102263
+        if [message] =~ "\A\{.+\}\z" {
+            json {
+                source => "message"
+                target => "logs"
+                skip_on_invalid_json => true
             }
-            remove_field => [
-                "[logs][msg]",
-                "[logs][ts]"
-            ]
-        }
-        de_dot {
-            fields => ["[logs][peer.address]"]
+            date {
+                match => [ "[logs][ts]", "ISO8601" ]
+            }
+            mutate {
+                replace => {
+                    "message" => "%{[logs][msg]}"
+                }
+                remove_field => [
+                    "[logs][msg]",
+                    "[logs][ts]"
+                ]
+            }
+            de_dot {
+                fields => ["[logs][peer.address]"]
+            }
         }
     }
 }


### PR DESCRIPTION
### Proposed change(s)
- Use a very basic JSON regex check before the mutation pipeline

The documentation for `skip_on_invalid_json` states:
>Allows for skipping the filter on invalid JSON (this allows you to handle JSON and non-JSON data without warnings)
Unfortunately, skipping the filter only seems to apply [to the json block itself](https://discuss.elastic.co/t/skip-on-invalid-json-skipping-all-filters/215195), and not the whole filter.

This means that if anything goes wrong inside the bootstrapper (fatal error/panic) and non-JSON output is dumped into the pipeline, our message will just be replaced with `%{[logs][msg]}"`. This of course makes it impossible to see the actual panic or fatal error, rendering this whole logging kinda useless.

This PR adds a [very basic](https://discuss.elastic.co/t/looking-for-a-way-to-detect-json/102263/6) approach to detect JSON inputs and only run the whole filter pipeline then. The filter is of course flawed in the sense that it is very basic (e.g. doesn't detect JSON arrays), but this seems to be fine for zap logger output.

There's very likely cleaner approaches to fix this. [Some say to use conditional blocks that can only pass when the JSON was parsed successfully](https://discuss.elastic.co/t/skip-on-invalid-json-skipping-all-filters/215195/3), but one comment down below says this still runs with invalid JSON. Plus we have the `date` and `de_dot` filter in there.

I don't know. I didn't write the config and don't want to try everything out given it's not a production pipeline. But I want to debug other bootstrapper issues now, so this would be my workaround for now unless someone directly knows what a cleaner way to handle this would be.
