### PR TITLE
terraform: valid Azure attestation provider name

### DIFF
--- a/cli/internal/terraform/terraform/azure/main.tf
+++ b/cli/internal/terraform/terraform/azure/main.tf
@@ -42,8 +42,9 @@ resource "random_password" "initSecret" {
 }
 
 resource "azurerm_attestation_provider" "attestation_provider" {
-  count               = var.create_maa ? 1 : 0
-  name                = format("%sap", var.name)
+  count = var.create_maa ? 1 : 0
+  # name must be between 3 and 24 characters in length and use numbers and lower-case letters only.
+  name                = format("%sap", replace(var.name, "/[^a-z0-9]/", ""))
   resource_group_name = var.resource_group
   location            = var.location
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix [bug in attestation provider naming](https://github.com/edgelesssys/constellation/actions/runs/4469849456/jobs/7852552415#step:9:1089), introduced in #1375
- e2e test run, Kubernetes 1.25, nop: https://github.com/edgelesssys/constellation/actions/runs/4470212067
<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
