### PR TITLE
terraform: unique Azure attestation provider name

### DIFF
--- a/cli/internal/terraform/terraform/azure/main.tf
+++ b/cli/internal/terraform/terraform/azure/main.tf
@@ -44,7 +44,7 @@ resource "random_password" "initSecret" {
 resource "azurerm_attestation_provider" "attestation_provider" {
   count = var.create_maa ? 1 : 0
   # name must be between 3 and 24 characters in length and use numbers and lower-case letters only.
-  name                = format("%sap", replace(var.name, "/[^a-z0-9]/", ""))
+  name                = format("constell%s", local.uid)
   resource_group_name = var.resource_group
   location            = var.location
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- While #1465 made the name valid, is also has to be unique. The name should use local.name instead of var.name, as first contains the uid.
- [`Attestation Provider Name: "e2etestap"): attestationproviders.AttestationProvidersClient#Create: Failure sending request: StatusCode=409 -- Original Error: autorest/azure: Service returned an error. Status=<nil> Code="DuplicateTenant" Message="The given service URI 'e2etestap' is already in use. Please try again with a different name."`](https://github.com/edgelesssys/constellation/actions/runs/4471281390/jobs/7855959048#step:9:929)

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
