### PR TITLE
bazel: upgrade bazel-zig-cc to allow caching of launcher

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -56,18 +56,22 @@ zig_cc_deps()
 
 load("@bazel-zig-cc//toolchain:defs.bzl", zig_toolchains = "toolchains")
 
+# If needed, we can specify a specific version of the Zig toolchain to use.
+# If not specified, bazel-zig-cc will use a known good version of Zig.
 # See https://ziglang.org/download/ for the latest releases
 
-zig_toolchains(
-    host_platform_sha256 = {
-        "linux-aarch64": "b759a11993949531c692ccfc3d1a004b14df714a7a3515fe0b5c90c9a7631d61",
-        "linux-x86_64": "028dad5189e02b2058679b64df16e854a1c1ca0e6044b334d4f3be6e35544f07",
-        "macos-aarch64": "5709c27d581988f50f5e6fd5b69d92707787e803a1d04992e290b764617664e6",
-        "macos-x86_64": "88d194adb2f3c1a9edbb4a24d018007d5f827a57d1d26b2d9f3459236da1b7b6",
-        "windows-x86_64": "75e510bda108e4d78b89d5d1d09e70ea8595fac7c43b5611f280668881adb09d",
-    },
-    version = "0.11.0-dev.1638+7199d7c77",
-)
+# zig_toolchains(
+#     host_platform_sha256 = {
+#         "linux-aarch64": "b759a11993949531c692ccfc3d1a004b14df714a7a3515fe0b5c90c9a7631d61",
+#         "linux-x86_64": "028dad5189e02b2058679b64df16e854a1c1ca0e6044b334d4f3be6e35544f07",
+#         "macos-aarch64": "5709c27d581988f50f5e6fd5b69d92707787e803a1d04992e290b764617664e6",
+#         "macos-x86_64": "88d194adb2f3c1a9edbb4a24d018007d5f827a57d1d26b2d9f3459236da1b7b6",
+#         "windows-x86_64": "75e510bda108e4d78b89d5d1d09e70ea8595fac7c43b5611f280668881adb09d",
+#     },
+#     version = "0.11.0-dev.1638+7199d7c77",
+# )
+
+zig_toolchains()
 
 register_toolchains(
     "@zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.34",

--- a/bazel/toolchains/zig_cc_deps.bzl
+++ b/bazel/toolchains/zig_cc_deps.bzl
@@ -2,8 +2,6 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-BAZEL_ZIG_CC_VERSION = "v1.0.0"
-
 def zig_cc_deps():
     """Loads the dependencies for bazel-zig-cc."""
 
@@ -16,9 +14,12 @@ def zig_cc_deps():
         ],
     )
 
+    # TODO(malt3): Update to a release version once the next release is out.
+    # Upgraded to work around https://github.com/uber/bazel-zig-cc/issues/22
+    # See also https://github.com/uber/bazel-zig-cc/pull/23
     http_archive(
         name = "bazel-zig-cc",
-        sha256 = "1f4a1d1e0f6b3e5aa6e1c225fcb23c032f8849441de97b9a38d6ea37362d28e2",
-        strip_prefix = "bazel-zig-cc-{}".format(BAZEL_ZIG_CC_VERSION),
-        urls = ["https://git.sr.ht/~motiejus/bazel-zig-cc/archive/{}.tar.gz".format(BAZEL_ZIG_CC_VERSION)],
+        sha256 = "bea372f7f9bd8541f7b0a152c76c7b9396201c36a0ed229b36c48301815c3141",
+        strip_prefix = "bazel-zig-cc-f3e4542bd62f4aef794a3d184140a9d30b8fadb8",
+        urls = ["https://github.com/uber/bazel-zig-cc/archive/f3e4542bd62f4aef794a3d184140a9d30b8fadb8.tar.gz"],
     )


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
Apply https://github.com/uber/bazel-zig-cc/pull/23 to see if it resolves flaky `SIGILL` emitted by bazel-zig-cc launcher when using Bazel's remote caching feature.


### Related issue
- https://github.com/edgelesssys/constellation/actions/runs/4477922647/jobs/7870052736?pr=1464#step:4:68
- https://github.com/uber/bazel-zig-cc/issues/22

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
