### PR TITLE
bazel: use pure go implementation of netdns for all builds 

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -20,6 +20,9 @@ build --strip=always
 # set build mode to opt by default (better reproducibility and performance)
 build --compilation_mode=opt
 
+# use pure go implementation of netdns
+build --define=gotags=netgo
+
 # enable tpm simulator for tests
 test --//bazel/settings:tpm_simulator
 
@@ -48,4 +51,4 @@ build:remote_cache --experimental_remote_build_event_upload=minimal
 build:remote_cache --experimental_remote_cache_compression
 build:remote_cache_readonly --noremote_upload_local_results # Uploads logs & artifacts without writing to cache
 
-try-import .bazeloverwriterc 
+try-import .bazeloverwriterc


### PR DESCRIPTION
All builds (with or without cgo support) should use netdns. This prevents weird issues we occasionally see when building linux binaries on macOS.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bazel: use pure go implementation of netdns for all builds 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
