### PR TITLE
ci: rename scheduled OS image build action

### DIFF
--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -1,4 +1,4 @@
-name: Build and Upload OS image
+name: Build and Upload OS image (scheduled)
 
 on:
   schedule:


### PR DESCRIPTION
Super minor change so both OS build image actions don't have exactly the same name in the Actions list.