### PR TITLE
e2e: install Terraform for macOS runner for boot log collection

### DIFF
--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Install basic tools (macOS)
         if: runner.os == 'macOS'
         shell: bash
-        run: brew install coreutils kubectl bash
+        run: brew install coreutils kubectl bash terraform
 
       - name: Checkout head
         if: inputs.git-ref == 'head'


### PR DESCRIPTION
### Proposed change(s)
- Install Terraform in macOS e2e test runner

The GitHub Ubuntu runner has Terraform preinstalled, the macOS doesn't. This breaks downloading boot logs for AWS or GCP. This doesn't fail the e2e test, but it would be cool to have the logs for debugging any issues occurring when doing an macOS test run.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
