### PR TITLE
versionsapi: Split GCP image URI to extract the image name

### DIFF
--- a/internal/versionsapi/cli/rm.go
+++ b/internal/versionsapi/cli/rm.go
@@ -529,7 +529,13 @@ type gcpComputeAPI interface {
 	io.Closer
 }
 
-func (g *gcpClient) deleteImage(ctx context.Context, image string, dryrun bool, log *logger.Logger) error {
+func (g *gcpClient) deleteImage(ctx context.Context, imageURI string, dryrun bool, log *logger.Logger) error {
+	// Extract image name from image URI
+	// Expected input into function: "projects/constellation-images/global/images/v2-6-0-stable"
+	// Required for computepb.DeleteImageRequest: "v2-6-0-stable"
+	imageURIParts := strings.Split(imageURI, "/")
+	image := imageURIParts[len(imageURIParts)-1] // Don't need to check if len(imageURIParts) == 0 since sep is not empty and thus length must be ≥ 1
+
 	req := &computepb.DeleteImageRequest{
 		Image:   image,
 		Project: g.project,


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Split GCP image URI to extract the image name from the information in image.json in the versionsapi CLI

Currently, image are not purged correctly on GCP:
https://github.com/edgelesssys/constellation/actions/runs/4481677681/jobs/7878710834#step:9:113

This is since our info.json encodes the image URI like this:
`projects/constellation-images/global/images/v2-6-0-stable`

But `computepb.DeleteImageRequest` expects only the name of the image, since `g.compute.Delete` does build the image URL by itself using the parameters given in `computepb.DeleteImageRequest`.

So let's split the string before.
I am giving this a quick test before merging by building an OS image that can be safely deleted: https://github.com/edgelesssys/constellation/actions/runs/4482202814 

(No special input validation given that images cannot have slashes in them and we also don't do this elsewhere)
