### PR TITLE
cli: add verify support for TDX (and various refactors + fixes regarding attesation variants for TDX)

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -56,18 +56,22 @@ zig_cc_deps()
 
 load("@bazel-zig-cc//toolchain:defs.bzl", zig_toolchains = "toolchains")
 
+# If needed, we can specify a specific version of the Zig toolchain to use.
+# If not specified, bazel-zig-cc will use a known good version of Zig.
 # See https://ziglang.org/download/ for the latest releases
 
-zig_toolchains(
-    host_platform_sha256 = {
-        "linux-aarch64": "b759a11993949531c692ccfc3d1a004b14df714a7a3515fe0b5c90c9a7631d61",
-        "linux-x86_64": "028dad5189e02b2058679b64df16e854a1c1ca0e6044b334d4f3be6e35544f07",
-        "macos-aarch64": "5709c27d581988f50f5e6fd5b69d92707787e803a1d04992e290b764617664e6",
-        "macos-x86_64": "88d194adb2f3c1a9edbb4a24d018007d5f827a57d1d26b2d9f3459236da1b7b6",
-        "windows-x86_64": "75e510bda108e4d78b89d5d1d09e70ea8595fac7c43b5611f280668881adb09d",
-    },
-    version = "0.11.0-dev.1638+7199d7c77",
-)
+# zig_toolchains(
+#     host_platform_sha256 = {
+#         "linux-aarch64": "b759a11993949531c692ccfc3d1a004b14df714a7a3515fe0b5c90c9a7631d61",
+#         "linux-x86_64": "028dad5189e02b2058679b64df16e854a1c1ca0e6044b334d4f3be6e35544f07",
+#         "macos-aarch64": "5709c27d581988f50f5e6fd5b69d92707787e803a1d04992e290b764617664e6",
+#         "macos-x86_64": "88d194adb2f3c1a9edbb4a24d018007d5f827a57d1d26b2d9f3459236da1b7b6",
+#         "windows-x86_64": "75e510bda108e4d78b89d5d1d09e70ea8595fac7c43b5611f280668881adb09d",
+#     },
+#     version = "0.11.0-dev.1638+7199d7c77",
+# )
+
+zig_toolchains()
 
 register_toolchains(
     "@zig_sdk//libc_aware/toolchain:linux_amd64_gnu.2.34",

--- a/bazel/toolchains/zig_cc_deps.bzl
+++ b/bazel/toolchains/zig_cc_deps.bzl
@@ -2,8 +2,6 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-BAZEL_ZIG_CC_VERSION = "v1.0.0"
-
 def zig_cc_deps():
     """Loads the dependencies for bazel-zig-cc."""
 
@@ -16,9 +14,12 @@ def zig_cc_deps():
         ],
     )
 
+    # TODO(malt3): Update to a release version once the next release is out.
+    # Upgraded to work around https://github.com/uber/bazel-zig-cc/issues/22
+    # See also https://github.com/uber/bazel-zig-cc/pull/23
     http_archive(
         name = "bazel-zig-cc",
-        sha256 = "1f4a1d1e0f6b3e5aa6e1c225fcb23c032f8849441de97b9a38d6ea37362d28e2",
-        strip_prefix = "bazel-zig-cc-{}".format(BAZEL_ZIG_CC_VERSION),
-        urls = ["https://git.sr.ht/~motiejus/bazel-zig-cc/archive/{}.tar.gz".format(BAZEL_ZIG_CC_VERSION)],
+        sha256 = "bea372f7f9bd8541f7b0a152c76c7b9396201c36a0ed229b36c48301815c3141",
+        strip_prefix = "bazel-zig-cc-f3e4542bd62f4aef794a3d184140a9d30b8fadb8",
+        urls = ["https://github.com/uber/bazel-zig-cc/archive/f3e4542bd62f4aef794a3d184140a9d30b8fadb8.tar.gz"],
     )

--- a/cli/internal/cloudcmd/BUILD.bazel
+++ b/cli/internal/cloudcmd/BUILD.bazel
@@ -74,6 +74,7 @@ go_test(
         "//internal/attestation/idkeydigest",
         "//internal/attestation/measurements",
         "//internal/attestation/qemu",
+        "//internal/attestation/tdx",
         "//internal/cloud/cloudprovider",
         "//internal/cloud/gcpshared",
         "//internal/compatibility",

--- a/cli/internal/cloudcmd/validators.go
+++ b/cli/internal/cloudcmd/validators.go
@@ -113,7 +113,7 @@ func (v *Validator) setMeasurements(config *config.Config) error {
 			return errors.New("no expected measurement provided")
 		}
 		v.measurements = gcpMeasurements
-	case oid.QEMUVTPM{}:
+	case oid.QEMUVTPM{}, oid.QEMUTDX{}:
 		qemuMeasurements := config.Provider.QEMU.Measurements
 		if len(qemuMeasurements) == 0 {
 			return errors.New("no expected measurement provided")

--- a/cli/internal/cloudcmd/validators_test.go
+++ b/cli/internal/cloudcmd/validators_test.go
@@ -81,7 +81,7 @@ func TestNewValidator(t *testing.T) {
 				},
 			},
 		},
-		"no pcrs provided": {
+		"no measurements provided": {
 			config: &config.Config{
 				AttestationVariant: oid.AzureSEVSNP{}.String(),
 				Provider: config.ProviderConfig{
@@ -127,7 +127,7 @@ func TestNewValidator(t *testing.T) {
 				assert.Error(err)
 			} else {
 				assert.NoError(err)
-				assert.Equal(tc.config.GetMeasurements(), validators.pcrs)
+				assert.Equal(tc.config.GetMeasurements(), validators.measurements)
 				variant, err := oid.FromString(tc.config.AttestationVariant)
 				require.NoError(t, err)
 				assert.Equal(variant, validators.attestationVariant)
@@ -156,29 +156,29 @@ func TestValidatorV(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		variant oid.Getter
-		pcrs    measurements.M
-		wantVs  atls.Validator
+		variant      oid.Getter
+		measurements measurements.M
+		wantVs       atls.Validator
 	}{
 		"gcp": {
-			variant: oid.GCPSEVES{},
-			pcrs:    newTestPCRs(),
-			wantVs:  gcp.NewValidator(newTestPCRs(), nil),
+			variant:      oid.GCPSEVES{},
+			measurements: newTestPCRs(),
+			wantVs:       gcp.NewValidator(newTestPCRs(), nil),
 		},
 		"azure cvm": {
-			variant: oid.AzureSEVSNP{},
-			pcrs:    newTestPCRs(),
-			wantVs:  snp.NewValidator(newTestPCRs(), idkeydigest.IDKeyDigests{}, false, nil),
+			variant:      oid.AzureSEVSNP{},
+			measurements: newTestPCRs(),
+			wantVs:       snp.NewValidator(newTestPCRs(), idkeydigest.IDKeyDigests{}, false, nil),
 		},
 		"azure trusted launch": {
-			variant: oid.AzureTrustedLaunch{},
-			pcrs:    newTestPCRs(),
-			wantVs:  trustedlaunch.NewValidator(newTestPCRs(), nil),
+			variant:      oid.AzureTrustedLaunch{},
+			measurements: newTestPCRs(),
+			wantVs:       trustedlaunch.NewValidator(newTestPCRs(), nil),
 		},
 		"qemu": {
-			variant: oid.QEMUVTPM{},
-			pcrs:    newTestPCRs(),
-			wantVs:  qemu.NewValidator(newTestPCRs(), nil),
+			variant:      oid.QEMUVTPM{},
+			measurements: newTestPCRs(),
+			wantVs:       qemu.NewValidator(newTestPCRs(), nil),
 		},
 	}
 
@@ -186,7 +186,7 @@ func TestValidatorV(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			validators := &Validator{attestationVariant: tc.variant, pcrs: tc.pcrs}
+			validators := &Validator{attestationVariant: tc.variant, measurements: tc.measurements}
 
 			resultValidator := validators.V(&cobra.Command{})
 
@@ -195,7 +195,7 @@ func TestValidatorV(t *testing.T) {
 	}
 }
 
-func TestValidatorUpdateInitPCRs(t *testing.T) {
+func TestValidatorUpdateInitMeasurements(t *testing.T) {
 	zero := measurements.WithAllBytes(0x00, true, measurements.PCRMeasurementLength)
 	one := measurements.WithAllBytes(0x11, true, measurements.PCRMeasurementLength)
 	one64 := base64.StdEncoding.EncodeToString(one.Expected[:])
@@ -231,53 +231,53 @@ func TestValidatorUpdateInitPCRs(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		variant   oid.Getter
-		pcrs      measurements.M
-		ownerID   string
-		clusterID string
-		wantErr   bool
+		variant      oid.Getter
+		measurements measurements.M
+		ownerID      string
+		clusterID    string
+		wantErr      bool
 	}{
 		"gcp update owner ID": {
-			variant: oid.GCPSEVES{},
-			pcrs:    newTestPCRs(),
-			ownerID: one64,
+			variant:      oid.GCPSEVES{},
+			measurements: newTestPCRs(),
+			ownerID:      one64,
 		},
 		"gcp update cluster ID": {
-			variant:   oid.GCPSEVES{},
-			pcrs:      newTestPCRs(),
-			clusterID: one64,
+			variant:      oid.GCPSEVES{},
+			measurements: newTestPCRs(),
+			clusterID:    one64,
 		},
 		"gcp update both": {
-			variant:   oid.GCPSEVES{},
-			pcrs:      newTestPCRs(),
-			ownerID:   one64,
-			clusterID: one64,
+			variant:      oid.GCPSEVES{},
+			measurements: newTestPCRs(),
+			ownerID:      one64,
+			clusterID:    one64,
 		},
 		"azure update owner ID": {
-			variant: oid.AzureSEVSNP{},
-			pcrs:    newTestPCRs(),
-			ownerID: one64,
+			variant:      oid.AzureSEVSNP{},
+			measurements: newTestPCRs(),
+			ownerID:      one64,
 		},
 		"azure update cluster ID": {
-			variant:   oid.AzureSEVSNP{},
-			pcrs:      newTestPCRs(),
-			clusterID: one64,
+			variant:      oid.AzureSEVSNP{},
+			measurements: newTestPCRs(),
+			clusterID:    one64,
 		},
 		"azure update both": {
-			variant:   oid.AzureSEVSNP{},
-			pcrs:      newTestPCRs(),
-			ownerID:   one64,
-			clusterID: one64,
+			variant:      oid.AzureSEVSNP{},
+			measurements: newTestPCRs(),
+			ownerID:      one64,
+			clusterID:    one64,
 		},
 		"owner ID and cluster ID empty": {
-			variant: oid.GCPSEVES{},
-			pcrs:    newTestPCRs(),
+			variant:      oid.GCPSEVES{},
+			measurements: newTestPCRs(),
 		},
 		"invalid encoding": {
-			variant: oid.GCPSEVES{},
-			pcrs:    newTestPCRs(),
-			ownerID: "invalid",
-			wantErr: true,
+			variant:      oid.GCPSEVES{},
+			measurements: newTestPCRs(),
+			ownerID:      "invalid",
+			wantErr:      true,
 		},
 	}
 
@@ -285,42 +285,42 @@ func TestValidatorUpdateInitPCRs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			validators := &Validator{attestationVariant: tc.variant, pcrs: tc.pcrs}
+			validators := &Validator{attestationVariant: tc.variant, measurements: tc.measurements}
 
-			err := validators.UpdateInitPCRs(tc.ownerID, tc.clusterID)
+			err := validators.UpdateInitMeasurements(tc.ownerID, tc.clusterID)
 
 			if tc.wantErr {
 				assert.Error(err)
 				return
 			}
 			assert.NoError(err)
-			for i := 0; i < len(tc.pcrs); i++ {
+			for i := 0; i < len(tc.measurements); i++ {
 				switch {
 				case i == int(measurements.PCRIndexClusterID) && tc.clusterID == "":
 					// should be deleted
-					_, ok := validators.pcrs[uint32(i)]
+					_, ok := validators.measurements[uint32(i)]
 					assert.False(ok)
 
 				case i == int(measurements.PCRIndexClusterID):
-					pcr, ok := validators.pcrs[uint32(i)]
+					pcr, ok := validators.measurements[uint32(i)]
 					assert.True(ok)
 					assert.Equal(pcrZeroUpdatedOne[:], pcr.Expected)
 
 				case i == int(measurements.PCRIndexOwnerID) && tc.ownerID == "":
 					// should be deleted
-					_, ok := validators.pcrs[uint32(i)]
+					_, ok := validators.measurements[uint32(i)]
 					assert.False(ok)
 
 				case i == int(measurements.PCRIndexOwnerID):
-					pcr, ok := validators.pcrs[uint32(i)]
+					pcr, ok := validators.measurements[uint32(i)]
 					assert.True(ok)
 					assert.Equal(pcrZeroUpdatedOne[:], pcr.Expected)
 
 				default:
 					if i >= 17 && i <= 22 {
-						assert.Equal(one, validators.pcrs[uint32(i)])
+						assert.Equal(one, validators.measurements[uint32(i)])
 					} else {
-						assert.Equal(zero, validators.pcrs[uint32(i)])
+						assert.Equal(zero, validators.measurements[uint32(i)])
 					}
 				}
 			}
@@ -328,82 +328,82 @@ func TestValidatorUpdateInitPCRs(t *testing.T) {
 	}
 }
 
-func TestUpdatePCR(t *testing.T) {
+func TestUpdateMeasurement(t *testing.T) {
 	emptyMap := measurements.M{}
-	defaultMap := measurements.M{
+	defaultMapPCRs := measurements.M{
 		0: measurements.WithAllBytes(0xAA, false, measurements.PCRMeasurementLength),
 		1: measurements.WithAllBytes(0xBB, false, measurements.PCRMeasurementLength),
 	}
 
 	testCases := map[string]struct {
-		pcrMap      measurements.M
-		pcrIndex    uint32
-		encoded     string
-		wantEntries int
-		wantErr     bool
+		measurementMap   measurements.M
+		measurementIndex uint32
+		encoded          string
+		wantEntries      int
+		wantErr          bool
 	}{
 		"empty input, empty map": {
-			pcrMap:      emptyMap,
-			pcrIndex:    10,
-			encoded:     "",
-			wantEntries: 0,
-			wantErr:     false,
+			measurementMap:   emptyMap,
+			measurementIndex: 10,
+			encoded:          "",
+			wantEntries:      0,
+			wantErr:          false,
 		},
 		"empty input, default map": {
-			pcrMap:      defaultMap,
-			pcrIndex:    10,
-			encoded:     "",
-			wantEntries: len(defaultMap),
-			wantErr:     false,
+			measurementMap:   defaultMapPCRs,
+			measurementIndex: 10,
+			encoded:          "",
+			wantEntries:      len(defaultMapPCRs),
+			wantErr:          false,
 		},
 		"correct input, empty map": {
-			pcrMap:      emptyMap,
-			pcrIndex:    10,
-			encoded:     base64.StdEncoding.EncodeToString([]byte("Constellation")),
-			wantEntries: 1,
-			wantErr:     false,
+			measurementMap:   emptyMap,
+			measurementIndex: 10,
+			encoded:          base64.StdEncoding.EncodeToString([]byte("Constellation")),
+			wantEntries:      1,
+			wantErr:          false,
 		},
 		"correct input, default map": {
-			pcrMap:      defaultMap,
-			pcrIndex:    10,
-			encoded:     base64.StdEncoding.EncodeToString([]byte("Constellation")),
-			wantEntries: len(defaultMap) + 1,
-			wantErr:     false,
+			measurementMap:   defaultMapPCRs,
+			measurementIndex: 10,
+			encoded:          base64.StdEncoding.EncodeToString([]byte("Constellation")),
+			wantEntries:      len(defaultMapPCRs) + 1,
+			wantErr:          false,
 		},
 		"hex input, empty map": {
-			pcrMap:      emptyMap,
-			pcrIndex:    10,
-			encoded:     hex.EncodeToString([]byte("Constellation")),
-			wantEntries: 1,
-			wantErr:     false,
+			measurementMap:   emptyMap,
+			measurementIndex: 10,
+			encoded:          hex.EncodeToString([]byte("Constellation")),
+			wantEntries:      1,
+			wantErr:          false,
 		},
 		"hex input, default map": {
-			pcrMap:      defaultMap,
-			pcrIndex:    10,
-			encoded:     hex.EncodeToString([]byte("Constellation")),
-			wantEntries: len(defaultMap) + 1,
-			wantErr:     false,
+			measurementMap:   defaultMapPCRs,
+			measurementIndex: 10,
+			encoded:          hex.EncodeToString([]byte("Constellation")),
+			wantEntries:      len(defaultMapPCRs) + 1,
+			wantErr:          false,
 		},
 		"unencoded input, empty map": {
-			pcrMap:      emptyMap,
-			pcrIndex:    10,
-			encoded:     "Constellation",
-			wantEntries: 0,
-			wantErr:     true,
+			measurementMap:   emptyMap,
+			measurementIndex: 10,
+			encoded:          "Constellation",
+			wantEntries:      0,
+			wantErr:          true,
 		},
 		"unencoded input, default map": {
-			pcrMap:      defaultMap,
-			pcrIndex:    10,
-			encoded:     "Constellation",
-			wantEntries: len(defaultMap),
-			wantErr:     true,
+			measurementMap:   defaultMapPCRs,
+			measurementIndex: 10,
+			encoded:          "Constellation",
+			wantEntries:      len(defaultMapPCRs),
+			wantErr:          true,
 		},
 		"empty input at occupied index": {
-			pcrMap:      defaultMap,
-			pcrIndex:    0,
-			encoded:     "",
-			wantEntries: len(defaultMap) - 1,
-			wantErr:     false,
+			measurementMap:   defaultMapPCRs,
+			measurementIndex: 0,
+			encoded:          "",
+			wantEntries:      len(defaultMapPCRs) - 1,
+			wantErr:          false,
 		},
 	}
 
@@ -411,23 +411,23 @@ func TestUpdatePCR(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			pcrs := make(measurements.M)
-			for k, v := range tc.pcrMap {
-				pcrs[k] = v
+			measurements := make(measurements.M)
+			for k, v := range tc.measurementMap {
+				measurements[k] = v
 			}
 
 			validators := &Validator{
 				attestationVariant: oid.GCPSEVES{},
-				pcrs:               pcrs,
+				measurements:       measurements,
 			}
-			err := validators.updatePCR(tc.pcrIndex, tc.encoded)
+			err := validators.updateMeasurement(tc.measurementIndex, tc.encoded)
 
 			if tc.wantErr {
 				assert.Error(err)
 			} else {
 				assert.NoError(err)
 			}
-			assert.Len(pcrs, tc.wantEntries)
+			assert.Len(measurements, tc.wantEntries)
 		})
 	}
 }

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -137,7 +137,7 @@ func (i *initCmd) initialize(cmd *cobra.Command, newDialer func(validator *cloud
 	i.log.Debugf("Checked license")
 	validator, err := cloudcmd.NewValidator(conf, i.log)
 	if err != nil {
-		return err
+		return fmt.Errorf("creating new validator: %w", err)
 	}
 	i.log.Debugf("Created a new validator")
 	serviceAccURI, err := i.getMarshaledServiceAccountURI(provider, conf, fileHandler)

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -400,7 +400,7 @@ func TestAttestation(t *testing.T) {
 	newDialer := func(v *cloudcmd.Validator) *dialer.Dialer {
 		validator := &testValidator{
 			Getter: oid.QEMUVTPM{},
-			pcrs:   v.PCRS(),
+			pcrs:   v.Measurements(),
 		}
 		return dialer.New(nil, validator, netDialer)
 	}

--- a/cli/internal/cmd/recover.go
+++ b/cli/internal/cmd/recover.go
@@ -97,7 +97,7 @@ func (r *recoverCmd) recover(
 
 	validator, err := cloudcmd.NewValidator(conf, r.log)
 	if err != nil {
-		return err
+		return fmt.Errorf("creating new validator: %w", err)
 	}
 	r.log.Debugf("Created a new validator")
 	doer.setDialer(newDialer(validator), flags.endpoint)

--- a/cli/internal/cmd/verify.go
+++ b/cli/internal/cmd/verify.go
@@ -88,12 +88,12 @@ func (v *verifyCmd) verify(cmd *cobra.Command, fileHandler file.Handler, verifyC
 	v.log.Debugf("Creating aTLS Validator for %s", provider)
 	validators, err := cloudcmd.NewValidator(conf, v.log)
 	if err != nil {
-		return err
+		return fmt.Errorf("creating new validator: %w", err)
 	}
 
 	v.log.Debugf("Updating expected measurements")
 	if err := validators.UpdateInitMeasurements(flags.ownerID, flags.clusterID); err != nil {
-		return err
+		return fmt.Errorf("updating expected measurements: %w", err)
 	}
 
 	nonce, err := crypto.GenerateRandomBytes(32)

--- a/cli/internal/cmd/verify.go
+++ b/cli/internal/cmd/verify.go
@@ -91,8 +91,8 @@ func (v *verifyCmd) verify(cmd *cobra.Command, fileHandler file.Handler, verifyC
 		return err
 	}
 
-	v.log.Debugf("Updating expected PCRs")
-	if err := validators.UpdateInitPCRs(flags.ownerID, flags.clusterID); err != nil {
+	v.log.Debugf("Updating expected measurements")
+	if err := validators.UpdateInitMeasurements(flags.ownerID, flags.clusterID); err != nil {
 		return err
 	}
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -495,7 +495,7 @@ func (c *Config) validAttestVariant(fl validator.FieldLevel) bool {
 		return c.Provider.Azure != nil
 	case oid.GCPSEVES{}:
 		return c.Provider.GCP != nil
-	case oid.QEMUVTPM{}:
+	case oid.QEMUVTPM{}, oid.QEMUTDX{}:
 		return c.Provider.QEMU != nil
 	default:
 		return false

--- a/internal/oid/oid.go
+++ b/internal/oid/oid.go
@@ -142,6 +142,11 @@ func (QEMUTDX) OID() asn1.ObjectIdentifier {
 	return asn1.ObjectIdentifier{1, 3, 9900, 5, 99}
 }
 
+// String returns the string representation of the OID.
+func (QEMUTDX) String() string {
+	return qemuTDX
+}
+
 const (
 	dummy              = "dummy"
 	awsNitroTPM        = "aws-nitro-tpm"

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -73,11 +73,11 @@ const (
 	// KonnectivityServerImage server image for konnectivity service.
 	KonnectivityServerImage = "registry.k8s.io/kas-network-proxy/proxy-server:v0.1.1@sha256:b1389e7014425a1752aac55f5043ef4c52edaef0e223bf4d48ed1324e298087c" // renovate:container
 	// JoinImage image of Constellation join service.
-	JoinImage = "ghcr.io/edgelesssys/constellation/join-service:tdx-20230309105609-197c38447c84" // renovate:container
+	JoinImage = "ghcr.io/edgelesssys/constellation/join-service:v2.7.0-pre.0.20230320112805-4eeb1fb99278@sha256:d4237a4dd11408908e3595af5cba9e0904a20c6696bfecfdbd2abd6210dce921" // renovate:container
 	// KeyServiceImage image of Constellation KMS server.
 	KeyServiceImage = "ghcr.io/edgelesssys/constellation/key-service:v2.7.0-pre.0.20230314104627-6ea5588bdc2f@sha256:ec42523be8d1c547325b68b761a0dec050271b55a5cb2e36314fc1bc3e798d31" // renovate:container
 	// VerificationImage image of Constellation verification service.
-	VerificationImage = "ghcr.io/edgelesssys/constellation/verification-service:tdx-20230309105609-197c38447c84" // renovate:container
+	VerificationImage = "ghcr.io/edgelesssys/constellation/verification-service:v2.7.0-pre.0.20230320112805-4eeb1fb99278@sha256:66c71d94e38e8c3399d1f59a83b7cbd75846ea8e4bebf3d1e212e06a80b3c958" // renovate:container
 	// GcpGuestImage image for GCP guest agent.
 	// Check for new versions at https://github.com/GoogleCloudPlatform/guest-agent/releases and update in /.github/workflows/build-gcp-guest-agent.yml.
 	GcpGuestImage = "ghcr.io/edgelesssys/gcp-guest-agent:20230221.0@sha256:8be328a5d8d601170b82481d413cf326b20c5219c016633f1651e35d95f1d6f1" // renovate:container


### PR DESCRIPTION
### Proposed change(s)
- Plenty of bug fixes regarding QEMU TDX when selecting the attestation variant
- Refactor the cloudcmd validator to remove most mentions of PCRs unless we actually talk about PCRs (to generalize for TPM & TDX measurements)
- Add `constellation verify` support for TDX

Plus one cherry-pick commits to get Bazel to work since the Zig toolchain couldn't be downloaded anymore from the URL and I don't want to rebase this to the current main branch yet. Gotta love this toolchain :/