### PR TITLE
cli: warn about missing support for upgrades on AWS, OpenStack, QEMU

### DIFF
--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -15,6 +15,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
 	"github.com/edgelesssys/constellation/v2/cli/internal/helm"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
+	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/compatibility"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/file"
@@ -80,23 +81,27 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, fileHandler file.Hand
 		return err
 	}
 
-	err = u.handleServiceUpgrade(cmd, conf, flags)
-	upgradeErr := &compatibility.InvalidUpgradeError{}
-	switch {
-	case errors.As(err, &upgradeErr):
-		cmd.PrintErrln(err)
-	case err != nil:
-		return fmt.Errorf("upgrading services: %w", err)
-	}
+	if conf.GetProvider() == cloudprovider.Azure || conf.GetProvider() == cloudprovider.GCP {
+		err = u.handleServiceUpgrade(cmd, conf, flags)
+		upgradeErr := &compatibility.InvalidUpgradeError{}
+		switch {
+		case errors.As(err, &upgradeErr):
+			cmd.PrintErrln(err)
+		case err != nil:
+			return fmt.Errorf("upgrading services: %w", err)
+		}
 
-	err = u.upgrader.UpgradeNodeVersion(cmd.Context(), conf)
-	switch {
-	case errors.Is(err, cloudcmd.ErrInProgress):
-		cmd.PrintErrln("Skipping image & Kubernetes upgrades. Another upgrade is in progress")
-	case errors.As(err, &upgradeErr):
-		cmd.PrintErrln(err)
-	case err != nil:
-		return fmt.Errorf("upgrading NodeVersion: %w", err)
+		err = u.upgrader.UpgradeNodeVersion(cmd.Context(), conf)
+		switch {
+		case errors.Is(err, cloudcmd.ErrInProgress):
+			cmd.PrintErrln("Skipping image and Kubernetes upgrades. Another upgrade is in progress.")
+		case errors.As(err, &upgradeErr):
+			cmd.PrintErrln(err)
+		case err != nil:
+			return fmt.Errorf("upgrading NodeVersion: %w", err)
+		}
+	} else {
+		cmd.PrintErrln("WARNING: Skipping service and image upgrades, which are currently only supported for Azure and GCP.")
 	}
 
 	// If an image upgrade was just executed there won't be a diff. The function will return nil in that case.

--- a/docs/docs/workflows/upgrade.md
+++ b/docs/docs/workflows/upgrade.md
@@ -6,6 +6,12 @@ You configure the desired versions in your local Constellation configuration and
 To learn about available versions you use the `upgrade check` command.
 Which versions are available depends on the CLI version you are using.
 
+:::caution
+
+Upgrades arent't yet implemented for AWS. If you require this feature, [let us know](https://github.com/edgelesssys/constellation/issues/new?assignees=&labels=&template=feature_request.md)!
+
+:::
+
 ## Update the CLI
 
 Each CLI comes with a set of supported microservice and Kubernetes versions.


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- The constellation-operator currently doesn't support the necessary operations for node upgrades on AWS, OpenStack and QEMU. Previously `upgrade apply` just executed on the aforementioned CSPs, no error reported. However, the nodes never successfully upgraded. Now the CLI prints a warning and does not apply any upgrades.
- Mention support in the docs.
- Ran [e2e-upgrade test on azure](https://github.com/edgelesssys/constellation/actions/runs/4509186713/jobs/7939036115) to see that the upgrade is still correctly triggered. Manually initiated an upgrade for an AWS cluster and go this output:
```
$ ./build/constellation upgrade apply --debug
WARNING: the config key `attestationVariant` is not set. This key will be required in the next version.
WARNING: Skipping service & image upgrades. Only supported for Azure and GCP.
You are about to change your cluster's measurements. Are you sure you want to continue? [y/n]: y
2023-03-24T09:29:56+01:00       DEBUG   cloudcmd/upgrade.go:207 Triggering measurements config map update now
Successfully updated the cluster's expected measurements
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
