### PR TITLE
bootstrapper: return error on context cancel in WaitForCilium

### DIFF
--- a/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
@@ -266,7 +266,6 @@ func (k *KubernetesUtil) WaitForCilium(ctx context.Context, log *logger.Logger) 
 				return err
 			}
 		}
-		}
 		resp.Body.Close()
 		if resp.StatusCode == 200 {
 			break

--- a/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
@@ -272,8 +272,6 @@ func (k *KubernetesUtil) WaitForCilium(ctx context.Context, log *logger.Logger) 
 			}
 		}
 	}
-
-	return nil
 }
 
 // FixCilium fixes https://github.com/cilium/cilium/issues/19958

--- a/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
@@ -259,8 +259,13 @@ func (k *KubernetesUtil) WaitForCilium(ctx context.Context, log *logger.Logger) 
 		}
 		resp, err := client.Do(req)
 		if err != nil {
-			log.With(zap.Error(err)).Infof("Waiting for local Cilium DaemonSet - Pod not healthy yet")
-			continue
+			if ctx.Err() == nil {
+				log.With(zap.Error(err)).Infof("Waiting for local Cilium DaemonSet - Pod not healthy yet")
+				continue
+			} else {
+				return err
+			}
+		}
 		}
 		resp.Body.Close()
 		if resp.StatusCode == 200 {


### PR DESCRIPTION
See title. Minor bug fix I noticed while debugging.
Otherwise this loop will continue even if the context is cancelled.