### PR TITLE
ci: set correct fromVersion for upgrade test in weekly e2e job

### DIFF
--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -232,7 +232,7 @@ jobs:
         max-parallel: 1
         matrix:
           fromVersion:
-            ["2.6"]
+            ["v2.6.0"]
           cloudProvider: ["gcp", "azure"]
     name: Run upgrade tests
     secrets: inherit


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- fromVersion input was not set correctly. The string is put into the curl command without any processing.
- [Successful run](https://github.com/edgelesssys/constellation/actions/runs/4532924648) :green_circle:. At least the upgrade jobs.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
