### PR TITLE
config: deprecate confidentialVM option for Azure clusters in favor of using attestationVariant option 

### DIFF
--- a/cli/internal/cloudcmd/create_test.go
+++ b/cli/internal/cloudcmd/create_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
+	"github.com/edgelesssys/constellation/v2/internal/variant"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -55,29 +56,55 @@ func TestCreator(t *testing.T) {
 			wantTerraformRollback: true,
 		},
 		"azure": {
-			tfClient:      &stubTerraformClient{ip: ip},
-			provider:      cloudprovider.Azure,
-			config:        config.Default(),
+			tfClient: &stubTerraformClient{ip: ip},
+			provider: cloudprovider.Azure,
+			config: func() *config.Config {
+				cfg := config.Default()
+				cfg.AttestationVariant = variant.AzureSEVSNP{}.String()
+				return cfg
+			}(),
+			policyPatcher: &stubPolicyPatcher{},
+		},
+		"azure trusted launch": {
+			tfClient: &stubTerraformClient{ip: ip},
+			provider: cloudprovider.Azure,
+			config: func() *config.Config {
+				cfg := config.Default()
+				cfg.AttestationVariant = variant.AzureTrustedLaunch{}.String()
+				return cfg
+			}(),
 			policyPatcher: &stubPolicyPatcher{},
 		},
 		"azure new policy patch error": {
-			tfClient:      &stubTerraformClient{ip: ip},
-			provider:      cloudprovider.Azure,
-			config:        config.Default(),
+			tfClient: &stubTerraformClient{ip: ip},
+			provider: cloudprovider.Azure,
+			config: func() *config.Config {
+				cfg := config.Default()
+				cfg.AttestationVariant = variant.AzureSEVSNP{}.String()
+				return cfg
+			}(),
 			policyPatcher: &stubPolicyPatcher{someErr},
 			wantErr:       true,
 		},
 		"azure newTerraformClient error": {
 			newTfClientErr: someErr,
 			provider:       cloudprovider.Azure,
-			config:         config.Default(),
-			policyPatcher:  &stubPolicyPatcher{},
-			wantErr:        true,
+			config: func() *config.Config {
+				cfg := config.Default()
+				cfg.AttestationVariant = variant.AzureSEVSNP{}.String()
+				return cfg
+			}(),
+			policyPatcher: &stubPolicyPatcher{},
+			wantErr:       true,
 		},
 		"azure create cluster error": {
-			tfClient:              &stubTerraformClient{createClusterErr: someErr},
-			provider:              cloudprovider.Azure,
-			config:                config.Default(),
+			tfClient: &stubTerraformClient{createClusterErr: someErr},
+			provider: cloudprovider.Azure,
+			config: func() *config.Config {
+				cfg := config.Default()
+				cfg.AttestationVariant = variant.AzureSEVSNP{}.String()
+				return cfg
+			}(),
 			policyPatcher:         &stubPolicyPatcher{},
 			wantErr:               true,
 			wantRollback:          true,

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -18,6 +18,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
+	"github.com/edgelesssys/constellation/v2/internal/variant"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -95,7 +96,12 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 		printedAWarning = true
 	}
 
-	if conf.IsAzureNonCVM() {
+	attestVariant, err := variant.FromString(conf.AttestationVariant)
+	if err != nil {
+		return fmt.Errorf("parsing attestation variant: %w", err)
+	}
+
+	if attestVariant.Equal(variant.AzureTrustedLaunch{}) {
 		cmd.PrintErrln("Disabling Confidential VMs is insecure. Use only for evaluation purposes.")
 		printedAWarning = true
 		if conf.IDKeyDigestPolicy() == idkeydigest.StrictChecking || conf.IDKeyDigestPolicy() == idkeydigest.MAAFallback {

--- a/cli/internal/image/BUILD.bazel
+++ b/cli/internal/image/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//internal/cloud/cloudprovider",
         "//internal/config",
+        "//internal/variant",
         "//internal/versionsapi",
         "//internal/versionsapi/fetcher",
         "@com_github_schollz_progressbar_v3//:progressbar",
@@ -30,6 +31,7 @@ go_test(
         "//internal/cloud/cloudprovider",
         "//internal/config",
         "//internal/file",
+        "//internal/variant",
         "//internal/versionsapi",
         "@com_github_spf13_afero//:afero",
         "@com_github_stretchr_testify//assert",

--- a/cli/internal/image/image_test.go
+++ b/cli/internal/image/image_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/file"
+	"github.com/edgelesssys/constellation/v2/internal/variant"
 	"github.com/edgelesssys/constellation/v2/internal/versionsapi"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -108,7 +109,7 @@ func TestGetReference(t *testing.T) {
 	}
 }
 
-func TestVariant(t *testing.T) {
+func TestImageVariant(t *testing.T) {
 	testCases := map[string]struct {
 		csp         cloudprovider.Provider
 		config      *config.Config
@@ -125,18 +126,16 @@ func TestVariant(t *testing.T) {
 		"Azure cvm": {
 			csp: cloudprovider.Azure,
 			config: &config.Config{
-				Image: "someImage", Provider: config.ProviderConfig{
-					Azure: &config.AzureConfig{ConfidentialVM: func() *bool { b := true; return &b }()},
-				},
+				AttestationVariant: variant.AzureSEVSNP{}.String(),
+				Image:              "someImage", Provider: config.ProviderConfig{Azure: &config.AzureConfig{}},
 			},
 			wantVariant: "cvm",
 		},
 		"Azure trustedlaunch": {
 			csp: cloudprovider.Azure,
 			config: &config.Config{
-				Image: "someImage", Provider: config.ProviderConfig{
-					Azure: &config.AzureConfig{ConfidentialVM: func() *bool { b := false; return &b }()},
-				},
+				AttestationVariant: variant.AzureTrustedLaunch{}.String(),
+				Image:              "someImage", Provider: config.ProviderConfig{Azure: &config.AzureConfig{}},
 			},
 			wantVariant: "trustedlaunch",
 		},
@@ -172,7 +171,7 @@ func TestVariant(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			vari, err := variant(tc.csp, tc.config)
+			vari, err := imageVariant(tc.csp, tc.config)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/internal/config/config_doc.go
+++ b/internal/config/config_doc.go
@@ -251,7 +251,7 @@ func init() {
 	AzureConfigDoc.Fields[9].Comments[encoder.LineComment] = "Deploy Azure Disk CSI driver with on-node encryption. For details see: https://docs.edgeless.systems/constellation/architecture/encrypted-storage"
 	AzureConfigDoc.Fields[10].Name = "confidentialVM"
 	AzureConfigDoc.Fields[10].Type = "bool"
-	AzureConfigDoc.Fields[10].Note = ""
+	AzureConfigDoc.Fields[10].Note = "TODO: v2.8 remove\n"
 	AzureConfigDoc.Fields[10].Description = "Use Confidential VMs. Always needs to be true."
 	AzureConfigDoc.Fields[10].Comments[encoder.LineComment] = "Use Confidential VMs. Always needs to be true."
 	AzureConfigDoc.Fields[11].Name = "secureBoot"

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -38,7 +38,7 @@ func TestValidateVersionCompatibilityHelper(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			err := validateVersionCompatibilityHelper(tc.cli, "Image", tc.target)
+			err := validateVersionCompatibilityHelper(tc.cli, "image", tc.target)
 			if tc.wantError {
 				assert.Error(err)
 				return


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove usage of `confidentialVM` option in Azure provider config in favor of using `attestationVariant`
  - `confidentialVM` has been marked as deprecated, setting it has no effect but will print a warning about future removal

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Should be merged to main after https://github.com/edgelesssys/constellation/pull/1538
