### PR TITLE
config: remove deprecated upgradeConfig and require name and microserviceVersion fields

### DIFF
--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -63,7 +63,6 @@ go_library(
         "//internal/logger",
         "//internal/retry",
         "//internal/sigstore",
-        "//internal/variant",
         "//internal/versions",
         "//internal/versionsapi",
         "//internal/versionsapi/fetcher",

--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -63,6 +63,7 @@ go_library(
         "//internal/logger",
         "//internal/retry",
         "//internal/sigstore",
+        "//internal/variant",
         "//internal/versions",
         "//internal/versionsapi",
         "//internal/versionsapi/fetcher",

--- a/cli/internal/cmd/configgenerate.go
+++ b/cli/internal/cmd/configgenerate.go
@@ -15,7 +15,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
-	"github.com/edgelesssys/constellation/v2/internal/variant"
 	"github.com/edgelesssys/constellation/v2/internal/versions"
 	"github.com/siderolabs/talos/pkg/machinery/config/encoder"
 	"github.com/spf13/afero"
@@ -104,18 +103,6 @@ func createConfig(provider cloudprovider.Provider) *config.Config {
 	// set a lower default for QEMU's state disk
 	if provider == cloudprovider.QEMU {
 		conf.StateDiskSizeGB = 10
-	}
-
-	// TODO(AB#2976): Replace hardcoded values with user input
-	switch provider {
-	case cloudprovider.AWS:
-		conf.AttestationVariant = variant.AWSNitroTPM{}.String()
-	case cloudprovider.Azure:
-		conf.AttestationVariant = variant.AzureSEVSNP{}.String()
-	case cloudprovider.GCP:
-		conf.AttestationVariant = variant.GCPSEVES{}.String()
-	case cloudprovider.QEMU:
-		conf.AttestationVariant = variant.QEMUVTPM{}.String()
 	}
 
 	return conf

--- a/cli/internal/cmd/configgenerate_test.go
+++ b/cli/internal/cmd/configgenerate_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
-	"github.com/edgelesssys/constellation/v2/internal/variant"
 	"github.com/edgelesssys/constellation/v2/internal/versions"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -92,9 +91,6 @@ func TestConfigGenerateDefaultGCPSpecific(t *testing.T) {
 
 	cg := &configGenerateCmd{log: logger.NewTest(t)}
 	require.NoError(cg.configGenerate(cmd, fileHandler, cloudprovider.GCP))
-
-	// TODO(AB#2976): Remove this once attestation variants are dynamically created
-	wantConf.AttestationVariant = variant.GCPSEVES{}.String()
 
 	var readConfig config.Config
 	err := fileHandler.ReadYAML(constants.ConfigFilename, &readConfig)

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -75,6 +75,7 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 
 	c.log.Debugf("Loading configuration file from %q", flags.configPath)
 	conf, err := config.New(fileHandler, flags.configPath, flags.force)
+	c.log.Debugf("Configuration file loaded: %+v", conf)
 	var configValidationErr *config.ValidationError
 	if errors.As(err, &configValidationErr) {
 		cmd.PrintErrln(configValidationErr.LongMessage())

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -64,7 +64,7 @@ type Config struct {
 	Image string `yaml:"image" validate:"required,version_compatibility"`
 	// description: |
 	//   Name of the cluster.
-	Name string `yaml:"name" validate:"valid_name"` // TODO: v2.7: Use "required" validation for name
+	Name string `yaml:"name" validate:"valid_name,required"`
 	// description: |
 	//   Size (in GB) of a node's disk to store the non-volatile state.
 	StateDiskSizeGB int `yaml:"stateDiskSizeGB" validate:"min=0"`
@@ -72,8 +72,8 @@ type Config struct {
 	//   Kubernetes version to be installed into the cluster.
 	KubernetesVersion string `yaml:"kubernetesVersion" validate:"required,supported_k8s_version"`
 	// description: |
-	//   Microservice version to be installed into the cluster. Setting this value is optional until v2.7. Defaults to the version of the CLI.
-	MicroserviceVersion string `yaml:"microserviceVersion" validate:"omitempty,version_compatibility"`
+	//   Microservice version to be installed into the cluster. Defaults to the version of the CLI.
+	MicroserviceVersion string `yaml:"microserviceVersion" validate:"required,version_compatibility"`
 	// description: |
 	//   DON'T USE IN PRODUCTION: enable debug mode and use debug images. For usage, see: https://github.com/edgelesssys/constellation/blob/main/debugd/README.md
 	DebugCluster *bool `yaml:"debugCluster" validate:"required"`
@@ -83,25 +83,6 @@ type Config struct {
 	// description: |
 	//   Supported cloud providers and their specific configurations.
 	Provider ProviderConfig `yaml:"provider" validate:"dive"`
-	// description: |
-	//   Configuration to apply during constellation upgrade.
-	// examples:
-	//   - value: 'UpgradeConfig{ Image: "", Measurements: Measurements{} }'
-	Upgrade UpgradeConfig `yaml:"upgrade,omitempty" validate:"required"`
-}
-
-// UpgradeConfig defines configuration used during constellation upgrade.
-type UpgradeConfig struct {
-	// description: |
-	//   Updated Constellation machine image to install on all nodes.
-	Image string `yaml:"image"`
-	// description: |
-	//   Measurements of the updated image.
-	Measurements Measurements `yaml:"measurements"`
-	// description: |
-	//   temporary field for upgrade migration
-	//   TODO(AB#2654): Remove with refactoring upgrade plan command
-	CSP cloudprovider.Provider `yaml:"csp"`
 }
 
 // ProviderConfig are cloud-provider specific configuration values used by the CLI.
@@ -638,9 +619,6 @@ func (c *Config) Validate(force bool) error {
 
 	// Register provider validation
 	validate.RegisterStructValidation(validateProvider, ProviderConfig{})
-
-	// register custom validator that prints a deprecation warning.
-	validate.RegisterStructValidation(validateUpgradeConfig, UpgradeConfig{})
 
 	err := validate.Struct(c)
 	if err == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,7 +79,7 @@ type Config struct {
 	DebugCluster *bool `yaml:"debugCluster" validate:"required"`
 	// description: |
 	//   Attestation variant used to verify the integrity of a node.
-	AttestationVariant string `yaml:"attestationVariant" validate:"valid_attestation_variant"` // TODO: v2.8: Mark required
+	AttestationVariant string `yaml:"attestationVariant,omitempty" validate:"valid_attestation_variant"` // TODO: v2.8: Mark required
 	// description: |
 	//   Supported cloud providers and their specific configurations.
 	Provider ProviderConfig `yaml:"provider" validate:"dive"`

--- a/internal/config/config_doc.go
+++ b/internal/config/config_doc.go
@@ -12,7 +12,6 @@ import (
 
 var (
 	ConfigDoc          encoder.Doc
-	UpgradeConfigDoc   encoder.Doc
 	ProviderConfigDoc  encoder.Doc
 	AWSConfigDoc       encoder.Doc
 	AzureConfigDoc     encoder.Doc
@@ -25,7 +24,7 @@ func init() {
 	ConfigDoc.Type = "Config"
 	ConfigDoc.Comments[encoder.LineComment] = "Config defines configuration used by CLI."
 	ConfigDoc.Description = "Config defines configuration used by CLI."
-	ConfigDoc.Fields = make([]encoder.Doc, 10)
+	ConfigDoc.Fields = make([]encoder.Doc, 9)
 	ConfigDoc.Fields[0].Name = "version"
 	ConfigDoc.Fields[0].Type = "string"
 	ConfigDoc.Fields[0].Note = ""
@@ -38,7 +37,7 @@ func init() {
 	ConfigDoc.Fields[1].Comments[encoder.LineComment] = "Machine image version used to create Constellation nodes."
 	ConfigDoc.Fields[2].Name = "name"
 	ConfigDoc.Fields[2].Type = "string"
-	ConfigDoc.Fields[2].Note = "TODO: v2.7: Use \"required\" validation for name\n"
+	ConfigDoc.Fields[2].Note = ""
 	ConfigDoc.Fields[2].Description = "Name of the cluster."
 	ConfigDoc.Fields[2].Comments[encoder.LineComment] = "Name of the cluster."
 	ConfigDoc.Fields[3].Name = "stateDiskSizeGB"
@@ -54,8 +53,8 @@ func init() {
 	ConfigDoc.Fields[5].Name = "microserviceVersion"
 	ConfigDoc.Fields[5].Type = "string"
 	ConfigDoc.Fields[5].Note = ""
-	ConfigDoc.Fields[5].Description = "Microservice version to be installed into the cluster. Setting this value is optional until v2.7. Defaults to the version of the CLI."
-	ConfigDoc.Fields[5].Comments[encoder.LineComment] = "Microservice version to be installed into the cluster. Setting this value is optional until v2.7. Defaults to the version of the CLI."
+	ConfigDoc.Fields[5].Description = "Microservice version to be installed into the cluster. Defaults to the version of the CLI."
+	ConfigDoc.Fields[5].Comments[encoder.LineComment] = "Microservice version to be installed into the cluster. Defaults to the version of the CLI."
 	ConfigDoc.Fields[6].Name = "debugCluster"
 	ConfigDoc.Fields[6].Type = "bool"
 	ConfigDoc.Fields[6].Note = ""
@@ -71,41 +70,6 @@ func init() {
 	ConfigDoc.Fields[8].Note = ""
 	ConfigDoc.Fields[8].Description = "Supported cloud providers and their specific configurations."
 	ConfigDoc.Fields[8].Comments[encoder.LineComment] = "Supported cloud providers and their specific configurations."
-	ConfigDoc.Fields[9].Name = "upgrade"
-	ConfigDoc.Fields[9].Type = "UpgradeConfig"
-	ConfigDoc.Fields[9].Note = ""
-	ConfigDoc.Fields[9].Description = "Configuration to apply during constellation upgrade."
-	ConfigDoc.Fields[9].Comments[encoder.LineComment] = "Configuration to apply during constellation upgrade."
-
-	ConfigDoc.Fields[9].AddExample("", UpgradeConfig{Image: "", Measurements: Measurements{}})
-
-	UpgradeConfigDoc.Type = "UpgradeConfig"
-	UpgradeConfigDoc.Comments[encoder.LineComment] = "UpgradeConfig defines configuration used during constellation upgrade."
-	UpgradeConfigDoc.Description = "UpgradeConfig defines configuration used during constellation upgrade."
-
-	UpgradeConfigDoc.AddExample("", UpgradeConfig{Image: "", Measurements: Measurements{}})
-	UpgradeConfigDoc.AppearsIn = []encoder.Appearance{
-		{
-			TypeName:  "Config",
-			FieldName: "upgrade",
-		},
-	}
-	UpgradeConfigDoc.Fields = make([]encoder.Doc, 3)
-	UpgradeConfigDoc.Fields[0].Name = "image"
-	UpgradeConfigDoc.Fields[0].Type = "string"
-	UpgradeConfigDoc.Fields[0].Note = ""
-	UpgradeConfigDoc.Fields[0].Description = "Updated Constellation machine image to install on all nodes."
-	UpgradeConfigDoc.Fields[0].Comments[encoder.LineComment] = "Updated Constellation machine image to install on all nodes."
-	UpgradeConfigDoc.Fields[1].Name = "measurements"
-	UpgradeConfigDoc.Fields[1].Type = "Measurements"
-	UpgradeConfigDoc.Fields[1].Note = ""
-	UpgradeConfigDoc.Fields[1].Description = "Measurements of the updated image."
-	UpgradeConfigDoc.Fields[1].Comments[encoder.LineComment] = "Measurements of the updated image."
-	UpgradeConfigDoc.Fields[2].Name = "csp"
-	UpgradeConfigDoc.Fields[2].Type = "Provider"
-	UpgradeConfigDoc.Fields[2].Note = ""
-	UpgradeConfigDoc.Fields[2].Description = "temporary field for upgrade migration\nTODO(AB#2654): Remove with refactoring upgrade plan command"
-	UpgradeConfigDoc.Fields[2].Comments[encoder.LineComment] = "temporary field for upgrade migration"
 
 	ProviderConfigDoc.Type = "ProviderConfig"
 	ProviderConfigDoc.Comments[encoder.LineComment] = "ProviderConfig are cloud-provider specific configuration values used by the CLI."
@@ -463,10 +427,6 @@ func (_ Config) Doc() *encoder.Doc {
 	return &ConfigDoc
 }
 
-func (_ UpgradeConfig) Doc() *encoder.Doc {
-	return &UpgradeConfigDoc
-}
-
 func (_ ProviderConfig) Doc() *encoder.Doc {
 	return &ProviderConfigDoc
 }
@@ -498,7 +458,6 @@ func GetConfigurationDoc() *encoder.FileDoc {
 		Description: "Definitions for  Constellation's user config file.\n\nThe config file is used by the CLI to create and manage a Constellation cluster.\n\nAll config relevant definitions, parsing and validation functions should go here.\n",
 		Structs: []*encoder.Doc{
 			&ConfigDoc,
-			&UpgradeConfigDoc,
 			&ProviderConfigDoc,
 			&AWSConfigDoc,
 			&AzureConfigDoc,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -386,7 +386,6 @@ func TestConfigGeneratedDocsFresh(t *testing.T) {
 	updateMsg := "remember to re-generate config docs! 🔨"
 
 	assert.Len(ConfigDoc.Fields, reflect.ValueOf(Config{}).NumField(), updateMsg)
-	assert.Len(UpgradeConfigDoc.Fields, reflect.ValueOf(UpgradeConfig{}).NumField(), updateMsg)
 	assert.Len(ProviderConfigDoc.Fields, reflect.ValueOf(ProviderConfig{}).NumField(), updateMsg)
 	assert.Len(AWSConfigDoc.Fields, reflect.ValueOf(AWSConfig{}).NumField(), updateMsg)
 	assert.Len(AzureConfigDoc.Fields, reflect.ValueOf(AzureConfig{}).NumField(), updateMsg)

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -462,7 +461,8 @@ func (c *Config) translateValidAttestVariantError(ut ut.Translator, _ validator.
 }
 
 func (c *Config) validAttestVariant(_ validator.FieldLevel) bool {
-	// TODO: v2.8: remove variant fallback and make variant a required field
+	// TODO(AB#3040): function will be obsolete in v2.8
+	// attestationVariant will be refactored into a required struct
 	c.addMissingVariant()
 
 	attestationVariant, err := variant.FromString(c.AttestationVariant)
@@ -492,8 +492,6 @@ func (c *Config) addMissingVariant() {
 	if c.AttestationVariant != "" {
 		return
 	}
-	fmt.Fprintln(os.Stderr, "WARNING: the config key `attestationVariant` is not set. This key will be required in the next version.")
-
 	switch c.GetProvider() {
 	case cloudprovider.AWS:
 		c.AttestationVariant = variant.AWSNitroTPM{}.String()

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -426,20 +426,6 @@ func returnsTrue(_ validator.FieldLevel) bool {
 	return true
 }
 
-// validateUpgradeConfig prints a warning to STDERR and validates the field successfully.
-func validateUpgradeConfig(sl validator.StructLevel) {
-	config, ok := sl.Current().Interface().(UpgradeConfig)
-	if !ok {
-		sl.ReportError(config, "upgrade", "UpgradeConfig", "malformed_upgrade_config", "")
-	}
-	// A valid `upgrade` section will always have a non-nil Measurements map.
-	// Only print a warning if the user actually specified an upgrade section.
-	if config.Image == "" && config.CSP == cloudprovider.Unknown && config.Measurements == nil {
-		return
-	}
-	fmt.Fprintln(os.Stderr, "WARNING: the config key `upgrade` will be deprecated in an upcoming version. Please check the documentation for more information.")
-}
-
 func registerValidateNameError(ut ut.Translator) error {
 	return ut.Add("validate_name", "{0} must be no more than {1} characters long", true)
 }
@@ -459,12 +445,6 @@ func (c *Config) translateValidateNameError(ut ut.Translator, fe validator.Field
 // Since this value may differ between providers, we can't simply use built-in validation.
 // This also allows us to eventually add more validation rules for constellation names if necessary.
 func (c *Config) validateName(fl validator.FieldLevel) bool {
-	// TODO: v2.7: remove fallback to defaultName and make name a required field
-	if c.Name == "" {
-		fmt.Fprintln(os.Stderr, "WARNING: the config key `name` is not set. This key will be required in the next version. Falling back to default name.")
-		c.Name = defaultName
-	}
-
 	if c.Provider.AWS != nil {
 		return len(fl.Field().String()) <= constants.AWSConstellationNameLength
 	}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove `upgradeConfig`  from config
  - This field was only partially functional in v2.5.0 and has been deprecated in v2.6.0
  - Setting it in v2.7.0 will return an error
- Require `name` field
  - Was optional in v2.6.0 with a warning for it to be required in the next version
- Required `microserviceVersion` field
  - This field was optional in v2.6.0
  - There was no hint about it being required in future versions, we might want to consider keeping it optional in v2.7.0 with a warning
- Removed a warning about unset `attestationVariant` field
  - This field was not yet present in v2.6.0
  - ~This field will be superseded in v2.8.0 by the `attestation` struct, as outlined in https://github.com/edgelesssys/constellation/pull/1436 and therefore won't throw a warning for not being set~
  - The value is no longer written to a users config on `constellation config generate` since it will be superseded in v2.8.0 by the `attestation` struct, as outlined in https://github.com/edgelesssys/constellation/pull/1436. We only use the default values (or the value specified by a users if they manually edited the config)

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->
