### PR TITLE
bootstrapper: fix journald ram usage

### DIFF
--- a/bootstrapper/internal/journald/BUILD.bazel
+++ b/bootstrapper/internal/journald/BUILD.bazel
@@ -12,5 +12,8 @@ go_test(
     name = "journald_test",
     srcs = ["journald_test.go"],
     embed = [":journald"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/bootstrapper/internal/journald/journald.go
+++ b/bootstrapper/internal/journald/journald.go
@@ -53,10 +53,8 @@ func (c *Collector) Pipe() (io.ReadCloser, error) {
 	return c.stdoutPipe, nil
 }
 
-// Error returns the error message of the journalctl command.
-// The first two parameters are what's written to stderr as
-// well as the exit/io error, the third one checks if the function
-// ran successfully.
+// Error returns output to stderr as bytes as well
+// as the exit code in form of an error.
 func (c *Collector) Error() ([]byte, error) {
 	stderr, err := io.ReadAll(c.stderrPipe)
 	if err != nil {

--- a/bootstrapper/internal/journald/journald.go
+++ b/bootstrapper/internal/journald/journald.go
@@ -17,6 +17,7 @@ import (
 
 type command interface {
 	Start() error
+	Wait() error
 }
 
 // Collector collects logs from journald.
@@ -52,11 +53,15 @@ func (c *Collector) Pipe() (io.ReadCloser, error) {
 	return c.stdoutPipe, nil
 }
 
-// Stderr returns the error message of the journalctl command.
-func (c *Collector) Stderr() ([]byte, error) {
+// Error returns the error message of the journalctl command.
+// The first two parameters are what's written to stderr as
+// well as the exit/io error, the third one checks if the function
+// ran succesfully.
+func (c *Collector) Error() ([]byte, error, error) {
+	exitCode := c.cmd.Wait()
 	stderr, err := io.ReadAll(c.stderrPipe)
 	if err != nil {
-		return nil, err
+		return nil, exitCode, err
 	}
-	return stderr, nil
+	return stderr, exitCode, nil
 }

--- a/bootstrapper/internal/journald/journald.go
+++ b/bootstrapper/internal/journald/journald.go
@@ -38,7 +38,7 @@ func NewCollector(ctx context.Context) (*Collector, error) {
 	return &Collector{cmd, pipe}, nil
 }
 
-// Collect gets all journald logs from a service and returns a byte slice with the plain text logs.
+// Pipe returns a pipe to read the systemd logs. This should be read with a bufio Reader.
 func (c *Collector) Pipe() (io.ReadCloser, error) {
 	if err := c.cmd.Start(); err != nil {
 		return nil, err

--- a/bootstrapper/internal/journald/journald.go
+++ b/bootstrapper/internal/journald/journald.go
@@ -23,8 +23,8 @@ type command interface {
 // Collector collects logs from journald.
 type Collector struct {
 	cmd        command
-	stdoutPipe *io.ReadCloser
-	stderrPipe *io.ReadCloser
+	stdoutPipe io.ReadCloser
+	stderrPipe io.ReadCloser
 }
 
 // NewCollector creates a new Collector for journald logs.
@@ -41,12 +41,12 @@ func NewCollector(ctx context.Context) (*Collector, error) {
 	if err != nil {
 		return nil, err
 	}
-	collector := Collector{cmd, &stdoutPipe, &stderrPipe}
+	collector := Collector{cmd, stdoutPipe, stderrPipe}
 	return &collector, nil
 }
 
 // Pipe returns a pipe to read the systemd logs. This should be read with a bufio Reader.
-func (c *Collector) Pipe() (*io.ReadCloser, error) {
+func (c *Collector) Pipe() (io.ReadCloser, error) {
 	if err := c.cmd.Start(); err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c *Collector) Pipe() (*io.ReadCloser, error) {
 // well as the exit/io error, the third one checks if the function
 // ran successfully.
 func (c *Collector) Error() ([]byte, error) {
-	stderr, err := io.ReadAll(*c.stderrPipe)
+	stderr, err := io.ReadAll(c.stderrPipe)
 	if err != nil {
 		return nil, err
 	}

--- a/bootstrapper/internal/journald/journald.go
+++ b/bootstrapper/internal/journald/journald.go
@@ -56,7 +56,7 @@ func (c *Collector) Pipe() (io.ReadCloser, error) {
 // Error returns the error message of the journalctl command.
 // The first two parameters are what's written to stderr as
 // well as the exit/io error, the third one checks if the function
-// ran succesfully.
+// ran successfully.
 func (c *Collector) Error() ([]byte, error, error) {
 	stderr, err := io.ReadAll(c.stderrPipe)
 	if err != nil {

--- a/bootstrapper/internal/journald/journald.go
+++ b/bootstrapper/internal/journald/journald.go
@@ -45,8 +45,8 @@ func NewCollector(ctx context.Context) (*Collector, error) {
 	return &collector, nil
 }
 
-// Pipe returns a pipe to read the systemd logs. This should be read with a bufio Reader.
-func (c *Collector) Pipe() (io.ReadCloser, error) {
+// Start returns a pipe to read the systemd logs. This should be read with a bufio Reader.
+func (c *Collector) Start() (io.ReadCloser, error) {
 	if err := c.cmd.Start(); err != nil {
 		return nil, err
 	}

--- a/bootstrapper/internal/journald/journald.go
+++ b/bootstrapper/internal/journald/journald.go
@@ -57,11 +57,11 @@ func (c *Collector) Pipe() (io.ReadCloser, error) {
 // The first two parameters are what's written to stderr as
 // well as the exit/io error, the third one checks if the function
 // ran successfully.
-func (c *Collector) Error() ([]byte, error, error) {
+func (c *Collector) Error() ([]byte, error) {
 	stderr, err := io.ReadAll(c.stderrPipe)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	exitCode := c.cmd.Wait()
-	return stderr, exitCode, nil
+	return stderr, exitCode
 }

--- a/bootstrapper/internal/journald/journald.go
+++ b/bootstrapper/internal/journald/journald.go
@@ -58,10 +58,10 @@ func (c *Collector) Pipe() (io.ReadCloser, error) {
 // well as the exit/io error, the third one checks if the function
 // ran succesfully.
 func (c *Collector) Error() ([]byte, error, error) {
-	exitCode := c.cmd.Wait()
 	stderr, err := io.ReadAll(c.stderrPipe)
 	if err != nil {
-		return nil, exitCode, err
+		return nil, nil, err
 	}
+	exitCode := c.cmd.Wait()
 	return stderr, exitCode, nil
 }

--- a/bootstrapper/internal/journald/journald.go
+++ b/bootstrapper/internal/journald/journald.go
@@ -23,8 +23,8 @@ type command interface {
 // Collector collects logs from journald.
 type Collector struct {
 	cmd        command
-	stdoutPipe io.ReadCloser
-	stderrPipe io.ReadCloser
+	stdoutPipe *io.ReadCloser
+	stderrPipe *io.ReadCloser
 }
 
 // NewCollector creates a new Collector for journald logs.
@@ -41,12 +41,12 @@ func NewCollector(ctx context.Context) (*Collector, error) {
 	if err != nil {
 		return nil, err
 	}
-	collector := Collector{cmd, stdoutPipe, stderrPipe}
+	collector := Collector{cmd, &stdoutPipe, &stderrPipe}
 	return &collector, nil
 }
 
 // Pipe returns a pipe to read the systemd logs. This should be read with a bufio Reader.
-func (c *Collector) Pipe() (io.ReadCloser, error) {
+func (c *Collector) Pipe() (*io.ReadCloser, error) {
 	if err := c.cmd.Start(); err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c *Collector) Pipe() (io.ReadCloser, error) {
 // well as the exit/io error, the third one checks if the function
 // ran successfully.
 func (c *Collector) Error() ([]byte, error) {
-	stderr, err := io.ReadAll(c.stderrPipe)
+	stderr, err := io.ReadAll(*c.stderrPipe)
 	if err != nil {
 		return nil, err
 	}

--- a/bootstrapper/internal/journald/journald_test.go
+++ b/bootstrapper/internal/journald/journald_test.go
@@ -8,6 +8,7 @@ package journald
 
 import (
 	"errors"
+	"io"
 	"os/exec"
 	"testing"
 
@@ -20,6 +21,24 @@ type stubJournaldCommand struct {
 
 func (j *stubJournaldCommand) Start() error {
 	return j.startError
+}
+
+type stubStderrPipe struct {
+	buffer   []byte
+	readErr  error
+	closeErr error
+}
+
+func (s stubStderrPipe) Read(p []byte) (n int, err error) {
+	size := len(s.buffer)
+	if s.readErr != nil {
+		size = 0
+	}
+	return size, s.readErr
+}
+
+func (s stubStderrPipe) Close() error {
+	return s.closeErr
 }
 
 func TestCollect(t *testing.T) {
@@ -52,6 +71,43 @@ func TestCollect(t *testing.T) {
 			_, err := collector.Pipe()
 			if tc.wantErr {
 				assert.Error(err)
+			}
+		})
+	}
+}
+
+func TestStderr(t *testing.T) {
+	someError := errors.New("failed")
+
+	testCases := map[string]struct {
+		stderrPipe io.ReadCloser
+		wantErr    bool
+	}{
+		"success": {
+			stderrPipe: stubStderrPipe{readErr: io.EOF},
+		},
+		"reading error": {
+			stderrPipe: stubStderrPipe{readErr: someError},
+			wantErr:    true,
+		},
+		"close error": {
+			stderrPipe: stubStderrPipe{closeErr: someError, readErr: io.EOF},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			collector := Collector{
+				stderrPipe: tc.stderrPipe,
+			}
+
+			stderrOut, err := collector.Stderr()
+			if tc.wantErr {
+				assert.Error(err)
+			} else {
+				assert.Equal(stderrOut, []byte{})
 			}
 		})
 	}

--- a/bootstrapper/internal/journald/journald_test.go
+++ b/bootstrapper/internal/journald/journald_test.go
@@ -85,10 +85,9 @@ func TestStderr(t *testing.T) {
 	someError := errors.New("failed")
 
 	testCases := map[string]struct {
-		stderrPipe  io.ReadCloser
-		exitCode    error
-		wantErr     bool
-		wantExitErr bool
+		stderrPipe io.ReadCloser
+		exitCode   error
+		wantErr    bool
 	}{
 		"success": {
 			stderrPipe: stubStderrPipe{readErr: io.EOF},
@@ -101,9 +100,9 @@ func TestStderr(t *testing.T) {
 			stderrPipe: stubStderrPipe{closeErr: someError, readErr: io.EOF},
 		},
 		"command exit": {
-			stderrPipe:  stubStderrPipe{readErr: io.EOF},
-			exitCode:    someError,
-			wantExitErr: true,
+			stderrPipe: stubStderrPipe{readErr: io.EOF},
+			exitCode:   someError,
+			wantErr:    true,
 		},
 	}
 
@@ -116,14 +115,11 @@ func TestStderr(t *testing.T) {
 				cmd:        &stubJournaldCommand{exitCode: tc.exitCode},
 			}
 
-			stderrOut, exitCode, err := collector.Error()
+			stderrOut, err := collector.Error()
 			if tc.wantErr {
 				assert.Error(err)
 			} else {
 				assert.Equal(stderrOut, []byte{})
-			}
-			if tc.wantExitErr {
-				assert.Error(exitCode)
 			}
 		})
 	}

--- a/bootstrapper/internal/journald/journald_test.go
+++ b/bootstrapper/internal/journald/journald_test.go
@@ -8,6 +8,7 @@ package journald
 
 import (
 	"errors"
+	"os/exec"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,6 +35,10 @@ func TestCollect(t *testing.T) {
 		},
 		"execution failed": {
 			command: &stubJournaldCommand{startError: someError},
+			wantErr: true,
+		},
+		"exit error": {
+			command: &stubJournaldCommand{startError: &exec.ExitError{}},
 			wantErr: true,
 		},
 	}

--- a/bootstrapper/internal/journald/journald_test.go
+++ b/bootstrapper/internal/journald/journald_test.go
@@ -58,7 +58,7 @@ func TestPipe(t *testing.T) {
 
 			collector := Collector{cmd: tc.command, stdoutPipe: tc.stdoutPipe}
 
-			pipe, err := collector.Pipe()
+			pipe, err := collector.Start()
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/bootstrapper/internal/journald/journald_test.go
+++ b/bootstrapper/internal/journald/journald_test.go
@@ -17,27 +17,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type stubCommand struct {
-	startCalled bool
-	startErr    error
-	waitErr     error
-}
-
-func (j *stubCommand) Start() error {
-	j.startCalled = true
-	return j.startErr
-}
-
-func (j *stubCommand) Wait() error {
-	return j.waitErr
-}
-
-type stubReadCloser struct {
-	reader   io.Reader
-	readErr  error
-	closeErr error
-}
-
 func (s *stubReadCloser) Read(p []byte) (n int, err error) {
 	if s.readErr != nil {
 		return 0, s.readErr
@@ -134,4 +113,25 @@ func TestError(t *testing.T) {
 			}
 		})
 	}
+}
+
+type stubCommand struct {
+	startCalled bool
+	startErr    error
+	waitErr     error
+}
+
+func (j *stubCommand) Start() error {
+	j.startCalled = true
+	return j.startErr
+}
+
+func (j *stubCommand) Wait() error {
+	return j.waitErr
+}
+
+type stubReadCloser struct {
+	reader   io.Reader
+	readErr  error
+	closeErr error
 }

--- a/bootstrapper/internal/journald/journald_test.go
+++ b/bootstrapper/internal/journald/journald_test.go
@@ -16,19 +16,19 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type stubJournaldCommand struct {
+type stubCommand struct {
 	stdout     *stubStdoutPipe
 	text       []byte
 	startError error
 	exitCode   error
 }
 
-func (j *stubJournaldCommand) Start() error {
+func (j *stubCommand) Start() error {
 	j.stdout.buffer = j.text
 	return j.startError
 }
 
-func (j *stubJournaldCommand) Wait() error {
+func (j *stubCommand) Wait() error {
 	return j.exitCode
 }
 
@@ -76,22 +76,22 @@ func TestPipe(t *testing.T) {
 	stdoutPipe := stubStdoutPipe{}
 
 	testCases := map[string]struct {
-		command      *stubJournaldCommand
+		command      *stubCommand
 		stdoutPipe   io.ReadCloser
 		wantedOutput []byte
 		wantErr      bool
 	}{
 		"success": {
-			command:      &stubJournaldCommand{stdout: &stdoutPipe, text: []byte("asdf")},
+			command:      &stubCommand{stdout: &stdoutPipe, text: []byte("asdf")},
 			wantedOutput: []byte("asdf"),
 			stdoutPipe:   &stdoutPipe,
 		},
 		"execution failed": {
-			command: &stubJournaldCommand{startError: someError, stdout: &stdoutPipe},
+			command: &stubCommand{startError: someError, stdout: &stdoutPipe},
 			wantErr: true,
 		},
 		"exit error": {
-			command: &stubJournaldCommand{startError: &exec.ExitError{}, stdout: &stdoutPipe},
+			command: &stubCommand{startError: &exec.ExitError{}, stdout: &stdoutPipe},
 			wantErr: true,
 		},
 	}
@@ -146,7 +146,7 @@ func TestError(t *testing.T) {
 
 			collector := Collector{
 				stderrPipe: &tc.stderrPipe,
-				cmd:        &stubJournaldCommand{exitCode: tc.exitCode},
+				cmd:        &stubCommand{exitCode: tc.exitCode},
 			}
 
 			stderrOut, err := collector.Error()

--- a/bootstrapper/internal/journald/journald_test.go
+++ b/bootstrapper/internal/journald/journald_test.go
@@ -43,7 +43,7 @@ func (s *stubStdoutPipe) Read(p []byte) (int, error) {
 		for i := range p {
 			p[i] = s.buffer[i]
 		}
-		return 4, nil
+		return len(p), nil
 	}
 	return 0, io.EOF
 }

--- a/bootstrapper/internal/journald/journald_test.go
+++ b/bootstrapper/internal/journald/journald_test.go
@@ -44,9 +44,8 @@ func (s *stubStdoutPipe) Read(p []byte) (int, error) {
 			p[i] = s.buffer[i]
 		}
 		return 4, nil
-	} else {
-		return 0, io.EOF
 	}
+	return 0, io.EOF
 }
 
 func (s stubStdoutPipe) Close() error {

--- a/bootstrapper/internal/journald/journald_test.go
+++ b/bootstrapper/internal/journald/journald_test.go
@@ -71,7 +71,7 @@ func (s stubStderrPipe) Close() error {
 	return s.closeErr
 }
 
-func TestCollect(t *testing.T) {
+func TestPipe(t *testing.T) {
 	someError := errors.New("failed")
 	stdoutPipe := stubStdoutPipe{}
 
@@ -115,7 +115,7 @@ func TestCollect(t *testing.T) {
 	}
 }
 
-func TestStderr(t *testing.T) {
+func TestError(t *testing.T) {
 	someError := errors.New("failed")
 
 	testCases := map[string]struct {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- let the journald package return a pipe to the stdout of the journalctl command instead of it's output to prevent killing the process due to high RAM usage

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
