### PR TITLE
ci: separate e2e permissions

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -35,7 +35,7 @@ inputs:
   gcpProject:
     description: "The GCP project to deploy Constellation in."
     required: false
-  gcpClusterServiceAccountKey:
+  gcpInClusterServiceAccountKey:
     description: "The GCP Service account to use inside the created Constellation cluster."
     required: false
   #
@@ -162,7 +162,7 @@ runs:
       if: inputs.cloudProvider == 'gcp' && !inputs.existingConfig # Skip if using existing config. serviceAccountKey.json is already present in that case.
       shell: bash
       env:
-        GCP_CLUSTER_SERVICE_ACCOUNT_KEY: ${{ inputs.gcpClusterServiceAccountKey }}
+        GCP_CLUSTER_SERVICE_ACCOUNT_KEY: ${{ inputs.gcpInClusterServiceAccountKey }}
       run: |
         echo "$GCP_CLUSTER_SERVICE_ACCOUNT_KEY" > serviceAccountKey.json
 

--- a/.github/actions/constellation_iam_destroy/action.yml
+++ b/.github/actions/constellation_iam_destroy/action.yml
@@ -1,9 +1,41 @@
 name: Delete IAM configuration
 description: Delete previously created IAM configuration.
 
+inputs:
+  cloudProvider:
+      description: "Either 'aws', 'azure' or 'gcp'."
+      required: true
+  gcpServiceAccount:
+      description: "GCP service account to use for authentication."
+      required: false
+  azureCredentials:
+      description: "Azure service principal to use for authentication."
+      required: false
+
 runs:
   using: "composite"
   steps:
+    - name: Login to GCP (IAM service account)
+      if: inputs.cloudProvider == 'gcp'
+      uses: ./.github/actions/login_gcp
+      with:
+        service_account: ${{ inputs.gcpServiceAccount }}
+
+    - name: Login to AWS (IAM role)
+      if: inputs.cloudProvider == 'aws'
+      uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+      with:
+        role-to-assume: arn:aws:iam::795746500882:role/GithubActionsE2EIAM
+        aws-region: eu-central-1
+        # extend token expiry to 6 hours to ensure constellation can terminate
+        role-duration-seconds: 21600
+
+    - name: Login to Azure (IAM service principal)
+      if: inputs.cloudProvider == 'azure'
+      uses: ./.github/actions/login_azure
+      with:
+        azure_credentials: ${{ inputs.azureCredentials }}
+
     - name: Delete IAM configuration
       shell: bash
       run: |

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -35,10 +35,13 @@ inputs:
   gcpProject:
     description: "The GCP project to deploy Constellation in."
     required: false
-  gcp_service_account:
-    description: "Service account with permissions to create Constellation on GCP."
+  gcpIAMServiceAccount:
+    description: "Service account with permissions to create IAM configuration on GCP."
     required: false
-  gcpClusterServiceAccountKey:
+  gcpClusterServiceAccount:
+    description: "Service account with permissions to create a Constellation cluster on GCP."
+    required: false
+  gcpInClusterServiceAccountKey:
     description: "Service account to use inside the created Constellation cluster on GCP."
     required: false
   awsOpenSearchDomain:
@@ -56,20 +59,26 @@ inputs:
   azureTenant:
     description: "The Azure tenant ID to deploy Constellation in."
     required: false
-  azureClientID:
-    description: "The client ID of the application registration created for Constellation in Azure."
+  azureIAMClientID:
+    description: "The client ID of the application registration created for Constellation in Azure. (IAM creation)"
     required: false
-  azureClientSecret:
-    description: "The client secret value of the used secret"
+  azureIAMClientSecret:
+    description: "The client secret value of the used secret. (IAM creation)"
     required: false
-  azureUserAssignedIdentity:
-    description: "The Azure user assigned identity to use for Constellation."
+  azureClusterClientID:
+    description: "The client ID of the application registration created for Constellation in Azure. (cluster creation)"
     required: false
-  azureResourceGroup:
-    description: "The resource group to use"
+  azureClusterClientSecret:
+    description: "The client secret value of the used secret. (cluster creation)"
     required: false
+  azureClusterCredentials:
+    description: "Azure credentials authorized to create a Constellation cluster."
+    required: true
+  azureIAMCredentials:
+    description: "Azure credentials authorized to create an IAM configuration."
+    required: true
   test:
-    description: "The test to run. Can currently be one of [sonobuoy full, sonobuoy quick, autoscaling, lb, perf-bench, verify, recover, nop, iamcreate]."
+    description: "The test to run. Can currently be one of [sonobuoy full, sonobuoy quick, autoscaling, lb, perf-bench, verify, recover, nop]."
     required: true
   sonobuoyTestSuiteCmd:
     description: "The sonobuoy test suite to run."
@@ -87,7 +96,7 @@ runs:
   using: "composite"
   steps:
     - name: Check input
-      if: (!contains(fromJson('["sonobuoy full", "sonobuoy quick", "autoscaling", "perf-bench", "verify", "lb", "recover", "nop", "iamcreate"]'), inputs.test))
+      if: (!contains(fromJson('["sonobuoy full", "sonobuoy quick", "autoscaling", "perf-bench", "verify", "lb", "recover", "nop"]'), inputs.test))
       shell: bash
       run: |
         echo "::error::Invalid input for test field: ${{ inputs.test }}"
@@ -155,25 +164,35 @@ runs:
         targetOS: ${{ steps.determine-build-target.outputs.hostOS }}
         targetArch: ${{ steps.determine-build-target.outputs.hostArch }}
 
-    - name: Login to GCP
+    - name: Login to GCP (IAM service account)
       if: inputs.cloudProvider == 'gcp'
       uses: ./.github/actions/login_gcp
       with:
-        service_account: ${{ inputs.gcp_service_account }}
+        service_account: ${{ inputs.gcpIAMServiceAccount }}
 
-    - name: Login to AWS
+    - name: Login to AWS (IAM role)
       if: inputs.cloudProvider == 'aws'
       uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
       with:
-        role-to-assume: arn:aws:iam::795746500882:role/GithubActionsE2E
+        role-to-assume: arn:aws:iam::795746500882:role/GithubActionsE2EIAM
         aws-region: eu-central-1
         # extend token expiry to 6 hours to ensure constellation can terminate
         role-duration-seconds: 21600
 
+    - name: Login to Azure (IAM service principal)
+      if: inputs.cloudProvider == 'azure'
+      uses: ./.github/actions/login_azure
+      with:
+        azure_credentials: ${{ inputs.azureIAMCredentials }}
+
     - name: Create IAM configuration
       id: constellation-iam-create
-      if: inputs.test == 'iamcreate' && inputs.cloudProvider != 'azure' # skip for Azure, as the SP / MI does not have the required permissions
       uses: ./.github/actions/constellation_iam_create
+      env:
+        ARM_CLIENT_ID: ${{ inputs.azureIAMClientID }}
+        ARM_CLIENT_SECRET: ${{ inputs.azureIAMClientSecret }}
+        ARM_SUBSCRIPTION_ID: ${{ inputs.azureSubscription }}
+        ARM_TENANT_ID: ${{ inputs.azureTenant }}
       with:
         cloudProvider: ${{ inputs.cloudProvider }}
         awsZone: eu-central-1c
@@ -185,13 +204,38 @@ runs:
         gcpZone: europe-west3-b
         gcpServiceAccountID: e2e-${{ github.run_id }}-${{ github.run_attempt }}-sa
 
+    - name: Login to GCP (Cluster service account)
+      if: inputs.cloudProvider == 'gcp'
+      uses: ./.github/actions/login_gcp
+      with:
+        service_account: ${{ inputs.gcpClusterServiceAccount }}
+
+    - name: Login to AWS (Cluster role)
+      if: inputs.cloudProvider == 'aws'
+      uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0
+      with:
+        role-to-assume: arn:aws:iam::795746500882:role/GithubActionsE2ECluster
+        aws-region: eu-central-1
+        # extend token expiry to 6 hours to ensure constellation can terminate
+        role-duration-seconds: 21600
+
+    - name: Login to Azure (Cluster service principal)
+      if: inputs.cloudProvider == 'azure'
+      uses: ./.github/actions/login_azure
+      with:
+        azure_credentials: ${{ inputs.azureClusterCredentials }}
+
     - name: Create cluster
       id: constellation-create
       uses: ./.github/actions/constellation_create
+      env:
+        ARM_CLIENT_ID: ${{ inputs.azureClusterClientID }}
+        ARM_CLIENT_SECRET: ${{ inputs.azureClusterClientSecret }}
+        ARM_SUBSCRIPTION_ID: ${{ inputs.azureSubscription }}
+        ARM_TENANT_ID: ${{ inputs.azureTenant }}
       with:
         cloudProvider: ${{ inputs.cloudProvider }}
-        gcpProject: ${{ inputs.gcpProject }}
-        gcpClusterServiceAccountKey: ${{ inputs.gcpClusterServiceAccountKey }}
+        gcpInClusterServiceAccountKey: ${{ inputs.gcpInClusterServiceAccountKey }}
         workerNodesCount: ${{ inputs.workerNodesCount }}
         controlNodesCount: ${{ inputs.controlNodesCount }}
         machineType: ${{ inputs.machineType }}
@@ -199,12 +243,6 @@ runs:
         isDebugImage: ${{ inputs.isDebugImage }}
         kubernetesVersion: ${{ inputs.kubernetesVersion }}
         keepMeasurements: ${{ inputs.keepMeasurements }}
-        azureSubscription: ${{ inputs.azureSubscription }}
-        azureTenant: ${{ inputs.azureTenant }}
-        azureClientID: ${{ inputs.azureClientID }}
-        azureClientSecret: ${{ inputs.azureClientSecret }}
-        azureUserAssignedIdentity: ${{ inputs.azureUserAssignedIdentity }}
-        azureResourceGroup: ${{ inputs.azureResourceGroup }}
         existingConfig: ${{ steps.constellation-iam-create.outputs.existingConfig }}
 
     #

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -53,24 +53,6 @@ inputs:
   awsOpenSearchPwd:
     description: "AWS OpenSearch Password to upload the benchmark results."
     required: false
-  azureSubscription:
-    description: "The Azure subscription ID to deploy Constellation in."
-    required: false
-  azureTenant:
-    description: "The Azure tenant ID to deploy Constellation in."
-    required: false
-  azureIAMClientID:
-    description: "The client ID of the application registration created for Constellation in Azure. (IAM creation)"
-    required: false
-  azureIAMClientSecret:
-    description: "The client secret value of the used secret. (IAM creation)"
-    required: false
-  azureClusterClientID:
-    description: "The client ID of the application registration created for Constellation in Azure. (cluster creation)"
-    required: false
-  azureClusterClientSecret:
-    description: "The client secret value of the used secret. (cluster creation)"
-    required: false
   azureClusterCredentials:
     description: "Azure credentials authorized to create a Constellation cluster."
     required: true
@@ -188,11 +170,6 @@ runs:
     - name: Create IAM configuration
       id: constellation-iam-create
       uses: ./.github/actions/constellation_iam_create
-      env:
-        ARM_CLIENT_ID: ${{ inputs.azureIAMClientID }}
-        ARM_CLIENT_SECRET: ${{ inputs.azureIAMClientSecret }}
-        ARM_SUBSCRIPTION_ID: ${{ inputs.azureSubscription }}
-        ARM_TENANT_ID: ${{ inputs.azureTenant }}
       with:
         cloudProvider: ${{ inputs.cloudProvider }}
         awsZone: eu-central-1c
@@ -228,11 +205,6 @@ runs:
     - name: Create cluster
       id: constellation-create
       uses: ./.github/actions/constellation_create
-      env:
-        ARM_CLIENT_ID: ${{ inputs.azureClusterClientID }}
-        ARM_CLIENT_SECRET: ${{ inputs.azureClusterClientSecret }}
-        ARM_SUBSCRIPTION_ID: ${{ inputs.azureSubscription }}
-        ARM_TENANT_ID: ${{ inputs.azureTenant }}
       with:
         cloudProvider: ${{ inputs.cloudProvider }}
         gcpInClusterServiceAccountKey: ${{ inputs.gcpInClusterServiceAccountKey }}

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -167,19 +167,26 @@ runs:
       with:
         azure_credentials: ${{ inputs.azureIAMCredentials }}
 
+    - name: Create UUID
+      id: create-uuid
+      shell: bash
+      run: |
+        uuid=$(uuidgen)
+        echo "uuid=${uuid%%-*}" >> $GITHUB_OUTPUT
+
     - name: Create IAM configuration
       id: constellation-iam-create
       uses: ./.github/actions/constellation_iam_create
       with:
         cloudProvider: ${{ inputs.cloudProvider }}
         awsZone: eu-central-1c
-        awsPrefix: e2e_${{ github.run_id }}_${{ github.run_attempt }}
+        awsPrefix: e2e_${{ github.run_id }}_${{ github.run_attempt }}_${{ steps.create-uuid.outputs.uuid }}
         azureRegion: northeurope
-        azureResourceGroup: e2e_${{ github.run_id }}_${{ github.run_attempt }}_rg
-        azureServicePrincipal: e2e_${{ github.run_id }}_${{ github.run_attempt }}_sp
+        azureResourceGroup: e2e_${{ github.run_id }}_${{ github.run_attempt }}_${{ steps.create-uuid.outputs.uuid }}_rg
+        azureServicePrincipal: e2e_${{ github.run_id }}_${{ github.run_attempt }}_${{ steps.create-uuid.outputs.uuid }}_sp
         gcpProjectID: ${{ inputs.gcpProject }}
         gcpZone: europe-west3-b
-        gcpServiceAccountID: e2e-${{ github.run_id }}-${{ github.run_attempt }}-sa
+        gcpServiceAccountID: e2e-${{ github.run_id }}-${{ github.run_attempt }}-${{ steps.create-uuid.outputs.uuid }}-sa
 
     - name: Login to GCP (Cluster service account)
       if: inputs.cloudProvider == 'gcp'

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -35,10 +35,10 @@ inputs:
   gcpProject:
     description: "The GCP project to deploy Constellation in."
     required: false
-  gcpIAMServiceAccount:
+  gcpIAMCreateServiceAccount:
     description: "Service account with permissions to create IAM configuration on GCP."
     required: false
-  gcpClusterServiceAccount:
+  gcpClusterCreateServiceAccount:
     description: "Service account with permissions to create a Constellation cluster on GCP."
     required: false
   gcpInClusterServiceAccountKey:
@@ -53,10 +53,10 @@ inputs:
   awsOpenSearchPwd:
     description: "AWS OpenSearch Password to upload the benchmark results."
     required: false
-  azureClusterCredentials:
+  azureClusterCreateCredentials:
     description: "Azure credentials authorized to create a Constellation cluster."
     required: true
-  azureIAMCredentials:
+  azureIAMCreateCredentials:
     description: "Azure credentials authorized to create an IAM configuration."
     required: true
   test:
@@ -150,7 +150,7 @@ runs:
       if: inputs.cloudProvider == 'gcp'
       uses: ./.github/actions/login_gcp
       with:
-        service_account: ${{ inputs.gcpIAMServiceAccount }}
+        service_account: ${{ inputs.gcpIAMCreateServiceAccount }}
 
     - name: Login to AWS (IAM role)
       if: inputs.cloudProvider == 'aws'
@@ -165,7 +165,7 @@ runs:
       if: inputs.cloudProvider == 'azure'
       uses: ./.github/actions/login_azure
       with:
-        azure_credentials: ${{ inputs.azureIAMCredentials }}
+        azure_credentials: ${{ inputs.azureIAMCreateCredentials }}
 
     - name: Create UUID
       id: create-uuid
@@ -192,7 +192,7 @@ runs:
       if: inputs.cloudProvider == 'gcp'
       uses: ./.github/actions/login_gcp
       with:
-        service_account: ${{ inputs.gcpClusterServiceAccount }}
+        service_account: ${{ inputs.gcpClusterCreateServiceAccount }}
 
     - name: Login to AWS (Cluster role)
       if: inputs.cloudProvider == 'aws'
@@ -207,7 +207,7 @@ runs:
       if: inputs.cloudProvider == 'azure'
       uses: ./.github/actions/login_azure
       with:
-        azure_credentials: ${{ inputs.azureClusterCredentials }}
+        azure_credentials: ${{ inputs.azureClusterCreateCredentials }}
 
     - name: Create cluster
       id: constellation-create

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -5,12 +5,6 @@ on:
   schedule:
     - cron: "0 3 * * 2-5" # At 03:00 on every day-of-week from Tuesday through Friday.
 
-env:
-  ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
-
 jobs:
   find-latest-image:
     strategy:

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -97,17 +97,20 @@ jobs:
           osImage: ${{ matrix.refStream == 'ref/release/stream/stable/?' && needs.find-latest-image.outputs.image-release-stable || needs.find-latest-image.outputs.image-main-debug }}
           isDebugImage: ${{ matrix.refStream == 'ref/main/stream/debug/?' }}
           cliVersion: ${{ matrix.refStream == 'ref/release/stream/stable/?' && needs.find-latest-image.outputs.image-release-stable || '' }}
-          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
-          azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
-          azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
-          azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-          azureUserAssignedIdentity: ${{ secrets.AZURE_E2E_USER_ASSIGNED_IDENTITY }}
-          azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
-          gcp_service_account: "constellation-e2e@constellation-331613.iam.gserviceaccount.com"
-          gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
+          gcpClusterServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpIAMServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
+          gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: "sonobuoy full"
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+          azureClusterCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
+          azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+          azureIAMClientID: ${{ secrets.AZURE_E2E_IAM_CLIENT_ID }}
+          azureIAMClientSecret: ${{ secrets.AZURE_E2E_IAM_CLIENT_SECRET }}
+          azureClusterClientID: ${{ secrets.AZURE_E2E_CLUSTER_CLIENT_ID }}
+          azureClusterClientSecret: ${{ secrets.AZURE_E2E_CLUSTER_CLIENT_SECRET }}
+          azureSubscription: ${{ secrets.AZURE_E2E_IAM_SUBSCRIPTION_ID }}
+          azureTenant: ${{ secrets.AZURE_E2E_IAM_TENANT_ID }}
 
       - name: Always terminate cluster
         if: always()
@@ -115,6 +118,15 @@ jobs:
         uses: ./.github/actions/constellation_destroy
         with:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
+
+      - name: Always delete IAM configuration
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/constellation_iam_destroy
+        with:
+          cloudProvider: ${{ matrix.provider }}
+          azureCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+          gcpServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
 
       - name: Notify teams channel
         if: failure() && github.ref == 'refs/heads/main'

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -76,13 +76,13 @@ jobs:
           isDebugImage: ${{ matrix.refStream == 'ref/main/stream/debug/?' }}
           cliVersion: ${{ matrix.refStream == 'ref/release/stream/stable/?' && needs.find-latest-image.outputs.image-release-stable || '' }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
-          gcpClusterServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
-          gcpIAMServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
+          gcpClusterCreateServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpIAMCreateServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
           gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: "sonobuoy full"
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
-          azureClusterCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
-          azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+          azureClusterCreateCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
+          azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -86,14 +86,12 @@ jobs:
 
       - name: Always terminate cluster
         if: always()
-        continue-on-error: true
         uses: ./.github/actions/constellation_destroy
         with:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
 
       - name: Always delete IAM configuration
         if: always()
-        continue-on-error: true
         uses: ./.github/actions/constellation_iam_destroy
         with:
           cloudProvider: ${{ matrix.provider }}

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -65,22 +65,6 @@ jobs:
         with:
           go-version: "1.20.3"
 
-      - name: Login to Azure
-        if: matrix.provider == 'azure'
-        uses: ./.github/actions/login_azure
-        with:
-          azure_credentials: ${{ secrets.AZURE_E2E_CREDENTIALS }}
-
-      - name: Create Azure resource group
-        if: matrix.provider == 'azure'
-        id: az_resource_group_gen
-        shell: bash
-        run: |
-          uuid=$(cat /proc/sys/kernel/random/uuid)
-          name=e2e-test-${uuid%%-*}
-          az group create --location northeurope --name "$name" --tags e2e
-          echo "res_group_name=$name" >> "$GITHUB_OUTPUT"
-
       - name: Run E2E test
         id: e2e_test
         uses: ./.github/actions/e2e_test
@@ -99,12 +83,6 @@ jobs:
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
           azureClusterCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
           azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
-          azureIAMClientID: ${{ secrets.AZURE_E2E_IAM_CLIENT_ID }}
-          azureIAMClientSecret: ${{ secrets.AZURE_E2E_IAM_CLIENT_SECRET }}
-          azureClusterClientID: ${{ secrets.AZURE_E2E_CLUSTER_CLIENT_ID }}
-          azureClusterClientSecret: ${{ secrets.AZURE_E2E_CLUSTER_CLIENT_SECRET }}
-          azureSubscription: ${{ secrets.AZURE_E2E_IAM_SUBSCRIPTION_ID }}
-          azureTenant: ${{ secrets.AZURE_E2E_IAM_TENANT_ID }}
 
       - name: Always terminate cluster
         if: always()
@@ -136,14 +114,3 @@ jobs:
             -H "Content-Type: application/json"         \
             -d @to-be-send.json                         \
             "${{ secrets.MS_TEAMS_WEBHOOK_URI }}"
-
-      - name: Always destroy Azure resource group
-        if: always() && matrix.provider == 'azure'
-        shell: bash
-        run: |
-          az group delete \
-            --name ${{ steps.az_resource_group_gen.outputs.res_group_name }} \
-            --force-deletion-types Microsoft.Compute/virtualMachineScaleSets \
-            --force-deletion-types Microsoft.Compute/virtualMachines \
-            --no-wait \
-            --yes

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -262,12 +262,6 @@ jobs:
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
           azureClusterCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
           azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
-          azureIAMClientID: ${{ secrets.AZURE_E2E_IAM_CLIENT_ID }}
-          azureIAMClientSecret: ${{ secrets.AZURE_E2E_IAM_CLIENT_SECRET }}
-          azureClusterClientID: ${{ secrets.AZURE_E2E_CLUSTER_CLIENT_ID }}
-          azureClusterClientSecret: ${{ secrets.AZURE_E2E_CLUSTER_CLIENT_SECRET }}
-          azureSubscription: ${{ secrets.AZURE_E2E_IAM_SUBSCRIPTION_ID }}
-          azureTenant: ${{ secrets.AZURE_E2E_IAM_TENANT_ID }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -247,8 +247,8 @@ jobs:
           cloudProvider: ${{ inputs.cloudProvider }}
           machineType: ${{ inputs.machineType }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
-          gcpClusterServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
-          gcpIAMServiceAccount: " constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
+          gcpClusterCreateServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpIAMCreateServiceAccount: " constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
           gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ inputs.test }}
           kubernetesVersion: ${{ inputs.kubernetesVersion }}
@@ -260,8 +260,8 @@ jobs:
           cliVersion: ${{ needs.split-cliImageVersion.outputs.cliVersion }}
           isDebugImage: ${{ needs.find-latest-image.outputs.isDebugImage }}
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
-          azureClusterCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
-          azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+          azureClusterCreateCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
+          azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -271,7 +271,6 @@ jobs:
 
       - name: Always delete IAM configuration
         if: always()
-        continue-on-error: true
         uses: ./.github/actions/constellation_iam_destroy
         with:
           cloudProvider: ${{ inputs.cloudProvider }}

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -244,22 +244,6 @@ jobs:
         if: inputs.cloudProvider == 'gcp' && runner.os == 'macOS'
         uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
 
-      - name: Login to Azure
-        if: inputs.cloudProvider == 'azure'
-        uses: ./.github/actions/login_azure
-        with:
-          azure_credentials: ${{ secrets.AZURE_E2E_CREDENTIALS }}
-
-      - name: Create Azure resource group
-        id: az_resource_group_gen
-        if: inputs.cloudProvider == 'azure'
-        shell: bash
-        run: |
-          uuid=$(uuidgen)
-          name=e2e-test-${uuid%%-*}
-          az group create --location westus --name "$name" --tags e2e
-          echo "res_group_name=$name" >> "$GITHUB_OUTPUT"
-
       - name: Run manual E2E test
         id: e2e_test
         uses: ./.github/actions/e2e_test
@@ -269,24 +253,27 @@ jobs:
           cloudProvider: ${{ inputs.cloudProvider }}
           machineType: ${{ inputs.machineType }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
-          gcp_service_account: "constellation-e2e@constellation-331613.iam.gserviceaccount.com"
-          gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
+          gcpClusterServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpIAMServiceAccount: " constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
+          gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ inputs.test }}
           kubernetesVersion: ${{ inputs.kubernetesVersion }}
           keepMeasurements: ${{ inputs.keepMeasurements }}
           awsOpenSearchDomain: ${{ secrets.AWS_OPENSEARCH_DOMAIN }}
           awsOpenSearchUsers: ${{ secrets.AWS_OPENSEARCH_USER }}
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
-          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
-          azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
-          azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
-          azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-          azureUserAssignedIdentity: ${{ secrets.AZURE_E2E_USER_ASSIGNED_IDENTITY }}
-          azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
           osImage: ${{ needs.find-latest-image.outputs.image }}
           cliVersion: ${{ needs.split-cliImageVersion.outputs.cliVersion }}
           isDebugImage: ${{ needs.find-latest-image.outputs.isDebugImage }}
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+          azureClusterCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
+          azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+          azureIAMClientID: ${{ secrets.AZURE_E2E_IAM_CLIENT_ID }}
+          azureIAMClientSecret: ${{ secrets.AZURE_E2E_IAM_CLIENT_SECRET }}
+          azureClusterClientID: ${{ secrets.AZURE_E2E_CLUSTER_CLIENT_ID }}
+          azureClusterClientSecret: ${{ secrets.AZURE_E2E_CLUSTER_CLIENT_SECRET }}
+          azureSubscription: ${{ secrets.AZURE_E2E_IAM_SUBSCRIPTION_ID }}
+          azureTenant: ${{ secrets.AZURE_E2E_IAM_TENANT_ID }}
 
       - name: Always terminate cluster
         if: always()
@@ -295,16 +282,10 @@ jobs:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
 
       - name: Always delete IAM configuration
-        if: always() && inputs.test == 'iamcreate' && inputs.cloudProvider != 'azure' # skip for Azure, as the SP / MI does not have the required permissions
+        if: always()
+        continue-on-error: true
         uses: ./.github/actions/constellation_iam_destroy
-
-      - name: Always destroy Azure resource group
-        if: always() && inputs.cloudProvider == 'azure'
-        shell: bash
-        run: |
-          az group delete \
-            --name ${{ steps.az_resource_group_gen.outputs.res_group_name }} \
-            --force-deletion-types Microsoft.Compute/virtualMachineScaleSets \
-            --force-deletion-types Microsoft.Compute/virtualMachines \
-            --no-wait \
-            --yes
+        with:
+          cloudProvider: ${{ inputs.cloudProvider }}
+          azureCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+          gcpServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -108,12 +108,6 @@ on:
         type: string
         required: true
 
-env:
-  ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
-
 jobs:
   split-cliImageVersion:
     name: Split cliImageVersion

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -150,23 +150,21 @@ jobs:
           cloudProvider: ${{ matrix.provider }}
           cliVersion: ""
           kubernetesVersion: ${{ matrix.kubernetes-version }}
+          keepMeasurements: "true"
           osImage: ""
           isDebugImage: "false"
-          keepMeasurements: "true"
           awsOpenSearchDomain: ${{ secrets.AWS_OPENSEARCH_DOMAIN }}
           awsOpenSearchUsers: ${{ secrets.AWS_OPENSEARCH_USER }}
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
-          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
-          azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
-          azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
-          azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-          azureUserAssignedIdentity: ${{ secrets.AZURE_E2E_USER_ASSIGNED_IDENTITY }}
-          azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
-          gcp_service_account: "constellation-e2e@constellation-331613.iam.gserviceaccount.com"
-          gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
+          gcpClusterCreateServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpIAMCreateServiceAccount: " constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
+          gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ matrix.test }}
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+          azureClusterCreateCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
+          azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+
 
       - name: Always terminate cluster
         if: always()
@@ -176,9 +174,13 @@ jobs:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
 
       - name: Always delete IAM configuration
-        if: always() && matrix.test == 'iamcreate' && matrix.provider != 'azure' # skip for Azure, as the SP / MI does not have the required permissions
+        if: always()
         continue-on-error: true
         uses: ./.github/actions/constellation_iam_destroy
+        with:
+          cloudProvider: ${{ matrix.provider }}
+          azureCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+          gcpServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
 
       - name: Notify teams channel
         if: failure() && github.ref == 'refs/heads/main'

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -58,7 +58,8 @@ jobs:
         kubernetes-version: ["v1.24", "v1.25", "v1.26"]
         refStream: ["ref/main/stream/debug/?", "ref/release/stream/stable/?"]
         exclude:
-          # Verify test runs only on latest kubernetes-version.
+          # Verify test runs only on latest kubernetes-version by default.
+          # Exclude it for main-debug as it needs to run on 1.25 / release-stable.
           - test: "verify"
             kubernetes-version: "v1.24"
           - refStream: "ref/main/stream/debug/?"

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -61,7 +61,8 @@ jobs:
           # Verify test runs only on latest kubernetes-version.
           - test: "verify"
             kubernetes-version: "v1.24"
-          - test: "verify"
+          - refStream: "ref/main/stream/debug/?"
+            test: "verify"
             kubernetes-version: "v1.25"
           # Recover test runs only on latest kubernetes-version.
           - test: "recover"
@@ -88,7 +89,7 @@ jobs:
             provider: "aws"
           - test: "perf-bench"
             provider: "aws"
-          # Only iamcreate for K8s v1.25 on all providers.
+          # Only verify for K8s v1.25 on all providers.
           - refStream: "ref/release/stream/stable/?"
             kubernetes-version: "v1.24"
           - refStream: "ref/release/stream/stable/?"
@@ -101,8 +102,6 @@ jobs:
             test: "autoscaling"
           - refStream: "ref/release/stream/stable/?"
             test: "sonobuoy full"
-          - refStream: "ref/release/stream/stable/?"
-            test: "verify"
           - refStream: "ref/release/stream/stable/?"
             test: "recover"
     runs-on: ubuntu-22.04

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -148,14 +148,12 @@ jobs:
 
       - name: Always terminate cluster
         if: always()
-        continue-on-error: true
         uses: ./.github/actions/constellation_destroy
         with:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
 
       - name: Always delete IAM configuration
         if: always()
-        continue-on-error: true
         uses: ./.github/actions/constellation_iam_destroy
         with:
           cloudProvider: ${{ matrix.provider }}

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -5,12 +5,6 @@ on:
   schedule:
     - cron: "0 3 * * 6" # At 03:00 on Saturday.
 
-env:
-  ARM_CLIENT_ID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
-  ARM_CLIENT_SECRET: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-  ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
-  ARM_TENANT_ID: ${{ secrets.AZURE_E2E_TENANT_ID }}
-
 jobs:
   find-latest-image:
     strategy:

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -138,13 +138,13 @@ jobs:
           awsOpenSearchUsers: ${{ secrets.AWS_OPENSEARCH_USER }}
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
-          gcpClusterServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
-          gcpIAMServiceAccount: " constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
+          gcpClusterCreateServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpIAMCreateServiceAccount: " constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
           gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ matrix.test }}
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
-          azureClusterCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
-          azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+          azureClusterCreateCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
+          azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -123,25 +123,6 @@ jobs:
         with:
           go-version: "1.20.3"
 
-      - name: Always delete IAM configuration
-        if: always()
-        continue-on-error: true
-        uses: ./.github/actions/constellation_iam_destroy
-        with:
-          cloudProvider: ${{ matrix.provider }}
-          azureCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
-          gcpServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
-
-      - name: Create Azure resource group
-        id: az_resource_group_gen
-        if: matrix.provider == 'azure'
-        shell: bash
-        run: |
-          uuid=$(cat /proc/sys/kernel/random/uuid)
-          name=e2e-test-${uuid%%-*}
-          az group create --location northeurope --name "$name" --tags e2e
-          echo "res_group_name=$name" >> "$GITHUB_OUTPUT"
-
       - name: Run E2E test
         id: e2e_test
         uses: ./.github/actions/e2e_test
@@ -164,12 +145,6 @@ jobs:
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
           azureClusterCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
           azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
-          azureIAMClientID: ${{ secrets.AZURE_E2E_IAM_CLIENT_ID }}
-          azureIAMClientSecret: ${{ secrets.AZURE_E2E_IAM_CLIENT_SECRET }}
-          azureClusterClientID: ${{ secrets.AZURE_E2E_CLUSTER_CLIENT_ID }}
-          azureClusterClientSecret: ${{ secrets.AZURE_E2E_CLUSTER_CLIENT_SECRET }}
-          azureSubscription: ${{ secrets.AZURE_E2E_IAM_SUBSCRIPTION_ID }}
-          azureTenant: ${{ secrets.AZURE_E2E_IAM_TENANT_ID }}
 
       - name: Always terminate cluster
         if: always()
@@ -201,17 +176,6 @@ jobs:
             -H "Content-Type: application/json"         \
             -d @to-be-send.json                         \
             "${{ secrets.MS_TEAMS_WEBHOOK_URI }}"
-
-      - name: Always destroy Azure resource group
-        if: always() && matrix.provider == 'azure'
-        shell: bash
-        run: |
-          az group delete \
-            --name ${{ steps.az_resource_group_gen.outputs.res_group_name }} \
-            --force-deletion-types Microsoft.Compute/virtualMachineScaleSets \
-            --force-deletion-types Microsoft.Compute/virtualMachines \
-            --no-wait \
-            --yes
 
   e2e-upgrade:
     strategy:

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -59,17 +59,11 @@ jobs:
             "lb",
             "verify",
             "recover",
-            "iamcreate",
           ]
         provider: ["gcp", "azure", "aws"]
         kubernetes-version: ["v1.24", "v1.25", "v1.26"]
         refStream: ["ref/main/stream/debug/?", "ref/release/stream/stable/?"]
         exclude:
-          # IAM create test runs only on latest kubernetes-version.
-          - test: "iamcreate"
-            kubernetes-version: "v1.24"
-          - test: "iamcreate"
-            kubernetes-version: "v1.25"
           # Verify test runs only on latest kubernetes-version.
           - test: "verify"
             kubernetes-version: "v1.24"
@@ -135,11 +129,14 @@ jobs:
         with:
           go-version: "1.20.3"
 
-      - name: Login to Azure
-        if: matrix.provider == 'azure'
-        uses: ./.github/actions/login_azure
+      - name: Always delete IAM configuration
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/constellation_iam_destroy
         with:
-          azure_credentials: ${{ secrets.AZURE_E2E_CREDENTIALS }}
+          cloudProvider: ${{ matrix.provider }}
+          azureCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+          gcpServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
 
       - name: Create Azure resource group
         id: az_resource_group_gen
@@ -165,17 +162,20 @@ jobs:
           awsOpenSearchDomain: ${{ secrets.AWS_OPENSEARCH_DOMAIN }}
           awsOpenSearchUsers: ${{ secrets.AWS_OPENSEARCH_USER }}
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
-          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
-          azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
-          azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
-          azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-          azureUserAssignedIdentity: ${{ secrets.AZURE_E2E_USER_ASSIGNED_IDENTITY }}
-          azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
-          gcp_service_account: "constellation-e2e@constellation-331613.iam.gserviceaccount.com"
-          gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
+          gcpClusterServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpIAMServiceAccount: " constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
+          gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ matrix.test }}
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+          azureClusterCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
+          azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+          azureIAMClientID: ${{ secrets.AZURE_E2E_IAM_CLIENT_ID }}
+          azureIAMClientSecret: ${{ secrets.AZURE_E2E_IAM_CLIENT_SECRET }}
+          azureClusterClientID: ${{ secrets.AZURE_E2E_CLUSTER_CLIENT_ID }}
+          azureClusterClientSecret: ${{ secrets.AZURE_E2E_CLUSTER_CLIENT_SECRET }}
+          azureSubscription: ${{ secrets.AZURE_E2E_IAM_SUBSCRIPTION_ID }}
+          azureTenant: ${{ secrets.AZURE_E2E_IAM_TENANT_ID }}
 
       - name: Always terminate cluster
         if: always()
@@ -185,9 +185,13 @@ jobs:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
 
       - name: Always delete IAM configuration
-        if: always() && matrix.test == 'iamcreate' && matrix.provider != 'azure' # skip for Azure, as the SP / MI does not have the required permissions
+        if: always()
         continue-on-error: true
         uses: ./.github/actions/constellation_iam_destroy
+        with:
+          cloudProvider: ${{ matrix.provider }}
+          azureCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+          gcpServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
 
       - name: Notify teams channel
         if: failure() && github.ref == 'refs/heads/main'

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -148,13 +148,13 @@ jobs:
           cliVersion: ${{ inputs.fromVersion }}
           isDebugImage: "false"
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
-          gcpClusterServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
-          gcpIAMServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
+          gcpClusterCreateServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpIAMCreateServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
           gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: "nop"
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
-          azureClusterCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
-          azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+          azureClusterCreateCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
+          azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
 
       - name: Run upgrade test
         run: |

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -147,17 +147,14 @@ jobs:
           osImage: ${{ inputs.fromVersion }}
           cliVersion: ${{ inputs.fromVersion }}
           isDebugImage: "false"
-          azureSubscription: ${{ secrets.AZURE_E2E_SUBSCRIPTION_ID }}
-          azureTenant: ${{ secrets.AZURE_E2E_TENANT_ID }}
-          azureClientID: ${{ secrets.AZURE_E2E_CLIENT_ID }}
-          azureClientSecret: ${{ secrets.AZURE_E2E_CLIENT_SECRET }}
-          azureUserAssignedIdentity: ${{ secrets.AZURE_E2E_USER_ASSIGNED_IDENTITY }}
-          azureResourceGroup: ${{ steps.az_resource_group_gen.outputs.res_group_name }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
-          gcp_service_account: "constellation-e2e@constellation-331613.iam.gserviceaccount.com"
-          gcpClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
+          gcpClusterServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpIAMServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
+          gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: "nop"
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+          azureClusterCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
+          azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
 
       - name: Run upgrade test
         run: |


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use the minimal e2e permissions (documented in #1442) in the e2e tests to be aligned with documentation and notice changes in permission requirements at test time.
  - e2e permissions are now managed in [edgeless-iam](https://github.com/edgelesssys/edgeless-iam/tree/feat/seperate-iam-accounts)
- Use [ad-hoc IAM creation](https://docs.edgeless.systems/constellation/workflows/config#creating-an-iam-configuration) (the way we recommend to users in the docs) for all CSPs, including Azure. With that, manual resource group creation / deletion is obsolote.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Successful test runs
- [Manual e2e test: AWS](https://github.com/edgelesssys/constellation/actions/runs/4561618154/jobs/8047791821)
- [Manual e2e test: Azure](https://github.com/edgelesssys/constellation/actions/runs/4561611430/jobs/8047775473)
- [Manual e2e test: GCP](https://github.com/edgelesssys/constellation/actions/runs/4561617079/jobs/8047788746)
- [Daily e2e test](https://github.com/edgelesssys/constellation/actions/runs/4561612340/jobs/8050253615)
- [Weekly e2e test](https://github.com/edgelesssys/constellation/actions/runs/4561846874)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
