### PR TITLE
internal: semver support for pseudoversions

### DIFF
--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -60,10 +60,11 @@ func New(version string) (Semver, error) {
 
 // String returns the string representation of the version.
 func (v Semver) String() string {
+	version := fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
 	if v.Prerelease != "" {
-		return fmt.Sprintf("v%d.%d.%d-%s", v.Major, v.Minor, v.Patch, v.Prerelease)
+		return fmt.Sprintf("%s-%s", version, v.Prerelease)
 	}
-	return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
+	return version
 }
 
 // Compare compares two versions. It relies on the semver.Compare function internally.

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -40,11 +40,7 @@ func New(version string) (Semver, error) {
 	version = semver.Canonical(version)
 
 	var major, minor, patch int
-	var pre string
-	if strings.Contains(version, "-") {
-		parts := strings.Split(version, "-")
-		pre = parts[1]
-	}
+	_, pre, _ := strings.Cut(version, "-")
 	_, err := fmt.Sscanf(version, "v%d.%d.%d", &major, &minor, &patch)
 	if err != nil {
 		return Semver{}, fmt.Errorf("parsing semver parts: %w", err)

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -20,9 +20,10 @@ import (
 
 // Semver represents a semantic version.
 type Semver struct {
-	Major int
-	Minor int
-	Patch int
+	Major      int
+	Minor      int
+	Patch      int
+	Prerelease string
 }
 
 // New returns a Version from a string.
@@ -39,20 +40,29 @@ func New(version string) (Semver, error) {
 	version = semver.Canonical(version)
 
 	var major, minor, patch int
+	var pre string
+	if strings.Contains(version, "-") {
+		parts := strings.Split(version, "-")
+		pre = parts[1]
+	}
 	_, err := fmt.Sscanf(version, "v%d.%d.%d", &major, &minor, &patch)
 	if err != nil {
 		return Semver{}, fmt.Errorf("parsing semver parts: %w", err)
 	}
 
 	return Semver{
-		Major: major,
-		Minor: minor,
-		Patch: patch,
+		Major:      major,
+		Minor:      minor,
+		Patch:      patch,
+		Prerelease: pre,
 	}, nil
 }
 
 // String returns the string representation of the version.
 func (v Semver) String() string {
+	if v.Prerelease != "" {
+		return fmt.Sprintf("v%d.%d.%d-%s", v.Major, v.Minor, v.Patch, v.Prerelease)
+	}
 	return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add support for `v.1.19.2-pre`-type pseudoversions in the semver package as specified in the [semver standard](https://semver.org/).
- Prerelease-info is being put to respect when comparing semvers.

### Related issue
- [AB#3017](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/3017/)

### Additional info
- Implementation using `strings.Contains` is probably not perfect, but I didn't found a way to nicely scan for "optional" characters with just `fmt.Sscanf`. Maybe Regex would be the next best option if the strings check is not appropriate.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
