### PR TITLE
ci: auto-group bazel deps by base name if os and arch differ

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -218,6 +218,30 @@
         "slsa-framework/slsa-github-generator"
       ],
       "pinDigests": false
+    },
+    {
+      "matchPackagePatterns": [
+        "_darwin_arm64$"
+      ],
+      "groupName": "{{{replace '_darwin_arm64' '' packageName}}}"
+    },
+    {
+      "matchPackagePatterns": [
+        "_darwin_amd64$"
+      ],
+      "groupName": "{{{replace '_darwin_amd64' '' packageName}}}"
+    },
+    {
+      "matchPackagePatterns": [
+        "_linux_arm64$"
+      ],
+      "groupName": "{{{replace '_linux_arm64' '' packageName}}}"
+    },
+    {
+      "matchPackagePatterns": [
+        "_linux_amd64$"
+      ],
+      "groupName": "{{{replace '_linux_amd64' '' packageName}}}"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: auto-group bazel deps by base name if os and arch differ

<!-- (uncomment if applicable)
### Related issue
- [AB#3070](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3070)
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
