### PR TITLE
azure: convert uami resource ID to clientID

### DIFF
--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -454,7 +454,7 @@ func (i *initCmd) getMarshaledServiceAccountURI(provider cloudprovider.Provider,
 			Location:          config.Provider.Azure.Location,
 			// TODO(malt3): Switch preferred auth method to uami as planned by AB#2961
 			PreferredAuthMethod: azureshared.AuthMethodUserAssignedIdentity,
-			UamiURI:             config.Provider.Azure.UserAssignedIdentity,
+			UamiResourceID:      config.Provider.Azure.UserAssignedIdentity,
 		}
 		return creds.ToCloudServiceAccountURI(), nil
 

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -453,7 +453,8 @@ func (i *initCmd) getMarshaledServiceAccountURI(provider cloudprovider.Provider,
 			ClientSecretValue: config.Provider.Azure.ClientSecretValue,
 			Location:          config.Provider.Azure.Location,
 			// TODO(malt3): Switch preferred auth method to uami as planned by AB#2961
-			PreferredAuthMethod: azureshared.AuthMethodServicePrincipal,
+			PreferredAuthMethod: azureshared.AuthMethodUserAssignedIdentity,
+			UamiURI:             config.Provider.Azure.UserAssignedIdentity,
 		}
 		return creds.ToCloudServiceAccountURI(), nil
 

--- a/internal/cloud/azure/azure.go
+++ b/internal/cloud/azure/azure.go
@@ -128,7 +128,7 @@ func (c *Cloud) GetCCMConfig(ctx context.Context, providerID string, cloudServic
 	var uamiClientID string
 	useManagedIdentityExtension := creds.PreferredAuthMethod == azureshared.AuthMethodUserAssignedIdentity
 	if useManagedIdentityExtension {
-		uamiClientID, err = c.getUAMIClientIDFromURI(ctx, providerID, cloudServiceAccountURI)
+		uamiClientID, err = c.getUAMIClientIDFromURI(ctx, providerID, creds.UamiResourceID)
 		if err != nil {
 			return nil, fmt.Errorf("retrieving user-assigned managed identity client ID: %w", err)
 		}

--- a/internal/cloud/azureshared/appcredentials.go
+++ b/internal/cloud/azureshared/appcredentials.go
@@ -20,7 +20,7 @@ type ApplicationCredentials struct {
 	AppClientID         string
 	ClientSecretValue   string
 	Location            string
-	UamiURI             string
+	UamiResourceID      string
 	PreferredAuthMethod AuthMethod
 }
 
@@ -43,7 +43,7 @@ func ApplicationCredentialsFromURI(cloudServiceAccountURI string) (ApplicationCr
 		AppClientID:         query.Get("client_id"),
 		ClientSecretValue:   query.Get("client_secret"),
 		Location:            query.Get("location"),
-		UamiURI:             query.Get("uami_uri"),
+		UamiResourceID:      query.Get("uami_resource_id"),
 		PreferredAuthMethod: preferredAuthMethod,
 	}, nil
 }
@@ -59,8 +59,8 @@ func (c ApplicationCredentials) ToCloudServiceAccountURI() string {
 	if c.ClientSecretValue != "" {
 		query.Add("client_secret", c.ClientSecretValue)
 	}
-	if c.UamiURI != "" {
-		query.Add("uami_uri", c.UamiURI)
+	if c.UamiResourceID != "" {
+		query.Add("uami_resource_id", c.UamiResourceID)
 	}
 	if c.PreferredAuthMethod != AuthMethodUnknown {
 		query.Add("preferred_auth_method", c.PreferredAuthMethod.String())

--- a/internal/cloud/azureshared/appcredentials.go
+++ b/internal/cloud/azureshared/appcredentials.go
@@ -20,6 +20,7 @@ type ApplicationCredentials struct {
 	AppClientID         string
 	ClientSecretValue   string
 	Location            string
+	UamiURI             string
 	PreferredAuthMethod AuthMethod
 }
 
@@ -42,6 +43,7 @@ func ApplicationCredentialsFromURI(cloudServiceAccountURI string) (ApplicationCr
 		AppClientID:         query.Get("client_id"),
 		ClientSecretValue:   query.Get("client_secret"),
 		Location:            query.Get("location"),
+		UamiURI:             query.Get("uami_uri"),
 		PreferredAuthMethod: preferredAuthMethod,
 	}, nil
 }
@@ -56,6 +58,9 @@ func (c ApplicationCredentials) ToCloudServiceAccountURI() string {
 	}
 	if c.ClientSecretValue != "" {
 		query.Add("client_secret", c.ClientSecretValue)
+	}
+	if c.UamiURI != "" {
+		query.Add("uami_uri", c.UamiURI)
 	}
 	if c.PreferredAuthMethod != AuthMethodUnknown {
 		query.Add("preferred_auth_method", c.PreferredAuthMethod.String())

--- a/internal/cloud/azureshared/appcredentials_test.go
+++ b/internal/cloud/azureshared/appcredentials_test.go
@@ -25,11 +25,13 @@ func TestApplicationCredentialsFromURI(t *testing.T) {
 		AppClientID:         "client-id",
 		ClientSecretValue:   "client-secret",
 		Location:            "location",
+		UamiResourceID:      "subscriptions/9b352db0-82af-408c-a02c-36fbffbf7015/resourceGroups/resourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/UAMIName",
 		PreferredAuthMethod: AuthMethodServicePrincipal,
 	}
 	credsWithoutSecret := ApplicationCredentials{
 		TenantID:            "tenant-id",
 		Location:            "location",
+		UamiResourceID:      "subscriptions/9b352db0-82af-408c-a02c-36fbffbf7015/resourceGroups/resourceGroupName/providers/Microsoft.ManagedIdentity/userAssignedIdentities/UAMIName",
 		PreferredAuthMethod: AuthMethodUserAssignedIdentity,
 	}
 	credsWithoutPreferrredAuthMethod := ApplicationCredentials{
@@ -44,11 +46,11 @@ func TestApplicationCredentialsFromURI(t *testing.T) {
 		wantErr                bool
 	}{
 		"getApplicationCredentials works": {
-			cloudServiceAccountURI: "serviceaccount://azure?tenant_id=tenant-id&client_id=client-id&client_secret=client-secret&location=location&preferred_auth_method=serviceprincipal",
+			cloudServiceAccountURI: "serviceaccount://azure?tenant_id=tenant-id&client_id=client-id&client_secret=client-secret&location=location&preferred_auth_method=serviceprincipal&uami_resource_id=subscriptions%2F9b352db0-82af-408c-a02c-36fbffbf7015%2FresourceGroups%2FresourceGroupName%2Fproviders%2FMicrosoft.ManagedIdentity%2FuserAssignedIdentities%2FUAMIName",
 			wantCreds:              creds,
 		},
 		"can parse URI without app registration / secret": {
-			cloudServiceAccountURI: "serviceaccount://azure?tenant_id=tenant-id&location=location&preferred_auth_method=userassignedidentity",
+			cloudServiceAccountURI: "serviceaccount://azure?tenant_id=tenant-id&location=location&preferred_auth_method=userassignedidentity&uami_resource_id=subscriptions%2F9b352db0-82af-408c-a02c-36fbffbf7015%2FresourceGroups%2FresourceGroupName%2Fproviders%2FMicrosoft.ManagedIdentity%2FuserAssignedIdentities%2FUAMIName",
 			wantCreds:              credsWithoutSecret,
 		},
 		"can parse URI without preferred auth method": {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- If one chooses to use UAMI for in-cluster auth, we translate the UAMI resource ID form the config to it's client ID via listing all UAMIs assinged to the current VM. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
