### PR TITLE
ci: match bazel deps using packageName template parameter

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -223,25 +223,25 @@
       "matchPackagePatterns": [
         "_darwin_arm64$"
       ],
-      "groupName": "{{{replace '_darwin_arm64' '' packageName}}}"
+      "groupName": "{{{replace '_darwin_arm64' '' depName}}}"
     },
     {
       "matchPackagePatterns": [
         "_darwin_amd64$"
       ],
-      "groupName": "{{{replace '_darwin_amd64' '' packageName}}}"
+      "groupName": "{{{replace '_darwin_amd64' '' depName}}}"
     },
     {
       "matchPackagePatterns": [
         "_linux_arm64$"
       ],
-      "groupName": "{{{replace '_linux_arm64' '' packageName}}}"
+      "groupName": "{{{replace '_linux_arm64' '' depName}}}"
     },
     {
       "matchPackagePatterns": [
         "_linux_amd64$"
       ],
-      "groupName": "{{{replace '_linux_amd64' '' packageName}}}"
+      "groupName": "{{{replace '_linux_amd64' '' depName}}}"
     }
   ],
   "regexManagers": [

--- a/renovate.json
+++ b/renovate.json
@@ -221,27 +221,9 @@
     },
     {
       "matchPackagePatterns": [
-        "_darwin_arm64$"
+        "_(darwin|linux)_(arm64|amd64)$"
       ],
-      "groupName": "{{{replace '_darwin_arm64' '' depName}}}"
-    },
-    {
-      "matchPackagePatterns": [
-        "_darwin_amd64$"
-      ],
-      "groupName": "{{{replace '_darwin_amd64' '' depName}}}"
-    },
-    {
-      "matchPackagePatterns": [
-        "_linux_arm64$"
-      ],
-      "groupName": "{{{replace '_linux_arm64' '' depName}}}"
-    },
-    {
-      "matchPackagePatterns": [
-        "_linux_amd64$"
-      ],
-      "groupName": "{{{replace '_linux_amd64' '' depName}}}"
+      "groupName": "{{packageName}}"
     }
   ],
   "regexManagers": [


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: match bazel deps using packageName template parameter

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info
- `"depName": "com_github_bufbuild_buf_linux_amd64"`
- `"packageName": "bufbuild/buf"`
- We can simply group by packageName in a single rule


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)