### PR TITLE
ci: do not skip e2e-weekly if trigger is successful

### DIFF
--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -32,8 +32,7 @@ jobs:
           echo 'Release workflow failed, exiting..'
           exit 1
 
-  e2e-weekly:
-    needs: [on-failure-quit]
+  e2e-tests:
     strategy:
       fail-fast: false
       max-parallel: 4


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- The `needs` key skips the tests if the trigger was successful. Remove it to get the correct behavior.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
