### PR TITLE
ci: do not run most release tests on macOS

### DIFF
--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -49,7 +49,7 @@ jobs:
           ]
         provider: ["gcp", "azure", "aws"]
         kubernetes-version: ["v1.24", "v1.25", "v1.26"]
-        runner: [ubuntu-22.04, macos-12]
+        runner: [ubuntu-22.04]
         exclude:
           # IAM create test runs only on latest kubernetes-version.
           - test: "iamcreate"
@@ -89,6 +89,16 @@ jobs:
           # Currently broken on AWS. Enable when AB#2780 is fixed.
           - test: "lb"
             provider: "aws"
+        include:
+          # Explicitly define two tests to run the CLI on macOS.
+          - test: "verify"
+            kubernetes-version: "v1.25"
+            runner: "macos-12"
+            provider: "azure"
+          - test: "iamcreate"
+            kubernetes-version: "v1.25"
+            runner: "macos-12"
+            provider: "gcp"
     runs-on: ${{ matrix.runner }}
     permissions:
       id-token: write


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- only run two tests on macOS as a simple smoketest
- Example from docs: https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#example-adding-configurations

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
