### PR TITLE
bazel-deps-mirror: upgrade command

### DIFF
--- a/.github/workflows/test-tidy.yml
+++ b/.github/workflows/test-tidy.yml
@@ -50,7 +50,9 @@ jobs:
       - name: Upload Bazel dependencies to the mirror
         if: startsWith(github.head_ref, 'renovate/')
         shell: bash
-        run: bazelisk run //bazel/ci:deps_mirror_upload
+        run: |
+          bazelisk run //bazel/ci:deps_mirror_upgrade
+          bazelisk run //bazel/ci:deps_mirror_upload
 
       - name: Run Bazel tidy
         shell: bash

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,6 +17,7 @@
 /e2e @katexochen
 /hack/azure-jump-host @malt3
 /hack/azure-snp-report-verify @derpsteb
+/hack/bazel-deps-mirror @malt3
 /hack/check-licenses.sh @thomasten
 /hack/clidocgen @thomasten
 /hack/fetch-broken-e2e @katexochen

--- a/bazel/ci/BUILD.bazel
+++ b/bazel/ci/BUILD.bazel
@@ -332,6 +332,10 @@ sh_template(
     template = "go_generate.sh.in",
 )
 
+# deps_mirror_fix fixes bazel workspace rules for external dependencies.
+# It normalizes the rules and rewrites WORKSPACE and bzl files.
+# If files are not in the mirror, it will fail.
+# Use deps_mirror_upload to upload missing files.
 repo_command(
     name = "deps_mirror_fix",
     args = [
@@ -341,6 +345,8 @@ repo_command(
     command = "//hack/bazel-deps-mirror",
 )
 
+# deps_mirror_upload fixes bazel workspace rules for external dependencies.
+# It uploads all dependencies to the mirror, normalizes the rules and rewrites WORKSPACE and bzl files.
 repo_command(
     name = "deps_mirror_upload",
     args = [
@@ -349,6 +355,21 @@ repo_command(
     command = "//hack/bazel-deps-mirror",
 )
 
+# deps_mirror_upgrade upgrades bazel workspace rules for external dependencies.
+# Users are supposed to replace any upstream URLs.
+# It replaces the expected hash and uploads the new dep to the mirror.
+repo_command(
+    name = "deps_mirror_upgrade",
+    args = [
+        "upgrade",
+    ],
+    command = "//hack/bazel-deps-mirror",
+)
+
+# deps_mirror_check checks bazel workspace rules for external dependencies.
+# It checks if all dependency rules have mirror urls and are properly formatted.
+# It doesn't check if the mirror has the files.
+# Use deps_mirror_check_mirror to check if the mirror has the files.
 repo_command(
     name = "deps_mirror_check",
     args = [
@@ -357,6 +378,8 @@ repo_command(
     command = "//hack/bazel-deps-mirror",
 )
 
+# deps_mirror_check_mirror checks bazel workspace rules for external dependencies.
+# It checks if all dependency rules are correctly mirrored and checks that the rules are properly formatted.
 repo_command(
     name = "deps_mirror_check_mirror",
     args = [

--- a/hack/bazel-deps-mirror/BUILD.bazel
+++ b/hack/bazel-deps-mirror/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "bazel-deps-mirror.go",
         "check.go",
         "fix.go",
+        "upgrade.go",
     ],
     importpath = "github.com/edgelesssys/constellation/v2/hack/bazel-deps-mirror",
     visibility = ["//visibility:private"],

--- a/hack/bazel-deps-mirror/bazel-deps-mirror.go
+++ b/hack/bazel-deps-mirror/bazel-deps-mirror.go
@@ -46,6 +46,7 @@ func newRootCmd() *cobra.Command {
 
 	rootCmd.AddCommand(newCheckCmd())
 	rootCmd.AddCommand(newFixCmd())
+	rootCmd.AddCommand(newUpgradeCmd())
 
 	return rootCmd
 }

--- a/hack/bazel-deps-mirror/check.go
+++ b/hack/bazel-deps-mirror/check.go
@@ -97,7 +97,7 @@ func checkBazelFile(ctx context.Context, fileHelper *bazelfiles.Helper, mirrorCh
 	found := rules.Rules(buildfile, rules.SupportedRules)
 	if len(found) == 0 {
 		log.Debugf("No rules found in file: %s", bazelFile.RelPath)
-		return
+		return issByFile, nil
 	}
 	log.Debugf("Found %d rules in file: %s", len(found), bazelFile.RelPath)
 	for _, rule := range found {
@@ -121,7 +121,7 @@ func checkBazelFile(ctx context.Context, fileHelper *bazelfiles.Helper, mirrorCh
 			}
 		}
 	}
-	return
+	return issByFile, nil
 }
 
 type checkFlags struct {

--- a/hack/bazel-deps-mirror/internal/mirror/BUILD.bazel
+++ b/hack/bazel-deps-mirror/internal/mirror/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "@com_github_aws_aws_sdk_go_v2_service_s3//:s3",
         "@com_github_aws_aws_sdk_go_v2_service_s3//types",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/hack/bazel-deps-mirror/internal/rules/rules.go
+++ b/hack/bazel-deps-mirror/internal/rules/rules.go
@@ -34,7 +34,7 @@ ruleLoop:
 			}
 		}
 	}
-	return
+	return rules
 }
 
 // ValidatePinned checks if the given rule is a pinned dependency rule.
@@ -78,7 +78,7 @@ func ValidatePinned(rule *build.Rule) (validationErrs []error) {
 			validationErrs = append(validationErrs, errors.New("rule has empty sha256 attribute"))
 		}
 	}
-	return
+	return validationErrs
 }
 
 // Check checks if a dependency rule is normalized and contains a mirror url.
@@ -107,7 +107,7 @@ func Check(rule *build.Rule) (validationErrs []error) {
 	if rule.Kind() == "rpm" && len(urls) != 1 {
 		validationErrs = append(validationErrs, errors.New("rpm rule has unstable urls that are not the edgeless mirror"))
 	}
-	return
+	return validationErrs
 }
 
 // Normalize normalizes a rule and returns true if the rule was changed.
@@ -122,11 +122,10 @@ func Normalize(rule *build.Rule) (changed bool) {
 	sortURLs(normalizedURLS)
 	normalizedURLS = deduplicateURLs(normalizedURLS)
 	if slices.Equal(urls, normalizedURLS) && rule.Attr("url") == nil {
-		return
+		return changed
 	}
 	setURLs(rule, normalizedURLS)
-	changed = true
-	return
+	return true
 }
 
 // AddURLs adds a url to a rule.
@@ -206,7 +205,7 @@ func deduplicateURLs(urls []string) (deduplicated []string) {
 			seen[url] = true
 		}
 	}
-	return
+	return deduplicated
 }
 
 // addTypeAttribute adds the type attribute to http_archive rules if it is missing.

--- a/hack/bazel-deps-mirror/upgrade.go
+++ b/hack/bazel-deps-mirror/upgrade.go
@@ -135,11 +135,10 @@ func upgradeRule(ctx context.Context, mirrorUpload mirrorUploader, rule *build.R
 	log.Debugf("Upgrading rule: %s", rule.Name())
 
 	upstreamURLs, err := rules.UpstreamURLs(rule)
-	if err != nil {
-		if errors.Is(err, rules.ErrNoUpstreamURL) {
-			log.Debugf("Rule has no upstream URL. Skipping.")
-			return
-		}
+	if errors.Is(err, rules.ErrNoUpstreamURL) {
+		log.Debugf("Rule has no upstream URL. Skipping.")
+		return
+	} else if err != nil {
 		iss = append(iss, err)
 		return
 	}


### PR DESCRIPTION
This command can be used to upgrade a dependency.
Users are supposed to replace any upstream URLs and run the upgrade command. It replaces the expected hash and uploads the new dep to the mirror.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bazel-deps-mirror: upgrade command
- bazel-deps-mirror: improve fix command to add hash if missing
