### PR TITLE
cli: add Terraform log support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ image/config.mk
 .terraform
 .terraform.tfstate.lock.info
 *.tfvars
+terraform.log
 
 # macOS
 .DS_Store

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -48,6 +48,7 @@ func NewRootCmd() *cobra.Command {
 
 	rootCmd.PersistentFlags().Bool("debug", false, "enable debug logging")
 	rootCmd.PersistentFlags().Bool("force", false, "disable version compatibility checks - might result in corrupted clusters")
+	rootCmd.PersistentFlags().String("tf-log", "NONE", "sets the Terraform log level (default \"NONE\" - no logs)")
 
 	rootCmd.AddCommand(cmd.NewConfigCmd())
 	rootCmd.AddCommand(cmd.NewCreateCmd())

--- a/cli/internal/cloudcmd/clients.go
+++ b/cli/internal/cloudcmd/clients.go
@@ -23,9 +23,9 @@ type imageFetcher interface {
 
 type terraformClient interface {
 	PrepareWorkspace(path string, input terraform.Variables) error
-	CreateCluster(ctx context.Context) (terraform.CreateOutput, error)
-	CreateIAMConfig(ctx context.Context, provider cloudprovider.Provider) (terraform.IAMOutput, error)
-	Destroy(ctx context.Context) error
+	CreateCluster(ctx context.Context, logLevel terraform.LogLevel) (terraform.CreateOutput, error)
+	CreateIAMConfig(ctx context.Context, provider cloudprovider.Provider, logLevel terraform.LogLevel) (terraform.IAMOutput, error)
+	Destroy(ctx context.Context, logLevel terraform.LogLevel) error
 	CleanUpWorkspace() error
 	RemoveInstaller()
 	Show(ctx context.Context) (*tfjson.State, error)

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -45,7 +45,7 @@ type stubTerraformClient struct {
 	showErr                error
 }
 
-func (c *stubTerraformClient) CreateCluster(_ context.Context) (terraform.CreateOutput, error) {
+func (c *stubTerraformClient) CreateCluster(_ context.Context, _ terraform.LogLevel) (terraform.CreateOutput, error) {
 	return terraform.CreateOutput{
 		IP:             c.ip,
 		Secret:         c.initSecret,
@@ -54,7 +54,7 @@ func (c *stubTerraformClient) CreateCluster(_ context.Context) (terraform.Create
 	}, c.createClusterErr
 }
 
-func (c *stubTerraformClient) CreateIAMConfig(_ context.Context, _ cloudprovider.Provider) (terraform.IAMOutput, error) {
+func (c *stubTerraformClient) CreateIAMConfig(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (terraform.IAMOutput, error) {
 	return c.iamOutput, c.iamOutputErr
 }
 
@@ -62,7 +62,7 @@ func (c *stubTerraformClient) PrepareWorkspace(_ string, _ terraform.Variables) 
 	return c.prepareWorkspaceErr
 }
 
-func (c *stubTerraformClient) Destroy(_ context.Context) error {
+func (c *stubTerraformClient) Destroy(_ context.Context, _ terraform.LogLevel) error {
 	c.destroyCalled = true
 	return c.destroyErr
 }

--- a/cli/internal/cloudcmd/create_test.go
+++ b/cli/internal/cloudcmd/create_test.go
@@ -215,7 +215,15 @@ func TestCreator(t *testing.T) {
 				policyPatcher: tc.policyPatcher,
 			}
 
-			idFile, err := creator.Create(context.Background(), tc.provider, tc.config, "type", 2, 3)
+			opts := CreateOptions{
+				Provider:          tc.provider,
+				Config:            tc.config,
+				InsType:           "type",
+				ControlPlaneCount: 2,
+				WorkerCount:       3,
+				TFLogLevel:        terraform.LogLevelNone,
+			}
+			idFile, err := creator.Create(context.Background(), opts)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -89,7 +89,7 @@ func TestIAMCreator(t *testing.T) {
 	testCases := map[string]struct {
 		tfClient       terraformClient
 		newTfClientErr error
-		config         *IAMConfig
+		config         *IAMConfigOptions
 		provider       cloudprovider.Provider
 		wantIAMIDFile  iamid.File
 		wantErr        bool
@@ -107,19 +107,19 @@ func TestIAMCreator(t *testing.T) {
 			tfClient:      &stubTerraformClient{iamOutput: validGCPIAMOutput},
 			wantIAMIDFile: validGCPIAMIDFile,
 			provider:      cloudprovider.GCP,
-			config:        &IAMConfig{GCP: validGCPIAMConfig},
+			config:        &IAMConfigOptions{GCP: validGCPIAMConfig},
 		},
 		"azure": {
 			tfClient:      &stubTerraformClient{iamOutput: validAzureIAMOutput},
 			wantIAMIDFile: validAzureIAMIDFile,
 			provider:      cloudprovider.Azure,
-			config:        &IAMConfig{Azure: validAzureIAMConfig},
+			config:        &IAMConfigOptions{Azure: validAzureIAMConfig},
 		},
 		"aws": {
 			tfClient:      &stubTerraformClient{iamOutput: validAWSIAMOutput},
 			wantIAMIDFile: validAWSIAMIDFile,
 			provider:      cloudprovider.AWS,
-			config:        &IAMConfig{AWS: validAWSIAMConfig},
+			config:        &IAMConfigOptions{AWS: validAWSIAMConfig},
 		},
 	}
 
@@ -188,7 +188,7 @@ func TestDestroyIAMConfiguration(t *testing.T) {
 			assert := assert.New(t)
 			destroyer := &IAMDestroyer{client: tc.tfClient}
 
-			err := destroyer.DestroyIAMConfiguration(context.Background())
+			err := destroyer.DestroyIAMConfiguration(context.Background(), terraform.LogLevelNone)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cloudcmd/rollback.go
+++ b/cli/internal/cloudcmd/rollback.go
@@ -11,22 +11,24 @@ import (
 	"errors"
 	"fmt"
 	"io"
+
+	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 )
 
 // rollbacker does a rollback.
 type rollbacker interface {
-	rollback(ctx context.Context) error
+	rollback(ctx context.Context, logLevel terraform.LogLevel) error
 }
 
 // rollbackOnError calls rollback on the rollbacker if the handed error is not nil,
 // and writes logs to the writer w.
-func rollbackOnError(w io.Writer, onErr *error, roll rollbacker) {
+func rollbackOnError(w io.Writer, onErr *error, roll rollbacker, logLevel terraform.LogLevel) {
 	if *onErr == nil {
 		return
 	}
 	fmt.Fprintf(w, "An error occurred: %s\n", *onErr)
 	fmt.Fprintln(w, "Attempting to roll back.")
-	if err := roll.rollback(context.Background()); err != nil {
+	if err := roll.rollback(context.Background(), logLevel); err != nil {
 		*onErr = errors.Join(*onErr, fmt.Errorf("on rollback: %w", err)) // TODO: print the error, or return it?
 		return
 	}
@@ -37,8 +39,8 @@ type rollbackerTerraform struct {
 	client terraformClient
 }
 
-func (r *rollbackerTerraform) rollback(ctx context.Context) error {
-	if err := r.client.Destroy(ctx); err != nil {
+func (r *rollbackerTerraform) rollback(ctx context.Context, logLevel terraform.LogLevel) error {
+	if err := r.client.Destroy(ctx, logLevel); err != nil {
 		return err
 	}
 	return r.client.CleanUpWorkspace()
@@ -50,9 +52,9 @@ type rollbackerQEMU struct {
 	createdWorkspace bool
 }
 
-func (r *rollbackerQEMU) rollback(ctx context.Context) (retErr error) {
+func (r *rollbackerQEMU) rollback(ctx context.Context, logLevel terraform.LogLevel) (retErr error) {
 	if r.createdWorkspace {
-		retErr = r.client.Destroy(ctx)
+		retErr = r.client.Destroy(ctx, logLevel)
 	}
 	if retErr := errors.Join(retErr, r.libvirt.Stop(ctx)); retErr != nil {
 		return retErr

--- a/cli/internal/cloudcmd/rollback_test.go
+++ b/cli/internal/cloudcmd/rollback_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +43,7 @@ func TestRollbackTerraform(t *testing.T) {
 				client: tc.tfClient,
 			}
 
-			err := rollbacker.rollback(context.Background())
+			err := rollbacker.rollback(context.Background(), terraform.LogLevelNone)
 			if tc.wantErr {
 				assert.Error(err)
 				if tc.tfClient.cleanUpWorkspaceErr == nil {
@@ -98,7 +99,7 @@ func TestRollbackQEMU(t *testing.T) {
 				createdWorkspace: tc.createdWorkspace,
 			}
 
-			err := rollbacker.rollback(context.Background())
+			err := rollbacker.rollback(context.Background(), terraform.LogLevelNone)
 			if tc.wantErr {
 				assert.Error(err)
 				if tc.tfClient.cleanUpWorkspaceErr == nil {

--- a/cli/internal/cloudcmd/terminate.go
+++ b/cli/internal/cloudcmd/terminate.go
@@ -33,7 +33,7 @@ func NewTerminator() *Terminator {
 }
 
 // Terminate deletes the could provider resources.
-func (t *Terminator) Terminate(ctx context.Context) (retErr error) {
+func (t *Terminator) Terminate(ctx context.Context, logLevel terraform.LogLevel) (retErr error) {
 	defer func() {
 		if retErr == nil {
 			retErr = t.newLibvirtRunner().Stop(ctx)
@@ -46,11 +46,11 @@ func (t *Terminator) Terminate(ctx context.Context) (retErr error) {
 	}
 	defer cl.RemoveInstaller()
 
-	return t.terminateTerraform(ctx, cl)
+	return t.terminateTerraform(ctx, cl, logLevel)
 }
 
-func (t *Terminator) terminateTerraform(ctx context.Context, cl terraformClient) error {
-	if err := cl.Destroy(ctx); err != nil {
+func (t *Terminator) terminateTerraform(ctx context.Context, cl terraformClient, logLevel terraform.LogLevel) error {
+	if err := cl.Destroy(ctx, logLevel); err != nil {
 		return err
 	}
 	return cl.CleanUpWorkspace()

--- a/cli/internal/cloudcmd/terminate_test.go
+++ b/cli/internal/cloudcmd/terminate_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -62,7 +63,7 @@ func TestTerminator(t *testing.T) {
 				},
 			}
 
-			err := terminator.Terminate(context.Background())
+			err := terminator.Terminate(context.Background(), terraform.LogLevelNone)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -120,6 +120,7 @@ go_test(
         "//cli/internal/helm",
         "//cli/internal/iamid",
         "//cli/internal/kubernetes",
+        "//cli/internal/terraform",
         "//disk-mapper/recoverproto",
         "//internal/atls",
         "//internal/attestation/measurements",

--- a/cli/internal/cmd/cloud.go
+++ b/cli/internal/cmd/cloud.go
@@ -12,18 +12,15 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
 	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/iamid"
+	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/gcpshared"
-	"github.com/edgelesssys/constellation/v2/internal/config"
 )
 
 type cloudCreator interface {
 	Create(
 		ctx context.Context,
-		provider cloudprovider.Provider,
-		config *config.Config,
-		insType string,
-		coordCount, nodeCount int,
+		opts cloudcmd.CreateOptions,
 	) (clusterid.File, error)
 }
 
@@ -31,15 +28,15 @@ type cloudIAMCreator interface {
 	Create(
 		ctx context.Context,
 		provider cloudprovider.Provider,
-		iamConfig *cloudcmd.IAMConfig,
+		opts *cloudcmd.IAMConfigOptions,
 	) (iamid.File, error)
 }
 
 type iamDestroyer interface {
-	DestroyIAMConfiguration(ctx context.Context) error
+	DestroyIAMConfiguration(ctx context.Context, logLevel terraform.LogLevel) error
 	GetTfstateServiceAccountKey(ctx context.Context) (gcpshared.ServiceAccountKey, error)
 }
 
 type cloudTerminator interface {
-	Terminate(context.Context) error
+	Terminate(ctx context.Context, logLevel terraform.LogLevel) error
 }

--- a/cli/internal/cmd/cloud_test.go
+++ b/cli/internal/cmd/cloud_test.go
@@ -13,9 +13,9 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
 	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/iamid"
+	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/gcpshared"
-	"github.com/edgelesssys/constellation/v2/internal/config"
 	"go.uber.org/goleak"
 )
 
@@ -34,13 +34,10 @@ type stubCloudCreator struct {
 
 func (c *stubCloudCreator) Create(
 	_ context.Context,
-	provider cloudprovider.Provider,
-	_ *config.Config,
-	_ string,
-	_, _ int,
+	opts cloudcmd.CreateOptions,
 ) (clusterid.File, error) {
 	c.createCalled = true
-	c.id.CloudProvider = provider
+	c.id.CloudProvider = opts.Provider
 	return c.id, c.createErr
 }
 
@@ -49,7 +46,7 @@ type stubCloudTerminator struct {
 	terminateErr error
 }
 
-func (c *stubCloudTerminator) Terminate(context.Context) error {
+func (c *stubCloudTerminator) Terminate(_ context.Context, _ terraform.LogLevel) error {
 	c.called = true
 	return c.terminateErr
 }
@@ -67,7 +64,7 @@ type stubIAMCreator struct {
 func (c *stubIAMCreator) Create(
 	_ context.Context,
 	provider cloudprovider.Provider,
-	_ *cloudcmd.IAMConfig,
+	_ *cloudcmd.IAMConfigOptions,
 ) (iamid.File, error) {
 	c.createCalled = true
 	c.id.CloudProvider = provider
@@ -82,7 +79,7 @@ type stubIAMDestroyer struct {
 	getTfstateKeyErr    error
 }
 
-func (d *stubIAMDestroyer) DestroyIAMConfiguration(_ context.Context) error {
+func (d *stubIAMDestroyer) DestroyIAMConfiguration(_ context.Context, _ terraform.LogLevel) error {
 	d.destroyCalled = true
 	return d.destroyErr
 }

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -153,7 +153,15 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 	}
 
 	spinner.Start("Creating", false)
-	idFile, err := creator.Create(cmd.Context(), provider, conf, instanceType, flags.controllerCount, flags.workerCount)
+	opts := cloudcmd.CreateOptions{
+		Provider:          provider,
+		Config:            conf,
+		InsType:           instanceType,
+		ControlPlaneCount: flags.controllerCount,
+		WorkerCount:       flags.workerCount,
+		TFLogLevel:        flags.tfLogLevel,
+	}
+	idFile, err := creator.Create(cmd.Context(), opts)
 	spinner.Stop()
 	if err != nil {
 		return translateCreateErrors(cmd, err)
@@ -206,10 +214,21 @@ func (c *createCmd) parseCreateFlags(cmd *cobra.Command) (createFlags, error) {
 	}
 	c.log.Debugf("force flag is %t", force)
 
+	logLevelString, err := cmd.Flags().GetString("tf-log")
+	if err != nil {
+		return createFlags{}, fmt.Errorf("parsing tf-log string: %w", err)
+	}
+	logLevel, err := terraform.ParseLogLevel(logLevelString)
+	if err != nil {
+		return createFlags{}, fmt.Errorf("parsing Terraform log level %s: %w", logLevelString, err)
+	}
+	c.log.Debugf("Terraform log level is %s", logLevel.String())
+
 	return createFlags{
 		controllerCount: controllerCount,
 		workerCount:     workerCount,
 		configPath:      configPath,
+		tfLogLevel:      logLevel,
 		force:           force,
 		yes:             yes,
 	}, nil
@@ -220,6 +239,7 @@ type createFlags struct {
 	controllerCount int
 	workerCount     int
 	configPath      string
+	tfLogLevel      terraform.LogLevel
 	force           bool
 	yes             bool
 }

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -222,7 +222,7 @@ func (c *createCmd) parseCreateFlags(cmd *cobra.Command) (createFlags, error) {
 	if err != nil {
 		return createFlags{}, fmt.Errorf("parsing Terraform log level %s: %w", logLevelString, err)
 	}
-	c.log.Debugf("Terraform log level is %s", logLevel.String())
+	c.log.Debugf("Terraform logs will be written into %s at level %s", constants.TerraformLogFile, logLevel.String())
 
 	return createFlags{
 		controllerCount: controllerCount,

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -198,7 +198,7 @@ func (c *createCmd) parseCreateFlags(cmd *cobra.Command) (createFlags, error) {
 
 	yes, err := cmd.Flags().GetBool("yes")
 	if err != nil {
-		return createFlags{}, fmt.Errorf("%w; Set '-yes' without a value to automatically confirm", err)
+		return createFlags{}, fmt.Errorf("parsing yes bool: %w", err)
 	}
 	c.log.Debugf("Yes flag is %t", yes)
 

--- a/cli/internal/cmd/create_test.go
+++ b/cli/internal/cmd/create_test.go
@@ -185,6 +185,7 @@ func TestCreate(t *testing.T) {
 			cmd.SetIn(bytes.NewBufferString(tc.stdin))
 			cmd.Flags().String("config", constants.ConfigFilename, "") // register persistent flag manually
 			cmd.Flags().Bool("force", true, "")                        // register persistent flag manually
+			cmd.Flags().String("tf-log", "NONE", "")                   // register persistent flag manually
 
 			if tc.yesFlag {
 				require.NoError(cmd.Flags().Set("yes", "true"))

--- a/cli/internal/cmd/iamcreate.go
+++ b/cli/internal/cmd/iamcreate.go
@@ -181,7 +181,7 @@ func newIAMCreator(cmd *cobra.Command, logLevel terraform.LogLevel) (*iamCreator
 	if err != nil {
 		return nil, fmt.Errorf("creating logger: %w", err)
 	}
-	log.Debugf("Terraform log level is %s", logLevel.String())
+	log.Debugf("Terraform logs will be written into %s at level %s", constants.TerraformLogFile, logLevel.String())
 
 	return &iamCreator{
 		cmd:         cmd,

--- a/cli/internal/cmd/iamcreate_test.go
+++ b/cli/internal/cmd/iamcreate_test.go
@@ -306,7 +306,7 @@ func TestIAMCreateAWS(t *testing.T) {
 				spinner:         &nopSpinner{},
 				creator:         tc.creator,
 				fileHandler:     fileHandler,
-				iamConfig:       &cloudcmd.IAMConfig{},
+				iamConfig:       &cloudcmd.IAMConfigOptions{},
 				provider:        tc.provider,
 				providerCreator: &awsIAMCreator{},
 			}
@@ -587,7 +587,7 @@ func TestIAMCreateAzure(t *testing.T) {
 				spinner:         &nopSpinner{},
 				creator:         tc.creator,
 				fileHandler:     fileHandler,
-				iamConfig:       &cloudcmd.IAMConfig{},
+				iamConfig:       &cloudcmd.IAMConfigOptions{},
 				provider:        tc.provider,
 				providerCreator: &azureIAMCreator{},
 			}
@@ -893,7 +893,7 @@ func TestIAMCreateGCP(t *testing.T) {
 				spinner:         &nopSpinner{},
 				creator:         tc.creator,
 				fileHandler:     fileHandler,
-				iamConfig:       &cloudcmd.IAMConfig{},
+				iamConfig:       &cloudcmd.IAMConfigOptions{},
 				provider:        tc.provider,
 				providerCreator: &gcpIAMCreator{},
 			}

--- a/cli/internal/cmd/iamcreate_test.go
+++ b/cli/internal/cmd/iamcreate_test.go
@@ -278,6 +278,7 @@ func TestIAMCreateAWS(t *testing.T) {
 			cmd.Flags().String("kubernetes", semver.MajorMinor(config.Default().KubernetesVersion), "")
 			cmd.Flags().Bool("yes", false, "")
 			cmd.Flags().String("name", "constell", "")
+			cmd.Flags().String("tf-log", "NONE", "")
 
 			if tc.zoneFlag != "" {
 				require.NoError(cmd.Flags().Set("zone", tc.zoneFlag))
@@ -550,12 +551,13 @@ func TestIAMCreateAzure(t *testing.T) {
 			cmd.SetErr(&bytes.Buffer{})
 			cmd.SetIn(bytes.NewBufferString(tc.stdin))
 
-			// register persistent flag manually
+			// register persistent flags manually
 			cmd.Flags().String("config", constants.ConfigFilename, "")
 			cmd.Flags().Bool("generate-config", false, "")
 			cmd.Flags().String("kubernetes", semver.MajorMinor(config.Default().KubernetesVersion), "")
 			cmd.Flags().Bool("yes", false, "")
 			cmd.Flags().String("name", "constell", "")
+			cmd.Flags().String("tf-log", "NONE", "")
 
 			if tc.regionFlag != "" {
 				require.NoError(cmd.Flags().Set("region", tc.regionFlag))
@@ -862,6 +864,7 @@ func TestIAMCreateGCP(t *testing.T) {
 			cmd.Flags().String("kubernetes", semver.MajorMinor(config.Default().KubernetesVersion), "")
 			cmd.Flags().Bool("yes", false, "")
 			cmd.Flags().String("name", "constell", "")
+			cmd.Flags().String("tf-log", "NONE", "")
 
 			if tc.zoneFlag != "" {
 				require.NoError(cmd.Flags().Set("zone", tc.zoneFlag))

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -177,7 +177,7 @@ func (c *destroyCmd) parseDestroyFlags(cmd *cobra.Command) (destroyFlags, error)
 	if err != nil {
 		return destroyFlags{}, fmt.Errorf("parsing Terraform log level %s: %w", logLevelString, err)
 	}
-	c.log.Debugf("Terraform log level is %s", logLevel.String())
+	c.log.Debugf("Terraform logs will be written into %s at level %s", constants.TerraformLogFile, logLevel.String())
 
 	return destroyFlags{
 		tfLogLevel: logLevel,

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -165,7 +165,7 @@ type destroyFlags struct {
 func (c *destroyCmd) parseDestroyFlags(cmd *cobra.Command) (destroyFlags, error) {
 	yes, err := cmd.Flags().GetBool("yes")
 	if err != nil {
-		return destroyFlags{}, fmt.Errorf("%w; Set '-yes' without a value to automatically confirm", err)
+		return destroyFlags{}, fmt.Errorf("parsing yes bool: %w", err)
 	}
 	c.log.Debugf("Yes flag is %t", yes)
 

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -105,6 +105,10 @@ func TestIAMDestroy(t *testing.T) {
 			cmd.SetOut(&bytes.Buffer{})
 			cmd.SetErr(&bytes.Buffer{})
 			cmd.SetIn(bytes.NewBufferString(tc.stdin))
+
+			// register persistent flags manually
+			cmd.Flags().String("tf-log", "NONE", "")
+
 			assert.NoError(cmd.Flags().Set("yes", tc.yesFlag))
 
 			c := &destroyCmd{log: logger.NewTest(t)}

--- a/cli/internal/cmd/miniup.go
+++ b/cli/internal/cmd/miniup.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
 	"github.com/edgelesssys/constellation/v2/cli/internal/libvirt"
+	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
@@ -73,17 +74,22 @@ func (m *miniUpCmd) up(cmd *cobra.Command, creator cloudCreator, spinner spinner
 		return fmt.Errorf("system requirements not met: %w", err)
 	}
 
+	flags, err := m.parseUpFlags(cmd)
+	if err != nil {
+		return fmt.Errorf("parsing flags: %w", err)
+	}
+
 	fileHandler := file.NewHandler(afero.NewOsFs())
 
 	// create config if not passed as flag and set default values
-	config, err := m.prepareConfig(cmd, fileHandler)
+	config, err := m.prepareConfig(cmd, fileHandler, flags)
 	if err != nil {
 		return fmt.Errorf("preparing config: %w", err)
 	}
 
 	// create cluster
 	spinner.Start("Creating cluster in QEMU ", false)
-	err = m.createMiniCluster(cmd.Context(), fileHandler, creator, config)
+	err = m.createMiniCluster(cmd.Context(), fileHandler, creator, config, flags.tfLogLevel)
 	spinner.Stop()
 	if err != nil {
 		return fmt.Errorf("creating cluster: %w", err)
@@ -173,20 +179,10 @@ func (m *miniUpCmd) checkSystemRequirements(out io.Writer) error {
 }
 
 // prepareConfig reads a given config, or creates a new minimal QEMU config.
-func (m *miniUpCmd) prepareConfig(cmd *cobra.Command, fileHandler file.Handler) (*config.Config, error) {
-	m.log.Debugf("Preparing configuration")
-	configPath, err := cmd.Flags().GetString("config")
-	if err != nil {
-		return nil, err
-	}
-	force, err := cmd.Flags().GetBool("force")
-	if err != nil {
-		return nil, fmt.Errorf("parsing force argument: %w", err)
-	}
-
+func (m *miniUpCmd) prepareConfig(cmd *cobra.Command, fileHandler file.Handler, flags upFlags) (*config.Config, error) {
 	// check for existing config
-	if configPath != "" {
-		conf, err := config.New(fileHandler, configPath, force)
+	if flags.configPath != "" {
+		conf, err := config.New(fileHandler, flags.configPath, flags.force)
 		var configValidationErr *config.ValidationError
 		if errors.As(err, &configValidationErr) {
 			cmd.PrintErrln(configValidationErr.LongMessage())
@@ -199,11 +195,11 @@ func (m *miniUpCmd) prepareConfig(cmd *cobra.Command, fileHandler file.Handler) 
 		}
 		return conf, nil
 	}
-	m.log.Debugf("Configuration path is %q", configPath)
+	m.log.Debugf("Configuration path is %q", flags.configPath)
 	if err := cmd.Flags().Set("config", constants.ConfigFilename); err != nil {
 		return nil, err
 	}
-	_, err = fileHandler.Stat(constants.ConfigFilename)
+	_, err := fileHandler.Stat(constants.ConfigFilename)
 	if err == nil {
 		// config already exists, prompt user to overwrite
 		cmd.PrintErrln("A config file already exists in the current workspace. Use --config to use an existing config file.")
@@ -227,9 +223,17 @@ func (m *miniUpCmd) prepareConfig(cmd *cobra.Command, fileHandler file.Handler) 
 }
 
 // createMiniCluster creates a new cluster using the given config.
-func (m *miniUpCmd) createMiniCluster(ctx context.Context, fileHandler file.Handler, creator cloudCreator, config *config.Config) error {
+func (m *miniUpCmd) createMiniCluster(ctx context.Context, fileHandler file.Handler, creator cloudCreator, config *config.Config, tfLogLevel terraform.LogLevel) error {
 	m.log.Debugf("Creating mini cluster")
-	idFile, err := creator.Create(ctx, cloudprovider.QEMU, config, "", 1, 1)
+	opts := cloudcmd.CreateOptions{
+		Provider:          cloudprovider.QEMU,
+		Config:            config,
+		InsType:           "",
+		ControlPlaneCount: 1,
+		WorkerCount:       1,
+		TFLogLevel:        tfLogLevel,
+	}
+	idFile, err := creator.Create(ctx, opts)
 	if err != nil {
 		return err
 	}
@@ -270,4 +274,40 @@ func (m *miniUpCmd) initializeMiniCluster(cmd *cobra.Command, fileHandler file.H
 	}
 	m.log.Debugf("Initialized mini cluster")
 	return nil
+}
+
+type upFlags struct {
+	configPath string
+	force      bool
+	tfLogLevel terraform.LogLevel
+}
+
+func (m *miniUpCmd) parseUpFlags(cmd *cobra.Command) (upFlags, error) {
+	m.log.Debugf("Preparing configuration")
+	configPath, err := cmd.Flags().GetString("config")
+	if err != nil {
+		return upFlags{}, fmt.Errorf("parsing config string: %w", err)
+	}
+	m.log.Debugf("Configuration path is %q", configPath)
+	force, err := cmd.Flags().GetBool("force")
+	if err != nil {
+		return upFlags{}, fmt.Errorf("parsing force bool: %w", err)
+	}
+	m.log.Debugf("force flag is %q", configPath)
+
+	logLevelString, err := cmd.Flags().GetString("tf-log")
+	if err != nil {
+		return upFlags{}, fmt.Errorf("parsing tf-log string: %w", err)
+	}
+	logLevel, err := terraform.ParseLogLevel(logLevelString)
+	if err != nil {
+		return upFlags{}, fmt.Errorf("parsing Terraform log level %s: %w", logLevelString, err)
+	}
+	m.log.Debugf("Terraform log level is %s", logLevel.String())
+
+	return upFlags{
+		configPath: configPath,
+		force:      force,
+		tfLogLevel: logLevel,
+	}, nil
 }

--- a/cli/internal/cmd/miniup.go
+++ b/cli/internal/cmd/miniup.go
@@ -303,7 +303,7 @@ func (m *miniUpCmd) parseUpFlags(cmd *cobra.Command) (upFlags, error) {
 	if err != nil {
 		return upFlags{}, fmt.Errorf("parsing Terraform log level %s: %w", logLevelString, err)
 	}
-	m.log.Debugf("Terraform log level is %s", logLevel.String())
+	m.log.Debugf("Terraform logs will be written into %s at level %s", constants.TerraformLogFile, logLevel.String())
 
 	return upFlags{
 		configPath: configPath,

--- a/cli/internal/cmd/terminate_test.go
+++ b/cli/internal/cmd/terminate_test.go
@@ -135,6 +135,9 @@ func TestTerminate(t *testing.T) {
 			cmd.SetErr(&bytes.Buffer{})
 			cmd.SetIn(bytes.NewBufferString(tc.stdin))
 
+			// register persistent flags manually
+			cmd.Flags().String("tf-log", "NONE", "")
+
 			require.NotNil(tc.setupFs)
 			fileHandler := file.NewHandler(tc.setupFs(require, tc.idFile))
 

--- a/cli/internal/terraform/BUILD.bazel
+++ b/cli/internal/terraform/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     name = "terraform",
     srcs = [
         "loader.go",
+        "logging.go",
         "terraform.go",
         "variables.go",
     ],

--- a/cli/internal/terraform/BUILD.bazel
+++ b/cli/internal/terraform/BUILD.bazel
@@ -73,6 +73,7 @@ go_library(
     visibility = ["//cli:__subpackages__"],
     deps = [
         "//internal/cloud/cloudprovider",
+        "//internal/constants",
         "//internal/file",
         "@com_github_hashicorp_go_version//:go-version",
         "@com_github_hashicorp_hc_install//:hc-install",

--- a/cli/internal/terraform/loader.go
+++ b/cli/internal/terraform/loader.go
@@ -10,12 +10,10 @@ import (
 	"bytes"
 	"embed"
 	"errors"
-	"fmt"
 	"io/fs"
 	"path/filepath"
 	"strings"
 
-	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/spf13/afero"
 )
@@ -31,9 +29,6 @@ var terraformFS embed.FS
 // and writes them into the workspace.
 func prepareWorkspace(path string, fileHandler file.Handler, workingDir string) error {
 	rootDir := path
-	if err := fileHandler.Write(filepath.Join(constants.TerraformLogFile), nil, file.OptMkdirAll); err != nil {
-		return fmt.Errorf("creating Terraform log file: %w", err)
-	}
 	return fs.WalkDir(terraformFS, rootDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/cli/internal/terraform/loader.go
+++ b/cli/internal/terraform/loader.go
@@ -10,10 +10,12 @@ import (
 	"bytes"
 	"embed"
 	"errors"
+	"fmt"
 	"io/fs"
 	"path/filepath"
 	"strings"
 
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/spf13/afero"
 )
@@ -29,6 +31,9 @@ var terraformFS embed.FS
 // and writes them into the workspace.
 func prepareWorkspace(path string, fileHandler file.Handler, workingDir string) error {
 	rootDir := path
+	if err := fileHandler.Write(filepath.Join(constants.TerraformLogFile), nil, file.OptMkdirAll); err != nil {
+		return fmt.Errorf("creating Terraform log file: %w", err)
+	}
 	return fs.WalkDir(terraformFS, rootDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/cli/internal/terraform/logging.go
+++ b/cli/internal/terraform/logging.go
@@ -1,0 +1,75 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package terraform
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	// LogLevelNone represents a log level that does not produce any output.
+	LogLevelNone LogLevel = iota
+	// LogLevelError enables log output at ERROR level.
+	LogLevelError
+	// LogLevelWarn enables log output at WARN level.
+	LogLevelWarn
+	// LogLevelInfo enables log output at INFO level.
+	LogLevelInfo
+	// LogLevelDebug enables log output at DEBUG level.
+	LogLevelDebug
+	// LogLevelTrace enables log output at TRACE level.
+	LogLevelTrace
+	// LogLevelJSON enables log output at TRACE level in JSON format.
+	LogLevelJSON
+)
+
+// LogLevel is a Terraform log level.
+// As per https://developer.hashicorp.com/terraform/internals/debugging
+type LogLevel int
+
+// ParseLogLevel parses a log level string into a Terraform log level.
+func ParseLogLevel(level string) (LogLevel, error) {
+	switch strings.ToUpper(level) {
+	case "NONE":
+		return LogLevelNone, nil
+	case "ERROR":
+		return LogLevelError, nil
+	case "WARN":
+		return LogLevelWarn, nil
+	case "INFO":
+		return LogLevelInfo, nil
+	case "DEBUG":
+		return LogLevelDebug, nil
+	case "TRACE":
+		return LogLevelTrace, nil
+	case "JSON":
+		return LogLevelJSON, nil
+	default:
+		return LogLevelNone, fmt.Errorf("invalid log level %s", level)
+	}
+}
+
+// String returns the string representation of a Terraform log level.
+func (l LogLevel) String() string {
+	switch l {
+	case LogLevelError:
+		return "ERROR"
+	case LogLevelWarn:
+		return "WARN"
+	case LogLevelInfo:
+		return "INFO"
+	case LogLevelDebug:
+		return "DEBUG"
+	case LogLevelTrace:
+		return "TRACE"
+	case LogLevelJSON:
+		return "JSON"
+	default:
+		return ""
+	}
+}

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"strings"
 
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
@@ -36,69 +35,9 @@ import (
 )
 
 const (
-	// LogLevelNone represents a log level that does not produce any output.
-	LogLevelNone LogLevel = iota
-	// LogLevelError enables log output at ERROR level.
-	LogLevelError
-	// LogLevelWarn enables log output at WARN level.
-	LogLevelWarn
-	// LogLevelInfo enables log output at INFO level.
-	LogLevelInfo
-	// LogLevelDebug enables log output at DEBUG level.
-	LogLevelDebug
-	// LogLevelTrace enables log output at TRACE level.
-	LogLevelTrace
-	// LogLevelJSON enables log output at TRACE level in JSON format.
-	LogLevelJSON
 	tfVersion         = ">= 1.2.0"
 	terraformVarsFile = "terraform.tfvars"
 )
-
-// LogLevel is a Terraform log level.
-// As per https://developer.hashicorp.com/terraform/internals/debugging
-type LogLevel int
-
-// ParseLogLevel parses a log level string into a Terraform log level.
-func ParseLogLevel(level string) (LogLevel, error) {
-	switch strings.ToUpper(level) {
-	case "NONE":
-		return LogLevelNone, nil
-	case "ERROR":
-		return LogLevelError, nil
-	case "WARN":
-		return LogLevelWarn, nil
-	case "INFO":
-		return LogLevelInfo, nil
-	case "DEBUG":
-		return LogLevelDebug, nil
-	case "TRACE":
-		return LogLevelTrace, nil
-	case "JSON":
-		return LogLevelJSON, nil
-	default:
-		return LogLevelNone, fmt.Errorf("invalid log level %s", level)
-	}
-}
-
-// String returns the string representation of a Terraform log level.
-func (l LogLevel) String() string {
-	switch l {
-	case LogLevelError:
-		return "ERROR"
-	case LogLevelWarn:
-		return "WARN"
-	case LogLevelInfo:
-		return "INFO"
-	case LogLevelDebug:
-		return "DEBUG"
-	case LogLevelTrace:
-		return "TRACE"
-	case LogLevelJSON:
-		return "JSON"
-	default:
-		return ""
-	}
-}
 
 // ErrTerraformWorkspaceExistsWithDifferentVariables is returned when existing Terraform files differ from the version the CLI wants to extract.
 var ErrTerraformWorkspaceExistsWithDifferentVariables = errors.New("creating cluster: a Terraform workspace already exists with different variables")

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -86,13 +86,8 @@ func (c *Client) PrepareWorkspace(path string, vars Variables) error {
 
 // CreateCluster creates a Constellation cluster using Terraform.
 func (c *Client) CreateCluster(ctx context.Context, logLevel LogLevel) (CreateOutput, error) {
-	if logLevel.String() != "" {
-		if err := c.tf.SetLog(logLevel.String()); err != nil {
-			return CreateOutput{}, fmt.Errorf("set log level %s: %w", logLevel.String(), err)
-		}
-		if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
-			return CreateOutput{}, fmt.Errorf("set log path: %w", err)
-		}
+	if err := c.setLogLevel(logLevel); err != nil {
+		return CreateOutput{}, fmt.Errorf("set terraform log level %s: %w", logLevel.String(), err)
 	}
 
 	if err := c.tf.Init(ctx); err != nil {
@@ -189,13 +184,8 @@ type AWSIAMOutput struct {
 
 // CreateIAMConfig creates an IAM configuration using Terraform.
 func (c *Client) CreateIAMConfig(ctx context.Context, provider cloudprovider.Provider, logLevel LogLevel) (IAMOutput, error) {
-	if logLevel.String() != "" {
-		if err := c.tf.SetLog(logLevel.String()); err != nil {
-			return IAMOutput{}, fmt.Errorf("set log level %s: %w", logLevel.String(), err)
-		}
-		if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
-			return IAMOutput{}, fmt.Errorf("set log path: %w", err)
-		}
+	if err := c.setLogLevel(logLevel); err != nil {
+		return IAMOutput{}, fmt.Errorf("set terraform log level %s: %w", logLevel.String(), err)
 	}
 
 	if err := c.tf.Init(ctx); err != nil {
@@ -306,17 +296,12 @@ func (c *Client) CreateIAMConfig(ctx context.Context, provider cloudprovider.Pro
 
 // Destroy destroys Terraform-created cloud resources.
 func (c *Client) Destroy(ctx context.Context, logLevel LogLevel) error {
-	if logLevel.String() != "" {
-		if err := c.tf.SetLog(logLevel.String()); err != nil {
-			return fmt.Errorf("set log level %s: %w", logLevel.String(), err)
-		}
-		if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
-			return fmt.Errorf("set log path: %w", err)
-		}
+	if err := c.setLogLevel(logLevel); err != nil {
+		return fmt.Errorf("set terraform log level %s: %w", logLevel.String(), err)
 	}
 
 	if err := c.tf.Init(ctx); err != nil {
-		return err
+		return fmt.Errorf("terraform init: %w", err)
 	}
 	return c.tf.Destroy(ctx)
 }
@@ -380,6 +365,19 @@ func (c *Client) writeVars(vars Variables) error {
 		return err
 	}
 
+	return nil
+}
+
+// setLogLevel sets the log level for Terraform.
+func (c *Client) setLogLevel(logLevel LogLevel) error {
+	if logLevel.String() != "" {
+		if err := c.tf.SetLog(logLevel.String()); err != nil {
+			return fmt.Errorf("set log level %s: %w", logLevel.String(), err)
+		}
+		if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
+			return fmt.Errorf("set log path: %w", err)
+		}
+	}
 	return nil
 }
 

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -80,6 +80,7 @@ func ParseLogLevel(level string) (LogLevel, error) {
 	}
 }
 
+// String returns the string representation of a Terraform log level.
 func (l LogLevel) String() string {
 	switch l {
 	case LogLevelError:
@@ -149,7 +150,7 @@ func (c *Client) CreateCluster(ctx context.Context, logLevel LogLevel) (CreateOu
 	if err := c.tf.SetLog(logLevel.String()); err != nil {
 		return CreateOutput{}, fmt.Errorf("set log level %s: %w", logLevel.String(), err)
 	}
-	if err := c.tf.SetLogPath(filepath.Join(c.workingDir, constants.TerraformLogFile)); err != nil {
+	if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
 		return CreateOutput{}, fmt.Errorf("set log path: %w", err)
 	}
 
@@ -250,7 +251,7 @@ func (c *Client) CreateIAMConfig(ctx context.Context, provider cloudprovider.Pro
 	if err := c.tf.SetLog(logLevel.String()); err != nil {
 		return IAMOutput{}, fmt.Errorf("set log level %s: %w", logLevel.String(), err)
 	}
-	if err := c.tf.SetLogPath(filepath.Join(c.workingDir, constants.TerraformLogFile)); err != nil {
+	if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
 		return IAMOutput{}, fmt.Errorf("set log path: %w", err)
 	}
 
@@ -365,7 +366,7 @@ func (c *Client) Destroy(ctx context.Context, logLevel LogLevel) error {
 	if err := c.tf.SetLog(logLevel.String()); err != nil {
 		return fmt.Errorf("set log level %s: %w", logLevel.String(), err)
 	}
-	if err := c.tf.SetLogPath(filepath.Join(c.workingDir, constants.TerraformLogFile)); err != nil {
+	if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
 		return fmt.Errorf("set log path: %w", err)
 	}
 

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -147,11 +147,13 @@ func (c *Client) PrepareWorkspace(path string, vars Variables) error {
 
 // CreateCluster creates a Constellation cluster using Terraform.
 func (c *Client) CreateCluster(ctx context.Context, logLevel LogLevel) (CreateOutput, error) {
-	if err := c.tf.SetLog(logLevel.String()); err != nil {
-		return CreateOutput{}, fmt.Errorf("set log level %s: %w", logLevel.String(), err)
-	}
-	if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
-		return CreateOutput{}, fmt.Errorf("set log path: %w", err)
+	if logLevel.String() != "" {
+		if err := c.tf.SetLog(logLevel.String()); err != nil {
+			return CreateOutput{}, fmt.Errorf("set log level %s: %w", logLevel.String(), err)
+		}
+		if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
+			return CreateOutput{}, fmt.Errorf("set log path: %w", err)
+		}
 	}
 
 	if err := c.tf.Init(ctx); err != nil {
@@ -248,11 +250,13 @@ type AWSIAMOutput struct {
 
 // CreateIAMConfig creates an IAM configuration using Terraform.
 func (c *Client) CreateIAMConfig(ctx context.Context, provider cloudprovider.Provider, logLevel LogLevel) (IAMOutput, error) {
-	if err := c.tf.SetLog(logLevel.String()); err != nil {
-		return IAMOutput{}, fmt.Errorf("set log level %s: %w", logLevel.String(), err)
-	}
-	if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
-		return IAMOutput{}, fmt.Errorf("set log path: %w", err)
+	if logLevel.String() != "" {
+		if err := c.tf.SetLog(logLevel.String()); err != nil {
+			return IAMOutput{}, fmt.Errorf("set log level %s: %w", logLevel.String(), err)
+		}
+		if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
+			return IAMOutput{}, fmt.Errorf("set log path: %w", err)
+		}
 	}
 
 	if err := c.tf.Init(ctx); err != nil {
@@ -363,11 +367,13 @@ func (c *Client) CreateIAMConfig(ctx context.Context, provider cloudprovider.Pro
 
 // Destroy destroys Terraform-created cloud resources.
 func (c *Client) Destroy(ctx context.Context, logLevel LogLevel) error {
-	if err := c.tf.SetLog(logLevel.String()); err != nil {
-		return fmt.Errorf("set log level %s: %w", logLevel.String(), err)
-	}
-	if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
-		return fmt.Errorf("set log path: %w", err)
+	if logLevel.String() != "" {
+		if err := c.tf.SetLog(logLevel.String()); err != nil {
+			return fmt.Errorf("set log level %s: %w", logLevel.String(), err)
+		}
+		if err := c.tf.SetLogPath(filepath.Join("..", constants.TerraformLogFile)); err != nil {
+			return fmt.Errorf("set log path: %w", err)
+		}
 	}
 
 	if err := c.tf.Init(ctx); err != nil {

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -422,7 +422,7 @@ func TestCreateCluster(t *testing.T) {
 
 			path := path.Join(tc.pathBase, strings.ToLower(tc.provider.String()))
 			require.NoError(c.PrepareWorkspace(path, tc.vars))
-			tfOutput, err := c.CreateCluster(context.Background(), LogLevelNone)
+			tfOutput, err := c.CreateCluster(context.Background(), LogLevelDebug)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -717,7 +717,7 @@ func TestCreateIAM(t *testing.T) {
 
 			path := path.Join(tc.pathBase, strings.ToLower(tc.provider.String()))
 			require.NoError(c.PrepareWorkspace(path, tc.vars))
-			IAMoutput, err := c.CreateIAMConfig(context.Background(), tc.provider, LogLevelNone)
+			IAMoutput, err := c.CreateIAMConfig(context.Background(), tc.provider, LogLevelDebug)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -760,7 +760,7 @@ func TestDestroyInstances(t *testing.T) {
 				tf: tc.tf,
 			}
 
-			err := c.Destroy(context.Background(), LogLevelNone)
+			err := c.Destroy(context.Background(), LogLevelDebug)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -299,6 +299,22 @@ func TestCreateCluster(t *testing.T) {
 			fs:       afero.NewMemMapFs(),
 			wantErr:  true,
 		},
+		"set log fails": {
+			pathBase: "terraform",
+			provider: cloudprovider.QEMU,
+			vars:     qemuVars,
+			tf:       &stubTerraform{setLogErr: someErr},
+			fs:       afero.NewMemMapFs(),
+			wantErr:  true,
+		},
+		"set log path fails": {
+			pathBase: "terraform",
+			provider: cloudprovider.QEMU,
+			vars:     qemuVars,
+			tf:       &stubTerraform{setLogPathErr: someErr},
+			fs:       afero.NewMemMapFs(),
+			wantErr:  true,
+		},
 		"no ip": {
 			pathBase: "terraform",
 			provider: cloudprovider.QEMU,
@@ -406,7 +422,7 @@ func TestCreateCluster(t *testing.T) {
 
 			path := path.Join(tc.pathBase, strings.ToLower(tc.provider.String()))
 			require.NoError(c.PrepareWorkspace(path, tc.vars))
-			tfOutput, err := c.CreateCluster(context.Background())
+			tfOutput, err := c.CreateCluster(context.Background(), LogLevelNone)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -481,6 +497,22 @@ func TestCreateIAM(t *testing.T) {
 		wantErr  bool
 		want     IAMOutput
 	}{
+		"set log fails": {
+			pathBase: path.Join("terraform", "iam"),
+			provider: cloudprovider.GCP,
+			vars:     gcpVars,
+			tf:       &stubTerraform{setLogErr: someErr},
+			fs:       afero.NewMemMapFs(),
+			wantErr:  true,
+		},
+		"set log path fails": {
+			pathBase: path.Join("terraform", "iam"),
+			provider: cloudprovider.GCP,
+			vars:     gcpVars,
+			tf:       &stubTerraform{setLogPathErr: someErr},
+			fs:       afero.NewMemMapFs(),
+			wantErr:  true,
+		},
 		"gcp works": {
 			pathBase: path.Join("terraform", "iam"),
 			provider: cloudprovider.GCP,
@@ -685,7 +717,7 @@ func TestCreateIAM(t *testing.T) {
 
 			path := path.Join(tc.pathBase, strings.ToLower(tc.provider.String()))
 			require.NoError(c.PrepareWorkspace(path, tc.vars))
-			IAMoutput, err := c.CreateIAMConfig(context.Background(), tc.provider)
+			IAMoutput, err := c.CreateIAMConfig(context.Background(), tc.provider, LogLevelNone)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -698,6 +730,7 @@ func TestCreateIAM(t *testing.T) {
 }
 
 func TestDestroyInstances(t *testing.T) {
+	someErr := errors.New("some error")
 	testCases := map[string]struct {
 		tf      *stubTerraform
 		wantErr bool
@@ -706,9 +739,15 @@ func TestDestroyInstances(t *testing.T) {
 			tf: &stubTerraform{},
 		},
 		"destroy fails": {
-			tf: &stubTerraform{
-				destroyErr: errors.New("error"),
-			},
+			tf:      &stubTerraform{destroyErr: someErr},
+			wantErr: true,
+		},
+		"setLog fails": {
+			tf:      &stubTerraform{setLogErr: someErr},
+			wantErr: true,
+		},
+		"setLogPath fails": {
+			tf:      &stubTerraform{setLogPathErr: someErr},
 			wantErr: true,
 		},
 	}
@@ -721,7 +760,7 @@ func TestDestroyInstances(t *testing.T) {
 				tf: tc.tf,
 			}
 
-			err := c.Destroy(context.Background())
+			err := c.Destroy(context.Background(), LogLevelNone)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -788,12 +827,121 @@ func TestCleanupWorkspace(t *testing.T) {
 	}
 }
 
+func TestParseLogLevel(t *testing.T) {
+	testCases := map[string]struct {
+		level   string
+		want    LogLevel
+		wantErr bool
+	}{
+		"json": {
+			level: "json",
+			want:  LogLevelJSON,
+		},
+		"trace": {
+			level: "trace",
+			want:  LogLevelTrace,
+		},
+		"debug": {
+			level: "debug",
+			want:  LogLevelDebug,
+		},
+		"info": {
+			level: "info",
+			want:  LogLevelInfo,
+		},
+		"warn": {
+			level: "warn",
+			want:  LogLevelWarn,
+		},
+		"error": {
+			level: "error",
+			want:  LogLevelError,
+		},
+		"none": {
+			level: "none",
+			want:  LogLevelNone,
+		},
+		"unknown": {
+			level:   "unknown",
+			wantErr: true,
+		},
+		"empty": {
+			level:   "",
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			level, err := ParseLogLevel(tc.level)
+			if tc.wantErr {
+				assert.Error(err)
+				return
+			}
+			assert.NoError(err)
+			assert.Equal(tc.want, level)
+		})
+	}
+}
+
+func TestLogLevelString(t *testing.T) {
+	testCases := map[string]struct {
+		level LogLevel
+		want  string
+	}{
+		"json": {
+			level: LogLevelJSON,
+			want:  "JSON",
+		},
+		"trace": {
+			level: LogLevelTrace,
+			want:  "TRACE",
+		},
+		"debug": {
+			level: LogLevelDebug,
+			want:  "DEBUG",
+		},
+		"info": {
+			level: LogLevelInfo,
+			want:  "INFO",
+		},
+		"warn": {
+			level: LogLevelWarn,
+			want:  "WARN",
+		},
+		"error": {
+			level: LogLevelError,
+			want:  "ERROR",
+		},
+		"none": {
+			level: LogLevelNone,
+			want:  "",
+		},
+		"invalid int": {
+			level: LogLevel(-1),
+			want:  "",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			assert.Equal(tc.want, tc.level.String())
+		})
+	}
+}
+
 type stubTerraform struct {
-	applyErr   error
-	destroyErr error
-	initErr    error
-	showErr    error
-	showState  *tfjson.State
+	applyErr      error
+	destroyErr    error
+	initErr       error
+	showErr       error
+	setLogErr     error
+	setLogPathErr error
+	showState     *tfjson.State
 }
 
 func (s *stubTerraform) Apply(context.Context, ...tfexec.ApplyOption) error {
@@ -810,4 +958,12 @@ func (s *stubTerraform) Init(context.Context, ...tfexec.InitOption) error {
 
 func (s *stubTerraform) Show(context.Context, ...tfexec.ShowOption) (*tfjson.State, error) {
 	return s.showState, s.showErr
+}
+
+func (s *stubTerraform) SetLog(_ string) error {
+	return s.setLogErr
+}
+
+func (s *stubTerraform) SetLogPath(_ string) error {
+	return s.setLogPathErr
 }

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -56,6 +56,7 @@ Work with the Constellation configuration file.
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation config generate
@@ -84,6 +85,7 @@ constellation config generate {aws|azure|gcp|openstack|qemu} [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation config fetch-measurements
@@ -114,6 +116,7 @@ constellation config fetch-measurements [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation config instance-types
@@ -140,6 +143,7 @@ constellation config instance-types [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation config kubernetes-versions
@@ -166,6 +170,7 @@ constellation config kubernetes-versions [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation create
@@ -195,6 +200,7 @@ constellation create [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation init
@@ -226,6 +232,7 @@ constellation init [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation mini
@@ -248,6 +255,7 @@ Manage MiniConstellation clusters.
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation mini up
@@ -275,8 +283,9 @@ constellation mini up [flags]
 ### Options inherited from parent commands
 
 ```
-      --debug   enable debug logging
-      --force   disable version compatibility checks - might result in corrupted clusters
+      --debug           enable debug logging
+      --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation mini down
@@ -304,6 +313,7 @@ constellation mini down [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation verify
@@ -333,6 +343,7 @@ constellation verify [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation upgrade
@@ -355,6 +366,7 @@ Find and apply upgrades to your Constellation cluster.
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation upgrade check
@@ -384,6 +396,7 @@ constellation upgrade check [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation upgrade apply
@@ -413,6 +426,7 @@ constellation upgrade apply [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation recover
@@ -443,6 +457,7 @@ constellation recover [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation terminate
@@ -472,6 +487,7 @@ constellation terminate [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation version
@@ -498,6 +514,7 @@ constellation version [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation iam
@@ -520,6 +537,7 @@ Work with the IAM configuration on your cloud provider.
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation iam create
@@ -545,6 +563,7 @@ Create IAM configuration on a cloud platform for your Constellation cluster.
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation iam create aws
@@ -576,6 +595,7 @@ constellation iam create aws [flags]
       --force               disable version compatibility checks - might result in corrupted clusters
       --generate-config     automatically generate a configuration file and fill in the required fields
   -k, --kubernetes string   Kubernetes version to use in format MAJOR.MINOR - only usable in combination with --generate-config (default "v1.25")
+      --tf-log string       sets the Terraform log level (default "NONE" - no logs) (default "NONE")
   -y, --yes                 create the IAM configuration without further confirmation
 ```
 
@@ -608,6 +628,7 @@ constellation iam create azure [flags]
       --force               disable version compatibility checks - might result in corrupted clusters
       --generate-config     automatically generate a configuration file and fill in the required fields
   -k, --kubernetes string   Kubernetes version to use in format MAJOR.MINOR - only usable in combination with --generate-config (default "v1.25")
+      --tf-log string       sets the Terraform log level (default "NONE" - no logs) (default "NONE")
   -y, --yes                 create the IAM configuration without further confirmation
 ```
 
@@ -643,6 +664,7 @@ constellation iam create gcp [flags]
       --force               disable version compatibility checks - might result in corrupted clusters
       --generate-config     automatically generate a configuration file and fill in the required fields
   -k, --kubernetes string   Kubernetes version to use in format MAJOR.MINOR - only usable in combination with --generate-config (default "v1.25")
+      --tf-log string       sets the Terraform log level (default "NONE" - no logs) (default "NONE")
   -y, --yes                 create the IAM configuration without further confirmation
 ```
 
@@ -671,6 +693,7 @@ constellation iam destroy [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 
 ## constellation status
@@ -699,5 +722,6 @@ constellation status [flags]
       --config string   path to the configuration file (default "constellation-conf.yaml")
       --debug           enable debug logging
       --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
 ```
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -152,6 +152,8 @@ const (
 	EnvVarNoSpinner = EnvVarPrefix + "NO_SPINNER"
 	// MiniConstellationUID is a sentinel value for the UID of a mini constellation.
 	MiniConstellationUID = "mini"
+	// TerraformLogFile is the file name of the Terraform log file.
+	TerraformLogFile = "terraform.log"
 
 	//
 	// Kubernetes.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add support for [Terraform logging](https://developer.hashicorp.com/terraform/internals/debugging) by passing the `--tf-log` flag from the CLI to the Terraform client.
  - The flag can be set to `NONE` (equals to not setting the flag), `ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`, or `JSON` (JSON-Formatted logs at `TRACE` level)
 
### Additional info
- The [terraform-exec module](https://pkg.go.dev/github.com/hashicorp/terraform-exec@v0.18.1/tfexec#Terraform.SetLog) only allows logging to files as logs are very verbose and could leak secret values. It also does not provide streaming logs but only writes all logs to the file at once after the full apply / init / ... has finished


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs) #1627 
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
