### PR TITLE
cli: fix misleading error while applying kubernetes-only upgrade

### DIFF
--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -172,7 +172,7 @@ jobs:
             KUBERNETES_FLAG="--target-kubernetes $KUBERNETES"
           fi
 
-          bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker "{$WORKERNODES}" --want-control "{$CONTROLNODES}" --target-image "{$IMAGE}" "{$KUBERNETES_FLAG}" "{$MICROSERVICES_FLAG}"
+          bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --target-image "$IMAGE" "{$KUBERNETES_FLAG}" "{$MICROSERVICES_FLAG}"
         env:
           KUBECONFIG: ${{ steps.e2e_test.outputs.kubeconfig }}
           IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-image.outputs.output }}

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -172,7 +172,7 @@ jobs:
             KUBERNETES_FLAG="--target-kubernetes=$KUBERNETES"
           fi
 
-          bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker $WORKERNODES --want-control $CONTROLNODES --target-image $IMAGE $KUBERNETES_FLAG $MICROSERVICES_FLAG
+          bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --target-image "$IMAGE" "$KUBERNETES_FLAG" "$MICROSERVICES_FLAG"
         env:
           KUBECONFIG: ${{ steps.e2e_test.outputs.kubeconfig }}
           IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-image.outputs.output }}

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -172,7 +172,7 @@ jobs:
             KUBERNETES_FLAG="--target-kubernetes $KUBERNETES"
           fi
 
-          bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --target-image "$IMAGE" "$KUBERNETES_FLAG" "$MICROSERVICES_FLAG"
+          bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker {$WORKERNODES} --want-control {$CONTROLNODES} --target-image {$IMAGE} {$KUBERNETES_FLAG} {$MICROSERVICES_FLAG}
         env:
           KUBECONFIG: ${{ steps.e2e_test.outputs.kubeconfig }}
           IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-image.outputs.output }}

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -172,7 +172,7 @@ jobs:
             KUBERNETES_FLAG="--target-kubernetes $KUBERNETES"
           fi
 
-          bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker {$WORKERNODES} --want-control {$CONTROLNODES} --target-image {$IMAGE} {$KUBERNETES_FLAG} {$MICROSERVICES_FLAG}
+          bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker "{$WORKERNODES}" --want-control "{$CONTROLNODES}" --target-image "{$IMAGE}" "{$KUBERNETES_FLAG}" "{$MICROSERVICES_FLAG}"
         env:
           KUBECONFIG: ${{ steps.e2e_test.outputs.kubeconfig }}
           IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-image.outputs.output }}

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -172,7 +172,7 @@ jobs:
             KUBERNETES_FLAG="--target-kubernetes $KUBERNETES"
           fi
 
-          eval "bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --target-image "$IMAGE" $KUBERNETES_FLAG $MICROSERVICES_FLAG"
+          eval "bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker $WORKERNODES --want-control $CONTROLNODES --target-image $IMAGE $KUBERNETES_FLAG $MICROSERVICES_FLAG"
         env:
           KUBECONFIG: ${{ steps.e2e_test.outputs.kubeconfig }}
           IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-image.outputs.output }}

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -172,7 +172,7 @@ jobs:
             KUBERNETES_FLAG="--target-kubernetes $KUBERNETES"
           fi
 
-          bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --target-image "$IMAGE" "{$KUBERNETES_FLAG}" "{$MICROSERVICES_FLAG}"
+          eval "bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --target-image "$IMAGE" $KUBERNETES_FLAG $MICROSERVICES_FLAG"
         env:
           KUBECONFIG: ${{ steps.e2e_test.outputs.kubeconfig }}
           IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-image.outputs.output }}

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -166,13 +166,13 @@ jobs:
           echo "Microservice target: $MICROSERVICES"
 
           if [[ -n ${MICROSERVICES} ]]; then
-            MICROSERVICES_FLAG="--target-microservices $MICROSERVICES"
+            MICROSERVICES_FLAG="--target-microservices=$MICROSERVICES"
           fi
           if [[ -n ${KUBERNETES} ]]; then
-            KUBERNETES_FLAG="--target-kubernetes $KUBERNETES"
+            KUBERNETES_FLAG="--target-kubernetes=$KUBERNETES"
           fi
 
-          eval "bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker $WORKERNODES --want-control $CONTROLNODES --target-image $IMAGE $KUBERNETES_FLAG $MICROSERVICES_FLAG"
+          bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker $WORKERNODES --want-control $CONTROLNODES --target-image $IMAGE $KUBERNETES_FLAG $MICROSERVICES_FLAG
         env:
           KUBECONFIG: ${{ steps.e2e_test.outputs.kubeconfig }}
           IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-image.outputs.output }}

--- a/cli/internal/kubernetes/upgrade.go
+++ b/cli/internal/kubernetes/upgrade.go
@@ -54,6 +54,17 @@ func GetConstellationVersion(ctx context.Context, client DynamicInterface) (upda
 	return nodeVersion, nil
 }
 
+// InvalidUpgradeError present an invalid upgrade. It wraps the source and destination version for improved debuggability.
+type applyError struct {
+	expected string
+	actual   string
+}
+
+// Error returns the String representation of this error.
+func (e *applyError) Error() string {
+	return fmt.Sprintf("expected NodeVersion to contain %s, got %s", e.expected, e.actual)
+}
+
 // Upgrader handles upgrading the cluster's components using the CLI.
 type Upgrader struct {
 	stableInterface  stableInterface
@@ -163,13 +174,13 @@ func (u *Upgrader) UpgradeNodeVersion(ctx context.Context, conf *config.Config) 
 	}
 	switch {
 	case updatedNodeVersion.Spec.ImageReference != nodeVersion.Spec.ImageReference:
-		return fmt.Errorf("expected NodeVersion to contain %s, got %s", nodeVersion.Spec.ImageReference, updatedNodeVersion.Spec.ImageReference)
+		return &applyError{expected: nodeVersion.Spec.ImageReference, actual: updatedNodeVersion.Spec.ImageReference}
 	case updatedNodeVersion.Spec.ImageVersion != nodeVersion.Spec.ImageVersion:
-		return fmt.Errorf("expected NodeVersion to contain %s, got %s", nodeVersion.Spec.ImageVersion, updatedNodeVersion.Spec.ImageVersion)
+		return &applyError{expected: nodeVersion.Spec.ImageVersion, actual: updatedNodeVersion.Spec.ImageVersion}
 	case updatedNodeVersion.Spec.KubernetesComponentsReference != nodeVersion.Spec.KubernetesComponentsReference:
-		return fmt.Errorf("expected NodeVersion to contain %s, got %s", nodeVersion.Spec.KubernetesComponentsReference, updatedNodeVersion.Spec.KubernetesComponentsReference)
+		return &applyError{expected: nodeVersion.Spec.KubernetesComponentsReference, actual: updatedNodeVersion.Spec.KubernetesComponentsReference}
 	case updatedNodeVersion.Spec.KubernetesClusterVersion != nodeVersion.Spec.KubernetesClusterVersion:
-		return fmt.Errorf("expected NodeVersion to contain %s, got %s", nodeVersion.Spec.KubernetesClusterVersion, updatedNodeVersion.Spec.KubernetesClusterVersion)
+		return &applyError{expected: nodeVersion.Spec.KubernetesClusterVersion, actual: updatedNodeVersion.Spec.KubernetesClusterVersion}
 	}
 
 	return errors.Join(upgradeErrs...)

--- a/cli/internal/kubernetes/upgrade.go
+++ b/cli/internal/kubernetes/upgrade.go
@@ -162,14 +162,14 @@ func (u *Upgrader) UpgradeNodeVersion(ctx context.Context, conf *config.Config) 
 		return fmt.Errorf("applying upgrade: %w", err)
 	}
 	switch {
-	case updatedNodeVersion.Spec.ImageReference != imageReference:
-		return fmt.Errorf("expected NodeVersion to contain %s, got %s", imageReference, updatedNodeVersion.Spec.ImageReference)
-	case updatedNodeVersion.Spec.ImageVersion != imageVersion.Version:
-		return fmt.Errorf("expected NodeVersion to contain %s, got %s", imageVersion.Version, updatedNodeVersion.Spec.ImageVersion)
+	case updatedNodeVersion.Spec.ImageReference != nodeVersion.Spec.ImageReference:
+		return fmt.Errorf("expected NodeVersion to contain %s, got %s", nodeVersion.Spec.ImageReference, updatedNodeVersion.Spec.ImageReference)
+	case updatedNodeVersion.Spec.ImageVersion != nodeVersion.Spec.ImageVersion:
+		return fmt.Errorf("expected NodeVersion to contain %s, got %s", nodeVersion.Spec.ImageVersion, updatedNodeVersion.Spec.ImageVersion)
 	case updatedNodeVersion.Spec.KubernetesComponentsReference != nodeVersion.Spec.KubernetesComponentsReference:
 		return fmt.Errorf("expected NodeVersion to contain %s, got %s", nodeVersion.Spec.KubernetesComponentsReference, updatedNodeVersion.Spec.KubernetesComponentsReference)
-	case updatedNodeVersion.Spec.KubernetesClusterVersion != versionConfig.ClusterVersion:
-		return fmt.Errorf("expected NodeVersion to contain %s, got %s", versionConfig.ClusterVersion, updatedNodeVersion.Spec.KubernetesClusterVersion)
+	case updatedNodeVersion.Spec.KubernetesClusterVersion != nodeVersion.Spec.KubernetesClusterVersion:
+		return fmt.Errorf("expected NodeVersion to contain %s, got %s", nodeVersion.Spec.KubernetesClusterVersion, updatedNodeVersion.Spec.KubernetesClusterVersion)
 	}
 
 	return errors.Join(upgradeErrs...)

--- a/cli/internal/kubernetes/upgrade_test.go
+++ b/cli/internal/kubernetes/upgrade_test.go
@@ -36,6 +36,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 		conditions            []metav1.Condition
 		currentImageVersion   string
 		newImageReference     string
+		badImageVersion       string
 		currentClusterVersion string
 		conf                  *config.Config
 		getErr                error
@@ -76,7 +77,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			wantUpdate: true,
 			wantErr:    true,
 			assertCorrectError: func(t *testing.T, err error) bool {
-				upgradeErr := &compatibility.InvalidUpgradeError{}
+				var upgradeErr *compatibility.InvalidUpgradeError
 				return assert.ErrorAs(t, err, &upgradeErr)
 			},
 		},
@@ -97,7 +98,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			wantUpdate: true,
 			wantErr:    true,
 			assertCorrectError: func(t *testing.T, err error) bool {
-				upgradeErr := &compatibility.InvalidUpgradeError{}
+				var upgradeErr *compatibility.InvalidUpgradeError
 				return assert.ErrorAs(t, err, &upgradeErr)
 			},
 		},
@@ -113,7 +114,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			stable:                &stubStableClient{},
 			wantErr:               true,
 			assertCorrectError: func(t *testing.T, err error) bool {
-				upgradeErr := &compatibility.InvalidUpgradeError{}
+				var upgradeErr *compatibility.InvalidUpgradeError
 				return assert.ErrorAs(t, err, &upgradeErr)
 			},
 		},
@@ -170,6 +171,28 @@ func TestUpgradeNodeVersion(t *testing.T) {
 				return assert.ErrorAs(t, err, &upgradeErr)
 			},
 		},
+		"apply returns bad object": {
+			conf: func() *config.Config {
+				conf := config.Default()
+				conf.Image = "v1.2.3"
+				conf.KubernetesVersion = versions.SupportedK8sVersions()[1]
+				return conf
+			}(),
+			currentImageVersion:   "v1.2.2",
+			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			badImageVersion:       "v3.2.1",
+			stable: &stubStableClient{
+				configMaps: map[string]*corev1.ConfigMap{
+					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
+				},
+			},
+			wantUpdate: true,
+			wantErr:    true,
+			assertCorrectError: func(t *testing.T, err error) bool {
+				var target *applyError
+				return assert.ErrorAs(t, err, &target)
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -190,7 +213,15 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			unstrNodeVersion, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&nodeVersion)
 			require.NoError(err)
 
-			dynamicClient := &stubDynamicClient{object: &unstructured.Unstructured{Object: unstrNodeVersion}, getErr: tc.getErr}
+			var badUpdatedObject *unstructured.Unstructured
+			if tc.badImageVersion != "" {
+				nodeVersion.Spec.ImageVersion = tc.badImageVersion
+				unstrBadNodeVersion, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&nodeVersion)
+				require.NoError(err)
+				badUpdatedObject = &unstructured.Unstructured{Object: unstrBadNodeVersion}
+			}
+
+			dynamicClient := &stubDynamicClient{object: &unstructured.Unstructured{Object: unstrNodeVersion}, badUpdatedObject: badUpdatedObject, getErr: tc.getErr}
 			upgrader := Upgrader{
 				stableInterface:  tc.stable,
 				dynamicInterface: dynamicClient,
@@ -443,10 +474,11 @@ func newJoinConfigMap(data string) *corev1.ConfigMap {
 }
 
 type stubDynamicClient struct {
-	object        *unstructured.Unstructured
-	updatedObject *unstructured.Unstructured
-	getErr        error
-	updateErr     error
+	object           *unstructured.Unstructured
+	updatedObject    *unstructured.Unstructured
+	badUpdatedObject *unstructured.Unstructured
+	getErr           error
+	updateErr        error
 }
 
 func (u *stubDynamicClient) GetCurrent(_ context.Context, _ string) (*unstructured.Unstructured, error) {
@@ -455,6 +487,9 @@ func (u *stubDynamicClient) GetCurrent(_ context.Context, _ string) (*unstructur
 
 func (u *stubDynamicClient) Update(_ context.Context, updatedObject *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	u.updatedObject = updatedObject
+	if u.badUpdatedObject != nil {
+		return u.badUpdatedObject, u.updateErr
+	}
 	return u.updatedObject, u.updateErr
 }
 

--- a/e2e/internal/upgrade/BUILD.bazel
+++ b/e2e/internal/upgrade/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//internal/logger",
         "//internal/versionsapi",
         "//internal/versionsapi/fetcher",
+        "@in_gopkg_yaml_v3//:yaml_v3",
         "@sh_helm_helm_v3//pkg/action",
         "@sh_helm_helm_v3//pkg/cli",
     ],

--- a/e2e/internal/upgrade/image.go
+++ b/e2e/internal/upgrade/image.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
-	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/versionsapi"
 	"github.com/edgelesssys/constellation/v2/internal/versionsapi/fetcher"
 )
@@ -38,17 +37,15 @@ func fetchUpgradeInfo(ctx context.Context, csp cloudprovider.Provider, toImage s
 		return upgradeInfo{}, err
 	}
 
-	measurementsURL, signatureURL, err := versionsapi.MeasurementURL(ver, csp)
+	measurementsURL, _, err := versionsapi.MeasurementURL(ver, csp)
 	if err != nil {
 		return upgradeInfo{}, err
 	}
 
 	var fetchedMeasurements measurements.M
-	_, err = fetchedMeasurements.FetchAndVerify(
+	err = fetchedMeasurements.Fetch(
 		ctx, http.DefaultClient,
 		measurementsURL,
-		signatureURL,
-		[]byte(constants.CosignPublicKey),
 		measurements.WithMetadata{
 			CSP:   csp,
 			Image: toImage,

--- a/e2e/internal/upgrade/upgrade_test.go
+++ b/e2e/internal/upgrade/upgrade_test.go
@@ -196,7 +196,7 @@ func testMicroservicesEventuallyHaveVersion(t *testing.T, wantMicroserviceVersio
 		}
 
 		if version != wantMicroserviceVersion {
-			log.Printf("Microservices still at version: %v\n", version)
+			log.Printf("Microservices still at version %v, want %v\n", version, wantMicroserviceVersion)
 			return false
 		}
 
@@ -227,12 +227,12 @@ func testNodesEventuallyHaveVersion(t *testing.T, k *kubernetes.Clientset, targe
 
 			kubeletVersion := node.Status.NodeInfo.KubeletVersion
 			if kubeletVersion != targetVersions.kubernetes.String() {
-				log.Printf("\t%s: K8s (Kubelet) %s\n", node.Name, kubeletVersion)
+				log.Printf("\t%s: K8s (Kubelet) %s, want %s\n", node.Name, kubeletVersion, targetVersions.kubernetes.String())
 				allUpdated = false
 			}
 			kubeProxyVersion := node.Status.NodeInfo.KubeProxyVersion
 			if kubeProxyVersion != targetVersions.kubernetes.String() {
-				log.Printf("\t%s: K8s (Proxy) %s\n", node.Name, kubeProxyVersion)
+				log.Printf("\t%s: K8s (Proxy) %s, want %s\n", node.Name, kubeProxyVersion, targetVersions.kubernetes.String())
 				allUpdated = false
 			}
 		}

--- a/e2e/internal/upgrade/upgrade_test.go
+++ b/e2e/internal/upgrade/upgrade_test.go
@@ -112,7 +112,7 @@ func TestUpgrade(t *testing.T) {
 	// This is only updated after the operator finishes one reconcile loop.
 	cmd = exec.CommandContext(context.Background(), cli, "status")
 	msg, err = cmd.CombinedOutput()
-	require.NoErrorf(err, "%s", string(msg))
+	require.NoError(err, string(msg))
 	log.Println(string(msg))
 
 	testMicroservicesEventuallyHaveVersion(t, targetVersions.microservices, *timeout)

--- a/e2e/internal/upgrade/upgrade_test.go
+++ b/e2e/internal/upgrade/upgrade_test.go
@@ -107,6 +107,14 @@ func TestUpgrade(t *testing.T) {
 	require.NoError(containsUnexepectedMsg(string(msg)))
 	log.Println(string(msg))
 
+	// Show versions set in cluster.
+	// The string after "Cluster status:" in the output might not be updated yet.
+	// This is only updated after the operator finishes one reconcile loop.
+	cmd = exec.CommandContext(context.Background(), cli, "status")
+	msg, err = cmd.CombinedOutput()
+	require.NoErrorf(err, "%s", string(msg))
+	log.Println(string(msg))
+
 	testMicroservicesEventuallyHaveVersion(t, targetVersions.microservices, *timeout)
 	testNodesEventuallyHaveVersion(t, k, targetVersions, *wantControl+*wantWorker, *timeout)
 }

--- a/internal/attestation/measurements/measurements.go
+++ b/internal/attestation/measurements/measurements.go
@@ -112,35 +112,6 @@ func (m *M) FetchAndVerify(
 	return hex.EncodeToString(shaHash[:]), nil
 }
 
-// Fetch fetches measurements via provided URLs, using client for download.
-func (m *M) Fetch(ctx context.Context, client *http.Client, measurementsURL *url.URL, metadata WithMetadata) error {
-	measurements, err := getFromURL(ctx, client, measurementsURL)
-	if err != nil {
-		return fmt.Errorf("failed to fetch measurements: %w", err)
-	}
-
-	var mWithMetadata WithMetadata
-	if err := json.Unmarshal(measurements, &mWithMetadata); err != nil {
-		if yamlErr := yaml.Unmarshal(measurements, &mWithMetadata); yamlErr != nil {
-			return errors.Join(
-				err,
-				fmt.Errorf("trying yaml format: %w", yamlErr),
-			)
-		}
-	}
-
-	if mWithMetadata.CSP != metadata.CSP {
-		return fmt.Errorf("invalid measurement metadata: CSP mismatch: expected %s, got %s", metadata.CSP, mWithMetadata.CSP)
-	}
-	if mWithMetadata.Image != metadata.Image {
-		return fmt.Errorf("invalid measurement metadata: image mismatch: expected %s, got %s", metadata.Image, mWithMetadata.Image)
-	}
-
-	*m = mWithMetadata.Measurements
-
-	return nil
-}
-
 // CopyFrom copies over all values from other. Overwriting existing values,
 // but keeping not specified values untouched.
 func (m *M) CopyFrom(other M) {


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Currently `upgrade apply` will show a misleading error message when the config specifies an invalid image upgrade and a valid Kubernetes upgrade. In that case the upgrade is applied as expected. However, the CLI prints an error like this: `Error: upgrading NodeVersion: expected NodeVersion to contain <new image reference>, got <current image reference>`. This patch fixes the check.
- Add unittest to check the errors are actually triggered if apply responds with an unexpected message
- Do not verify measurements during e2e test. If we are upgrading to release images we can't verify the release signatures with the dev pub key in the CLI.

### Additional info
- Test run: [GCP, 1+1, 2.6 --> main](https://github.com/edgelesssys/constellation/actions/runs/4687145738/jobs/8306066558) :green_circle:. Executes only kubernetes upgrade 1.25.7 -> 1.26.3.
- A backport would be nice, but is not urgent imo. As far as I see it, `apply` triggers any upgrades as expected. 

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
