### PR TITLE
ci: prevent accidental GOOS and GOARCH confusion in host go toolchain

### DIFF
--- a/.github/actions/build_cdbg/action.yml
+++ b/.github/actions/build_cdbg/action.yml
@@ -21,13 +21,13 @@ runs:
     - name: Build cdbg
       shell: bash
       env:
-        GOOS: ${{ inputs.targetOS }}
-        GOARCH: ${{ inputs.targetArch }}
+        TARGET_GOOS: ${{ inputs.targetOS }}
+        TARGET_GOARCH: ${{ inputs.targetArch }}
         OUTPUT_PATH: ${{ inputs.outputPath }}
       run: |
         echo "::group::Build cdbg"
         mkdir -p "$(dirname "${OUTPUT_PATH}")"
-        label="//debugd/cmd/cdbg:cdbg_${GOOS}_${GOARCH}"
+        label="//debugd/cmd/cdbg:cdbg_${TARGET_GOOS}_${TARGET_GOARCH}"
         bazel build "${label}"
         repository_root=$(git rev-parse --show-toplevel)
         out_rel=$(bazel cquery --output=files "${label}")

--- a/.github/actions/build_cli/action.yml
+++ b/.github/actions/build_cli/action.yml
@@ -43,8 +43,8 @@ runs:
     - name: Build CLI
       shell: bash
       env:
-        GOOS: ${{ inputs.targetOS }}
-        GOARCH: ${{ inputs.targetArch }}
+        TARGET_GOOS: ${{ inputs.targetOS }}
+        TARGET_GOARCH: ${{ inputs.targetArch }}
         OUTPUT_PATH: ${{ inputs.outputPath || format('./build/constellation-{0}-{1}', inputs.targetOS, inputs.targetArch) }}
       run: |
         echo "::group::Build CLI"
@@ -55,7 +55,7 @@ runs:
         else
           cli_variant=oss
         fi
-        label="//cli:cli_${cli_variant}_${GOOS}_${GOARCH}"
+        label="//cli:cli_${cli_variant}_${TARGET_GOOS}_${TARGET_GOARCH}"
         bazel build "${label}"
         repository_root=$(git rev-parse --show-toplevel)
         out_rel=$(bazel cquery --output=files "${label}")


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: prevent accidental GOOS and GOARCH confusion in host go toolchain

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Setting those environment variables would lead to the pseudo-version tool being built for foreign GOOS / GOARCH, leading to it being non executable on the runner. This ultimately lead to the version stamping information not being emitted.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
