### PR TITLE
kubernetes: update CSI driver versions to v1.2.0

### DIFF
--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/azuredisk-csi-driver/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/azuredisk-csi-driver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "v1.1.0"
+appVersion: "v1.2.0"
 description: Azure disk Container Storage Interface (CSI) Storage Plugin with on-node encryption support
 name: azuredisk-csi-driver
-version: v1.1.2
+version: v1.2.0

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -66,7 +66,7 @@ spec:
             - "--feature-gates=Topology=true"
             - "--csi-address=$(ADDRESS)"
             - "--v=2"
-            - "--timeout=15s"
+            - "--timeout=30s"
             - "--leader-election"
             - "--leader-election-namespace={{ .Release.Namespace }}"
             - "--worker-threads={{ .Values.controller.provisionerWorkerThreads }}"
@@ -94,8 +94,8 @@ spec:
             - "-leader-election"
             - "--leader-election-namespace={{ .Release.Namespace }}"
             - "-worker-threads={{ .Values.controller.attacherWorkerThreads }}"
-            - "-kube-api-qps=50"
-            - "-kube-api-burst=100"
+            - "-kube-api-qps=200"
+            - "-kube-api-burst=400"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -157,6 +157,18 @@ spec:
             - name: socket-dir
               mountPath: /csi
           resources: {{- toYaml .Values.controller.resources.livenessProbe | nindent 12 }}
+{{- if eq .Values.controller.enableTrafficManager true }}
+        - image: mcr.microsoft.com/aks/ccp/ccp-auto-thrust:master.221118.2
+          imagePullPolicy: IfNotPresent
+          name: proxy
+          command:
+            - /ccp-auto-thrust
+          args:
+            - "--port={{ .Values.controller.trafficManagerPort }}"
+          ports:
+          - containerPort: {{ .Values.controller.trafficManagerPort }}
+            protocol: TCP
+{{- end }}
         - name: azuredisk
 {{- if hasPrefix "/" .Values.image.azuredisk.repository }}
           image: "{{ .Values.image.baseRepo }}{{ .Values.image.azuredisk.repository }}:{{ .Values.image.azuredisk.tag }}"
@@ -176,6 +188,8 @@ spec:
             - "--user-agent-suffix={{ .Values.driver.userAgentSuffix }}"
             - "--allow-empty-cloud-config={{ .Values.controller.allowEmptyCloudConfig }}"
             - "--vmss-cache-ttl-seconds={{ .Values.controller.vmssCacheTTLInSeconds }}"
+            - "--enable-traffic-manager={{ .Values.controller.enableTrafficManager }}"
+            - "--traffic-manager-port={{ .Values.controller.trafficManagerPort }}"
           ports:
             - containerPort: {{ .Values.controller.livenessProbe.healthPort }}
               name: healthz

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/azuredisk-csi-driver/templates/csi-snapshot-controller.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/azuredisk-csi-driver/templates/csi-snapshot-controller.yaml
@@ -55,4 +55,28 @@ spec:
             - "--leader-election-namespace={{ .Release.Namespace }}"
           resources: {{- toYaml .Values.snapshot.snapshotController.resources | nindent 12 }}
           imagePullPolicy: {{ .Values.snapshot.image.csiSnapshotController.pullPolicy }}
+
+---
+{{- if .Values.snapshot.VolumeSnapshotClass.enabled -}}
+kind: VolumeSnapshotClass
+apiVersion: snapshot.storage.k8s.io/v1
+metadata:
+  name: {{ .Values.snapshot.VolumeSnapshotClass.name }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install
+driver: {{ .Values.driver.name }}
+deletionPolicy: {{ .Values.snapshot.VolumeSnapshotClass.deletionPolicy }}
+parameters:
+  incremental: {{ .Values.snapshot.VolumeSnapshotClass.parameters.incremental }}
+  {{- if ne .Values.snapshot.VolumeSnapshotClass.parameters.resourceGroup "" }}
+  resourceGroup: {{ .Values.snapshot.VolumeSnapshotClass.parameters.resourceGroup }}
+  {{- end }}
+  tags: {{ .Values.snapshot.VolumeSnapshotClass.parameters.tags }}
+{{- with .Values.snapshot.VolumeSnapshotClass.additionalLabels }}
+additionalLabels:
+{{ toYaml . | indent 2 }}
+{{- end }}
+{{- end -}}
 {{- end -}}

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/azuredisk-csi-driver/values.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/azuredisk-csi-driver/values.yaml
@@ -2,27 +2,27 @@ image:
   baseRepo: mcr.microsoft.com
   azuredisk:
     repository: ghcr.io/edgelesssys/constellation/azure-csi-driver
-    tag: v1.1.0
+    tag: v1.2.0@sha256:a5346a6650ec702d0ba86acee808c0102340ea4cb3375d956c6b34020b292527
     pullPolicy: IfNotPresent
   csiProvisioner:
     repository: /oss/kubernetes-csi/csi-provisioner
-    tag: v3.2.0
+    tag: v3.3.0@sha256:3ef7d954946bd1cf9e5e3564a8d1acf8e5852616f7ae96bcbc5ced8c275483ee
     pullPolicy: IfNotPresent
   csiAttacher:
     repository: /oss/kubernetes-csi/csi-attacher
-    tag: v3.5.0
+    tag: v4.0.0@sha256:bc317fea7e7bbaff65130d7ac6ea7c96bc15eb1f086374b8c3359f11988ac024
     pullPolicy: IfNotPresent
   csiResizer:
     repository: /oss/kubernetes-csi/csi-resizer
-    tag: v1.5.0
+    tag: v1.6.0@sha256:9ba6483d2f8aa6051cb3a50e42d638fc17a6e4699a6689f054969024b7c12944
     pullPolicy: IfNotPresent
   livenessProbe:
     repository: /oss/kubernetes-csi/livenessprobe
-    tag: v2.7.0
+    tag: v2.8.0@sha256:fcb73e1939d9abeb2d1e1680b476a10a422a04a73ea5a65e64eec3fde1f2a5a1
     pullPolicy: IfNotPresent
   nodeDriverRegistrar:
     repository: /oss/kubernetes-csi/csi-node-driver-registrar
-    tag: v2.5.1
+    tag: v2.6.2@sha256:515b883deb0ae8d58eef60312f4d460ff8a3f52a2a5e487c94a8ebb2ca362720
     pullPolicy: IfNotPresent
 
 serviceAccount:
@@ -40,6 +40,8 @@ controller:
   cloudConfigSecretName: azureconfig
   cloudConfigSecretNamespace: kube-system
   allowEmptyCloudConfig: false
+  enableTrafficManager: false
+  trafficManagerPort: 7788
   replicas: 1
   metricsPort: 29604
   livenessProbe:
@@ -49,7 +51,7 @@ controller:
   disableAvailabilitySetNodes: false
   vmType: ""
   provisionerWorkerThreads: 100
-  attacherWorkerThreads: 500
+  attacherWorkerThreads: 1000
   vmssCacheTTLInSeconds: -1
   logLevel: 5
   tolerations:
@@ -153,6 +155,15 @@ snapshot:
       requests:
         cpu: 10m
         memory: 20Mi
+  VolumeSnapshotClass:
+    enabled: false
+    name: csi-azuredisk-vsc
+    deletionPolicy: Delete
+    parameters:
+      incremental: '"true"' # available values: "true", "false" ("true" by default for Azure Public Cloud, and "false" by default for Azure Stack Cloud)
+      resourceGroup: "" # available values: EXISTING RESOURCE GROUP (If not specified, snapshot will be stored in the same resource group as source Azure disk)
+      tags: "" # tag format: 'key1=val1,key2=val2'
+    additionalLabels: {}
 
 feature:
   enableFSGroupPolicy: true

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/Chart.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 1.1.0
-appVersion: "v1.1.2"
+version: 1.2.0
+appVersion: "v1.2.0"
 description: GCP Compute Persistent Disk Container Storage Interface (CSI) Storage Plugin with on-node encryption support
 name: gcp-compute-persistent-disk-csi-driver

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/templates/controller.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/templates/controller.yaml
@@ -45,7 +45,7 @@ spec:
             - "--feature-gates=Topology=true"
             - "--http-endpoint=:22011"
             - "--leader-election-namespace=$(PDCSI_NAMESPACE)"
-            - "--timeout=450s"
+            - "--timeout=250s"
             - "--extra-create-metadata"
           # - "--run-controller-service=false"  # disable the controller service of the CSI driver
           # - "--run-node-service=false"        # disable the node service of the CSI driver
@@ -81,7 +81,7 @@ spec:
             - "--http-endpoint=:22012"
             - "--leader-election"
             - "--leader-election-namespace=$(PDCSI_NAMESPACE)"
-            - "--timeout=450s"
+            - "--timeout=250s"
           env:
             - name: PDCSI_NAMESPACE
               valueFrom:
@@ -141,7 +141,7 @@ spec:
             - "--metrics-address=:22014"
             - "--leader-election"
             - "--leader-election-namespace=$(PDCSI_NAMESPACE)"
-            - "--timeout=450s"
+            - "--timeout=300s"
           env:
             - name: PDCSI_NAMESPACE
               valueFrom:

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/templates/storageclass_default.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/templates/storageclass_default.yaml
@@ -6,7 +6,7 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
   name: encrypted-rwo
 parameters:
-  type: pd-standard
+  type: pd-balanced
 provisioner: gcp.csi.confidential.cloud
 allowVolumeExpansion: true
 reclaimPolicy: Delete

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/values.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/values.yaml
@@ -1,28 +1,28 @@
 image:
   csiProvisioner:
-    repo: k8s.gcr.io/sig-storage/csi-provisioner
-    tag: "v3.1.1"
+    repo: registry.k8s.io/sig-storage/csi-provisioner
+    tag: v3.4.0@sha256:e468dddcd275163a042ab297b2d8c2aca50d5e148d2d22f3b6ba119e2f31fa79
     pullPolicy: IfNotPresent
   csiAttacher:
-    repo: k8s.gcr.io/sig-storage/csi-attacher
-    tag: "v3.5.0"
+    repo: registry.k8s.io/sig-storage/csi-attacher
+    tag: v4.2.0@sha256:34cf9b32736c6624fc9787fb149ea6e0fbeb45415707ac2f6440ac960f1116e6
     pullPolicy: IfNotPresent
   csiResizer:
-    repo: k8s.gcr.io/sig-storage/csi-resizer
-    tag: "v1.5.0"
+    repo: registry.k8s.io/sig-storage/csi-resizer
+    tag: v1.7.0@sha256:3a7bdf5d105783d05d0962fa06ca53032b01694556e633f27366201c2881e01d
     pullPolicy: IfNotPresent
   csiSnapshotter:
-    repo: k8s.gcr.io/sig-storage/csi-snapshotter
-    tag: "v6.0.1"
+    repo: registry.k8s.io/sig-storage/csi-snapshotter
+    tag: v6.1.0@sha256:291334908ddf71a4661fd7f6d9d97274de8a5378a2b6fdfeb2ce73414a34f82f
     pullPolicy: IfNotPresent
   csiNodeRegistrar:
-    repo: k8s.gcr.io/sig-storage/csi-node-driver-registrar
-    tag: "v2.5.1"
+    repo: registry.k8s.io/sig-storage/csi-node-driver-registrar
+    tag: v2.7.0@sha256:4a4cae5118c4404e35d66059346b7fa0835d7e6319ff45ed73f4bba335cf5183
     pullPolicy: IfNotPresent
   gcepdDriver:
     repo: ghcr.io/edgelesssys/constellation/gcp-csi-driver
     # CSI driver version is independent of Constellation releases
-    tag: "v1.1.0"
+    tag: v1.2.0@sha256:84810096ab2244c77eeeab4c03445df69949e23f7f40d84bc434f122997a5692
     pullPolicy: IfNotPresent
 
 csiController:

--- a/cli/internal/helm/loader_test.go
+++ b/cli/internal/helm/loader_test.go
@@ -375,6 +375,8 @@ func prepareAzureValues(values map[string]any) error {
 		"tenantID":       "TenantID",
 	}
 
+	testTag := "v0.0.0"
+	pullPolicy := "IfNotPresent"
 	verificationVals, ok := values["verification-service"].(map[string]any)
 	if !ok {
 		return errors.New("missing 'verification-service' key")
@@ -386,6 +388,67 @@ func prepareAzureValues(values map[string]any) error {
 		return errors.New("missing 'konnectivity' key")
 	}
 	konnectivityVals["loadBalancerIP"] = "127.0.0.1"
+
+	csiVals, ok := values["azuredisk-csi-driver"].(map[string]any)
+	if !ok {
+		csiVals = map[string]any{}
+		values["azuredisk-csi-driver"] = csiVals
+	}
+	csiImages, ok := csiVals["image"].(map[string]any)
+	if !ok {
+		csiImages = map[string]any{}
+		csiVals["image"] = csiImages
+	}
+	csiImages["azuredisk"] = map[string]any{
+		"repository": "azure-csi-driver",
+		"tag":        testTag,
+		"pullPolicy": pullPolicy,
+	}
+	csiImages["csiProvisioner"] = map[string]any{
+		"repository": "csi-provisioner",
+		"tag":        testTag,
+		"pullPolicy": pullPolicy,
+	}
+	csiImages["csiAttacher"] = map[string]any{
+		"repository": "csi-attacher",
+		"tag":        testTag,
+		"pullPolicy": pullPolicy,
+	}
+	csiImages["csiResizer"] = map[string]any{
+		"repository": "csi-resizer",
+		"tag":        testTag,
+		"pullPolicy": pullPolicy,
+	}
+	csiImages["livenessProbe"] = map[string]any{
+		"repository": "livenessprobe",
+		"tag":        testTag,
+		"pullPolicy": pullPolicy,
+	}
+	csiImages["nodeDriverRegistrar"] = map[string]any{
+		"repository": "csi-node-driver-registrar",
+		"tag":        testTag,
+		"pullPolicy": pullPolicy,
+	}
+	csiSnapshot, ok := csiVals["snapshot"].(map[string]any)
+	if !ok {
+		csiSnapshot = map[string]any{}
+		csiVals["snapshot"] = csiSnapshot
+	}
+	csiSnapshotImage, ok := csiSnapshot["image"].(map[string]any)
+	if !ok {
+		csiSnapshotImage = map[string]any{}
+		csiSnapshot["image"] = csiSnapshotImage
+	}
+	csiSnapshotImage["csiSnapshotter"] = map[string]any{
+		"repository": "csi-snapshotter",
+		"tag":        testTag,
+		"pullPolicy": pullPolicy,
+	}
+	csiSnapshotImage["snapshotController"] = map[string]any{
+		"repository": "snapshot-controller",
+		"tag":        testTag,
+		"pullPolicy": pullPolicy,
+	}
 
 	return nil
 }

--- a/cli/internal/helm/testdata/Azure/constellation-services/charts/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-services/charts/azuredisk-csi-driver/templates/csi-azuredisk-controller.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: "testRelease"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/name: "azuredisk-csi-driver"
-    app.kubernetes.io/version: "v1.1.0"
-    helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    helm.sh/chart: "azuredisk-csi-driver-v1.2.0"
 spec:
   replicas: 1
   selector:
@@ -20,8 +20,8 @@ spec:
         app.kubernetes.io/instance: "testRelease"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/name: "azuredisk-csi-driver"
-        app.kubernetes.io/version: "v1.1.0"
-        helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        helm.sh/chart: "azuredisk-csi-driver-v1.2.0"
         app: csi-azuredisk-controller
     spec:
       serviceAccountName: csi-azuredisk-controller-sa
@@ -48,12 +48,12 @@ spec:
           operator: Exists
       containers:
         - name: csi-provisioner
-          image: "mcr.microsoft.com/oss/kubernetes-csi/csi-provisioner:v3.2.0"
+          image: "csi-provisioner:v0.0.0"
           args:
             - "--feature-gates=Topology=true"
             - "--csi-address=$(ADDRESS)"
             - "--v=2"
-            - "--timeout=15s"
+            - "--timeout=30s"
             - "--leader-election"
             - "--leader-election-namespace=testNamespace"
             - "--worker-threads=100"
@@ -74,16 +74,16 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-attacher
-          image: "mcr.microsoft.com/oss/kubernetes-csi/csi-attacher:v3.5.0"
+          image: "csi-attacher:v0.0.0"
           args:
             - "-v=2"
             - "-csi-address=$(ADDRESS)"
             - "-timeout=1200s"
             - "-leader-election"
             - "--leader-election-namespace=testNamespace"
-            - "-worker-threads=500"
-            - "-kube-api-qps=50"
-            - "-kube-api-burst=100"
+            - "-worker-threads=1000"
+            - "-kube-api-qps=200"
+            - "-kube-api-burst=400"
           env:
             - name: ADDRESS
               value: /csi/csi.sock
@@ -97,7 +97,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-snapshotter
-          image: "mcr.microsoft.com/oss/kubernetes-csi/csi-snapshotter:v5.0.1"
+          image: "csi-snapshotter:v0.0.0"
           args:
             - "-csi-address=$(ADDRESS)"
             - "-leader-election"
@@ -116,7 +116,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: csi-resizer
-          image: "mcr.microsoft.com/oss/kubernetes-csi/csi-resizer:v1.5.0"
+          image: "csi-resizer:v0.0.0"
           args:
             - "-csi-address=$(ADDRESS)"
             - "-v=2"
@@ -138,7 +138,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: liveness-probe
-          image: "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.7.0"
+          image: "livenessprobe:v0.0.0"
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
@@ -154,7 +154,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: azuredisk
-          image: "ghcr.io/edgelesssys/constellation/azure-csi-driver:v1.1.0"
+          image: "azure-csi-driver:v0.0.0"
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
@@ -168,6 +168,8 @@ spec:
             - "--user-agent-suffix=OSS-helm"
             - "--allow-empty-cloud-config=false"
             - "--vmss-cache-ttl-seconds=-1"
+            - "--enable-traffic-manager=false"
+            - "--traffic-manager-port=7788"
           ports:
             - containerPort: 29602
               name: healthz

--- a/cli/internal/helm/testdata/Azure/constellation-services/charts/azuredisk-csi-driver/templates/csi-azuredisk-driver.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-services/charts/azuredisk-csi-driver/templates/csi-azuredisk-driver.yaml
@@ -3,8 +3,8 @@ kind: CSIDriver
 metadata:
   name: azuredisk.csi.confidential.cloud
   annotations:
-    csiDriver: "v1.1.0"
-    snapshot: "v5.0.1"
+    csiDriver: "v0.0.0"
+    snapshot: "v0.0.0"
 spec:
   attachRequired: true
   podInfoOnMount: false

--- a/cli/internal/helm/testdata/Azure/constellation-services/charts/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-services/charts/azuredisk-csi-driver/templates/csi-azuredisk-node.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: "testRelease"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/name: "azuredisk-csi-driver"
-    app.kubernetes.io/version: "v1.1.0"
-    helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    helm.sh/chart: "azuredisk-csi-driver-v1.2.0"
 spec:
   updateStrategy:
     rollingUpdate:
@@ -23,8 +23,8 @@ spec:
         app.kubernetes.io/instance: "testRelease"
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/name: "azuredisk-csi-driver"
-        app.kubernetes.io/version: "v1.1.0"
-        helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+        app.kubernetes.io/version: "v1.2.0"
+        helm.sh/chart: "azuredisk-csi-driver-v1.2.0"
         app: csi-azuredisk-node
     spec:
       serviceAccountName: csi-azuredisk-node-sa
@@ -48,7 +48,7 @@ spec:
           volumeMounts:
             - mountPath: /csi
               name: socket-dir
-          image: "mcr.microsoft.com/oss/kubernetes-csi/livenessprobe:v2.7.0"
+          image: "livenessprobe:v0.0.0"
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
@@ -61,7 +61,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: node-driver-registrar
-          image: "mcr.microsoft.com/oss/kubernetes-csi/csi-node-driver-registrar:v2.5.1"
+          image: "csi-node-driver-registrar:v0.0.0"
           args:
             - --csi-address=$(ADDRESS)
             - --kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)
@@ -91,7 +91,7 @@ spec:
               cpu: 10m
               memory: 20Mi
         - name: azuredisk
-          image: "ghcr.io/edgelesssys/constellation/azure-csi-driver:v1.1.0"
+          image: "azure-csi-driver:v0.0.0"
           args:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"

--- a/cli/internal/helm/testdata/Azure/constellation-services/charts/azuredisk-csi-driver/templates/rbac-csi-azuredisk-controller.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-services/charts/azuredisk-csi-driver/templates/rbac-csi-azuredisk-controller.yaml
@@ -6,8 +6,8 @@ metadata:
     app.kubernetes.io/instance: "testRelease"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/name: "azuredisk-csi-driver"
-    app.kubernetes.io/version: "v1.1.0"
-    helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    helm.sh/chart: "azuredisk-csi-driver-v1.2.0"
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -47,8 +47,8 @@ metadata:
     app.kubernetes.io/instance: "testRelease"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/name: "azuredisk-csi-driver"
-    app.kubernetes.io/version: "v1.1.0"
-    helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    helm.sh/chart: "azuredisk-csi-driver-v1.2.0"
 subjects:
   - kind: ServiceAccount
     name: csi-azuredisk-controller-sa
@@ -68,8 +68,8 @@ metadata:
     app.kubernetes.io/instance: "testRelease"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/name: "azuredisk-csi-driver"
-    app.kubernetes.io/version: "v1.1.0"
-    helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    helm.sh/chart: "azuredisk-csi-driver-v1.2.0"
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -99,8 +99,8 @@ metadata:
     app.kubernetes.io/instance: "testRelease"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/name: "azuredisk-csi-driver"
-    app.kubernetes.io/version: "v1.1.0"
-    helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    helm.sh/chart: "azuredisk-csi-driver-v1.2.0"
 subjects:
   - kind: ServiceAccount
     name: csi-azuredisk-controller-sa
@@ -120,8 +120,8 @@ metadata:
     app.kubernetes.io/instance: "testRelease"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/name: "azuredisk-csi-driver"
-    app.kubernetes.io/version: "v1.1.0"
-    helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    helm.sh/chart: "azuredisk-csi-driver-v1.2.0"
 rules:
   - apiGroups: [""]
     resources: ["events"]
@@ -151,8 +151,8 @@ metadata:
     app.kubernetes.io/instance: "testRelease"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/name: "azuredisk-csi-driver"
-    app.kubernetes.io/version: "v1.1.0"
-    helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    helm.sh/chart: "azuredisk-csi-driver-v1.2.0"
 subjects:
   - kind: ServiceAccount
     name: csi-azuredisk-controller-sa
@@ -171,8 +171,8 @@ metadata:
     app.kubernetes.io/instance: "testRelease"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/name: "azuredisk-csi-driver"
-    app.kubernetes.io/version: "v1.1.0"
-    helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    helm.sh/chart: "azuredisk-csi-driver-v1.2.0"
 rules:
   - apiGroups: [""]
     resources: ["persistentvolumes"]
@@ -201,8 +201,8 @@ metadata:
     app.kubernetes.io/instance: "testRelease"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/name: "azuredisk-csi-driver"
-    app.kubernetes.io/version: "v1.1.0"
-    helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    helm.sh/chart: "azuredisk-csi-driver-v1.2.0"
 subjects:
   - kind: ServiceAccount
     name: csi-azuredisk-controller-sa

--- a/cli/internal/helm/testdata/Azure/constellation-services/charts/azuredisk-csi-driver/templates/serviceaccount-csi-azuredisk-controller.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-services/charts/azuredisk-csi-driver/templates/serviceaccount-csi-azuredisk-controller.yaml
@@ -7,5 +7,5 @@ metadata:
     app.kubernetes.io/instance: "testRelease"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/name: "azuredisk-csi-driver"
-    app.kubernetes.io/version: "v1.1.0"
-    helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    helm.sh/chart: "azuredisk-csi-driver-v1.2.0"

--- a/cli/internal/helm/testdata/Azure/constellation-services/charts/azuredisk-csi-driver/templates/serviceaccount-csi-azuredisk-node.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-services/charts/azuredisk-csi-driver/templates/serviceaccount-csi-azuredisk-node.yaml
@@ -7,5 +7,5 @@ metadata:
     app.kubernetes.io/instance: "testRelease"
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/name: "azuredisk-csi-driver"
-    app.kubernetes.io/version: "v1.1.0"
-    helm.sh/chart: "azuredisk-csi-driver-v1.1.2"
+    app.kubernetes.io/version: "v1.2.0"
+    helm.sh/chart: "azuredisk-csi-driver-v1.2.0"

--- a/cli/internal/helm/testdata/GCP/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/templates/controller.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/templates/controller.yaml
@@ -41,7 +41,7 @@ spec:
             - "--feature-gates=Topology=true"
             - "--http-endpoint=:22011"
             - "--leader-election-namespace=$(PDCSI_NAMESPACE)"
-            - "--timeout=450s"
+            - "--timeout=250s"
             - "--extra-create-metadata"
           # - "--run-controller-service=false"  # disable the controller service of the CSI driver
           # - "--run-node-service=false"        # disable the node service of the CSI driver
@@ -77,7 +77,7 @@ spec:
             - "--http-endpoint=:22012"
             - "--leader-election"
             - "--leader-election-namespace=$(PDCSI_NAMESPACE)"
-            - "--timeout=450s"
+            - "--timeout=250s"
           env:
             - name: PDCSI_NAMESPACE
               valueFrom:
@@ -137,7 +137,7 @@ spec:
             - "--metrics-address=:22014"
             - "--leader-election"
             - "--leader-election-namespace=$(PDCSI_NAMESPACE)"
-            - "--timeout=450s"
+            - "--timeout=300s"
           env:
             - name: PDCSI_NAMESPACE
               valueFrom:

--- a/cli/internal/helm/testdata/GCP/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/templates/storageclass_default.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/templates/storageclass_default.yaml
@@ -5,7 +5,7 @@ metadata:
     storageclass.kubernetes.io/is-default-class: "true"
   name: encrypted-rwo
 parameters:
-  type: pd-standard
+  type: pd-balanced
 provisioner: gcp.csi.confidential.cloud
 allowVolumeExpansion: true
 reclaimPolicy: Delete

--- a/cli/internal/helm/update-csi-charts.sh
+++ b/cli/internal/helm/update-csi-charts.sh
@@ -59,11 +59,9 @@ download_chart() {
 }
 
 ## GCP CSI Driver
-# TODO: clone from main branch once we rebase on upstream
-download_chart "https://github.com/edgelesssys/constellation-gcp-compute-persistent-disk-csi-driver" "v1.1.2" "charts" "gcp-compute-persistent-disk-csi-driver"
+download_chart "https://github.com/edgelesssys/constellation-gcp-compute-persistent-disk-csi-driver" "v1.2.0" "charts" "gcp-compute-persistent-disk-csi-driver"
 
 ## Azure CSI Driver
-# TODO: clone from main branch once we rebase on upstream
-download_chart "https://github.com/edgelesssys/constellation-azuredisk-csi-driver" "v1.1.2" "charts/edgeless" "azuredisk-csi-driver"
+download_chart "https://github.com/edgelesssys/constellation-azuredisk-csi-driver" "v1.2.0" "charts/edgeless" "azuredisk-csi-driver"
 
 echo # final newline


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
Update CSI drivers to v1.2.0, which are based on v1.9.2 (GCP) and v1.27.1 (Azure) of their upstream counterparts.
This also enables cryptsetup read/write workqueue bypass in the drivers, which should speed up write and read speeds on encrypted disks 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
