### PR TITLE
cli: force-delete Azure resource group

### DIFF
--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -89,9 +89,9 @@ func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destr
 
 	if !flags.yes {
 		// Confirmation
-		confirmString := "Do you really want to destroy your IAM configuration?"
+		confirmString := "Do you really want to destroy your IAM configuration? Note that this will remove all resources in the resource group."
 		if gcpFileExists {
-			confirmString += fmt.Sprintf(" (This will also delete %q)", constants.GCPServiceAccountKeyFile)
+			confirmString += fmt.Sprintf("\nThis will also delete %q", constants.GCPServiceAccountKeyFile)
 		}
 		ok, err := askToConfirm(cmd, confirmString)
 		if err != nil {

--- a/cli/internal/terraform/terraform/azure/main.tf
+++ b/cli/internal/terraform/terraform/azure/main.tf
@@ -12,7 +12,9 @@ terraform {
 }
 
 provider "azurerm" {
-  features {}
+  features {
+    prevent_deletion_if_contains_resources = false
+  }
 }
 
 locals {

--- a/cli/internal/terraform/terraform/azure/main.tf
+++ b/cli/internal/terraform/terraform/azure/main.tf
@@ -13,7 +13,9 @@ terraform {
 
 provider "azurerm" {
   features {
-    prevent_deletion_if_contains_resources = false
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
   }
 }
 

--- a/cli/internal/terraform/terraform/iam/azure/main.tf
+++ b/cli/internal/terraform/terraform/iam/azure/main.tf
@@ -13,7 +13,11 @@ terraform {
 
 # Configure Azure resource management provider
 provider "azurerm" {
-  features {}
+  features {
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
 }
 
 # Configure Azure active directory provider

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -264,3 +264,8 @@ Delete the IAM configuration by executing the following command in the same dire
 ```bash
 constellation iam destroy
 ```
+
+:::caution
+For Azure, deleting the IAM configuration by executing `constellation iam destroy` will delete the whole resource group created by `constellation iam create`.
+This also includes any additional resources in the resource group that were not created by Constellation.
+:::

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -267,5 +267,5 @@ constellation iam destroy
 
 :::caution
 For Azure, deleting the IAM configuration by executing `constellation iam destroy` will delete the whole resource group created by `constellation iam create`.
-This also includes any additional resources in the resource group that were not created by Constellation.
+This also includes any additional resources in the resource group that weren't created by Constellation.
 :::


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Disable the [`prevent_deletion_if_contains_resources`](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/guides/features-block) of the Azure Terraform provider. This fixes the issues created by the failure anomaly detector. This can be changed once the [issue](https://github.com/hashicorp/terraform-provider-azurerm/issues/18026) gets addressed by Microsoft.
- Add docs on the behaviour in the case of additional resources being added manually into the resource group (they are also deleted by `constellation iam destroy`)

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [Successful run ](https://github.com/edgelesssys/constellation/actions/runs/4720646803/jobs/8372948576)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
