### PR TITLE
ci: limit prefix length of AWS IAM resources

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -189,7 +189,7 @@ runs:
       id: create-prefix
       shell: bash
       run: |
-        uuid=$(uuidgen | head -c 23)
+        uuid=$(uuidgen)
         uuid=${uuid%%-*}
         echo "uuid=${uuid}" | tee -a $GITHUB_OUTPUT
         echo "prefix=e2e-${{ github.run_id }}-${{ github.run_attempt }}-${uuid}" | tee -a $GITHUB_OUTPUT

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -189,7 +189,7 @@ runs:
       id: create-prefix
       shell: bash
       run: |
-        uuid=$(uuidgen)
+        uuid=$(uuidgen | head -c 23)
         uuid=${uuid%%-*}
         echo "uuid=${uuid}" | tee -a $GITHUB_OUTPUT
         echo "prefix=e2e-${{ github.run_id }}-${{ github.run_attempt }}-${uuid}" | tee -a $GITHUB_OUTPUT

--- a/cli/internal/cmd/iamcreate.go
+++ b/cli/internal/cmd/iamcreate.go
@@ -389,6 +389,9 @@ func (c *awsIAMCreator) parseFlagsAndSetupConfig(cmd *cobra.Command, flags iamFl
 	if err != nil {
 		return iamFlags{}, fmt.Errorf("parsing prefix string: %w", err)
 	}
+	if len(prefix) > 36 {
+		return iamFlags{}, fmt.Errorf("prefix must be 36 characters or less")
+	}
 	zone, err := cmd.Flags().GetString("zone")
 	if err != nil {
 		return iamFlags{}, fmt.Errorf("parsing zone string: %w", err)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
[AB#3103](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3103)
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: limit prefix length of AWS IAM resources

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info

IAM create fails in the CI on AWS:

```
Error: expected length of name to be in the range (1 - 64), got e2e-4705664276-1-387ada92-9a16-40c1-8f35-adafacf04581_control_plane_role
```

So we have to shorten the prefix used for e2e tests.
