### PR TITLE
bazel: fix MacOS builds

### DIFF
--- a/tools/workspace_status.sh
+++ b/tools/workspace_status.sh
@@ -34,7 +34,7 @@ ensure_pseudo_version_tool() {
     get_pseudo_version_tool
   fi
   expected=$(cat "${REPOSITORY_ROOT}/tools/pseudo_version_$(goos)_$(goarch).sha256")
-  if ! sha256sum -c --status <(echo "${expected}  ${REPOSITORY_ROOT}/tools/pseudo-version"); then
+  if ! shasum -a 256 -c --status <(echo "${expected}  ${REPOSITORY_ROOT}/tools/pseudo-version"); then
     get_pseudo_version_tool
   fi
 }

--- a/tools/workspace_status.sh
+++ b/tools/workspace_status.sh
@@ -21,6 +21,7 @@ goarch() {
   case $(uname -m) in
   x86_64) echo 'amd64' ;;
   arm) echo 'arm64' ;; # this is slightly simplified, but we only care about arm64
+  arm64) echo 'arm64' ;;
   *)
     echo 'Unknown arch' >&2
     exit 1


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix `bazel run ::/devbuild` on MacOS (aarch64) by:
  - Allowing `arm64`arch
  - Using the [`shasum`](https://www.linux.org/docs/man1/shasum.html) command, which should be available on Linux and MacOS systems

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Output:
```
➜  build git:(fix/bazel/darwin-builds) bazel run //:devbuild
INFO: Invocation ID: a025b43e-048c-4161-854a-b7d10fa3a17d
INFO: Analyzed target //:devbuild (0 packages loaded, 0 targets configured).
INFO: Found 1 target...
Target //bazel/devbuild:devbuild up-to-date:
  bazel-bin/bazel/devbuild/devbuild-script.bash
  bazel-bin/bazel/devbuild/devbuild
INFO: Elapsed time: 12.537s, Critical Path: 9.68s
INFO: 19 processes: 2 internal, 17 darwin-sandbox.
INFO: Build completed successfully, 19 total actions
INFO: Running command line: bazel-bin/bazel/devbuild/devbuild
```
### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
