### PR TITLE
bazel: allow custom container_prefix

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -55,4 +55,4 @@ build:remote_cache --experimental_remote_cache_compression
 build:remote_cache --nolegacy_important_outputs
 build:remote_cache_readonly --noremote_upload_local_results # Uploads logs & artifacts without writing to cache
 
-try-import .bazeloverwriterc
+try-import %workspace%/.bazeloverwriterc

--- a/.bazelrc
+++ b/.bazelrc
@@ -26,6 +26,9 @@ build --define=gotags=netgo
 # enable tpm simulator for tests
 test --//bazel/settings:tpm_simulator
 
+# set registry flag alias
+build --flag_alias=container_prefix=//bazel/settings:container_prefix
+
 # disable test caching (rerun all test cases even if they passed before)
 test --cache_test_results=no
 

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -23,12 +23,7 @@ alias(
 
 alias(
     name = "devbuild",
-    actual = "//bazel/devbuild:devbuild",
-)
-
-alias(
-    name = "push",
-    actual = "//bazel/release:push",
+    actual = "//bazel/release:build_and_push",
 )
 
 # These magic Gazelle commands need to be in the top-level BUILD file.

--- a/bazel/oci/containers.bzl
+++ b/bazel/oci/containers.bzl
@@ -2,11 +2,8 @@
 This module holds the definitions of the containers that are built.
 """
 
-load("@rules_oci//oci:defs.bzl", _oci_push = "oci_push", _oci_tarball = "oci_tarball")
-load("//bazel/oci:pin.bzl", "oci_sum")
-
-_default_registry = "ghcr.io"
-_default_prefix = "edgelesssys/constellation"
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
 def containers():
     return [
@@ -15,9 +12,7 @@ def containers():
             "image_name": "join-service",
             "name": "joinservice",
             "oci": "//joinservice/cmd:joinservice",
-            "prefix": _default_prefix,
-            "registry": _default_registry,
-            "tag_file": "//bazel/settings:tag",
+            "repotag_file": "//bazel/release:joinservice_tag.txt",
             "used_by": ["helm"],
         },
         {
@@ -25,9 +20,7 @@ def containers():
             "image_name": "key-service",
             "name": "keyservice",
             "oci": "//keyservice/cmd:keyservice",
-            "prefix": _default_prefix,
-            "registry": _default_registry,
-            "tag_file": "//bazel/settings:tag",
+            "repotag_file": "//bazel/release:keyservice_tag.txt",
             "used_by": ["helm"],
         },
         {
@@ -35,9 +28,7 @@ def containers():
             "image_name": "verification-service",
             "name": "verificationservice",
             "oci": "//verify/cmd:verificationservice",
-            "prefix": _default_prefix,
-            "registry": _default_registry,
-            "tag_file": "//bazel/settings:tag",
+            "repotag_file": "//bazel/release:verificationservice_tag.txt",
             "used_by": ["helm"],
         },
         {
@@ -45,9 +36,7 @@ def containers():
             "image_name": "node-operator",
             "name": "nodeoperator",
             "oci": "//operators/constellation-node-operator:node_operator",
-            "prefix": _default_prefix,
-            "registry": _default_registry,
-            "tag_file": "//bazel/settings:tag",
+            "repotag_file": "//bazel/release:nodeoperator_tag.txt",
             "used_by": ["helm"],
         },
         {
@@ -55,9 +44,7 @@ def containers():
             "image_name": "qemu-metadata-api",
             "name": "qemumetadata",
             "oci": "//hack/qemu-metadata-api:qemumetadata",
-            "prefix": _default_prefix,
-            "registry": _default_registry,
-            "tag_file": "//bazel/settings:tag",
+            "repotag_file": "//bazel/release:qemumetadata_tag.txt",
             "used_by": ["config"],
         },
         {
@@ -65,9 +52,7 @@ def containers():
             "image_name": "libvirt",
             "name": "libvirt",
             "oci": "//cli/internal/libvirt:constellation_libvirt",
-            "prefix": _default_prefix,
-            "registry": _default_registry,
-            "tag_file": "//bazel/settings:tag",
+            "repotag_file": "//bazel/release:libvirt_tag.txt",
             "used_by": ["config"],
         },
     ]
@@ -78,58 +63,21 @@ def helm_containers():
 def config_containers():
     return [container for container in containers() if "config" in container["used_by"]]
 
-def container_sum(name, oci, registry, prefix, image_name, **kwargs):
-    tag = kwargs.get("tag", None)
-    tag_file = kwargs.get("tag_file", None)
-    oci_sum(
-        name = name + "_sum",
-        oci = oci,
-        registry = registry,
-        prefix = prefix,
-        image_name = image_name,
-        tag = tag,
-        tag_file = tag_file,
-        visibility = ["//visibility:public"],
-    )
+def _container_reponame_impl(ctx):
+    container_prefix = ctx.attr._prefix[BuildSettingInfo].value
+    if container_prefix == None:
+        fail("container_prefix is not set")
 
-def oci_push(name, image, registry, image_name, **kwargs):
-    """oci_push pushes an OCI image to a registry.
+    full_container_tag = paths.join(container_prefix, ctx.attr.container_name)
 
-    Args:
-        name: The name of the target.
-        image: The OCI image to push.
-        registry: The registry to push to.
-        image_name: The name of the image.
-        **kwargs: Additional arguments to pass to oci_push.
-    """
-    prefix = kwargs.pop("prefix", None)
-    tag = kwargs.pop("tag", None)
-    tag_file = kwargs.pop("tag_file", None)
-    if prefix == None:
-        repository = registry + "/" + image_name
-    else:
-        repository = registry + "/" + prefix + "/" + image_name
-    _oci_push(
-        name = name,
-        image = image,
-        repository = repository,
-        tag = tag,
-        tag_file = tag_file,
-        visibility = ["//visibility:public"],
-        **kwargs
-    )
+    output = ctx.actions.declare_file(ctx.attr.container_name + "_container_repotag")
+    ctx.actions.write(output = output, content = full_container_tag)
+    return [DefaultInfo(files = depset([output]))]
 
-# TODO(malt3): allow repotags (registry + tag) to be read from a file.
-def oci_tarball(name, image):
-    """oci_tarball creates a tarball of an OCI image.
-
-    Args:
-        name: The name of the target.
-        image: The OCI image to create a tarball of.
-    """
-    _oci_tarball(
-        name = name,
-        image = image,
-        repotags = [],
-        visibility = ["//visibility:public"],
-    )
+container_reponame = rule(
+    implementation = _container_reponame_impl,
+    attrs = {
+        "container_name": attr.string(),
+        "_prefix": attr.label(default = Label("//bazel/settings:container_prefix")),
+    },
+)

--- a/bazel/oci/pin.bzl
+++ b/bazel/oci/pin.bzl
@@ -24,17 +24,11 @@ def stamp_tags(name, repotags, **kwargs):
 def _oci_go_source_impl(ctx):
     oci = ctx.file.oci
     inputs = [oci]
-    if ctx.attr.tag_file:
-        inputs.append(ctx.file.tag_file)
+    if ctx.attr.repotag_file:
+        inputs.append(ctx.file.repotag_file)
     output = ctx.actions.declare_file(ctx.label.name + ".go")
     args = [
         "codegen",
-        "--image-registry",
-        ctx.attr.registry,
-        "--image-prefix",
-        ctx.attr.prefix,
-        "--image-name",
-        ctx.attr.image_name,
         "--oci-path",
         oci.path,
         "--package",
@@ -47,9 +41,9 @@ def _oci_go_source_impl(ctx):
     if ctx.attr.tag:
         args.append("--image-tag")
         args.append(ctx.attr.tag)
-    if ctx.attr.tag_file:
-        args.append("--image-tag-file")
-        args.append(ctx.file.tag_file.path)
+    if ctx.attr.repotag_file:
+        args.append("--repoimage-tag-file")
+        args.append(ctx.file.repotag_file.path)
 
     ctx.actions.run(
         inputs = inputs,
@@ -82,17 +76,10 @@ _go_source_attrs = {
         mandatory = True,
         doc = "Package to use for the generated Go source.",
     ),
-    "prefix": attr.string(
-        doc = "Prefix to use for the generated Go source.",
-    ),
-    "registry": attr.string(
-        mandatory = True,
-        doc = "Registry to use for the generated Go source.",
-    ),
     "tag": attr.string(
         doc = "OCI image tag to use for the generated Go source.",
     ),
-    "tag_file": attr.label(
+    "repotag_file": attr.label(
         allow_single_file = True,
         doc = "OCI image tag file to use for the generated Go source.",
     ),
@@ -112,29 +99,19 @@ oci_go_source = rule(
 def _oci_sum_impl(ctx):
     oci = ctx.file.oci
     inputs = [oci]
-    if ctx.attr.tag_file:
-        inputs.append(ctx.file.tag_file)
+    if ctx.attr.repotag_file:
+        inputs.append(ctx.file.repotag_file)
     output = ctx.actions.declare_file(ctx.label.name + ".sha256")
     args = [
         "sum",
-        "--image-name",
-        ctx.attr.image_name,
         "--oci-path",
         oci.path,
         "--output",
         output.path,
-        "--registry",
-        ctx.attr.registry,
     ]
-    if ctx.attr.prefix:
-        args.append("--prefix")
-        args.append(ctx.attr.prefix)
-    if ctx.attr.tag:
-        args.append("--image-tag")
-        args.append(ctx.attr.tag)
-    if ctx.attr.tag_file:
-        args.append("--image-tag-file")
-        args.append(ctx.file.tag_file.path)
+    if ctx.attr.repotag_file:
+        args.append("--repoimage-tag-file")
+        args.append(ctx.file.repotag_file.path)
 
     ctx.actions.run(
         inputs = inputs,
@@ -159,17 +136,7 @@ _sum_attrs = {
         allow_single_file = True,
         doc = "OCI image to extract the digest from.",
     ),
-    "prefix": attr.string(
-        doc = "Prefix to use for the sum entry.",
-    ),
-    "registry": attr.string(
-        mandatory = True,
-        doc = "Registry to use for the sum entry.",
-    ),
-    "tag": attr.string(
-        doc = "OCI image tag to use for the sum entry.",
-    ),
-    "tag_file": attr.label(
+    "repotag_file": attr.label(
         allow_single_file = True,
         doc = "OCI image tag file to use for the sum entry.",
     ),

--- a/bazel/oci/pin.bzl
+++ b/bazel/oci/pin.bzl
@@ -76,12 +76,12 @@ _go_source_attrs = {
         mandatory = True,
         doc = "Package to use for the generated Go source.",
     ),
-    "tag": attr.string(
-        doc = "OCI image tag to use for the generated Go source.",
-    ),
     "repotag_file": attr.label(
         allow_single_file = True,
         doc = "OCI image tag file to use for the generated Go source.",
+    ),
+    "tag": attr.string(
+        doc = "OCI image tag to use for the generated Go source.",
     ),
     "_oci_pin": attr.label(
         allow_single_file = True,

--- a/bazel/release/BUILD.bazel
+++ b/bazel/release/BUILD.bazel
@@ -2,8 +2,8 @@
 This folder contains labels used to collect release artifacts.
 """
 
-load("@rules_oci//oci:defs.bzl", "oci_push")
 load("@com_github_ash2k_bazel_tools//multirun:def.bzl", "multirun")
+load("@rules_oci//oci:defs.bzl", "oci_push")
 load("//bazel/oci:containers.bzl", "container_reponame", "containers")
 load("//bazel/oci:pin.bzl", "oci_sum", "oci_sum_merge")
 

--- a/bazel/release/BUILD.bazel
+++ b/bazel/release/BUILD.bazel
@@ -29,7 +29,7 @@ load("//bazel/oci:pin.bzl", "oci_sum", "oci_sum_merge")
     for container in containers()
 ]
 
-# TODO(3u13r): re-enable target one https://github.com/bazel-contrib/rules_oci/issues/184 is fixed
+# TODO(3u13r): re-enable target once https://github.com/bazel-contrib/rules_oci/issues/184 is fixed
 # [
 #     oci_tarball(
 #         name = container["name"] + "_tar",

--- a/bazel/release/BUILD.bazel
+++ b/bazel/release/BUILD.bazel
@@ -2,26 +2,49 @@
 This folder contains labels used to collect release artifacts.
 """
 
+load("@rules_oci//oci:defs.bzl", "oci_push")
 load("@com_github_ash2k_bazel_tools//multirun:def.bzl", "multirun")
-load("//bazel/oci:containers.bzl", "container_sum", "containers", "oci_push", "oci_tarball")
-load("//bazel/oci:pin.bzl", "oci_sum_merge")
+load("//bazel/oci:containers.bzl", "container_reponame", "containers")
+load("//bazel/oci:pin.bzl", "oci_sum", "oci_sum_merge")
 
 [
-    oci_tarball(
-        name = container["name"] + "_tar",
-        image = container["oci"],
+    container_reponame(
+        name = container["name"] + "_reponame",
+        container_name = container["image_name"],
     )
     for container in containers()
 ]
 
 [
-    container_sum(
-        name = container["name"],
+    genrule(
+        name = container["name"] + "_repotag",
+        srcs = [
+            "//bazel/release:" + container["name"] + "_reponame",
+            "//bazel/settings:tag",
+        ],
+        outs = [container["repotag_file"]],
+        cmd = "echo -n ':' | cat $(location //bazel/release:" + container["name"] + "_reponame) - $(location //bazel/settings:tag) > $@",
+        visibility = ["//visibility:public"],
+    )
+    for container in containers()
+]
+
+# TODO(3u13r): re-enable target one https://github.com/bazel-contrib/rules_oci/issues/184 is fixed
+# [
+#     oci_tarball(
+#         name = container["name"] + "_tar",
+#         image = container["oci"],
+#         repotag_file = container["repotag_file"],
+#     )
+#     for container in containers()
+# ]
+
+[
+    oci_sum(
+        name = container["name"] + "_sum",
         image_name = container["image_name"],
         oci = container["oci"],
-        prefix = container["prefix"],
-        registry = container["registry"],
-        tag_file = container["tag_file"],
+        repotag_file = container["repotag_file"],
     )
     for container in containers()
 ]
@@ -35,16 +58,11 @@ oci_sum_merge(
     visibility = ["//visibility:public"],
 )
 
-# TODO(malt3): use config setting to allow devs the use of custom registries
-# https://www.grahambrooks.com/software-development/2021/08/30/user-defined-bazel-arguments.html
 [
     oci_push(
         name = container["name"] + "_push",
         image = container["oci"],
-        image_name = container["image_name"],
-        prefix = container["prefix"],
-        registry = container["registry"],
-        repotags = container["tag_file"],
+        repotags = container["repotag_file"],
     )
     for container in containers()
 ]
@@ -56,5 +74,14 @@ multirun(
         for container in containers()
     ],
     jobs = 0,  # execute in parallel
+    visibility = ["//visibility:public"],
+)
+
+multirun(
+    name = "build_and_push",
+    commands = [
+        "//bazel/devbuild:devbuild",
+        "//bazel/release:push",
+    ],
     visibility = ["//visibility:public"],
 )

--- a/bazel/settings/BUILD.bazel
+++ b/bazel/settings/BUILD.bazel
@@ -35,6 +35,12 @@ string_flag(
     ],
 )
 
+string_flag(
+    name = "container_prefix",
+    build_setting_default = "ghcr.io/edgelesssys/constellation",
+    visibility = ["//visibility:public"],
+)
+
 bool_flag(
     name = "select_never",
     build_setting_default = False,

--- a/bazel/toolchains/oci_deps.bzl
+++ b/bazel/toolchains/oci_deps.bzl
@@ -5,11 +5,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def oci_deps():
     http_archive(
         name = "rules_oci",
-        sha256 = "4a738bdbeacb0e1df070209dddfa7b55fed9bbc553b905cf3d2dd25115e0b598",
-        strip_prefix = "rules_oci-0.3.8",
+        strip_prefix = "rules_oci-0.4.0",
         type = "tar.gz",
         urls = [
-            "https://cdn.confidential.cloud/constellation/cas/sha256/4a738bdbeacb0e1df070209dddfa7b55fed9bbc553b905cf3d2dd25115e0b598",
-            "https://github.com/bazel-contrib/rules_oci/releases/download/v0.3.8/rules_oci-v0.3.8.tar.gz",
+            "https://cdn.confidential.cloud/constellation/cas/sha256/d7b0760ba28554b71941ea0bbfd0a9f089bf250fd4448f9c116e1cb7a63b3933",
+            "https://github.com/bazel-contrib/rules_oci/releases/download/v0.4.0/rules_oci-v0.4.0.tar.gz",
         ],
+        sha256 = "d7b0760ba28554b71941ea0bbfd0a9f089bf250fd4448f9c116e1cb7a63b3933",
     )

--- a/bootstrapper/bootstrapper
+++ b/bootstrapper/bootstrapper
@@ -1,1 +1,0 @@
-/home/euler/.cache/bazel/_bazel_euler/5bf61ef3c352f6209de5e3798ca9aef2/execroot/__main__/bazel-out/k8-opt-ST-94ef9162bf55/bin/bootstrapper/cmd/bootstrapper/bootstrapper_/bootstrapper

--- a/bootstrapper/bootstrapper
+++ b/bootstrapper/bootstrapper
@@ -1,0 +1,1 @@
+/home/euler/.cache/bazel/_bazel_euler/5bf61ef3c352f6209de5e3798ca9aef2/execroot/__main__/bazel-out/k8-opt-ST-94ef9162bf55/bin/bootstrapper/cmd/bootstrapper/bootstrapper_/bootstrapper

--- a/cli/internal/helm/imageversion/BUILD.bazel
+++ b/cli/internal/helm/imageversion/BUILD.bazel
@@ -24,9 +24,7 @@ go_library(
         image_name = container["image_name"],
         oci = container["oci"],
         package = "imageversion",
-        prefix = container["prefix"],
-        registry = container["registry"],
-        tag_file = container["tag_file"],
+        repotag_file = container["repotag_file"],
         visibility = ["//cli:__subpackages__"],
     )
     for container in helm_containers()

--- a/dev-docs/workflows/build-test-run.md
+++ b/dev-docs/workflows/build-test-run.md
@@ -28,12 +28,19 @@ mkdir build
 cd build
 # build required binaries for a dev build
 # and symlink them into the current directory
-bazel run //:devbuild
+# also push the built container images
+bazel run //:devbuild --container_prefix=ghcr.io/USERNAME
 ./constellation ...
 # modify code
 # rerun to ensure that all binaries are up to date
 bazel run //:devbuild
 ./constellation ...
+```
+
+Overwrite the default container_prefix in the `.bazeloverwriterc` in the root of the workspace:
+```bazel
+# cat .bazeloverwriterc
+build --container_prefix=ghcr.io/USERNAME
 ```
 
 Bazel build:

--- a/dev-docs/workflows/build-test-run.md
+++ b/dev-docs/workflows/build-test-run.md
@@ -29,7 +29,8 @@ cd build
 # build required binaries for a dev build
 # and symlink them into the current directory
 # also push the built container images
-bazel run //:devbuild --container_prefix=ghcr.io/USERNAME
+# After the first run, set the pushed imaged to public.
+bazel run //:devbuild --container_prefix=ghcr.io/USERNAME/constellation
 ./constellation ...
 # modify code
 # rerun to ensure that all binaries are up to date

--- a/internal/config/imageversion/BUILD.bazel
+++ b/internal/config/imageversion/BUILD.bazel
@@ -24,9 +24,7 @@ go_library(
         image_name = container["image_name"],
         oci = container["oci"],
         package = "imageversion",
-        prefix = container["prefix"],
-        registry = container["registry"],
-        tag_file = container["tag_file"],
+        repotag_file = container["repotag_file"],
         visibility = ["//:__subpackages__"],
     )
     for container in config_containers()


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add `container_prefix` flag which where the container images of this build should be hosted.
- Automatically push the container images on `//:devbuild`

The container references in the CLI also use this value.

I'd also like to thank @malt3 for the support on this feature.
<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
