### PR TITLE
ci: prevent google auth warnings when reauthenticating

### DIFF
--- a/.github/actions/login_gcp/action.yml
+++ b/.github/actions/login_gcp/action.yml
@@ -7,6 +7,18 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Clean env to prevent warnings
+      shell: bash
+      run: |
+        echo "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=" >> "$GITHUB_ENV"
+        echo "GOOGLE_APPLICATION_CREDENTIALS=" >> "$GITHUB_ENV"
+        echo "GOOGLE_GHA_CREDS_PATH=" >> "$GITHUB_ENV"
+        echo "CLOUDSDK_CORE_PROJECT=" >> "$GITHUB_ENV"
+        echo "CLOUDSDK_PROJECT=" >> "$GITHUB_ENV"
+        echo "GCLOUD_PROJECT=" >> "$GITHUB_ENV"
+        echo "GCP_PROJECT=" >> "$GITHUB_ENV"
+        echo "GOOGLE_CLOUD_PROJECT=" >> "$GITHUB_ENV"
+
     # As described at:
     # https://github.com/google-github-actions/setup-gcloud#service-account-key-json
     - name: Authorize GCP access


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Set the env vars to empty before authenticating, so that the login doesn't throw a warning when doing repeated auth.
- Run without warings: https://github.com/edgelesssys/constellation/actions/runs/4817304142

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
