### PR TITLE
ci: rename all usages of bazel push target from //:push to //bazel/release:push

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -82,7 +82,7 @@ outputs:
   namePrefix:
     description: "The name prefix of the cloud resources used in the e2e test."
     value: ${{ steps.create-prefix.outputs.prefix }}
-    
+
 runs:
   using: "composite"
   steps:
@@ -165,7 +165,7 @@ runs:
     - name: Upload container images
       if: inputs.cliVersion == ''
       shell: bash
-      run: bazel run //:push
+      run: bazel run //bazel/release:push
 
     - name: Login to GCP (IAM service account)
       if: inputs.cloudProvider == 'gcp'

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Upload referenced container images
         shell: bash
-        run: bazel run //:push
+        run: bazel run //bazel/release:push
 
   provenance-subjects:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
[AB#3119](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3119)
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: rename all usages of bazel push target from //:push to //bazel/release:push

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

CI would fail since it referenced an old alias for the push target that was since removed.

