### PR TITLE
cli: create namespaced folders for upgrade backups

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -184,7 +184,12 @@ runs:
         echo "Creating cluster using config:"
         cat constellation-conf.yaml
         sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts' || true
-        constellation create -c ${{ inputs.controlNodesCount }} -w ${{ inputs.workerNodesCount }} -y --force --debug --tf-log=DEBUG
+
+        output=$(constellation --help)
+        if [[ $output == *"tf-log"* ]]; then
+          TFFLAG="--tf-log=DEBUG"
+        fi
+        constellation create -c ${{ inputs.controlNodesCount }} -w ${{ inputs.workerNodesCount }} -y --force --debug ${TFFLAG:-}
 
     - name: Cdbg deploy
       if: inputs.isDebugImage == 'true'

--- a/.github/actions/constellation_destroy/action.yml
+++ b/.github/actions/constellation_destroy/action.yml
@@ -40,4 +40,9 @@ runs:
 
     - name: Constellation terminate
       shell: bash
-      run: constellation terminate --yes --tf-log=DEBUG
+      run: |
+        output=$(constellation --help)
+        if [[ $output == *"tf-log"* ]]; then
+          TFFLAG="--tf-log=DEBUG"
+        fi
+        constellation terminate --yes ${TFFLAG:-}

--- a/.github/actions/constellation_iam_create/action.yml
+++ b/.github/actions/constellation_iam_create/action.yml
@@ -51,11 +51,15 @@ runs:
       shell: bash
       if: inputs.cloudProvider == 'azure'
       run: |
+        output=$(constellation --help)
+        if [[ $output == *"tf-log"* ]]; then
+          TFFLAG="--tf-log=DEBUG"
+        fi
         constellation iam create azure \
           --region=${{ inputs.azureRegion }} \
           --resourceGroup="${{ inputs.namePrefix }}-rg" \
           --servicePrincipal="${{ inputs.namePrefix }}-sp" \
-          --generate-config --yes --tf-log=DEBUG
+          --generate-config --yes ${TFFLAG:-}
 
     - name: Constellation iam create gcp
       shell: bash

--- a/.github/actions/constellation_iam_destroy/action.yml
+++ b/.github/actions/constellation_iam_destroy/action.yml
@@ -39,4 +39,8 @@ runs:
     - name: Delete IAM configuration
       shell: bash
       run: |
-        constellation iam destroy --yes --tf-log=DEBUG
+        output=$(constellation --help)
+        if [[ $output == *"tf-log"* ]]; then
+          TFFLAG="--tf-log=DEBUG"
+        fi
+        constellation iam destroy --yes ${TFFLAG:-}

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -167,6 +167,7 @@ jobs:
             KUBERNETES_FLAG="--target-kubernetes=$KUBERNETES"
           fi
 
+          bazelisk run //bazel/release:push
           bazelisk run //e2e/internal/upgrade:upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --target-image "$IMAGE" "$KUBERNETES_FLAG" "$MICROSERVICES_FLAG"
 
       - name: Always fetch logs

--- a/cli/internal/helm/backup.go
+++ b/cli/internal/helm/backup.go
@@ -63,7 +63,11 @@ func (c *Client) backupCRs(ctx context.Context, crds []apiextensionsv1.CustomRes
 			}
 
 			for _, cr := range crs {
-				path := filepath.Join(backupFolder, cr.GetName()+".yaml")
+				targetFolder := filepath.Join(backupFolder, cr.GetKind(), cr.GetNamespace())
+				if err := c.fs.MkdirAll(targetFolder); err != nil {
+					return fmt.Errorf("creating resource dir: %w", err)
+				}
+				path := filepath.Join(targetFolder, cr.GetName()+".yaml")
 				yamlBytes, err := yaml.Marshal(cr.Object)
 				if err != nil {
 					return err

--- a/cli/internal/helm/backup_test.go
+++ b/cli/internal/helm/backup_test.go
@@ -133,7 +133,7 @@ func TestBackupCRs(t *testing.T) {
 			}
 			assert.NoError(err)
 
-			data, err := afero.ReadFile(memFs, filepath.Join(backupFolder, tc.resource.GetName()+".yaml"))
+			data, err := afero.ReadFile(memFs, filepath.Join(backupFolder, tc.resource.GetKind(), tc.resource.GetNamespace(), tc.resource.GetName()+".yaml"))
 			require.NoError(err)
 			assert.YAMLEq(tc.expectedFile, string(data))
 		})


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- There might be cases in which a resource name is reused for multiple resources or across namespaces. In that case `upgrade apply` would fail while creating the local resource backups. This is because files are dumped into one folder with the resource name as file name. This is fixed by creating paths with this pattern: `constellation-upgrade/backups/<kind>/<namespace>/<name>.yaml`.

### Additional info
- [Azure, 1+1, microservice only, 2.7.0 -> 2.8.0-pre](https://github.com/edgelesssys/constellation/actions/runs/4830779572). Failure of the actual upgrade is expected. Needs #1649. But backups happen before upgrade is tried. No errors there.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
