### PR TITLE
image: fix pcr 12 calculation

### DIFF
--- a/image/measured-boot/precalculate_pcr_12.sh
+++ b/image/measured-boot/precalculate_pcr_12.sh
@@ -23,9 +23,8 @@ cmdline_measure() {
   local path="$1"
   local tmp
   tmp=$(mktemp)
-  # convert to utf-16le and add a null terminator
+  # convert to utf-16le
   iconv -f utf-8 -t utf-16le "${path}" -o "${tmp}"
-  truncate -s +2 "${tmp}"
   sha256sum "${tmp}" | cut -d " " -f 1
   rm "${tmp}"
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- image: fix pcr 12 calculation

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info
- Kernel cmdline embedded in UKIs had no null terminator before
- After upgrading mkosi in #1684, PCR12 would not match up with the precalculated value
- The UKI now contains a null-terminated version of the kernel commandline
