### PR TITLE
cli: create namespaced folders for upgrade backups (#1702)

### DIFF
--- a/cli/internal/helm/backup.go
+++ b/cli/internal/helm/backup.go
@@ -63,7 +63,11 @@ func (c *Client) backupCRs(ctx context.Context, crds []apiextensionsv1.CustomRes
 			}
 
 			for _, cr := range crs {
-				path := filepath.Join(backupFolder, cr.GetName()+".yaml")
+				targetFolder := filepath.Join(backupFolder, cr.GetKind(), cr.GetNamespace())
+				if err := c.fs.MkdirAll(targetFolder); err != nil {
+					return fmt.Errorf("creating resource dir: %w", err)
+				}
+				path := filepath.Join(targetFolder, cr.GetName()+".yaml")
 				yamlBytes, err := yaml.Marshal(cr.Object)
 				if err != nil {
 					return err

--- a/cli/internal/helm/backup_test.go
+++ b/cli/internal/helm/backup_test.go
@@ -133,7 +133,7 @@ func TestBackupCRs(t *testing.T) {
 			}
 			assert.NoError(err)
 
-			data, err := afero.ReadFile(memFs, filepath.Join(backupFolder, tc.resource.GetName()+".yaml"))
+			data, err := afero.ReadFile(memFs, filepath.Join(backupFolder, tc.resource.GetKind(), tc.resource.GetNamespace(), tc.resource.GetName()+".yaml"))
 			require.NoError(err)
 			assert.YAMLEq(tc.expectedFile, string(data))
 		})


### PR DESCRIPTION
Resource names are only unique per kind+ns. Without this patch it might happen that there are two resources with the same name in different namespaces. Upgrade might fail in that case.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
