### PR TITLE
image: fix pcr 12 calculation (#1706)

### DIFF
--- a/image/measured-boot/precalculate_pcr_12.sh
+++ b/image/measured-boot/precalculate_pcr_12.sh
@@ -23,9 +23,8 @@ cmdline_measure() {
   local path="$1"
   local tmp
   tmp=$(mktemp)
-  # convert to utf-16le and add a null terminator
+  # convert to utf-16le
   iconv -f utf-8 -t utf-16le "${path}" -o "${tmp}"
-  truncate -s +2 "${tmp}"
   sha256sum "${tmp}" | cut -d " " -f 1
   rm "${tmp}"
 }


### PR DESCRIPTION
Kernel cmdline embedded in UKIs had no null terminator before. With newer versions of mkosi, it is already null-terminated so we shouldn't null terminate it twice.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
