### PR TITLE
cli: remove ambiguity in path for CR backups

### DIFF
--- a/cli/internal/helm/backup.go
+++ b/cli/internal/helm/backup.go
@@ -63,7 +63,7 @@ func (c *Client) backupCRs(ctx context.Context, crds []apiextensionsv1.CustomRes
 			}
 
 			for _, cr := range crs {
-				targetFolder := filepath.Join(backupFolder, cr.GetKind(), cr.GetNamespace())
+				targetFolder := filepath.Join(backupFolder, gvr.Group, gvr.Version, cr.GetNamespace(), cr.GetKind())
 				if err := c.fs.MkdirAll(targetFolder); err != nil {
 					return fmt.Errorf("creating resource dir: %w", err)
 				}

--- a/cli/internal/helm/backup_test.go
+++ b/cli/internal/helm/backup_test.go
@@ -133,7 +133,7 @@ func TestBackupCRs(t *testing.T) {
 			}
 			assert.NoError(err)
 
-			data, err := afero.ReadFile(memFs, filepath.Join(backupFolder, tc.resource.GetKind(), tc.resource.GetNamespace(), tc.resource.GetName()+".yaml"))
+			data, err := afero.ReadFile(memFs, filepath.Join(backupFolder, tc.crd.Spec.Group, tc.crd.Spec.Versions[0].Name, tc.resource.GetNamespace(), tc.resource.GetKind(), tc.resource.GetName()+".yaml"))
 			require.NoError(err)
 			assert.YAMLEq(tc.expectedFile, string(data))
 		})


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- During upgrade all custom resources are backed up to files on the local file system. Since old versions are also backed up, we need to reflect the version in the name. This is a fixup for #1702 .
- Tested the change locally by running against a bigger cluster.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
