### PR TITLE
cli: remove ambiguity in path for CR backups (#1719)

### DIFF
--- a/cli/internal/helm/backup.go
+++ b/cli/internal/helm/backup.go
@@ -63,7 +63,7 @@ func (c *Client) backupCRs(ctx context.Context, crds []apiextensionsv1.CustomRes
 			}
 
 			for _, cr := range crs {
-				targetFolder := filepath.Join(backupFolder, cr.GetKind(), cr.GetNamespace())
+				targetFolder := filepath.Join(backupFolder, gvr.Group, gvr.Version, cr.GetNamespace(), cr.GetKind())
 				if err := c.fs.MkdirAll(targetFolder); err != nil {
 					return fmt.Errorf("creating resource dir: %w", err)
 				}

--- a/cli/internal/helm/backup_test.go
+++ b/cli/internal/helm/backup_test.go
@@ -133,7 +133,7 @@ func TestBackupCRs(t *testing.T) {
 			}
 			assert.NoError(err)
 
-			data, err := afero.ReadFile(memFs, filepath.Join(backupFolder, tc.resource.GetKind(), tc.resource.GetNamespace(), tc.resource.GetName()+".yaml"))
+			data, err := afero.ReadFile(memFs, filepath.Join(backupFolder, tc.crd.Spec.Group, tc.crd.Spec.Versions[0].Name, tc.resource.GetNamespace(), tc.resource.GetKind(), tc.resource.GetName()+".yaml"))
 			require.NoError(err)
 			assert.YAMLEq(tc.expectedFile, string(data))
 		})


### PR DESCRIPTION
During upgrade all custom resources are backed up to files on the local file system. Since old versions are also backed up, we need to reflect the version in the name.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->


<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
- [x] Add labels (e.g., for changelog category)
