### PR TITLE
ci: guard measurement removal behind config version check

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -121,25 +121,44 @@ runs:
       if: inputs.keepMeasurements == 'false'
       shell: bash
       run: |
-        yq eval -i \
-          "(.attestation | select(. | has(\"awsNitroTPM\")).awsNitroTPM.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
-          constellation-conf.yaml
+        if [[ $(yq '.version' constellation-conf.yaml) == "v2" ]]
+        then
+          yq eval -i \
+            "(.provider | select(. | has(\"aws\")).aws.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
+            constellation-conf.yaml
 
-        yq eval -i \
-          "(.attestation | select(. | has(\"azureSEVSNP\")).azureSEVSNP.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
-          constellation-conf.yaml
+          yq eval -i \
+            "(.provider | select(. | has(\"azure\")).azure.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
+            constellation-conf.yaml
 
-        yq eval -i \
-          "(.attestation | select(. | has(\"azureTrustedLaunch\")).azureTrustedLaunch.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
-          constellation-conf.yaml
+          yq eval -i \
+            "(.provider | select(. | has(\"gcp\")).gcp.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}"\
+            constellation-conf.yaml
 
-        yq eval -i \
-          "(.attestation | select(. | has(\"gcpSEVES\")).gcpSEVES.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}"\
-          constellation-conf.yaml
+          yq eval -i \
+            "(.provider | select(. | has(\"qemu\")).qemu.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
+            constellation-conf.yaml
+        else
+          yq eval -i \
+            "(.attestation | select(. | has(\"awsNitroTPM\")).awsNitroTPM.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
+            constellation-conf.yaml
 
-        yq eval -i \
-          "(.attestation | select(. | has(\"qemuVTPM\")).qemuVTPM.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
-          constellation-conf.yaml
+          yq eval -i \
+            "(.attestation | select(. | has(\"azureSEVSNP\")).azureSEVSNP.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
+            constellation-conf.yaml
+
+          yq eval -i \
+            "(.attestation | select(. | has(\"azureTrustedLaunch\")).azureTrustedLaunch.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
+            constellation-conf.yaml
+
+          yq eval -i \
+            "(.attestation | select(. | has(\"gcpSEVES\")).gcpSEVES.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}"\
+            constellation-conf.yaml
+
+          yq eval -i \
+            "(.attestation | select(. | has(\"qemuVTPM\")).qemuVTPM.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
+            constellation-conf.yaml
+        fi
 
     - name: Set image
       id: setImage


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Guard removal of expected measurements in e2e tests behind a config version check
  - for v2 configs the old format is used
  - for v3 configs the new attestation config format is used

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->
