### PR TITLE
bazel: provide semi-hermetic python toolchain

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -1,3 +1,17 @@
+# Python toolchain
+load("//bazel/toolchains:python_deps.bzl", "python_deps")
+
+python_deps()
+
+load("@rules_python//python:repositories.bzl", "py_repositories", "python_register_toolchains")
+
+py_repositories()
+
+python_register_toolchains(
+    name = "python3_11",
+    python_version = "3.11",
+)
+
 # Go toolchain
 load("//bazel/toolchains:go_rules_deps.bzl", "go_deps")
 

--- a/bazel/container/Containerfile
+++ b/bazel/container/Containerfile
@@ -16,6 +16,8 @@ RUN chmod +x /usr/local/bin/bazelisk && \
 	dnf install -y \
 	git \
 	diffutils \
+	libxcrypt-compat \
+	python3 \
 	&& \
 	dnf clean all && \
 	groupadd --gid 1000 builder && \

--- a/bazel/toolchains/python_deps.bzl
+++ b/bazel/toolchains/python_deps.bzl
@@ -1,0 +1,15 @@
+"""python toolchain rules"""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def python_deps():
+    http_archive(
+        name = "rules_python",
+        sha256 = "94750828b18044533e98a129003b6a68001204038dc4749f40b195b24c38f49f",
+        strip_prefix = "rules_python-0.21.0",
+        urls = [
+            "https://cdn.confidential.cloud/constellation/cas/sha256/94750828b18044533e98a129003b6a68001204038dc4749f40b195b24c38f49f",
+            "https://github.com/bazelbuild/rules_python/releases/download/0.21.0/rules_python-0.21.0.tar.gz",
+        ],
+        type = "tar.gz",
+    )


### PR DESCRIPTION
The actual python version used in bazel is hermetic after this PR. However, we still require a host python toolchain for bootstrapping (this will be fixed soon upstream) and host wide glibc (+ libcrypt.so.1).

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bazel: provide semi-hermetic python toolchain

### Related issues
- https://github.com/bazelbuild/rules_python/issues/691
- https://github.com/bazelbuild/rules_python/issues/1211

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
