### PR TITLE
ci: update the e2e-upgrade fromVersion

### DIFF
--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -238,7 +238,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        fromVersion: ["v2.6.0"]
+        fromVersion: ["v2.7.1"]
         cloudProvider: ["gcp", "azure"]
     name: Run upgrade tests
     secrets: inherit

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -253,7 +253,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        fromVersion: ["v2.6.0"]
+        fromVersion: ["v2.7.1"]
         cloudProvider: ["gcp", "azure"]
     name: Run upgrade tests
     secrets: inherit


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ~During weekly tests we always want to test upgrades from the latests release version to current main. The `fromVersion` has fallen behind and is updated. Also add a release step to have this updated automatically during release. The idea is that the bigger version of the two versions (existing fromVersion & release version) is kept in fromVersion.~
- automation is futile. will solve during refactoring. 