### PR TITLE
ci: run `upgrade check` during e2e-upgrade

### DIFF
--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -319,10 +319,9 @@ type supportedVersionInfo struct {
 // supportedVersions returns slices of supported versions.
 func (v *versionCollector) supportedVersions(ctx context.Context, version, currentK8sVersion string) (supportedVersionInfo, error) {
 	k8sVersions := versions.SupportedK8sVersions()
-	serviceVersion, err := helm.AvailableServiceVersions()
-	if err != nil {
-		return supportedVersionInfo{}, fmt.Errorf("loading service versions: %w", err)
-	}
+	// Each CLI comes with a set of services that have the same version as the CLI.
+	serviceVersion := compatibility.EnsurePrefixV(constants.VersionInfo())
+
 	imageVersions, err := v.newImages(ctx, version)
 	if err != nil {
 		return supportedVersionInfo{}, fmt.Errorf("loading image versions: %w", err)

--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -100,16 +100,6 @@ func NewLoader(csp cloudprovider.Provider, k8sVersion versions.ValidK8sVersion) 
 	}
 }
 
-// AvailableServiceVersions returns the chart version number of the bundled service versions.
-func AvailableServiceVersions() (string, error) {
-	servicesChart, err := loadChartsDir(helmFS, constellationServicesInfo.path)
-	if err != nil {
-		return "", fmt.Errorf("loading constellation-services chart: %w", err)
-	}
-
-	return compatibility.EnsurePrefixV(servicesChart.Metadata.Version), nil
-}
-
 // Load the embedded helm charts.
 func (i *ChartLoader) Load(config *config.Config, conformanceMode bool, masterSecret, salt []byte) ([]byte, error) {
 	ciliumRelease, err := i.loadRelease(ciliumInfo)

--- a/e2e/internal/upgrade/BUILD.bazel
+++ b/e2e/internal/upgrade/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
         "//internal/constants",
         "//internal/file",
         "//internal/semver",
+        "//internal/versions",
         "@com_github_spf13_afero//:afero",
         "@com_github_stretchr_testify//require",
         "@io_k8s_api//core/v1:core",


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- We did not run a e2e test on `upgrade check` so far. This add a basic smoke test. A detailed verification of the output seems like too much effort for little gain to me. This patch only checks for existence of some strings.
- Fix a bug where the supported microservice versions are not reported correctly in `upgrade check`
- [Azure, 1+1, no upgrades](https://github.com/edgelesssys/constellation/actions/runs/4992674280) :green_circle: 

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
