### PR TITLE
config: support latest as version value

### DIFF
--- a/internal/attestation/azure/snp/validator.go
+++ b/internal/attestation/azure/snp/validator.go
@@ -147,7 +147,7 @@ func (v *Validator) validateSNPReport(
 		return errDebugEnabled
 	}
 
-	if !report.CommittedTCB.isVersion(v.config.BootloaderVersion, v.config.TEEVersion, v.config.SNPVersion, v.config.MicrocodeVersion) {
+	if !report.CommittedTCB.isVersion(v.config.BootloaderVersion.Value(), v.config.TEEVersion.Value(), v.config.SNPVersion.Value(), v.config.MicrocodeVersion.Value()) {
 		return &versionError{"COMMITTED_TCB", report.CommittedTCB}
 	}
 	if report.LaunchTCB != report.CommittedTCB {

--- a/internal/attestation/azure/snp/validator_test.go
+++ b/internal/attestation/azure/snp/validator_test.go
@@ -364,7 +364,7 @@ func TestNewSNPReportFromBytes(t *testing.T) {
 				assert.Equal(hex.EncodeToString(report.IDKeyDigest[:]), "57e229e0ffe5fa92d0faddff6cae0e61c926fc9ef9afd20a8b8cfcf7129db9338cbe5bf3f6987733a2bf65d06dc38fc1")
 				// This is a canary for us: If this fails in the future we possibly downgraded a SVN.
 				cfg := config.DefaultForAzureSEVSNP()
-				assert.True(report.LaunchTCB.isVersion(cfg.BootloaderVersion, cfg.TEEVersion, cfg.SNPVersion, cfg.MicrocodeVersion))
+				assert.True(report.LaunchTCB.isVersion(cfg.BootloaderVersion.Value(), cfg.TEEVersion.Value(), cfg.SNPVersion.Value(), cfg.MicrocodeVersion.Value()))
 			}
 		})
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -87,6 +87,28 @@ func TestFromFile(t *testing.T) {
 				return conf
 			}(),
 		},
+		"latest as version value gets replaced with integer value": {
+			config: func() *Config {
+				conf := Default()
+				conf.Attestation.AzureSEVSNP.BootloaderVersion = "latest"
+				return conf
+			}(),
+			configName: constants.ConfigFilename,
+			wantResult: func() *Config {
+				conf := Default()
+				conf.Attestation.AzureSEVSNP.BootloaderVersion = "2"
+				return conf
+			}(),
+		},
+		"refuse invalid version value": {
+			config: func() *Config {
+				conf := Default()
+				conf.Attestation.AzureSEVSNP.BootloaderVersion = "1a"
+				return conf
+			}(),
+			configName: constants.ConfigFilename,
+			wantErr:    true,
+		},
 	}
 
 	for name, tc := range testCases {

--- a/internal/config/version/BUILD.bazel
+++ b/internal/config/version/BUILD.bazel
@@ -1,0 +1,8 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "version",
+    srcs = ["version.go"],
+    importpath = "github.com/edgelesssys/constellation/v2/internal/config/version",
+    visibility = ["//:__subpackages__"],
+)

--- a/internal/config/version/version.go
+++ b/internal/config/version/version.go
@@ -1,0 +1,67 @@
+package version
+
+import (
+	"fmt"
+	"strconv"
+)
+
+const (
+	Bootloader Type = iota // Bootloader is the version of the Azure SEVSNP bootloader.
+	TEE                    // TEE is the version of the Azure SEVSNP TEE.
+	SNP                    // SNP is the version of the Azure SEVSNP SNP.
+	Microcode              // Microcode is the version of the Azure SEVSNP microcode.
+)
+
+// Type is the type of the version to be requested.
+type Type int
+
+// Version stores the version of a given type.
+type Version (string)
+
+// NewVersion validates that the given string is either "latest" or uint version number.
+func NewVersion(raw string) (Version, error) {
+	if raw != "latest" {
+		_, err := strconv.ParseUint(raw, 10, 8)
+		if err != nil {
+			return Version(raw), err
+		}
+	}
+	return Version(raw), nil
+}
+
+// Value returns the uint value of the version.
+func (v Version) Value() uint8 {
+	// ignore error as it is already validated in NewVersion
+	res, _ := strconv.ParseUint(string(v), 10, 8)
+	return uint8(res)
+}
+
+// UnmarshalYAML implements a custom unmarshaler to resolve the latest version value.
+func (v *Version) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	var raw string
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	res, err := NewVersion(raw)
+	if err != nil {
+		return fmt.Errorf("invalid version %q: %w", raw, err)
+	}
+	*v = res
+	return nil
+}
+
+// GetVersion returns the version of the given type.
+func GetVersion(t Type) Version {
+	switch t {
+	case Bootloader:
+		return Version("2")
+	case TEE:
+		return Version("0")
+	case SNP:
+		return Version("6")
+	case Microcode:
+		return Version("93")
+	default:
+		return Version("1")
+	}
+}


### PR DESCRIPTION

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- support to set "latest" as value for the respective version of Azure SEVSNP. The value gets replaced with the current version when reading the config file.

For now, the values are harcoded. Version checking against a JSON in a S3 bucket will be added/

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->
see AB3042

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
