### PR TITLE
cli: split image into oss and enterprise

### DIFF
--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -42,10 +42,6 @@ runs:
         username: ${{ github.actor }}
         password: ${{ inputs.githubToken }}
 
-    - name: Upload referenced container images
-      shell: bash
-      run: bazelisk run //bazel/release:push
-
     - name: MiniConstellation E2E
       shell: bash
       env:
@@ -53,4 +49,4 @@ runs:
         ARM_SUBSCRIPTION_ID: ${{ inputs.azureSubscriptionID }}
         ARM_TENANT_ID: ${{ inputs.azureTenantID }}
       run: |
-        bazelisk run //e2e/miniconstellation:remote_test
+        bazelisk run //e2e/miniconstellation:push_remote_test

--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -80,11 +80,11 @@ jobs:
           defaultVersionReg='defaultImage = \"[^\"]*\"'
 
           # Ensure regexp matches (otherwise the file was changed or the workflow is broken).
-          grep -E "${defaultVersionReg}" internal/config/image.go
+          grep -E "${defaultVersionReg}" internal/config/image_enterprise.go
 
           # Update version.
           newVersion="ref\/${{ steps.version.outputs.branchName }}\/stream\/nightly\/${{ steps.version.outputs.version }}"
-          sed -i "s/${defaultVersionReg}/defaultImage = \"${newVersion}\"/" internal/config/image.go
+          sed -i "s/${defaultVersionReg}/defaultImage = \"${newVersion}\"/" internal/config/image_enterprise.go
 
       - name: Build generateMeasurements tool
         working-directory: internal/attestation/measurements/measurement-generator

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,12 +147,11 @@ jobs:
           defaultVersionReg='defaultImage = \"[^\"]*\"'
 
           # Ensure regexp matches (otherwise the file was changed or the workflow is broken).
-          grep -E "${defaultVersionReg}" internal/config/image.go
+          grep -E "${defaultVersionReg}" internal/config/image_enterprise.go
 
           # Update version.
-          sed -i "s/${defaultVersionReg}/defaultImage = \"${VERSION}\"/" internal/config/image.go
-          git add internal/config/image.go
-
+          sed -i "s/${defaultVersionReg}/defaultImage = \"${VERSION}\"/" internal/config/image_enterprise.go
+          git add internal/config/image_enterprise.go
       - name: Commit
         run: |
           git config --global user.name "edgelessci"

--- a/cli/internal/cloudcmd/create.go
+++ b/cli/internal/cloudcmd/create.go
@@ -428,7 +428,7 @@ func (c *Creator) createQEMU(ctx context.Context, cl terraformClient, lv libvirt
 	// if no libvirt URI is specified, start a libvirt container
 	case libvirtURI == "":
 		if err := lv.Start(ctx, opts.Config.Name, opts.Config.Provider.QEMU.LibvirtContainerImage); err != nil {
-			return clusterid.File{}, err
+			return clusterid.File{}, fmt.Errorf("start libvirt container: %w", err)
 		}
 		libvirtURI = libvirt.LibvirtTCPConnectURI
 
@@ -485,7 +485,7 @@ func (c *Creator) createQEMU(ctx context.Context, cl terraformClient, lv libvirt
 	}
 
 	if err := cl.PrepareWorkspace(path.Join("terraform", strings.ToLower(cloudprovider.QEMU.String())), &vars); err != nil {
-		return clusterid.File{}, err
+		return clusterid.File{}, fmt.Errorf("prepare workspace: %w", err)
 	}
 
 	// Allow rollback of QEMU Terraform workspace from this point on
@@ -493,7 +493,7 @@ func (c *Creator) createQEMU(ctx context.Context, cl terraformClient, lv libvirt
 
 	tfOutput, err := cl.CreateCluster(ctx, opts.TFLogLevel)
 	if err != nil {
-		return clusterid.File{}, err
+		return clusterid.File{}, fmt.Errorf("create cluster: %w", err)
 	}
 
 	return clusterid.File{

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -411,13 +411,13 @@ func (c *Client) writeVars(vars Variables) error {
 		// If a variables file already exists, check if it's the same as we're expecting, so we can continue using it.
 		varsContent, err := c.file.Read(pathToVarsFile)
 		if err != nil {
-			return err
+			return fmt.Errorf("read variables file: %w", err)
 		}
 		if vars.String() != string(varsContent) {
 			return ErrTerraformWorkspaceExistsWithDifferentVariables
 		}
 	} else if err != nil {
-		return err
+		return fmt.Errorf("write variables file: %w", err)
 	}
 
 	return nil

--- a/e2e/miniconstellation/BUILD.bazel
+++ b/e2e/miniconstellation/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@com_github_ash2k_bazel_tools//multirun:def.bzl", "multirun")
 load("//bazel/sh:def.bzl", "sh_template")
 
 filegroup(
@@ -30,4 +31,14 @@ sh_template(
     deps = [
         ":dependencies_lib",
     ],
+)
+
+multirun(
+    name = "push_remote_test",
+    commands = [
+        "//bazel/release:push",
+        ":remote_test",
+    ],
+    jobs = 1,  # execute sequentially
+    visibility = ["//visibility:public"],
 )

--- a/internal/config/BUILD.bazel
+++ b/internal/config/BUILD.bazel
@@ -8,7 +8,10 @@ go_library(
         "azure.go",
         "config.go",
         "config_doc.go",
-        "image.go",
+        # keep
+        "image_enterprise.go",
+        # keep
+        "image_oss.go",
         "qemu.go",
         "validation.go",
     ],

--- a/internal/config/image_enterprise.go
+++ b/internal/config/image_enterprise.go
@@ -1,0 +1,14 @@
+//go:build enterprise
+
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package config
+
+const (
+	// defaultImage is the default image to use.
+	defaultImage = "ref/main/stream/nightly/v2.8.0-pre.0.20230518105910-3b7bae753540"
+)

--- a/internal/config/image_oss.go
+++ b/internal/config/image_oss.go
@@ -1,3 +1,5 @@
+//go:build !enterprise
+
 /*
 Copyright (c) Edgeless Systems GmbH
 
@@ -8,5 +10,5 @@ package config
 
 const (
 	// defaultImage is the default image to use.
-	defaultImage = "ref/main/stream/nightly/v2.8.0-pre.0.20230518105910-3b7bae753540"
+	defaultImage = ""
 )


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- move the "push containers before running the minicon test" dependency to bazel
- add some more error messages to more easily trace problems
- split `image.go` into `image_oss.go` and `image_enterprise.go`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
