### PR TITLE
ci: run e2e tests as last step of release pipeline

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -67,7 +67,7 @@ inputs:
     required: false
   buildBuddyApiKey:
     description: "BuildBuddy API key for caching Bazel artifacts"
-    required: true
+    required: false
   registry:
     description: "Container registry to use"
     required: true
@@ -113,7 +113,7 @@ runs:
     - name: Setup bazel
       uses: ./.github/actions/setup_bazel
       with:
-        useCache: "true"
+        useCache: ${{ inputs.buildBuddyApiKey != '' }}
         buildBuddyApiKey: ${{ inputs.buildBuddyApiKey }}
 
     - name: Log in to the Container registry

--- a/.github/workflows/e2e-mini.yml
+++ b/.github/workflows/e2e-mini.yml
@@ -5,9 +5,6 @@ name: e2e test qemu (MiniConstellation)
 # e2e-test-release uses the same branch as the triggering workflow and not the commit of the triggering workflow. This is because the release workflow produces further commits.
 
 on:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
   workflow_dispatch:
     inputs:
       ref:
@@ -22,14 +19,6 @@ on:
         description: "Git ref to checkout"
 
 jobs:
-  on-failure-quit:
-    runs-on: ubuntu-22.04
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success'
-    steps:
-      - run: |
-          echo 'Release workflow failed, exiting..'
-          exit 1
-
   e2e-mini:
     runs-on: ubuntu-22.04
     environment: e2e

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -6,26 +6,23 @@ name: e2e test release
 # - any tests on the last release
 # - loadbalancer tests for AWS. Test test is currently broken and should not block a release. AB#2780.
 #
-# The workflow is triggered by the completion of the release workflow.
-# The workflow only executes, after being triggered, if the triggering workflow completed successfully.
-# e2e-test-release uses the same branch as the triggering workflow and not the commit of the triggering workflow. This is because the release workflow produces further commits.
-# e2e-test-release depends on the fact that actions/constellation_create does not overwrite the default osImage, if no osImage is supplied.
+# The workflow is triggered as the last step of the release workflow.
 
 on:
   workflow_dispatch:
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
+    inputs:
+      ref:
+        type: string
+        description: "Git ref to checkout"
+        required: false
+  workflow_call:
+    inputs:
+      ref:
+        type: string
+        description: "Git ref to checkout"
+        required: true
 
 jobs:
-  on-failure-quit:
-    runs-on: ubuntu-22.04
-    if: github.event_name == 'workflow_run' && github.event.workflow_run.conclusion != 'success'
-    steps:
-      - run: |
-          echo 'Release workflow failed, exiting..'
-          exit 1
-
   e2e-tests:
     strategy:
       fail-fast: false
@@ -165,7 +162,7 @@ jobs:
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           fetch-depth: 0
-          ref: ${{ !github.event.pull_request.head.repo.fork && github.event.workflow_run.head_branch || '' }}
+          ref: ${{ inputs.ref || github.head_ref }}
 
       - name: Setup Go environment
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
@@ -254,3 +251,4 @@ jobs:
       cloudProvider: ${{ matrix.cloudProvider }}
       workerNodesCount: 2
       controlNodesCount: 3
+      gitRef: ${{ inputs.ref || github.head_ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,13 @@ jobs:
 
       - name: Update enterprise image version
         run: |
-          sed -i "s/defaultImage = \"v[0-9]\+\.[0-9]\+\.[0-9]\+\"/defaultImage = \"${VERSION}\"/" internal/config/image.go
+          defaultVersionReg='defaultImage = \"[^\"]*\"'
+
+          # Ensure regexp matches (otherwise the file was changed or the workflow is broken).
+          grep -E "${defaultVersionReg}" internal/config/image.go
+
+          # Update version.
+          sed -i "s/${defaultVersionReg}/defaultImage = \"${VERSION}\"/" internal/config/image.go
           git add internal/config/image.go
 
       - name: Commit
@@ -240,3 +246,30 @@ jobs:
     secrets: inherit
     with:
       ref: "refs/tags/${{ inputs.version }}"
+      pushContainers: true
+
+  e2e-tests:
+    name: Run E2E tests
+    needs: [verify-inputs, draft-release-cli]
+    uses: ./.github/workflows/e2e-test-release.yml
+    permissions:
+      checks: write
+      packages: write
+      id-token: write
+      contents: read
+    secrets: inherit
+    with:
+      ref: ${{ needs.verify-inputs.outputs.RELEASE_BRANCH }}
+
+  mini-e2e:
+    name: Run mini E2E tests
+    needs: [verify-inputs, draft-release-cli]
+    uses: ./.github/workflows/e2e-mini.yml
+    permissions:
+      checks: write
+      packages: write
+      id-token: write
+      contents: read
+    secrets: inherit
+    with:
+      ref: ${{ needs.verify-inputs.outputs.RELEASE_BRANCH }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.

[AB#3129](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3129)
[AB#3088](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3088)

-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: run e2e tests as last step of release pipeline

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info
- [e2e test run](https://github.com/edgelesssys/constellation/actions/runs/5002073500)


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
