### PR TITLE
cli: support StackIT provider on config generate

### DIFF
--- a/cli/internal/cmd/configgenerate.go
+++ b/cli/internal/cmd/configgenerate.go
@@ -25,7 +25,7 @@ import (
 
 func newConfigGenerateCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "generate {aws|azure|gcp|openstack|qemu}",
+		Use:   "generate {aws|azure|gcp|openstack|qemu|stackit}",
 		Short: "Generate a default configuration file",
 		Long:  "Generate a default configuration file for your selected cloud provider.",
 		Args: cobra.MatchAll(
@@ -186,7 +186,7 @@ func parseGenerateFlags(cmd *cobra.Command) (generateFlags, error) {
 func generateCompletion(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 	switch len(args) {
 	case 0:
-		return []string{"aws", "gcp", "azure", "qemu"}, cobra.ShellCompDirectiveNoFileComp
+		return []string{"aws", "gcp", "azure", "qemu", "stackit"}, cobra.ShellCompDirectiveNoFileComp
 	default:
 		return []string{}, cobra.ShellCompDirectiveError
 	}

--- a/cli/internal/cmd/configgenerate_test.go
+++ b/cli/internal/cmd/configgenerate_test.go
@@ -55,7 +55,7 @@ func TestConfigGenerateKubernetesVersion(t *testing.T) {
 			require.NoError(err)
 
 			cg := &configGenerateCmd{log: logger.NewTest(t)}
-			err = cg.configGenerate(cmd, fileHandler, cloudprovider.Unknown)
+			err = cg.configGenerate(cmd, fileHandler, cloudprovider.Unknown, "")
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -74,7 +74,7 @@ func TestConfigGenerateDefault(t *testing.T) {
 	cmd := newConfigGenerateCmd()
 
 	cg := &configGenerateCmd{log: logger.NewTest(t)}
-	require.NoError(cg.configGenerate(cmd, fileHandler, cloudprovider.Unknown))
+	require.NoError(cg.configGenerate(cmd, fileHandler, cloudprovider.Unknown, ""))
 
 	var readConfig config.Config
 	err := fileHandler.ReadYAML(constants.ConfigFilename, &readConfig)
@@ -102,7 +102,32 @@ func TestConfigGenerateDefaultProviderSpecific(t *testing.T) {
 			wantConf.RemoveProviderAndAttestationExcept(provider)
 
 			cg := &configGenerateCmd{log: logger.NewTest(t)}
-			require.NoError(cg.configGenerate(cmd, fileHandler, provider))
+			require.NoError(cg.configGenerate(cmd, fileHandler, provider, ""))
+
+			var readConfig config.Config
+			err := fileHandler.ReadYAML(constants.ConfigFilename, &readConfig)
+			assert.NoError(err)
+			assert.Equal(*wantConf, readConfig)
+		})
+	}
+}
+
+func TestConfigGenerateWithStackIt(t *testing.T) {
+	openStackProviders := []string{"stackit"}
+
+	for _, openStackProvider := range openStackProviders {
+		t.Run(openStackProvider, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			fileHandler := file.NewHandler(afero.NewMemMapFs())
+			cmd := newConfigGenerateCmd()
+
+			wantConf := config.Default().WithOpenStackProviderDefaults(openStackProvider)
+			wantConf.RemoveProviderAndAttestationExcept(cloudprovider.OpenStack)
+
+			cg := &configGenerateCmd{log: logger.NewTest(t)}
+			require.NoError(cg.configGenerate(cmd, fileHandler, cloudprovider.OpenStack, openStackProvider))
 
 			var readConfig config.Config
 			err := fileHandler.ReadYAML(constants.ConfigFilename, &readConfig)
@@ -120,7 +145,7 @@ func TestConfigGenerateDefaultExists(t *testing.T) {
 	cmd := newConfigGenerateCmd()
 
 	cg := &configGenerateCmd{log: logger.NewTest(t)}
-	require.Error(cg.configGenerate(cmd, fileHandler, cloudprovider.Unknown))
+	require.Error(cg.configGenerate(cmd, fileHandler, cloudprovider.Unknown, ""))
 }
 
 func TestConfigGenerateFileFlagRemoved(t *testing.T) {
@@ -131,7 +156,7 @@ func TestConfigGenerateFileFlagRemoved(t *testing.T) {
 	cmd.ResetFlags()
 
 	cg := &configGenerateCmd{log: logger.NewTest(t)}
-	require.Error(cg.configGenerate(cmd, fileHandler, cloudprovider.Unknown))
+	require.Error(cg.configGenerate(cmd, fileHandler, cloudprovider.Unknown, ""))
 }
 
 func TestConfigGenerateStdOut(t *testing.T) {
@@ -146,7 +171,7 @@ func TestConfigGenerateStdOut(t *testing.T) {
 	require.NoError(cmd.Flags().Set("file", "-"))
 
 	cg := &configGenerateCmd{log: logger.NewTest(t)}
-	require.NoError(cg.configGenerate(cmd, fileHandler, cloudprovider.Unknown))
+	require.NoError(cg.configGenerate(cmd, fileHandler, cloudprovider.Unknown, ""))
 
 	var readConfig config.Config
 	require.NoError(yaml.NewDecoder(&outBuffer).Decode(&readConfig))
@@ -168,7 +193,7 @@ func TestNoValidProviderAttestationCombination(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			_, err := createConfigWithAttestationType(test.provider, test.attestation)
+			_, err := createConfigWithAttestationType(test.provider, "", test.attestation)
 			assert.Error(err)
 		})
 	}
@@ -216,7 +241,7 @@ func TestValidProviderAttestationCombination(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("Provider:%s,Attestation:%s", test.provider, test.attestation), func(t *testing.T) {
-			sut, err := createConfigWithAttestationType(test.provider, test.attestation)
+			sut, err := createConfigWithAttestationType(test.provider, "", test.attestation)
 			assert := assert.New(t)
 			assert.NoError(err)
 			assert.Equal(test.expected, sut.Attestation)
@@ -271,7 +296,7 @@ func TestAttestationArgument(t *testing.T) {
 			fileHandler := file.NewHandler(afero.NewMemMapFs())
 
 			cg := &configGenerateCmd{log: logger.NewTest(t)}
-			err := cg.configGenerate(cmd, fileHandler, test.provider)
+			err := cg.configGenerate(cmd, fileHandler, test.provider, "")
 			if test.expectErr {
 				assert.Error(err)
 			} else {

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -69,7 +69,7 @@ Generate a default configuration file
 Generate a default configuration file for your selected cloud provider.
 
 ```
-constellation config generate {aws|azure|gcp|openstack|qemu} [flags]
+constellation config generate {aws|azure|gcp|openstack|qemu|stackit} [flags]
 ```
 
 ### Options

--- a/internal/cloud/cloudprovider/cloudprovider.go
+++ b/internal/cloud/cloudprovider/cloudprovider.go
@@ -64,6 +64,10 @@ func (p *Provider) UnmarshalYAML(unmarshal func(any) error) error {
 // FromString returns cloud provider from string.
 func FromString(s string) Provider {
 	s = strings.ToLower(s)
+	if isOpenStackProvider(s) {
+		return OpenStack
+	}
+
 	switch s {
 	case "aws":
 		return AWS
@@ -71,13 +75,18 @@ func FromString(s string) Provider {
 		return Azure
 	case "gcp":
 		return GCP
-	case "openstack":
-		return OpenStack
-	case "stackit":
-		return OpenStack // StackIT uses OpenStack, use this as a workaround to support commands using "stackit"
 	case "qemu":
 		return QEMU
 	default:
 		return Unknown
 	}
+}
+
+// IsOpenStackProvider returns true if the provider is based on OpenStack.
+func isOpenStackProvider(s string) bool {
+	switch strings.ToLower(s) {
+	case "openstack", "stackit":
+		return true
+	}
+	return false
 }

--- a/internal/cloud/cloudprovider/cloudprovider.go
+++ b/internal/cloud/cloudprovider/cloudprovider.go
@@ -73,6 +73,8 @@ func FromString(s string) Provider {
 		return GCP
 	case "openstack":
 		return OpenStack
+	case "stackit":
+		return OpenStack // StackIT uses OpenStack, use this as a workaround to support commands using "stackit"
 	case "qemu":
 		return QEMU
 	default:

--- a/internal/cloud/cloudprovider/cloudprovider_test.go
+++ b/internal/cloud/cloudprovider/cloudprovider_test.go
@@ -235,6 +235,10 @@ func TestFromString(t *testing.T) {
 			input: "openstack",
 			want:  OpenStack,
 		},
+		"stackit": {
+			input: "stackit",
+			want:  OpenStack,
+		},
 		"qemu": {
 			input: "qemu",
 			want:  QEMU,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -730,6 +730,28 @@ func (c *Config) Validate(force bool) error {
 	return &ValidationError{validationErrMsgs: validationErrMsgs}
 }
 
+// WithOpenStackProviderDefaults fills the default values for the specific OpenStack provider.
+// If the provider is not supported or not an OpenStack provider, the config is returned unchanged.
+func (c *Config) WithOpenStackProviderDefaults(openStackProvider string) *Config {
+	switch openStackProvider {
+	case "stackit":
+		c.Provider.OpenStack.Cloud = "stackit"
+		c.Provider.OpenStack.FlavorID = "2715eabe-3ffc-4c36-b02a-efa8c141a96a"
+		c.Provider.OpenStack.FloatingIPPoolID = "970ace5c-458f-484a-a660-0903bcfd91ad"
+		c.Provider.OpenStack.StateDiskType = "storage_premium_perf6"
+		c.Provider.OpenStack.AuthURL = "https://keystone.api.iaas.eu01.stackit.cloud/v3"
+		c.Provider.OpenStack.UserDomainName = "portal_mvp"
+		c.Provider.OpenStack.ProjectDomainName = "portal_mvp"
+		c.Provider.OpenStack.RegionName = "RegionOne"
+		c.Provider.OpenStack.DeployYawolLoadBalancer = toPtr(true)
+		c.Provider.OpenStack.YawolImageID = "43d9bede-1e7a-4ca7-82c5-0a5c72388619"
+		c.Provider.OpenStack.YawolFlavorID = "3b11b27e-6c73-470d-b595-1d85b95a8cdf"
+		c.Provider.OpenStack.DirectDownload = toPtr(true)
+		return c
+	}
+	return c
+}
+
 // AWSNitroTPM is the configuration for AWS Nitro TPM attestation.
 type AWSNitroTPM struct {
 	// description: |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -746,6 +746,7 @@ func (c *Config) WithOpenStackProviderDefaults(openStackProvider string) *Config
 		c.Provider.OpenStack.DeployYawolLoadBalancer = toPtr(true)
 		c.Provider.OpenStack.YawolImageID = "43d9bede-1e7a-4ca7-82c5-0a5c72388619"
 		c.Provider.OpenStack.YawolFlavorID = "3b11b27e-6c73-470d-b595-1d85b95a8cdf"
+		c.Provider.OpenStack.DeployCSIDriver = toPtr(true)
 		c.Provider.OpenStack.DirectDownload = toPtr(true)
 		return c
 	}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add `stackit` to the list of supported cloudproviders, while using the OpenStack implementation under the hood.
- Add a `stackit` option to `constellation config generate`, which generates an OpenStack config file.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
