### PR TITLE
ci: disable codeql autobuild for go

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,7 @@
 name: CodeQL
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -17,6 +18,10 @@ jobs:
   codeql:
     name: CodeQL
     runs-on: ubuntu-22.04
+    env:
+      # Force CodeQL to run the extraction on the files compiled by our custom
+      # build command, as opposed to letting the autobuilder figure it out.
+      CODEQL_EXTRACTOR_GO_BUILD_TRACING: 'on'
     permissions:
       actions: read
       contents: read
@@ -56,7 +61,8 @@ jobs:
           done
           echo "::endgroup::"
 
-      - name: Autobuild
+      - name: Build
+        if: matrix.language == 'python'
         uses: github/codeql-action/autobuild@29b1f65c5e92e24fe6b6647da1eaabe529cec70f # v2.3.3
 
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
Disable autobuild for go as it uses an outdated way to get the Go dependencies (see below)

```
Attempting to automatically build go code
  /opt/hostedtoolcache/CodeQL/2.13.1-20230428/x64/codeql/codeql version --format=terse
  2.13.1
  /opt/hostedtoolcache/CodeQL/2.13.1-20230428/x64/codeql/go/tools/autobuild.sh
  2023/05/24 23:09:06 Autobuilder was built with go1.20.3, environment has go1.20.4
  2023/05/24 23:09:06 LGTM_SRC is /home/runner/work/constellation/constellation
  2023/05/24 23:09:06 Found go.mod, enabling go modules
  go: downloading github.com/google/go-sev-guest v0.4.1
  go: downloading github.com/google/trillian v1.5.1
  go: downloading github.com/onsi/ginkgo v1.10.3
  go: downloading golang.org/x/exp v0.0.0-20230124195608-d38c7dcee874
  go: downloading github.com/frankban/quicktest v1.14.3
  go: downloading github.com/sergi/go-diff v1.2.0
  2023/05/24 23:09:10 Import path is 'github.com/edgelesssys/constellation'
  2023/05/24 23:09:10 Build failed, continuing to install dependencies.
  2023/05/24 23:09:10 Installing dependencies using `go get -v ./...`.
  go: downloading k8s.io/kubernetes v1.16.0-alpha.0
  go: downloading k8s.io/klog v0.3.0
  Error: The operation was canceled.
```
<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
