### PR TITLE
image: add aws_aws-sev-snp variant

### DIFF
--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -263,6 +263,8 @@ jobs:
         include:
           - csp: aws
             attestation_variant: aws-nitro-tpm
+          - csp: aws
+            attestation_variant: aws-sev-snp
           - csp: azure
             attestation_variant: azure-sev-snp
           - csp: gcp
@@ -384,6 +386,8 @@ jobs:
         include:
           - csp: aws
             attestation_variant: aws-nitro-tpm
+          - csp: aws
+            attestation_variant: aws-sev-snp
           - csp: azure
             attestation_variant: azure-sev-snp
           - csp: gcp
@@ -545,6 +549,8 @@ jobs:
         include:
           - csp: aws
             attestation_variant: aws-nitro-tpm
+          - csp: aws
+            attestation_variant: aws-sev-snp
           - csp: azure
             attestation_variant: azure-sev-snp
           - csp: gcp

--- a/image/Makefile
+++ b/image/Makefile
@@ -19,7 +19,7 @@ export INSTALL_DEBUGD            ?= $(DEBUG)
 export CONSOLE_MOTD = $(AUTOLOGIN)
 -include $(CURDIR)/config.mk
 csps := aws azure gcp openstack qemu
-variants := aws_aws-nitro-tpm azure_azure-sev-snp gcp_gcp-sev-es gcp_gcp-sev-snp openstack_qemu-vtpm qemu_qemu-vtpm
+variants := aws_aws-sev-snp aws_aws-nitro-tpm azure_azure-sev-snp gcp_gcp-sev-es gcp_gcp-sev-snp openstack_qemu-vtpm qemu_qemu-vtpm
 certs := $(PKI)/PK.cer $(PKI)/KEK.cer $(PKI)/db.cer
 
 SYSTEMD_FIXED_RPMS := systemd-251.11-2.fc37.x86_64.rpm systemd-libs-251.11-2.fc37.x86_64.rpm systemd-networkd-251.11-2.fc37.x86_64.rpm systemd-pam-251.11-2.fc37.x86_64.rpm systemd-resolved-251.11-2.fc37.x86_64.rpm systemd-udev-251.11-2.fc37.x86_64.rpm


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- In the spirit of keeping PRs small, I present...
- No changes to the existing AWS image are required as far as I can tell. The images have worked without modification. Only need to specify the different attestation variant on the cmdline.
- ~[testrun](https://github.com/edgelesssys/constellation/actions/runs/5088915234)~ :green_circle: 
- [testrun](https://github.com/edgelesssys/constellation/actions/runs/5129688092) :green_circle: 
### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
