### PR TITLE
bazel: make imagefetcher visible to all subpackages

### DIFF
--- a/internal/imagefetcher/BUILD.bazel
+++ b/internal/imagefetcher/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
         "raw.go",
     ],
     importpath = "github.com/edgelesssys/constellation/v2/internal/imagefetcher",
-    visibility = ["//cli:__subpackages__"],
+    visibility = ["//:__subpackages__"],
     deps = [
         "//internal/api/fetcher",
         "//internal/api/versionsapi",


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- The 'imagefetcher` library Bazel target was scoped to `//cli:__subpackages__`, while the file lived in `internal`. Therefore, the path could not be resolved which resulted in an error.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
