### PR TITLE
ci: remove setup-go action / disable cache where applicable

### DIFF
--- a/.github/workflows/azure-snp-reporter.yml
+++ b/.github/workflows/azure-snp-reporter.yml
@@ -16,11 +16,6 @@ jobs:
         with:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
-      - name: Set up Go
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version: 1.20.4
-
       - name: Build and upload azure SNP reporter container image
         id: build-and-upload
         uses: ./.github/actions/build_micro_service
@@ -68,6 +63,7 @@ jobs:
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: 1.20.4
+          cache: false
 
       - name: Download report JWT
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2

--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -70,6 +70,7 @@ jobs:
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: "1.20.4"
+          cache: false
 
       - name: Determine version
         id: version

--- a/.github/workflows/build-versionsapi-ci-image.yml
+++ b/.github/workflows/build-versionsapi-ci-image.yml
@@ -23,11 +23,6 @@ jobs:
         with:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
-      - name: Setup Go environment
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version: "1.20.4"
-
       - name: Build and upload container image
         uses: ./.github/actions/build_micro_service
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,7 @@ jobs:
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
         with:
           go-version: "1.20.4"
+          cache: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@29b1f65c5e92e24fe6b6647da1eaabe529cec70f # v2.3.3

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -63,11 +63,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
-      - name: Setup Go environment
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version: "1.20.4"
-
       - name: Run E2E test
         id: e2e_test
         uses: ./.github/actions/e2e_test

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -227,11 +227,6 @@ jobs:
         with:
           ref: ${{ inputs.git-ref }}
 
-      - name: Setup Go environment
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version: "1.20.4"
-
       - name: Set up gcloud CLI (macOS)
         if: inputs.cloudProvider == 'gcp' && runner.os == 'macOS'
         uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -168,11 +168,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.ref || github.head_ref }}
 
-      - name: Setup Go environment
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version: "1.20.4"
-
       - name: Set up gcloud CLI (macOS)
         if: matrix.provider == 'gcp' && runner.os == 'macOS'
         uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -183,11 +183,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
-      - name: Setup Go environment
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version: "1.20.4"
-
       - name: Run E2E test
         id: e2e_test
         uses: ./.github/actions/e2e_test

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -115,11 +115,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.gitRef }}
 
-      - name: Setup Go environment
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version: "1.20.4"
-
       - name: Login to AWS
         uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:

--- a/.github/workflows/test-tidy.yml
+++ b/.github/workflows/test-tidy.yml
@@ -35,11 +35,6 @@ jobs:
           useCache: "true"
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
 
-      - name: Setup Go environment
-        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9 # v4.0.0
-        with:
-          go-version: "1.20.4"
-
       - name: Assume AWS role to upload Bazel dependencies to S3
         if: startsWith(github.head_ref, 'renovate/')
         uses: aws-actions/configure-aws-credentials@e1e17a757e536f70e52b5a12b2e8d1d1c60e04ef # v2.0.0


### PR DESCRIPTION
Runners sometimes fail because they run out of disk space. One reason this happens is a change in the setup-go action@v4:

> The V4 edition of the action offers: Enabled caching by default

To combat this, we now disable the cache if it was not enabled explicitly before. Additionally, we remove setup-go where it is no longer needed.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.

[AB#3181](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3181)
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: remove setup-go action / disable cache where applicable

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [e2e test](https://github.com/edgelesssys/constellation/actions/runs/5142586524)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
