### PR TITLE
Correctly deploy the AWS CCM

### DIFF
--- a/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
@@ -54,6 +54,7 @@ type Client interface {
 	AddNodeSelectorsToDeployment(ctx context.Context, selectors map[string]string, name string, namespace string) error
 	ListAllNamespaces(ctx context.Context) (*corev1.NamespaceList, error)
 	AnnotateNode(ctx context.Context, nodeName, annotationKey, annotationValue string) error
+	EnforceCoreDNSSpread(ctx context.Context) error
 }
 
 type componentsInstaller interface {

--- a/bootstrapper/internal/kubernetes/kubernetes.go
+++ b/bootstrapper/internal/kubernetes/kubernetes.go
@@ -125,7 +125,8 @@ func (k *KubeWrapper) InitCluster(
 
 	// Step 2: configure kubeadm init config
 	ccmSupported := cloudprovider.FromString(k.cloudProvider) == cloudprovider.Azure ||
-		cloudprovider.FromString(k.cloudProvider) == cloudprovider.GCP
+		cloudprovider.FromString(k.cloudProvider) == cloudprovider.GCP ||
+		cloudprovider.FromString(k.cloudProvider) == cloudprovider.AWS
 	initConfig := k.configProvider.InitConfiguration(ccmSupported, versionString)
 	initConfig.SetNodeIP(nodeIP)
 	initConfig.SetClusterName(clusterName)

--- a/bootstrapper/internal/kubernetes/kubernetes_test.go
+++ b/bootstrapper/internal/kubernetes/kubernetes_test.go
@@ -577,7 +577,7 @@ func (s *stubKubectl) ListAllNamespaces(_ context.Context) (*corev1.NamespaceLis
 	return s.listAllNamespacesResp, s.listAllNamespacesErr
 }
 
-func (s *stubKubectl) EnforceCoreDNSSpread(ctx context.Context) error {
+func (s *stubKubectl) EnforceCoreDNSSpread(_ context.Context) error {
 	return s.enforceCoreDNSSpreadErr
 }
 

--- a/bootstrapper/internal/kubernetes/kubernetes_test.go
+++ b/bootstrapper/internal/kubernetes/kubernetes_test.go
@@ -544,6 +544,7 @@ type stubKubectl struct {
 	waitForCRDsErr                   error
 	listAllNamespacesErr             error
 	annotateNodeErr                  error
+	enforceCoreDNSSpreadErr          error
 
 	listAllNamespacesResp *corev1.NamespaceList
 }
@@ -574,6 +575,10 @@ func (s *stubKubectl) WaitForCRDs(_ context.Context, _ []string) error {
 
 func (s *stubKubectl) ListAllNamespaces(_ context.Context) (*corev1.NamespaceList, error) {
 	return s.listAllNamespacesResp, s.listAllNamespacesErr
+}
+
+func (s *stubKubectl) EnforceCoreDNSSpread(ctx context.Context) error {
+	return s.enforceCoreDNSSpreadErr
 }
 
 type stubHelmClient struct {

--- a/cli/internal/terraform/terraform/aws/main.tf
+++ b/cli/internal/terraform/terraform/aws/main.tf
@@ -242,8 +242,8 @@ module "instance_group_control_plane" {
     { Name = local.name },
     { constellation-role = "control-plane" },
     { constellation-uid = local.uid },
-    { KubernetesCluster = "Constellation-${local.uid}" },
-    { constellation-init-secret-hash = local.initSecretHash }
+    { constellation-init-secret-hash = local.initSecretHash },
+    { "kubernetes.io/cluster/${local.name}" = "owned" }
   )
 }
 
@@ -266,7 +266,7 @@ module "instance_group_worker_nodes" {
     { Name = local.name },
     { constellation-role = "worker" },
     { constellation-uid = local.uid },
-    { KubernetesCluster = "Constellation-${local.uid}" },
-    { constellation-init-secret-hash = local.initSecretHash }
+    { constellation-init-secret-hash = local.initSecretHash },
+    { "kubernetes.io/cluster/${local.name}" = "owned" }
   )
 }

--- a/cli/internal/terraform/terraform/aws/modules/instance_group/main.tf
+++ b/cli/internal/terraform/terraform/aws/modules/instance_group/main.tf
@@ -23,7 +23,7 @@ resource "aws_launch_template" "launch_template" {
   metadata_options {
     http_endpoint               = "enabled"
     http_tokens                 = "required"
-    instance_metadata_tags      = "enabled"
+    instance_metadata_tags      = "disabled"
     http_put_response_hop_limit = 2
   }
 

--- a/debugd/internal/debugd/constants.go
+++ b/debugd/internal/debugd/constants.go
@@ -12,7 +12,7 @@ import "time"
 const (
 	DebugdMetadataFlag              = "constellation-debugd"
 	GRPCTimeout                     = 5 * time.Minute
-	DiscoverDebugdInterval          = 30 * time.Second
+	DiscoverDebugdInterval          = 10 * time.Second
 	DownloadRetryBackoff            = 1 * time.Minute
 	BinaryAccessMode                = 0o755 // -rwxr-xr-x
 	BootstrapperDeployFilename      = "/run/state/bin/bootstrapper"

--- a/debugd/internal/debugd/metadata/scheduler.go
+++ b/debugd/internal/debugd/metadata/scheduler.go
@@ -54,12 +54,13 @@ func (s *Scheduler) Start(ctx context.Context, wg *sync.WaitGroup) {
 			ips, err := s.fetcher.DiscoverDebugdIPs(ctx)
 			if err != nil {
 				s.log.With(zap.Error(err)).Warnf("Discovering debugd IPs failed")
-				continue
 			}
-			s.log.With(zap.Strings("ips", ips)).Infof("Discovered instances")
-			s.download(ctx, ips)
-			if s.deploymentDone && s.infoDone {
-				return
+			if err == nil {
+				s.log.With(zap.Strings("ips", ips)).Infof("Discovered instances")
+				s.download(ctx, ips)
+				if s.deploymentDone && s.infoDone {
+					return
+				}
 			}
 
 			select {

--- a/internal/cloud/aws/aws.go
+++ b/internal/cloud/aws/aws.go
@@ -52,7 +52,6 @@ type ec2API interface {
 
 type imdsAPI interface {
 	GetInstanceIdentityDocument(context.Context, *imds.GetInstanceIdentityDocumentInput, ...func(*imds.Options)) (*imds.GetInstanceIdentityDocumentOutput, error)
-	GetMetadata(context.Context, *imds.GetMetadataInput, ...func(*imds.Options)) (*imds.GetMetadataOutput, error)
 }
 
 // Cloud provides AWS metadata and API access.

--- a/internal/cloud/aws/aws.go
+++ b/internal/cloud/aws/aws.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -81,7 +80,12 @@ func New(ctx context.Context) (*Cloud, error) {
 
 // List retrieves all instances belonging to the current Constellation.
 func (c *Cloud) List(ctx context.Context) ([]metadata.InstanceMetadata, error) {
-	uid, err := readInstanceTag(ctx, c.imds, cloud.TagUID)
+	identity, err := c.imds.GetInstanceIdentityDocument(ctx, &imds.GetInstanceIdentityDocumentInput{})
+	if err != nil {
+		return nil, fmt.Errorf("retrieving instance identity: %w", err)
+	}
+
+	uid, err := c.readInstanceTag(ctx, identity.InstanceID, cloud.TagUID)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving uid tag: %w", err)
 	}
@@ -100,7 +104,7 @@ func (c *Cloud) Self(ctx context.Context) (metadata.InstanceMetadata, error) {
 		return metadata.InstanceMetadata{}, fmt.Errorf("retrieving instance identity: %w", err)
 	}
 
-	instanceRole, err := readInstanceTag(ctx, c.imds, cloud.TagRole)
+	instanceRole, err := c.readInstanceTag(ctx, identity.InstanceID, cloud.TagRole)
 	if err != nil {
 		return metadata.InstanceMetadata{}, fmt.Errorf("retrieving role tag: %w", err)
 	}
@@ -115,12 +119,22 @@ func (c *Cloud) Self(ctx context.Context) (metadata.InstanceMetadata, error) {
 
 // UID returns the UID of the Constellation.
 func (c *Cloud) UID(ctx context.Context) (string, error) {
-	return readInstanceTag(ctx, c.imds, cloud.TagUID)
+	identity, err := c.imds.GetInstanceIdentityDocument(ctx, &imds.GetInstanceIdentityDocumentInput{})
+	if err != nil {
+		return "", fmt.Errorf("retrieving instance identity: %w", err)
+	}
+
+	return c.readInstanceTag(ctx, identity.InstanceID, cloud.TagUID)
 }
 
 // InitSecretHash returns the InitSecretHash of the current instance.
 func (c *Cloud) InitSecretHash(ctx context.Context) ([]byte, error) {
-	initSecretHash, err := readInstanceTag(ctx, c.imds, cloud.TagInitSecretHash)
+	identity, err := c.imds.GetInstanceIdentityDocument(ctx, &imds.GetInstanceIdentityDocumentInput{})
+	if err != nil {
+		return nil, fmt.Errorf("retrieving instance identity: %w", err)
+	}
+
+	initSecretHash, err := c.readInstanceTag(ctx, identity.InstanceID, cloud.TagInitSecretHash)
 	if err != nil {
 		return nil, fmt.Errorf("retrieving init secret hash tag: %w", err)
 	}
@@ -129,7 +143,12 @@ func (c *Cloud) InitSecretHash(ctx context.Context) ([]byte, error) {
 
 // GetLoadBalancerEndpoint returns the endpoint of the load balancer.
 func (c *Cloud) GetLoadBalancerEndpoint(ctx context.Context) (string, error) {
-	uid, err := readInstanceTag(ctx, c.imds, cloud.TagUID)
+	identity, err := c.imds.GetInstanceIdentityDocument(ctx, &imds.GetInstanceIdentityDocumentInput{})
+	if err != nil {
+		return "", fmt.Errorf("retrieving instance identity: %w", err)
+	}
+
+	uid, err := c.readInstanceTag(ctx, identity.InstanceID, cloud.TagUID)
 	if err != nil {
 		return "", fmt.Errorf("retrieving uid tag: %w", err)
 	}
@@ -269,16 +288,19 @@ func (c *Cloud) convertToMetadataInstance(ec2Instances []ec2Types.Instance) ([]m
 	return instances, nil
 }
 
-func readInstanceTag(ctx context.Context, api imdsAPI, tag string) (string, error) {
-	reader, err := api.GetMetadata(ctx, &imds.GetMetadataInput{
-		Path: "/tags/instance/" + tag,
+func (c *Cloud) readInstanceTag(ctx context.Context, instanceID string, tag string) (string, error) {
+	out, err := c.ec2.DescribeInstances(ctx, &ec2.DescribeInstancesInput{
+		InstanceIds: []string{instanceID},
 	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("descibing instances: %w", err)
 	}
-	defer reader.Content.Close()
-	instanceTag, err := io.ReadAll(reader.Content)
-	return string(instanceTag), err
+
+	if len(out.Reservations) != 1 || len(out.Reservations[0].Instances) != 1 {
+		return "", fmt.Errorf("expected 1 instance, got %d", len(out.Reservations[0].Instances))
+	}
+
+	return findTag(out.Reservations[0].Instances[0].Tags, tag)
 }
 
 func findTag(tags []ec2Types.Tag, wantKey string) (string, error) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Retrieve instance tags though the ec2 API and not the IMDS API
- Correctly tag the instances according to https://cloud-provider-aws.sigs.k8s.io/getting_started/ Step 5
- let coredns run before the CCM is up, since it requires DNS to lookup tags from the ec2 api
- unrelated: make debugd less noisy by respecting the interval in all cases


image: `ref/feat-aws-correct-ccm-deployment/stream/debug/v2.8.0-pre.0.20230601144711-dacd80e4372b`
new image: `ref/feat-aws-correct-ccm-deployment/stream/debug/v2.8.0-pre.0.20230602114037-b06ddeb4026c` see: https://github.com/edgelesssys/constellation/actions/runs/5155150759

Migration:
I'm not really sure how to do migration for this, since it involves basically the steps from https://cloud-provider-aws.sigs.k8s.io/getting_started/ which are intrusive since they change the e.g. the kubelet's config. I'm open to any suggestion how to handle such cases.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
