### PR TITLE
config: Azure SNP tool can delete specific version from attestation API

### DIFF
--- a/cli/internal/cmd/configfetchmeasurements_test.go
+++ b/cli/internal/cmd/configfetchmeasurements_test.go
@@ -299,14 +299,14 @@ func (f fakeAttestationFetcher) FetchAzureSEVSNPVersionList(_ context.Context, _
 	), nil
 }
 
-func (f fakeAttestationFetcher) FetchAzureSEVSNPVersion(_ context.Context, _ attestationconfig.AzureSEVSNPVersionGet) (attestationconfig.AzureSEVSNPVersionGet, error) {
-	return attestationconfig.AzureSEVSNPVersionGet{
+func (f fakeAttestationFetcher) FetchAzureSEVSNPVersion(_ context.Context, _ attestationconfig.AzureSEVSNPVersionAPI) (attestationconfig.AzureSEVSNPVersionAPI, error) {
+	return attestationconfig.AzureSEVSNPVersionAPI{
 		AzureSEVSNPVersion: testCfg,
 	}, nil
 }
 
-func (f fakeAttestationFetcher) FetchAzureSEVSNPVersionLatest(_ context.Context) (attestationconfig.AzureSEVSNPVersionGet, error) {
-	return attestationconfig.AzureSEVSNPVersionGet{
+func (f fakeAttestationFetcher) FetchAzureSEVSNPVersionLatest(_ context.Context) (attestationconfig.AzureSEVSNPVersionAPI, error) {
+	return attestationconfig.AzureSEVSNPVersionAPI{
 		AzureSEVSNPVersion: testCfg,
 	}, nil
 }

--- a/cli/internal/cmd/configfetchmeasurements_test.go
+++ b/cli/internal/cmd/configfetchmeasurements_test.go
@@ -16,7 +16,7 @@ import (
 	"net/url"
 	"testing"
 
-	configapi "github.com/edgelesssys/constellation/v2/internal/api/attestationconfig"
+	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig"
 	versionsapi "github.com/edgelesssys/constellation/v2/internal/api/versions"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
@@ -281,7 +281,7 @@ func TestConfigFetchMeasurements(t *testing.T) {
 			require.NoError(err)
 			cfm := &configFetchMeasurementsCmd{canFetchMeasurements: true, log: logger.NewTest(t)}
 
-			err = cfm.configFetchMeasurements(cmd, tc.cosign, tc.rekor, fileHandler, fakeConfigFetcher{}, client)
+			err = cfm.configFetchMeasurements(cmd, tc.cosign, tc.rekor, fileHandler, fakeAttestationFetcher{}, client)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -291,27 +291,27 @@ func TestConfigFetchMeasurements(t *testing.T) {
 	}
 }
 
-type fakeConfigFetcher struct{}
+type fakeAttestationFetcher struct{}
 
-func (f fakeConfigFetcher) FetchAzureSEVSNPVersionList(_ context.Context, _ configapi.AzureSEVSNPVersionList) (configapi.AzureSEVSNPVersionList, error) {
-	return configapi.AzureSEVSNPVersionList(
+func (f fakeAttestationFetcher) FetchAzureSEVSNPVersionList(_ context.Context, _ attestationconfig.AzureSEVSNPVersionList) (attestationconfig.AzureSEVSNPVersionList, error) {
+	return attestationconfig.AzureSEVSNPVersionList(
 		[]string{},
 	), nil
 }
 
-func (f fakeConfigFetcher) FetchAzureSEVSNPVersion(_ context.Context, _ configapi.AzureSEVSNPVersionGet) (configapi.AzureSEVSNPVersionGet, error) {
-	return configapi.AzureSEVSNPVersionGet{
+func (f fakeAttestationFetcher) FetchAzureSEVSNPVersion(_ context.Context, _ attestationconfig.AzureSEVSNPVersionGet) (attestationconfig.AzureSEVSNPVersionGet, error) {
+	return attestationconfig.AzureSEVSNPVersionGet{
 		AzureSEVSNPVersion: testCfg,
 	}, nil
 }
 
-func (f fakeConfigFetcher) FetchAzureSEVSNPVersionLatest(_ context.Context) (configapi.AzureSEVSNPVersionGet, error) {
-	return configapi.AzureSEVSNPVersionGet{
+func (f fakeAttestationFetcher) FetchAzureSEVSNPVersionLatest(_ context.Context) (attestationconfig.AzureSEVSNPVersionGet, error) {
+	return attestationconfig.AzureSEVSNPVersionGet{
 		AzureSEVSNPVersion: testCfg,
 	}, nil
 }
 
-var testCfg = configapi.AzureSEVSNPVersion{
+var testCfg = attestationconfig.AzureSEVSNPVersion{
 	Microcode:  93,
 	TEE:        0,
 	SNP:        6,

--- a/cli/internal/cmd/create_test.go
+++ b/cli/internal/cmd/create_test.go
@@ -202,7 +202,7 @@ func TestCreate(t *testing.T) {
 
 			fileHandler := file.NewHandler(tc.setupFs(require, tc.provider))
 			c := &createCmd{log: logger.NewTest(t)}
-			err := c.create(cmd, tc.creator, fileHandler, &nopSpinner{}, fakeConfigFetcher{})
+			err := c.create(cmd, tc.creator, fileHandler, &nopSpinner{}, fakeAttestationFetcher{})
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -175,7 +175,7 @@ func TestInitialize(t *testing.T) {
 			defer cancel()
 			cmd.SetContext(ctx)
 			i := &initCmd{log: logger.NewTest(t), spinner: &nopSpinner{}}
-			err := i.initialize(cmd, newDialer, fileHandler, &stubLicenseClient{}, fakeConfigFetcher{})
+			err := i.initialize(cmd, newDialer, fileHandler, &stubLicenseClient{}, fakeAttestationFetcher{})
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -519,7 +519,7 @@ func TestAttestation(t *testing.T) {
 	cmd.SetContext(ctx)
 
 	i := &initCmd{log: logger.NewTest(t), spinner: &nopSpinner{}}
-	err := i.initialize(cmd, newDialer, fileHandler, &stubLicenseClient{}, fakeConfigFetcher{})
+	err := i.initialize(cmd, newDialer, fileHandler, &stubLicenseClient{}, fakeAttestationFetcher{})
 	assert.Error(err)
 	// make sure the error is actually a TLS handshake error
 	assert.Contains(err.Error(), "transport: authentication handshake failed")

--- a/cli/internal/cmd/recover_test.go
+++ b/cli/internal/cmd/recover_test.go
@@ -163,7 +163,7 @@ func TestRecover(t *testing.T) {
 			))
 
 			newDialer := func(atls.Validator) *dialer.Dialer { return nil }
-			r := &recoverCmd{log: logger.NewTest(t), configFetcher: fakeConfigFetcher{}}
+			r := &recoverCmd{log: logger.NewTest(t), configFetcher: fakeAttestationFetcher{}}
 			err := r.recover(cmd, fileHandler, time.Millisecond, tc.doer, newDialer)
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -142,7 +142,7 @@ func TestUpgradeApply(t *testing.T) {
 			require.NoError(handler.WriteYAML(constants.ConfigFilename, cfg))
 			require.NoError(handler.WriteJSON(constants.ClusterIDsFileName, clusterid.File{}))
 
-			upgrader := upgradeApplyCmd{upgrader: tc.upgrader, log: logger.NewTest(t), imageFetcher: tc.fetcher, configFetcher: fakeConfigFetcher{}}
+			upgrader := upgradeApplyCmd{upgrader: tc.upgrader, log: logger.NewTest(t), imageFetcher: tc.fetcher, configFetcher: fakeAttestationFetcher{}}
 			err := upgrader.upgradeApply(cmd, handler)
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -271,7 +271,7 @@ func TestUpgradeCheck(t *testing.T) {
 
 			cmd := newUpgradeCheckCmd()
 
-			err := checkCmd.upgradeCheck(cmd, fileHandler, fakeConfigFetcher{}, tc.flags)
+			err := checkCmd.upgradeCheck(cmd, fileHandler, fakeAttestationFetcher{}, tc.flags)
 			if tc.wantError {
 				assert.Error(err)
 				return

--- a/cli/internal/cmd/verify_test.go
+++ b/cli/internal/cmd/verify_test.go
@@ -190,7 +190,7 @@ func TestVerify(t *testing.T) {
 			}
 
 			v := &verifyCmd{log: logger.NewTest(t)}
-			err := v.verify(cmd, fileHandler, tc.protoClient, tc.formatter, fakeConfigFetcher{})
+			err := v.verify(cmd, fileHandler, tc.protoClient, tc.formatter, fakeAttestationFetcher{})
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/hack/configapi/cmd/BUILD.bazel
+++ b/hack/configapi/cmd/BUILD.bazel
@@ -13,8 +13,10 @@ go_library(
         "//internal/api/attestationconfig",
         "//internal/api/attestationconfig/client",
         "//internal/api/attestationconfig/fetcher",
+        "//internal/logger",
         "//internal/staticupload",
         "@com_github_spf13_cobra//:cobra",
+        "@org_uber_go_zap//:zap",
     ],
 )
 
@@ -27,7 +29,6 @@ go_test(
     embed = [":cmd"],
     deps = [
         "//internal/api/attestationconfig",
-        "//internal/variant",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],

--- a/hack/configapi/cmd/BUILD.bazel
+++ b/hack/configapi/cmd/BUILD.bazel
@@ -3,7 +3,10 @@ load("//bazel/go:go_test.bzl", "go_test")
 
 go_library(
     name = "cmd",
-    srcs = ["root.go"],
+    srcs = [
+        "delete.go",
+        "root.go",
+    ],
     importpath = "github.com/edgelesssys/constellation/v2/hack/configapi/cmd",
     visibility = ["//visibility:public"],
     deps = [
@@ -17,10 +20,15 @@ go_library(
 
 go_test(
     name = "cmd_test",
-    srcs = ["root_test.go"],
+    srcs = [
+        "delete_test.go",
+        "root_test.go",
+    ],
     embed = [":cmd"],
     deps = [
         "//internal/api/attestationconfig",
+        "//internal/variant",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/hack/configapi/cmd/delete.go
+++ b/hack/configapi/cmd/delete.go
@@ -1,0 +1,61 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig/client"
+	"github.com/edgelesssys/constellation/v2/internal/staticupload"
+	"github.com/spf13/cobra"
+)
+
+// newDeleteCmd creates the delete command.
+func newDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "delete a specific version from the config api",
+		RunE:  runDelete,
+	}
+	cmd.PersistentFlags().StringP("version", "v", "", "Name of the version to delete (without .json suffix)")
+	must(enforceRequiredFlags(cmd, "version"))
+	return cmd
+}
+
+type deleteCmd struct {
+	attestationclient client.Client
+	closefn           client.CloseFunc
+}
+
+func (d deleteCmd) delete(ctx context.Context, cmd *cobra.Command) error {
+	defer func() {
+		if d.closefn != nil {
+			if err := d.closefn(ctx); err != nil {
+				fmt.Printf("close client: %s\n", err.Error())
+			}
+		}
+	}()
+	version := cmd.Flag("version").Value.String()
+	return d.attestationclient.DeleteAzureSEVSNVersion(ctx, version)
+}
+
+func runDelete(cmd *cobra.Command, _ []string) error {
+	ctx := context.Background()
+	cfg := staticupload.Config{
+		Bucket: awsBucket,
+		Region: awsRegion,
+	}
+	repo, closefn, err := client.New(ctx, cfg, []byte(cosignPwd), []byte(privateKey))
+	if err != nil {
+		return fmt.Errorf("create attestation client: %w", err)
+	}
+	deleteCmd := deleteCmd{
+		attestationclient: repo,
+		closefn:           closefn,
+	}
+	return deleteCmd.delete(ctx, cmd)
+}

--- a/hack/configapi/cmd/delete.go
+++ b/hack/configapi/cmd/delete.go
@@ -49,7 +49,7 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 		Bucket: awsBucket,
 		Region: awsRegion,
 	}
-	repo, closefn, err := client.New(ctx, cfg, []byte(cosignPwd), []byte(privateKey))
+	repo, closefn, err := client.New(ctx, cfg, []byte(cosignPwd), []byte(privateKey), false, log())
 	if err != nil {
 		return fmt.Errorf("create attestation client: %w", err)
 	}

--- a/hack/configapi/cmd/delete.go
+++ b/hack/configapi/cmd/delete.go
@@ -28,7 +28,6 @@ func newDeleteCmd() *cobra.Command {
 
 type deleteCmd struct {
 	attestationClient deleteClient
-	closeFn           client.CloseFunc
 }
 
 type deleteClient interface {
@@ -53,7 +52,7 @@ func runDelete(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("create attestation client: %w", err)
 	}
 	defer func() {
-		if err := closefn(); err != nil {
+		if err := closefn(cmd.Context()); err != nil {
 			cmd.Printf("close client: %s\n", err.Error())
 		}
 	}()

--- a/hack/configapi/cmd/delete.go
+++ b/hack/configapi/cmd/delete.go
@@ -31,16 +31,16 @@ type deleteCmd struct {
 	closefn           client.CloseFunc
 }
 
-func (d deleteCmd) delete(ctx context.Context, cmd *cobra.Command) error {
+func (d deleteCmd) delete(cmd *cobra.Command) error {
 	defer func() {
 		if d.closefn != nil {
 			if err := d.closefn(ctx); err != nil {
-				fmt.Printf("close client: %s\n", err.Error())
+				cmd.Printf("close client: %s\n", err.Error())
 			}
 		}
 	}()
 	version := cmd.Flag("version").Value.String()
-	return d.attestationclient.DeleteAzureSEVSNVersion(ctx, version)
+	return d.attestationclient.DeleteAzureSEVSNVersion(cmd.Context(), version)
 }
 
 func runDelete(cmd *cobra.Command, _ []string) error {

--- a/hack/configapi/cmd/delete_test.go
+++ b/hack/configapi/cmd/delete_test.go
@@ -9,10 +9,7 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
-	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig"
-	"github.com/edgelesssys/constellation/v2/internal/variant"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -20,11 +17,11 @@ import (
 func TestDeleteVersion(t *testing.T) {
 	client := &fakeAttestationClient{}
 	sut := deleteCmd{
-		attestationclient: client,
+		attestationClient: client,
 	}
 	cmd := newDeleteCmd()
-	require.NoError(t, cmd.PersistentFlags().Set("version", "2021-01-01"))
-	assert.NoError(t, sut.delete(context.Background(), cmd))
+	require.NoError(t, cmd.Flags().Set("version", "2021-01-01"))
+	assert.NoError(t, sut.delete(cmd))
 	assert.True(t, client.isCalled)
 }
 
@@ -32,22 +29,10 @@ type fakeAttestationClient struct {
 	isCalled bool
 }
 
-func (f *fakeAttestationClient) DeleteAzureSEVSNVersion(_ context.Context, version string) error {
+func (f *fakeAttestationClient) DeleteAzureSEVSNPVersion(_ context.Context, version string) error {
 	if version == "2021-01-01" {
 		f.isCalled = true
 		return nil
 	}
 	return errors.New("version does not exist")
-}
-
-func (f fakeAttestationClient) UploadAzureSEVSNP(_ context.Context, _ attestationconfig.AzureSEVSNPVersion, _ time.Time) error {
-	return nil
-}
-
-func (f fakeAttestationClient) DeleteList(_ context.Context, _ variant.Variant) error {
-	return nil
-}
-
-func (f fakeAttestationClient) List(_ context.Context, _ variant.Variant) ([]string, error) {
-	return []string{}, nil
 }

--- a/hack/configapi/cmd/delete_test.go
+++ b/hack/configapi/cmd/delete_test.go
@@ -1,0 +1,53 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig"
+	"github.com/edgelesssys/constellation/v2/internal/variant"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeleteVersion(t *testing.T) {
+	client := &fakeAttestationClient{}
+	sut := deleteCmd{
+		attestationclient: client,
+	}
+	cmd := newDeleteCmd()
+	require.NoError(t, cmd.PersistentFlags().Set("version", "2021-01-01"))
+	assert.NoError(t, sut.delete(context.Background(), cmd))
+	assert.True(t, client.isCalled)
+}
+
+type fakeAttestationClient struct {
+	isCalled bool
+}
+
+func (f *fakeAttestationClient) DeleteAzureSEVSNVersion(_ context.Context, version string) error {
+	if version == "2021-01-01" {
+		f.isCalled = true
+		return nil
+	}
+	return errors.New("version does not exist")
+}
+
+func (f fakeAttestationClient) UploadAzureSEVSNP(_ context.Context, _ attestationconfig.AzureSEVSNPVersion, _ time.Time) error {
+	return nil
+}
+
+func (f fakeAttestationClient) DeleteList(_ context.Context, _ variant.Variant) error {
+	return nil
+}
+
+func (f fakeAttestationClient) List(_ context.Context, _ variant.Variant) ([]string, error) {
+	return []string{}, nil
+}

--- a/hack/configapi/cmd/root.go
+++ b/hack/configapi/cmd/root.go
@@ -95,11 +95,11 @@ func runCmd(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("comparing versions: %w", err)
 	}
 	if isNewer {
-		fmt.Printf("Input version: %+v is newer than latest API version: %+v\n", inputVersion, latestAPIVersion)
+		cmd.Printf("Input version: %+v is newer than latest API version: %+v\n", inputVersion, latestAPIVersion)
 		sut, sutClose, err := attestationconfigclient.New(ctx, cfg, []byte(cosignPwd), []byte(privateKey), false, log())
 		defer func() {
 			if err := sutClose(ctx); err != nil {
-				fmt.Printf("closing repo: %v\n", err)
+				cmd.Printf("closing repo: %v\n", err)
 			}
 		}()
 		if err != nil {

--- a/hack/configapi/cmd/root.go
+++ b/hack/configapi/cmd/root.go
@@ -55,7 +55,7 @@ func newRootCmd() *cobra.Command {
 	}
 	rootCmd.PersistentFlags().StringVarP(&versionFilePath, "version-file", "f", "", "File path to the version json file.")
 	must(enforceRequiredFlags(rootCmd, "version-file"))
-
+	rootCmd.AddCommand(newDeleteCmd())
 	return rootCmd
 }
 

--- a/hack/configapi/cmd/root.go
+++ b/hack/configapi/cmd/root.go
@@ -56,7 +56,7 @@ func newRootCmd() *cobra.Command {
 		RunE:    runCmd,
 	}
 	rootCmd.PersistentFlags().StringVarP(&versionFilePath, "version-file", "f", "", "File path to the version json file.")
-	must(enforceRequiredFlags(rootCmd, "version-file"))
+	must(enforcePersistentRequiredFlags(rootCmd, "version-file"))
 	rootCmd.AddCommand(newDeleteCmd())
 	return rootCmd
 }
@@ -145,6 +145,15 @@ func isInputNewerThanLatestAPI(input, latest attestationconfig.AzureSEVSNPVersio
 }
 
 func enforceRequiredFlags(cmd *cobra.Command, flags ...string) error {
+	for _, flag := range flags {
+		if err := cmd.MarkFlagRequired(flag); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func enforcePersistentRequiredFlags(cmd *cobra.Command, flags ...string) error {
 	for _, flag := range flags {
 		if err := cmd.MarkPersistentFlagRequired(flag); err != nil {
 			return err

--- a/hack/configapi/cmd/root.go
+++ b/hack/configapi/cmd/root.go
@@ -16,6 +16,8 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig"
 	attestationconfigclient "github.com/edgelesssys/constellation/v2/internal/api/attestationconfig/client"
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig/fetcher"
+	"github.com/edgelesssys/constellation/v2/internal/logger"
+	"go.uber.org/zap"
 
 	"github.com/edgelesssys/constellation/v2/internal/staticupload"
 	"github.com/spf13/cobra"
@@ -94,7 +96,7 @@ func runCmd(cmd *cobra.Command, _ []string) error {
 	}
 	if isNewer {
 		fmt.Printf("Input version: %+v is newer than latest API version: %+v\n", inputVersion, latestAPIVersion)
-		sut, sutClose, err := attestationconfigclient.New(ctx, cfg, []byte(cosignPwd), []byte(privateKey))
+		sut, sutClose, err := attestationconfigclient.New(ctx, cfg, []byte(cosignPwd), []byte(privateKey), false, log())
 		defer func() {
 			if err := sutClose(ctx); err != nil {
 				fmt.Printf("closing repo: %v\n", err)
@@ -155,4 +157,8 @@ func must(err error) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func log() *logger.Logger {
+	return logger.New(logger.PlainLog, zap.DebugLevel).Named("attestationconfig")
 }

--- a/internal/api/attestationconfig/azure.go
+++ b/internal/api/attestationconfig/azure.go
@@ -34,6 +34,35 @@ type AzureSEVSNPVersion struct {
 	Microcode uint8 `json:"microcode"`
 }
 
+// AzureSEVSNPVersionSignature is the object to perform CRUD operations on the config api.
+type AzureSEVSNPVersionSignature struct {
+	Version   string `json:"-"`
+	Signature []byte `json:"signature"`
+}
+
+// JSONPath returns the path to the JSON file for the request to the config api.
+func (s AzureSEVSNPVersionSignature) JSONPath() string {
+	return path.Join(attestationURLPath, variant.AzureSEVSNP{}.String(), s.Version, ".sig")
+}
+
+// URL returns the URL for the request to the config api.
+func (s AzureSEVSNPVersionSignature) URL() (string, error) {
+	return getURL(s)
+}
+
+// ValidateRequest validates the request.
+func (s AzureSEVSNPVersionSignature) ValidateRequest() error {
+	if !strings.HasSuffix(s.Version, ".json") {
+		return fmt.Errorf("version has no .json suffix")
+	}
+	return nil
+}
+
+// Validate is a No-Op at the moment.
+func (s AzureSEVSNPVersionSignature) Validate() error {
+	return nil
+}
+
 // AzureSEVSNPVersionAPI is the request to get the version information of the specific version in the config api.
 type AzureSEVSNPVersionAPI struct {
 	Version string `json:"-"`
@@ -42,12 +71,7 @@ type AzureSEVSNPVersionAPI struct {
 
 // URL returns the URL for the request to the config api.
 func (i AzureSEVSNPVersionAPI) URL() (string, error) {
-	url, err := url.Parse(constants.CDNRepositoryURL)
-	if err != nil {
-		return "", fmt.Errorf("parsing CDN URL: %w", err)
-	}
-	url.Path = i.JSONPath()
-	return url.String(), nil
+	return getURL(i)
 }
 
 // JSONPath returns the path to the JSON file for the request to the config api.
@@ -73,12 +97,7 @@ type AzureSEVSNPVersionList []string
 
 // URL returns the URL for the request to the config api.
 func (i AzureSEVSNPVersionList) URL() (string, error) {
-	url, err := url.Parse(constants.CDNRepositoryURL)
-	if err != nil {
-		return "", fmt.Errorf("parsing CDN URL: %w", err)
-	}
-	url.Path = i.JSONPath()
-	return url.String(), nil
+	return getURL(i)
 }
 
 // JSONPath returns the path to the JSON file for the request to the config api.
@@ -97,4 +116,17 @@ func (i AzureSEVSNPVersionList) Validate() error {
 		return fmt.Errorf("no versions found in /list")
 	}
 	return nil
+}
+
+func getURL(obj jsoPather) (string, error) {
+	url, err := url.Parse(constants.CDNRepositoryURL)
+	if err != nil {
+		return "", fmt.Errorf("parsing CDN URL: %w", err)
+	}
+	url.Path = obj.JSONPath()
+	return url.String(), nil
+}
+
+type jsoPather interface {
+	JSONPath() string
 }

--- a/internal/api/attestationconfig/azure.go
+++ b/internal/api/attestationconfig/azure.go
@@ -34,14 +34,14 @@ type AzureSEVSNPVersion struct {
 	Microcode uint8 `json:"microcode"`
 }
 
-// AzureSEVSNPVersionGet is the request to get the version information of the specific version in the config api.
-type AzureSEVSNPVersionGet struct {
+// AzureSEVSNPVersionAPI is the request to get the version information of the specific version in the config api.
+type AzureSEVSNPVersionAPI struct {
 	Version string `json:"-"`
 	AzureSEVSNPVersion
 }
 
 // URL returns the URL for the request to the config api.
-func (i AzureSEVSNPVersionGet) URL() (string, error) {
+func (i AzureSEVSNPVersionAPI) URL() (string, error) {
 	url, err := url.Parse(constants.CDNRepositoryURL)
 	if err != nil {
 		return "", fmt.Errorf("parsing CDN URL: %w", err)
@@ -51,12 +51,12 @@ func (i AzureSEVSNPVersionGet) URL() (string, error) {
 }
 
 // JSONPath returns the path to the JSON file for the request to the config api.
-func (i AzureSEVSNPVersionGet) JSONPath() string {
+func (i AzureSEVSNPVersionAPI) JSONPath() string {
 	return path.Join(attestationURLPath, variant.AzureSEVSNP{}.String(), i.Version)
 }
 
 // ValidateRequest validates the request.
-func (i AzureSEVSNPVersionGet) ValidateRequest() error {
+func (i AzureSEVSNPVersionAPI) ValidateRequest() error {
 	if !strings.HasSuffix(i.Version, ".json") {
 		return fmt.Errorf("version has no .json suffix")
 	}
@@ -64,7 +64,7 @@ func (i AzureSEVSNPVersionGet) ValidateRequest() error {
 }
 
 // Validate is a No-Op at the moment.
-func (i AzureSEVSNPVersionGet) Validate() error {
+func (i AzureSEVSNPVersionAPI) Validate() error {
 	return nil
 }
 

--- a/internal/api/attestationconfig/client/BUILD.bazel
+++ b/internal/api/attestationconfig/client/BUILD.bazel
@@ -9,8 +9,9 @@ go_library(
     deps = [
         "//internal/api/attestationconfig",
         "//internal/api/attestationconfig/fetcher",
+        "//internal/api/client",
         "//internal/constants",
-        "//internal/kms/storage",
+        "//internal/logger",
         "//internal/sigstore",
         "//internal/staticupload",
         "//internal/variant",

--- a/internal/api/attestationconfig/client/BUILD.bazel
+++ b/internal/api/attestationconfig/client/BUILD.bazel
@@ -15,8 +15,6 @@ go_library(
         "//internal/sigstore",
         "//internal/staticupload",
         "//internal/variant",
-        "@com_github_aws_aws_sdk_go_v2_feature_s3_manager//:manager",
-        "@com_github_aws_aws_sdk_go_v2_service_s3//:s3",
     ],
 )
 
@@ -33,6 +31,5 @@ go_test(
     deps = [
         "//internal/api/attestationconfig",
         "@com_github_stretchr_testify//assert",
-        "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/api/attestationconfig/client/BUILD.bazel
+++ b/internal/api/attestationconfig/client/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/api/attestationconfig",
+        "//internal/api/attestationconfig/fetcher",
         "//internal/constants",
         "//internal/kms/storage",
         "//internal/sigstore",
@@ -23,14 +24,14 @@ go_test(
     srcs = ["client_test.go"],
     # keep
     count = 1,
+    embed = [":client"],
     # keep
     gotags = ["e2e"],
     # keep
     tags = ["manual"],
     deps = [
-        ":client",
         "//internal/api/attestationconfig",
-        "//internal/staticupload",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/internal/api/attestationconfig/client/client.go
+++ b/internal/api/attestationconfig/client/client.go
@@ -243,7 +243,7 @@ func (d deleteCmd) Execute(ctx context.Context, c s3Client, bucketID string) err
 	return deleteObj(ctx, c, bucketID, d.path)
 }
 
-// TODO call put and merge below cmd
+// TODO call putCmd and merge below cmd.
 type updateCmd struct {
 	apiObject apiclient.APIObject
 }

--- a/internal/api/attestationconfig/client/client_test.go
+++ b/internal/api/attestationconfig/client/client_test.go
@@ -1,82 +1,51 @@
-//go:build e2e
-
 /*
 Copyright (c) Edgeless Systems GmbH
 
 SPDX-License-Identifier: AGPL-3.0-only
 */
-package client_test
+package client
 
 import (
-	"context"
-	"flag"
-	"fmt"
-	"io"
-	"os"
+	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig"
-	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig/client"
-	"github.com/edgelesssys/constellation/v2/internal/staticupload"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	awsBucket   = "cdn-constellation-backend"
-	awsRegion   = "eu-central-1"
-	envAwsKeyID = "AWS_ACCESS_KEY_ID"
-	envAwsKey   = "AWS_ACCESS_KEY"
-)
+// TODO replace with unit testable version
+//func TestUploadAzureSEVSNPVersions(t *testing.T) {
+//	ctx := context.Background()
+//	client, clientClose, err := New(ctx, cfg, []byte(*cosignPwd), privateKey)
+//	require.NoError(t, err)
+//	defer func() { _ = clientClose(ctx) }()
+//	d := time.Date(2021, 1, 1, 1, 1, 1, 1, time.UTC)
+//	require.NoError(t, client.UploadAzureSEVSNP(ctx, versionValues, d))
+//}
 
-var cfg staticupload.Config
+func TestDeleteAzureSEVSNPVersions(t *testing.T) {
+	sut := client{
+		bucketID: "bucket",
+	}
+	versions := attestationconfig.AzureSEVSNPVersionList([]string{"2023-01-01.json", "2021-01-01.json", "2019-01-01.json"})
 
-var (
-	cosignPwd      = flag.String("cosign-pwd", "", "Password to decrypt the cosign private key. Required for signing.")
-	privateKeyPath = flag.String("private-key", "", "Path to the private key used for signing. Required for signing.")
-	privateKey     []byte
-)
+	ops, err := sut.deleteAzureSEVSNVersion(versions, "2021-01-01")
 
-func TestMain(m *testing.M) {
-	flag.Parse()
-	if *cosignPwd == "" || *privateKeyPath == "" {
-		flag.Usage()
-		fmt.Println("Required flags not set: --cosign-pwd, --private-key. Skipping tests.")
-		os.Exit(1)
-	}
-	if _, present := os.LookupEnv(envAwsKey); !present {
-		fmt.Printf("%s not set. Skipping tests.\n", envAwsKey)
-		os.Exit(1)
-	}
-	if _, present := os.LookupEnv(envAwsKeyID); !present {
-		fmt.Printf("%s not set. Skipping tests.\n", envAwsKeyID)
-		os.Exit(1)
-	}
-	cfg = staticupload.Config{
-		Bucket: awsBucket,
-		Region: awsRegion,
-	}
-	file, _ := os.Open(*privateKeyPath)
-	var err error
-	privateKey, err = io.ReadAll(file)
-	if err != nil {
-		panic(err)
-	}
-	os.Exit(m.Run())
-}
+	assert := assert.New(t)
+	assert.NoError(err)
+	assert.Contains(ops, deleteCmd{
+		path: "constellation/v1/attestation/azure-sev-snp/2021-01-01.json",
+	})
+	assert.Contains(ops, deleteCmd{
+		path: "constellation/v1/attestation/azure-sev-snp/2021-01-01.json.sig",
+	})
 
-var versionValues = attestationconfig.AzureSEVSNPVersion{
-	Bootloader: 2,
-	TEE:        0,
-	SNP:        6,
-	Microcode:  93,
-}
-
-func TestUploadAzureSEVSNPVersions(t *testing.T) {
-	ctx := context.Background()
-	client, clientClose, err := client.New(ctx, cfg, []byte(*cosignPwd), privateKey)
+	removedVersions := attestationconfig.AzureSEVSNPVersionList([]string{"2023-01-01.json", "2019-01-01.json"})
+	dt, err := json.Marshal(removedVersions)
 	require.NoError(t, err)
-	defer func() { _ = clientClose(ctx) }()
-	d := time.Date(2021, 1, 1, 1, 1, 1, 1, time.UTC)
-	require.NoError(t, client.UploadAzureSEVSNP(ctx, versionValues, d))
+	assert.Contains(ops, putCmd{
+		path: "constellation/v1/attestation/azure-sev-snp/list",
+		data: dt,
+	})
 }

--- a/internal/api/attestationconfig/client/client_test.go
+++ b/internal/api/attestationconfig/client/client_test.go
@@ -6,13 +6,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 package client
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestUploadAzureSEVSNP(t *testing.T) {
@@ -26,19 +24,19 @@ func TestUploadAzureSEVSNP(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(err)
 	dateStr := "2023-01-01-01-01.json"
-	assert.Contains(ops, updateCmd{
+	assert.Contains(ops, putCmd{
 		apiObject: attestationconfig.AzureSEVSNPVersionAPI{
 			Version:            dateStr,
 			AzureSEVSNPVersion: version,
 		},
 	})
-	assert.Contains(ops, updateCmd{
+	assert.Contains(ops, putCmd{
 		apiObject: attestationconfig.AzureSEVSNPVersionSignature{
 			Version:   dateStr,
 			Signature: []byte("signature"),
 		},
 	})
-	assert.Contains(ops, updateCmd{
+	assert.Contains(ops, putCmd{
 		apiObject: attestationconfig.AzureSEVSNPVersionList([]string{"2023-01-01-01-01.json", "2021-01-01-01-01.json", "2019-01-01-01-01.json"}),
 	})
 }
@@ -54,18 +52,18 @@ func TestDeleteAzureSEVSNPVersions(t *testing.T) {
 	assert := assert.New(t)
 	assert.NoError(err)
 	assert.Contains(ops, deleteCmd{
-		path: "constellation/v1/attestation/azure-sev-snp/2021-01-01.json",
+		apiObject: attestationconfig.AzureSEVSNPVersionAPI{
+			Version: "2021-01-01.json",
+		},
 	})
 	assert.Contains(ops, deleteCmd{
-		path: "constellation/v1/attestation/azure-sev-snp/2021-01-01.json.sig",
+		apiObject: attestationconfig.AzureSEVSNPVersionSignature{
+			Version: "2021-01-01.json",
+		},
 	})
 
-	removedVersions := attestationconfig.AzureSEVSNPVersionList([]string{"2023-01-01.json", "2019-01-01.json"})
-	dt, err := json.Marshal(removedVersions)
-	require.NoError(t, err)
 	assert.Contains(ops, putCmd{
-		path: "constellation/v1/attestation/azure-sev-snp/list",
-		data: dt,
+		apiObject: attestationconfig.AzureSEVSNPVersionList([]string{"2023-01-01.json", "2019-01-01.json"}),
 	})
 }
 

--- a/internal/api/attestationconfig/client/client_test.go
+++ b/internal/api/attestationconfig/client/client_test.go
@@ -25,12 +25,12 @@ import (
 //}
 
 func TestDeleteAzureSEVSNPVersions(t *testing.T) {
-	sut := client{
+	sut := Client{
 		bucketID: "bucket",
 	}
 	versions := attestationconfig.AzureSEVSNPVersionList([]string{"2023-01-01.json", "2021-01-01.json", "2019-01-01.json"})
 
-	ops, err := sut.deleteAzureSEVSNVersion(versions, "2021-01-01")
+	ops, err := sut.deleteAzureSEVSNPVersion(versions, "2021-01-01")
 
 	assert := assert.New(t)
 	assert.NoError(err)

--- a/internal/api/attestationconfig/client/test/integration_test.go
+++ b/internal/api/attestationconfig/client/test/integration_test.go
@@ -1,0 +1,84 @@
+//go:build integration
+
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+package test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig"
+	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig/client"
+	"github.com/edgelesssys/constellation/v2/internal/logger"
+	"github.com/edgelesssys/constellation/v2/internal/staticupload"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+const (
+	awsBucket   = "cdn-constellation-backend"
+	awsRegion   = "eu-central-1"
+	envAwsKeyID = "AWS_ACCESS_KEY_ID"
+	envAwsKey   = "AWS_ACCESS_KEY"
+)
+
+var cfg staticupload.Config
+
+var (
+	cosignPwd      = flag.String("cosign-pwd", "", "Password to decrypt the cosign private key. Required for signing.")
+	privateKeyPath = flag.String("private-key", "", "Path to the private key used for signing. Required for signing.")
+	privateKey     []byte
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	if *cosignPwd == "" || *privateKeyPath == "" {
+		flag.Usage()
+		fmt.Println("Required flags not set: --cosign-pwd, --private-key. Skipping tests.")
+		os.Exit(1)
+	}
+	if _, present := os.LookupEnv(envAwsKey); !present {
+		fmt.Printf("%s not set. Skipping tests.\n", envAwsKey)
+		os.Exit(1)
+	}
+	if _, present := os.LookupEnv(envAwsKeyID); !present {
+		fmt.Printf("%s not set. Skipping tests.\n", envAwsKeyID)
+		os.Exit(1)
+	}
+	cfg = staticupload.Config{
+		Bucket: awsBucket,
+		Region: awsRegion,
+	}
+	file, _ := os.Open(*privateKeyPath)
+	var err error
+	privateKey, err = io.ReadAll(file)
+	if err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+var versionValues = attestationconfig.AzureSEVSNPVersion{
+	Bootloader: 2,
+	TEE:        0,
+	SNP:        6,
+	Microcode:  93,
+}
+
+func TestUploadAzureSEVSNPVersions(t *testing.T) {
+	ctx := context.Background()
+	client, clientClose, err := client.New(ctx, cfg, []byte(*cosignPwd), privateKey, false, logger.New(logger.PlainLog, zap.DebugLevel).Named("attestationconfig"))
+	require.NoError(t, err)
+	defer func() { _ = clientClose(ctx) }()
+	d := time.Date(2021, 1, 1, 1, 1, 1, 1, time.UTC)
+	require.NoError(t, client.UploadAzureSEVSNP(ctx, versionValues, d))
+}

--- a/internal/api/attestationconfig/fetcher/fetcher.go
+++ b/internal/api/attestationconfig/fetcher/fetcher.go
@@ -24,9 +24,9 @@ const cosignPublicKey = constants.CosignPublicKeyReleases
 
 // AttestationConfigAPIFetcher fetches config API resources without authentication.
 type AttestationConfigAPIFetcher interface {
-	FetchAzureSEVSNPVersion(ctx context.Context, azureVersion attestationconfig.AzureSEVSNPVersionGet) (attestationconfig.AzureSEVSNPVersionGet, error)
+	FetchAzureSEVSNPVersion(ctx context.Context, azureVersion attestationconfig.AzureSEVSNPVersionAPI) (attestationconfig.AzureSEVSNPVersionAPI, error)
 	FetchAzureSEVSNPVersionList(ctx context.Context, attestation attestationconfig.AzureSEVSNPVersionList) (attestationconfig.AzureSEVSNPVersionList, error)
-	FetchAzureSEVSNPVersionLatest(ctx context.Context) (attestationconfig.AzureSEVSNPVersionGet, error)
+	FetchAzureSEVSNPVersionLatest(ctx context.Context) (attestationconfig.AzureSEVSNPVersionAPI, error)
 }
 
 // Fetcher fetches AttestationCfg API resources without authentication.
@@ -50,7 +50,7 @@ func (f *Fetcher) FetchAzureSEVSNPVersionList(ctx context.Context, attestation a
 }
 
 // FetchAzureSEVSNPVersion fetches the version information from the config API.
-func (f *Fetcher) FetchAzureSEVSNPVersion(ctx context.Context, azureVersion attestationconfig.AzureSEVSNPVersionGet) (attestationconfig.AzureSEVSNPVersionGet, error) {
+func (f *Fetcher) FetchAzureSEVSNPVersion(ctx context.Context, azureVersion attestationconfig.AzureSEVSNPVersionAPI) (attestationconfig.AzureSEVSNPVersionAPI, error) {
 	urlString, err := azureVersion.URL()
 	if err != nil {
 		return azureVersion, err
@@ -77,13 +77,13 @@ func (f *Fetcher) FetchAzureSEVSNPVersion(ctx context.Context, azureVersion atte
 }
 
 // FetchAzureSEVSNPVersionLatest returns the latest versions of the given type.
-func (f *Fetcher) FetchAzureSEVSNPVersionLatest(ctx context.Context) (res attestationconfig.AzureSEVSNPVersionGet, err error) {
+func (f *Fetcher) FetchAzureSEVSNPVersionLatest(ctx context.Context) (res attestationconfig.AzureSEVSNPVersionAPI, err error) {
 	var list attestationconfig.AzureSEVSNPVersionList
 	list, err = f.FetchAzureSEVSNPVersionList(ctx, list)
 	if err != nil {
 		return res, fmt.Errorf("fetching versions list: %w", err)
 	}
-	get := attestationconfig.AzureSEVSNPVersionGet{Version: list[0]} // get latest version (as sorted reversely alphanumerically)
+	get := attestationconfig.AzureSEVSNPVersionAPI{Version: list[0]} // get latest version (as sorted reversely alphanumerically)
 	get, err = f.FetchAzureSEVSNPVersion(ctx, get)
 	if err != nil {
 		return res, fmt.Errorf("failed fetching version: %w", err)

--- a/internal/api/attestationconfig/fetcher/fetcher_test.go
+++ b/internal/api/attestationconfig/fetcher/fetcher_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var testCfg = configapi.AzureSEVSNPVersionGet{
+var testCfg = configapi.AzureSEVSNPVersionAPI{
 	AzureSEVSNPVersion: configapi.AzureSEVSNPVersion{
 		Microcode:  93,
 		TEE:        0,
@@ -31,7 +31,7 @@ func TestFetchLatestAzureSEVSNPVersion(t *testing.T) {
 	testcases := map[string]struct {
 		signature []byte
 		wantErr   bool
-		want      configapi.AzureSEVSNPVersionGet
+		want      configapi.AzureSEVSNPVersionAPI
 	}{
 		"get version with valid signature": {
 			signature: []byte("MEQCIBPEbYg89MIQuaGStLhKGLGMKvKFoYCaAniDLwoIwulqAiB+rj7KMaMOMGxmUsjI7KheCXSNM8NzN+tuDw6AywI75A=="), // signed with release key

--- a/internal/api/client/client.go
+++ b/internal/api/client/client.go
@@ -177,14 +177,15 @@ func ptr[T any](t T) *T {
 	return &t
 }
 
-type apiObject interface {
+// APIObject is an object that is used to perform CRUD operations on the API.
+type APIObject interface {
 	ValidateRequest() error
 	Validate() error
 	JSONPath() string
 }
 
 // Fetch fetches the given apiObject from the public Constellation CDN.
-func Fetch[T apiObject](ctx context.Context, c *Client, obj T) (T, error) {
+func Fetch[T APIObject](ctx context.Context, c *Client, obj T) (T, error) {
 	if err := obj.ValidateRequest(); err != nil {
 		return *new(T), fmt.Errorf("validating request for %T: %w", obj, err)
 	}
@@ -217,7 +218,7 @@ func Fetch[T apiObject](ctx context.Context, c *Client, obj T) (T, error) {
 }
 
 // Update creates/updates the given apiObject in the public Constellation API.
-func Update(ctx context.Context, c *Client, obj apiObject) error {
+func Update(ctx context.Context, c *Client, obj APIObject) error {
 	if err := obj.Validate(); err != nil {
 		return fmt.Errorf("validating %T struct: %w", obj, err)
 	}
@@ -249,7 +250,7 @@ func Update(ctx context.Context, c *Client, obj apiObject) error {
 }
 
 // Delete deletes the given apiObject from the public Constellation API.
-func Delete(ctx context.Context, c *Client, obj apiObject) error {
+func Delete(ctx context.Context, c *Client, obj APIObject) error {
 	if err := obj.ValidateRequest(); err != nil {
 		return fmt.Errorf("validating request for %T: %w", obj, err)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -885,14 +885,14 @@ func (f fakeConfigFetcher) FetchAzureSEVSNPVersionList(_ context.Context, _ conf
 	), nil
 }
 
-func (f fakeConfigFetcher) FetchAzureSEVSNPVersion(_ context.Context, _ configapi.AzureSEVSNPVersionGet) (configapi.AzureSEVSNPVersionGet, error) {
-	return configapi.AzureSEVSNPVersionGet{
+func (f fakeConfigFetcher) FetchAzureSEVSNPVersion(_ context.Context, _ configapi.AzureSEVSNPVersionAPI) (configapi.AzureSEVSNPVersionAPI, error) {
+	return configapi.AzureSEVSNPVersionAPI{
 		AzureSEVSNPVersion: testCfg,
 	}, nil
 }
 
-func (f fakeConfigFetcher) FetchAzureSEVSNPVersionLatest(_ context.Context) (configapi.AzureSEVSNPVersionGet, error) {
-	return configapi.AzureSEVSNPVersionGet{
+func (f fakeConfigFetcher) FetchAzureSEVSNPVersionLatest(_ context.Context) (configapi.AzureSEVSNPVersionAPI, error) {
+	return configapi.AzureSEVSNPVersionAPI{
 		AzureSEVSNPVersion: testCfg,
 	}, nil
 }

--- a/internal/sigstore/sign.go
+++ b/internal/sigstore/sign.go
@@ -26,6 +26,29 @@ const (
 	sigstorePrivateKeyPemType = "ENCRYPTED SIGSTORE PRIVATE KEY"
 )
 
+// Signer is used to sign the version file. Used for unit testing.
+type Signer interface {
+	Sign(content []byte) (res []byte, err error)
+}
+
+// NewSigner returns a new Signer.
+func NewSigner(cosignPwd, privKey []byte) Signer {
+	return signer{cosignPwd: cosignPwd, privKey: privKey}
+}
+
+type signer struct {
+	cosignPwd []byte // used to decrypt the cosign private key
+	privKey   []byte // used to sign
+}
+
+func (s signer) Sign(content []byte) (signature []byte, err error) {
+	signature, err = SignContent(s.cosignPwd, s.privKey, content)
+	if err != nil {
+		return signature, fmt.Errorf("sign version file: %w", err)
+	}
+	return
+}
+
 // SignContent signs the content with the cosign encrypted private key and corresponding cosign password.
 func SignContent(password, encryptedPrivateKey, content []byte) ([]byte, error) {
 	sv, err := loadPrivateKey(encryptedPrivateKey, password)

--- a/internal/staticupload/staticupload.go
+++ b/internal/staticupload/staticupload.go
@@ -93,7 +93,7 @@ func (e InvalidationError) Unwrap() error {
 	return e.inner
 }
 
-// New creates a new Client.
+// New creates a new Client. Call CloseFunc when done with operations.
 func New(ctx context.Context, config Config) (*Client, CloseFunc, error) {
 	config.SetsDefault()
 	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithRegion(config.Region))
@@ -114,12 +114,7 @@ func New(ctx context.Context, config Config) (*Client, CloseFunc, error) {
 		cacheInvalidationWaitTimeout: config.CacheInvalidationWaitTimeout,
 		bucketID:                     config.Bucket,
 	}
-	clientClose := func(ctx context.Context) error {
-		// ensure that all keys are invalidated
-		return client.Flush(ctx)
-	}
-
-	return client, clientClose, nil
+	return client, client.Flush, nil
 }
 
 // Flush flushes the client by invalidating the CDN cache for modified keys.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add unit tests for attestationconfig.Client
- add delete command to tool
- refactor attestationconfig.Client to use the general apiclient

TODO: also make rest of attestation client testable?
<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
