### PR TITLE
api: use correct error types in versions/cli

### DIFF
--- a/internal/api/versions/cli/BUILD.bazel
+++ b/internal/api/versions/cli/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
     importpath = "github.com/edgelesssys/constellation/v2/internal/api/versions/cli",
     visibility = ["//visibility:private"],
     deps = [
-        "//internal/api/fetcher",
+        "//internal/api/client",
         "//internal/api/versions",
         "//internal/api/versions/client",
         "//internal/constants",

--- a/internal/api/versions/cli/add.go
+++ b/internal/api/versions/cli/add.go
@@ -11,7 +11,7 @@ import (
 	"errors"
 	"fmt"
 
-	apifetcher "github.com/edgelesssys/constellation/v2/internal/api/fetcher"
+	apiclient "github.com/edgelesssys/constellation/v2/internal/api/client"
 	versionsapi "github.com/edgelesssys/constellation/v2/internal/api/versions"
 	verclient "github.com/edgelesssys/constellation/v2/internal/api/versions/client"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
@@ -116,7 +116,7 @@ func ensureVersion(ctx context.Context, client *verclient.VersionsClient, kind v
 		Kind:        kind,
 	}
 	verList, err := client.FetchVersionList(ctx, verListReq)
-	var notFoundErr *apifetcher.NotFoundError
+	var notFoundErr *apiclient.NotFoundError
 	if errors.As(err, &notFoundErr) {
 		log.Infof("Version list for %s versions under %q does not exist. Creating new list", gran.String(), ver.Major())
 		verList = verListReq
@@ -152,7 +152,7 @@ func updateLatest(ctx context.Context, client *verclient.VersionsClient, kind ve
 		Kind:   kind,
 	}
 	latest, err := client.FetchVersionLatest(ctx, latest)
-	var notFoundErr *apifetcher.NotFoundError
+	var notFoundErr *apiclient.NotFoundError
 	if errors.As(err, &notFoundErr) {
 		log.Debugf("Latest version for ref %q and stream %q not found", ver.Ref, ver.Stream)
 	} else if err != nil {

--- a/internal/api/versions/cli/list.go
+++ b/internal/api/versions/cli/list.go
@@ -16,7 +16,7 @@ import (
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/mod/semver"
 
-	apifetcher "github.com/edgelesssys/constellation/v2/internal/api/fetcher"
+	apiclient "github.com/edgelesssys/constellation/v2/internal/api/client"
 	versionsapi "github.com/edgelesssys/constellation/v2/internal/api/versions"
 	verclient "github.com/edgelesssys/constellation/v2/internal/api/versions/client"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
@@ -69,7 +69,7 @@ func runList(cmd *cobra.Command, _ []string) error {
 	} else {
 		log.Debugf("Getting minor versions")
 		minorVersions, err = listMinorVersions(cmd.Context(), client, flags.ref, flags.stream)
-		var errNotFound *apifetcher.NotFoundError
+		var errNotFound *apiclient.NotFoundError
 		if err != nil && errors.As(err, &errNotFound) {
 			log.Infof("No minor versions found for ref %q and stream %q.", flags.ref, flags.stream)
 			return nil
@@ -80,7 +80,7 @@ func runList(cmd *cobra.Command, _ []string) error {
 
 	log.Debugf("Getting patch versions")
 	patchVersions, err := listPatchVersions(cmd.Context(), client, flags.ref, flags.stream, minorVersions)
-	var errNotFound *apifetcher.NotFoundError
+	var errNotFound *apiclient.NotFoundError
 	if err != nil && errors.As(err, &errNotFound) {
 		log.Infof("No patch versions found for ref %q, stream %q and minor versions %v.", flags.ref, flags.stream, minorVersions)
 		return nil

--- a/internal/api/versions/cli/rm.go
+++ b/internal/api/versions/cli/rm.go
@@ -24,7 +24,7 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/smithy-go"
-	apifetcher "github.com/edgelesssys/constellation/v2/internal/api/fetcher"
+	apiclient "github.com/edgelesssys/constellation/v2/internal/api/client"
 	versionsapi "github.com/edgelesssys/constellation/v2/internal/api/versions"
 	verclient "github.com/edgelesssys/constellation/v2/internal/api/versions/client"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
@@ -158,7 +158,7 @@ func deleteRef(ctx context.Context, clients rmImageClients, ref string, dryrun b
 		log.Infof("Listing versions of stream %s", stream)
 
 		minorVersions, err := listMinorVersions(ctx, clients.version, ref, stream)
-		var notFoundErr *apifetcher.NotFoundError
+		var notFoundErr *apiclient.NotFoundError
 		if errors.As(err, &notFoundErr) {
 			log.Debugf("No minor versions found for stream %s", stream)
 			continue
@@ -203,7 +203,7 @@ func deleteImage(ctx context.Context, clients rmImageClients, ver versionsapi.Ve
 		Version: ver.Version,
 	}
 	imageInfo, err := clients.version.FetchImageInfo(ctx, imageInfo)
-	var notFound *apifetcher.NotFoundError
+	var notFound *apiclient.NotFoundError
 	if errors.As(err, &notFound) {
 		log.Warnf("Image info for %s not found", ver.Version)
 		log.Warnf("Skipping image deletion")

--- a/internal/api/versions/client/BUILD.bazel
+++ b/internal/api/versions/client/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/api/client",
-        "//internal/api/fetcher",
         "//internal/api/versions",
         "//internal/constants",
         "//internal/logger",

--- a/internal/api/versions/client/client.go
+++ b/internal/api/versions/client/client.go
@@ -18,7 +18,6 @@ import (
 	"golang.org/x/mod/semver"
 
 	apiclient "github.com/edgelesssys/constellation/v2/internal/api/client"
-	apifetcher "github.com/edgelesssys/constellation/v2/internal/api/fetcher"
 	versionsapi "github.com/edgelesssys/constellation/v2/internal/api/versions"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
@@ -166,7 +165,7 @@ func (c *VersionsClient) deleteVersionFromMinorVersionList(ctx context.Context, 
 	}
 	c.Client.Log.Debugf("Fetching minor version list for version %s", ver.Version)
 	minorList, err := c.FetchVersionList(ctx, minorList)
-	var notFoundErr *apifetcher.NotFoundError
+	var notFoundErr *apiclient.NotFoundError
 	if errors.As(err, &notFoundErr) {
 		c.Client.Log.Warnf("Minor version list for version %s not found", ver.Version)
 		c.Client.Log.Warnf("Skipping update of minor version list")
@@ -223,7 +222,7 @@ func (c *VersionsClient) deleteVersionFromLatest(ctx context.Context, ver versio
 	}
 	c.Client.Log.Debugf("Fetching latest version from %s", latest.JSONPath())
 	latest, err := c.FetchVersionLatest(ctx, latest)
-	var notFoundErr *apifetcher.NotFoundError
+	var notFoundErr *apiclient.NotFoundError
 	if errors.As(err, &notFoundErr) {
 		c.Client.Log.Warnf("Latest version for %s not found", latest.JSONPath())
 		return nil


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Imported wrong error types during refactoring. This leads to checks like [this](https://github.com/edgelesssys/constellation/blob/main/internal/api/versions/cli/rm.go#L162) to not recognize errors correctly as the error returned is `client.NotFoundError`.
