### PR TITLE
staticupload: don't request empty invalidation

### DIFF
--- a/internal/staticupload/staticupload.go
+++ b/internal/staticupload/staticupload.go
@@ -14,7 +14,6 @@ package staticupload
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -179,10 +178,6 @@ func (c *Client) invalidate(ctx context.Context, keys []string) error {
 func (c *Client) invalidateCacheForKeys(ctx context.Context, keys []string) (string, error) {
 	if len(keys) > 3000 {
 		return "", InvalidationError{inner: fmt.Errorf("too many keys to invalidate: %d", len(keys))}
-	}
-
-	if len(keys) == 0 {
-		return "", InvalidationError{inner: errors.New("no keys to invalidate")}
 	}
 
 	for i, key := range keys {

--- a/internal/staticupload/staticupload_test.go
+++ b/internal/staticupload/staticupload_test.go
@@ -357,6 +357,7 @@ func TestFlush(t *testing.T) {
 			wantCacheInvalidationErr: true,
 		},
 		"waiting for invalidation times out": {
+			dirtyKeys: []string{"test-key-1"},
 			invalidationIDs: []string{
 				"test-invalidation-id-2",
 				"test-invalidation-id-3",

--- a/internal/staticupload/staticupload_test.go
+++ b/internal/staticupload/staticupload_test.go
@@ -365,6 +365,9 @@ func TestFlush(t *testing.T) {
 			cacheInvalidationWaitTimeout: time.Microsecond,
 			wantCacheInvalidationErr:     true,
 		},
+		"no invalidations": {
+			dirtyKeys: []string{},
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- If no files have been touched, do not initiate an invalidation. Otherwise, the AWS API is unhappy.
