### PR TITLE
fix: use new UploadAzureSEVSNP impl

### DIFF
--- a/hack/configapi/cmd/root.go
+++ b/hack/configapi/cmd/root.go
@@ -56,9 +56,9 @@ func newRootCmd() *cobra.Command {
 		PreRunE: envCheck,
 		RunE:    runCmd,
 	}
-	rootCmd.PersistentFlags().StringVarP(&versionFilePath, "version-file", "f", "", "File path to the version json file.")
+	rootCmd.Flags().StringVarP(&versionFilePath, "version-file", "f", "", "File path to the version json file.")
 	rootCmd.Flags().BoolVar(&force, "force", false, "force to upload version regardless of comparison to latest API value.")
-	must(enforcePersistentRequiredFlags(rootCmd, "version-file"))
+	must(enforceRequiredFlags(rootCmd, "version-file"))
 	rootCmd.AddCommand(newDeleteCmd())
 	return rootCmd
 }
@@ -153,15 +153,6 @@ func isInputNewerThanLatestAPI(input, latest attestationconfig.AzureSEVSNPVersio
 func enforceRequiredFlags(cmd *cobra.Command, flags ...string) error {
 	for _, flag := range flags {
 		if err := cmd.MarkFlagRequired(flag); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func enforcePersistentRequiredFlags(cmd *cobra.Command, flags ...string) error {
-	for _, flag := range flags {
-		if err := cmd.MarkPersistentFlagRequired(flag); err != nil {
 			return err
 		}
 	}

--- a/hack/configapi/cmd/root.go
+++ b/hack/configapi/cmd/root.go
@@ -14,8 +14,8 @@ import (
 	"time"
 
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig"
-	attestationconfigclient "github.com/edgelesssys/constellation/v2/internal/api/attestationconfig/client"
-	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfig/fetcher"
+	attestationconfigapiclient "github.com/edgelesssys/constellation/v2/internal/api/attestationconfig/client"
+	attestationconfigapifetcher "github.com/edgelesssys/constellation/v2/internal/api/attestationconfig/fetcher"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"go.uber.org/zap"
 
@@ -35,6 +35,7 @@ const (
 
 var (
 	versionFilePath string
+	force           bool
 	// Cosign credentials.
 	cosignPwd  string
 	privateKey string
@@ -56,6 +57,7 @@ func newRootCmd() *cobra.Command {
 		RunE:    runCmd,
 	}
 	rootCmd.PersistentFlags().StringVarP(&versionFilePath, "version-file", "f", "", "File path to the version json file.")
+	rootCmd.Flags().BoolVar(&force, "force", false, "force to upload version regardless of comparison to latest API value.")
 	must(enforcePersistentRequiredFlags(rootCmd, "version-file"))
 	rootCmd.AddCommand(newDeleteCmd())
 	return rootCmd
@@ -85,7 +87,7 @@ func runCmd(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("unmarshalling version file: %w", err)
 	}
 
-	latestAPIVersion, err := fetcher.New().FetchAzureSEVSNPVersionLatest(ctx)
+	latestAPIVersion, err := attestationconfigapifetcher.New().FetchAzureSEVSNPVersionLatest(ctx)
 	if err != nil {
 		return fmt.Errorf("fetching latest version: %w", err)
 	}
@@ -94,9 +96,13 @@ func runCmd(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("comparing versions: %w", err)
 	}
-	if isNewer {
-		cmd.Printf("Input version: %+v is newer than latest API version: %+v\n", inputVersion, latestAPIVersion)
-		sut, sutClose, err := attestationconfigclient.New(ctx, cfg, []byte(cosignPwd), []byte(privateKey), false, log())
+	if isNewer || force {
+		if force {
+			cmd.Println("Forcing upload of new version")
+		} else {
+			cmd.Printf("Input version: %+v is newer than latest API version: %+v\n", inputVersion, latestAPIVersion)
+		}
+		sut, sutClose, err := attestationconfigapiclient.New(ctx, cfg, []byte(cosignPwd), []byte(privateKey), false, log())
 		defer func() {
 			if err := sutClose(ctx); err != nil {
 				cmd.Printf("closing repo: %v\n", err)

--- a/internal/api/attestationconfig/azure.go
+++ b/internal/api/attestationconfig/azure.go
@@ -42,7 +42,7 @@ type AzureSEVSNPVersionSignature struct {
 
 // JSONPath returns the path to the JSON file for the request to the config api.
 func (s AzureSEVSNPVersionSignature) JSONPath() string {
-	return path.Join(attestationURLPath, variant.AzureSEVSNP{}.String(), s.Version, ".sig")
+	return path.Join(attestationURLPath, variant.AzureSEVSNP{}.String(), s.Version+".sig")
 }
 
 // URL returns the URL for the request to the config api.
@@ -53,7 +53,7 @@ func (s AzureSEVSNPVersionSignature) URL() (string, error) {
 // ValidateRequest validates the request.
 func (s AzureSEVSNPVersionSignature) ValidateRequest() error {
 	if !strings.HasSuffix(s.Version, ".json") {
-		return fmt.Errorf("version has no .json suffix")
+		return fmt.Errorf("%s version has no .json suffix", s.Version)
 	}
 	return nil
 }

--- a/internal/api/attestationconfig/client/BUILD.bazel
+++ b/internal/api/attestationconfig/client/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "//internal/api/attestationconfig",
         "//internal/api/attestationconfig/fetcher",
         "//internal/api/client",
-        "//internal/constants",
         "//internal/logger",
         "//internal/sigstore",
         "//internal/staticupload",

--- a/internal/api/attestationconfig/fetcher/fetcher.go
+++ b/internal/api/attestationconfig/fetcher/fetcher.go
@@ -54,19 +54,19 @@ func (f *Fetcher) FetchAzureSEVSNPVersion(ctx context.Context, azureVersion atte
 	}
 	versionBytes, err := json.Marshal(fetchedVersion)
 	if err != nil {
-		return fetchedVersion, fmt.Errorf("marshal version for verify %s: %w", fetchedVersion.Version, err)
+		return fetchedVersion, fmt.Errorf("marshal version for verify %s: %w", azureVersion.Version, err)
 	}
 
 	signature, err := fetcher.Fetch(ctx, f.HTTPClient, attestationconfig.AzureSEVSNPVersionSignature{
 		Version: azureVersion.Version,
 	})
 	if err != nil {
-		return fetchedVersion, fmt.Errorf("fetch version %s signature: %w", fetchedVersion.Version, err)
+		return fetchedVersion, fmt.Errorf("fetch version %s signature: %w", azureVersion.Version, err)
 	}
 
 	err = sigstore.CosignVerifier{}.VerifySignature(versionBytes, signature.Signature, []byte(cosignPublicKey))
 	if err != nil {
-		return fetchedVersion, fmt.Errorf("verify version %s signature: %w", fetchedVersion.Version, err)
+		return fetchedVersion, fmt.Errorf("verify version %s signature: %w", azureVersion.Version, err)
 	}
 	return fetchedVersion, nil
 }

--- a/internal/api/attestationconfig/fetcher/fetcher_test.go
+++ b/internal/api/attestationconfig/fetcher/fetcher_test.go
@@ -93,7 +93,14 @@ func (f *fakeConfigAPIHandler) RoundTrip(req *http.Request) (*http.Response, err
 
 	} else if req.URL.Path == "/constellation/v1/attestation/azure-sev-snp/2021-01-01-01-01.json.sig" {
 		res := &http.Response{}
-		res.Body = io.NopCloser(bytes.NewReader(f.signature))
+		obj := configapi.AzureSEVSNPVersionSignature{
+			Signature: f.signature,
+		}
+		bt, err := json.Marshal(obj)
+		if err != nil {
+			return nil, err
+		}
+		res.Body = io.NopCloser(bytes.NewReader(bt))
 		res.StatusCode = http.StatusOK
 		return res, nil
 

--- a/internal/api/client/client.go
+++ b/internal/api/client/client.go
@@ -184,7 +184,7 @@ type APIObject interface {
 	JSONPath() string
 }
 
-// Fetch fetches the given apiObject from the public Constellation CDN.
+// Fetch fetches the given apiObject from the public Constellation API.
 func Fetch[T APIObject](ctx context.Context, c *Client, obj T) (T, error) {
 	if err := obj.ValidateRequest(); err != nil {
 		return *new(T), fmt.Errorf("validating request for %T: %w", obj, err)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- #1863 did not yet replace the old implementation, so we use it now

Why does it matter?
COMPATIBILITY ISSUE:
In order to use the new generic fetcher (`internal/api/fetcher`) all objects need to be marshalled as JSON. This also means that the signature needs to be stored as JSON and not as raw bytes anymore.
In order to avoid backward-compatibility issues to the old raw byte format, we should ship the new JSON format in the release.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
