### PR TITLE
cli: prevent tf apply drift when patching and re-applying existing tf deployment

### DIFF
--- a/cli/internal/terraform/terraform/gcp/modules/instance_group/main.tf
+++ b/cli/internal/terraform/terraform/gcp/modules/instance_group/main.tf
@@ -16,7 +16,7 @@ locals {
 resource "google_compute_instance_template" "template" {
   name         = local.name
   machine_type = var.instance_type
-  tags         = ["constellation-${var.uid}"] // Note that this is also applied as a label 
+  tags         = ["constellation-${var.uid}"] // Note that this is also applied as a label
   labels       = merge(var.labels, { constellation-role = local.role_dashed })
 
   confidential_instance_config {
@@ -77,6 +77,19 @@ resource "google_compute_instance_template" "template" {
     enable_secure_boot          = true
     enable_vtpm                 = true
     enable_integrity_monitoring = true
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+      labels,
+      disk, # required. update procedure modifies the instance template externally
+      metadata,
+      network_interface,
+      scheduling,
+      service_account,
+      shielded_instance_config,
+    ]
   }
 }
 


### PR DESCRIPTION
The implementation would recreate the gcp instance templates (including all instances and state disks) whenever the image tfvar changes.

Fixed by ignoring lifecycle changes on the instance templates.
Fixes 8c3b963

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: prevent tf apply drift when patching and re-applying existing tf deployment

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info

Output of constellation upgrade apply:

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # module.instance_group_control_plane.google_compute_instance_template.template must be replaced
-/+ resource "google_compute_instance_template" "template" {
        # [...]
        name                 = "malte-08f6a599-control-plane"
      + tags_fingerprint     = (known after apply)
        # (4 unchanged attributes hidden)

      ~ disk {
          ~ device_name       = "persistent-disk-0" -> (known after apply)
          ~ disk_type         = "pd-standard" -> (known after apply)
          ~ interface         = "SCSI" -> (known after apply)
          - labels            = {} -> null
          - resource_policies = [] -> null
          ~ source_image      = "projects/constellation-images/global/images/v2-7-1-stable" -> "projects/constellation-images/global/images/v2-8-0-stable" # forces replacement
          ~ type              = "PERSISTENT" -> (known after apply)
            # (4 unchanged attributes hidden)
        }
      ~ disk {
          ~ interface         = "SCSI" -> (known after apply)
          - labels            = {} -> null
          - resource_policies = [] -> null
          + source_image      = (known after apply)
            # (7 unchanged attributes hidden)
        }

        # [...]
    }

  # module.instance_group_worker.google_compute_instance_template.template must be replaced
-/+ resource "google_compute_instance_template" "template" {
        # [...]
        name                 = "malte-08f6a599-1-worker"
      + tags_fingerprint     = (known after apply)
        # (4 unchanged attributes hidden)

      ~ disk {
          ~ device_name       = "persistent-disk-0" -> (known after apply)
          ~ disk_type         = "pd-standard" -> (known after apply)
          ~ interface         = "SCSI" -> (known after apply)
          - labels            = {} -> null
          - resource_policies = [] -> null
          ~ source_image      = "projects/constellation-images/global/images/v2-7-1-stable" -> "projects/constellation-images/global/images/v2-8-0-stable" # forces replacement
          ~ type              = "PERSISTENT" -> (known after apply)
            # (4 unchanged attributes hidden)
        }
      ~ disk {
          ~ interface         = "SCSI" -> (known after apply)
          - labels            = {} -> null
          - resource_policies = [] -> null
          + source_image      = (known after apply)
            # (7 unchanged attributes hidden)
        }

      # [...]

```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
