### PR TITLE
ci: select correct target version for upgrade e2e test in release pipeline

### DIFF
--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -15,11 +15,19 @@ on:
         type: string
         description: "Git ref to checkout"
         required: false
+      targetVersion:
+        type: string
+        description: "Target version to test"
+        required: true
   workflow_call:
     inputs:
       ref:
         type: string
         description: "Git ref to checkout"
+        required: true
+      targetVersion:
+        type: string
+        description: "Target version to test"
         required: true
 
 jobs:
@@ -218,18 +226,7 @@ jobs:
         with:
           artifactNameSuffix: ${{ steps.e2e_test.outputs.namePrefix }}
 
-  determine-version:
-    runs-on: ubuntu-22.04
-    outputs:
-      targetVersion: ${{ steps.determine-version.outputs.targetVersion }}
-    steps:
-    - name: Determine version
-      id: determine-version
-      shell: bash
-      run: echo "targetVersion=$(cat version.txt)" | tee -a "$GITHUB_OUTPUT"
-
   e2e-upgrade:
-    needs: determine-version
     strategy:
       fail-fast: false
       max-parallel: 1
@@ -246,7 +243,7 @@ jobs:
     uses: ./.github/workflows/e2e-upgrade.yml
     with:
       fromVersion: ${{ matrix.fromVersion }}
-      toImage: ${{ needs.determine-version.outputs.targetVersion }}
+      toImage: ${{ inputs.targetVersion }}
       cloudProvider: ${{ matrix.cloudProvider }}
       workerNodesCount: 2
       controlNodesCount: 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,6 +279,7 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ needs.verify-inputs.outputs.WORKING_BRANCH }}
+      targetVersion: ${{ inputs.version }}
 
   mini-e2e:
     name: Run mini E2E tests


### PR DESCRIPTION
Previous implementation would select the target version `""`, since `determine-version` tried to read `version.txt` without checking out the release branch first.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: select correct target version for upgrade e2e test in release pipeline

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
