### PR TITLE
ci: fix docker-login on macOS runner

### DIFF
--- a/.github/actions/build_micro_service/action.yml
+++ b/.github/actions/build_micro_service/action.yml
@@ -54,7 +54,7 @@ runs:
 
     - name: Log in to the Container registry
       id: docker-login
-      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # tag=v2.1.0
+      uses: ./.github/actions/container_registry_login
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/actions/container_registry_login/action.yml
+++ b/.github/actions/container_registry_login/action.yml
@@ -1,0 +1,35 @@
+name: Create container registry login credentials file
+description: Delete previously created IAM configuration.
+
+inputs:
+  registry:
+    description: "Container registry to use"
+    required: true
+  username:
+    description: "Username used for authentication."
+    required: true
+  password:
+    description: "Password used for authentication."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Use docker for logging in
+      if: runner.os != 'macOS'
+      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # tag=v2.1.0
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+
+    - name: Manually create docker config.json
+      if: runner.os == 'macOS'
+      shell: bash
+      env:
+        REGISTRY: ${{ inputs.registry }}
+        USERNAME: ${{ inputs.username }}
+        PASSWORD: ${{ inputs.password }}
+      run: |
+        mkdir -p ~/.docker
+        echo "{\"auths\":{\"${REGISTRY}\":{\"username\":\"${USERNAME}\",\"password\":\"${PASSWORD}\"}}}"  | tee ~/.docker/config.json

--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -36,7 +36,7 @@ runs:
         buildBuddyApiKey: ${{ inputs.buildBuddyApiKey }}
 
     - name: Log in to the Container registry
-      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # tag=v2.1.0
+      uses: ./.github/actions/container_registry_login
       with:
         registry: ${{ inputs.registry }}
         username: ${{ github.actor }}

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -117,7 +117,7 @@ runs:
         buildBuddyApiKey: ${{ inputs.buildBuddyApiKey }}
 
     - name: Log in to the Container registry
-      uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # tag=v2.1.0
+      uses: ./.github/actions/container_registry_login
       with:
         registry: ${{ inputs.registry }}
         username: ${{ github.actor }}
@@ -192,7 +192,7 @@ runs:
       id: create-prefix
       shell: bash
       run: |
-        uuid=$(uuidgen)
+        uuid=$(uuidgen | tr "[:upper:]" "[:lower:]")
         uuid=${uuid%%-*}
         echo "uuid=${uuid}" | tee -a $GITHUB_OUTPUT
         echo "prefix=e2e-${{ github.run_id }}-${{ github.run_attempt }}-${uuid}" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Log in to the Container registry
         id: docker-login
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # tag=v2.1.0
+        uses: ./.github/actions/container_registry_login
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/build-gcp-guest-agent.yml
+++ b/.github/workflows/build-gcp-guest-agent.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Log in to the Container registry
         id: docker-login
         if: steps.needs-build.outputs.out == 'true'
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # tag=v2.1.0
+        uses: ./.github/actions/container_registry_login
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -241,7 +241,7 @@ jobs:
           machineType: ${{ inputs.machineType }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcpClusterCreateServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
-          gcpIAMCreateServiceAccount: " constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
+          gcpIAMCreateServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
           gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ inputs.test }}
           kubernetesVersion: ${{ inputs.kubernetesVersion }}

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -197,7 +197,7 @@ jobs:
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcpClusterCreateServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
-          gcpIAMCreateServiceAccount: " constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
+          gcpIAMCreateServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
           gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ matrix.test }}
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -199,7 +199,7 @@ jobs:
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcpClusterCreateServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
-          gcpIAMCreateServiceAccount: " constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
+          gcpIAMCreateServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
           gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ matrix.test }}
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -89,7 +89,7 @@ jobs:
           useCache: "false"
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f4ef78c080cd8ba55a85445d5b36e214a81df20a # tag=v2.1.0
+        uses: ./.github/actions/container_registry_login
         with:
           registry: ${{ inputs.registry }}
           username: ${{ github.actor }}


### PR DESCRIPTION
docker-login action fails on macOS runner since docker is not installed.

<!-- [AB#3189](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3189) -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: fix docker-login on macOS runner

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info
- [e2e](https://github.com/edgelesssys/constellation/actions/runs/5186617789)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
