### PR TITLE
config: disable user-facing version fetch for Azure SEV SNP

### DIFF
--- a/internal/attestation/azure/snp/validator_test.go
+++ b/internal/attestation/azure/snp/validator_test.go
@@ -218,6 +218,10 @@ func TestTrustedKeyFromSNP(t *testing.T) {
 				AcceptedKeyDigests: tc.idkeydigests,
 				EnforcementPolicy:  tc.enforceIDKeyDigest,
 			}
+			cfg.BootloaderVersion = config.AttestationVersion{Value: 2}
+			cfg.TEEVersion = config.AttestationVersion{Value: 0}
+			cfg.MicrocodeVersion = config.AttestationVersion{Value: 93}
+			cfg.SNPVersion = config.AttestationVersion{Value: 6}
 
 			validator := &Validator{
 				hclValidator: &instanceInfo,
@@ -349,6 +353,12 @@ func TestNewSNPReportFromBytes(t *testing.T) {
 		},
 	}
 	cfg := config.DefaultForAzureSEVSNP()
+
+	cfg.BootloaderVersion = config.AttestationVersion{Value: 2}
+	cfg.TEEVersion = config.AttestationVersion{Value: 0}
+	cfg.MicrocodeVersion = config.AttestationVersion{Value: 93}
+	cfg.SNPVersion = config.AttestationVersion{Value: 6}
+
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)

--- a/internal/config/attestationversion.go
+++ b/internal/config/attestationversion.go
@@ -8,6 +8,7 @@ package config
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -33,7 +34,7 @@ func (v AttestationVersion) MarshalYAML() (any, error) {
 	if v.IsLatest {
 		return "latest", nil
 	}
-	return v.Value, nil
+	return int(v.Value), nil
 }
 
 // UnmarshalYAML implements a custom unmarshaller to resolve "atest" values.
@@ -67,12 +68,16 @@ func (v *AttestationVersion) parseRawUnmarshal(rawUnmarshal any) error {
 	switch s := rawUnmarshal.(type) {
 	case string:
 		if strings.ToLower(s) == "latest" {
-			v.IsLatest = true
-			v.Value = placeholderVersionValue
-		} else {
-			return fmt.Errorf("invalid version value: %s", s)
+			// TODO(elchead): activate latest logic for next release AB#3036
+			return errors.New("latest is not supported as a version value")
+			// v.IsLatest = true
+			// v.Value = placeholderVersionValue
 		}
+		return fmt.Errorf("invalid version value: %s", s)
 	case int:
+		v.Value = uint8(s)
+	// yaml spec allows "1" as float64, so version number might come as a float:  https://github.com/go-yaml/yaml/issues/430
+	case float64:
 		v.Value = uint8(s)
 	default:
 		return fmt.Errorf("invalid version value type: %s", s)

--- a/internal/config/attestationversion_test.go
+++ b/internal/config/attestationversion_test.go
@@ -9,6 +9,7 @@ package config
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
 )
@@ -41,6 +42,42 @@ func TestVersionMarshalYAML(t *testing.T) {
 			bt, err := yaml.Marshal(tt.sut)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, string(bt))
+		})
+	}
+}
+
+func TestVersionUnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name      string
+		expected  AttestationVersion
+		yamlInput string
+		wantErr   bool
+	}{
+		// TODO(elchead): activate latest logic for next release AB#3036
+		{
+			name:      "latest value is not allowed",
+			expected:  AttestationVersion{},
+			yamlInput: "latest\n",
+			wantErr:   true,
+		},
+		{
+			name: "value 5 resolves to 5",
+			expected: AttestationVersion{
+				Value: 5,
+			},
+			yamlInput: "5\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sut := AttestationVersion{}
+			err := yaml.Unmarshal([]byte(tt.yamlInput), &sut)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected.IsLatest, sut.IsLatest)
 		})
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,20 +41,21 @@ func TestDefaultConfig(t *testing.T) {
 	assert.NotNil(def)
 }
 
-func TestDefaultConfigWritesLatestVersion(t *testing.T) {
-	conf := Default()
-	bt, err := yaml.Marshal(conf)
-	require := require.New(t)
-	require.NoError(err)
+// TODO(elchead): activate latest logic for next release AB#3036
+// func TestDefaultConfigWritesLatestVersion(t *testing.T) {
+//	conf := Default()
+//	bt, err := yaml.Marshal(conf)
+//	require := require.New(t)
+//	require.NoError(err)
 
-	var mp configMap
-	require.NoError(yaml.Unmarshal(bt, &mp))
-	assert := assert.New(t)
-	assert.Equal("latest", mp.getAzureSEVSNPVersion("microcodeVersion"))
-	assert.Equal("latest", mp.getAzureSEVSNPVersion("teeVersion"))
-	assert.Equal("latest", mp.getAzureSEVSNPVersion("snpVersion"))
-	assert.Equal("latest", mp.getAzureSEVSNPVersion("bootloaderVersion"))
-}
+//	var mp configMap
+//	require.NoError(yaml.Unmarshal(bt, &mp))
+//	assert := assert.New(t)
+//	assert.Equal("latest", mp.getAzureSEVSNPVersion("microcodeVersion"))
+//	assert.Equal("latest", mp.getAzureSEVSNPVersion("teeVersion"))
+//	assert.Equal("latest", mp.getAzureSEVSNPVersion("snpVersion"))
+//	assert.Equal("latest", mp.getAzureSEVSNPVersion("bootloaderVersion"))
+//}
 
 func TestReadConfigFile(t *testing.T) {
 	testCases := map[string]struct {
@@ -63,29 +64,41 @@ func TestReadConfigFile(t *testing.T) {
 		wantResult *Config
 		wantErr    bool
 	}{
-		"mix of Latest and uint as version value": {
+		// TODO(elchead): activate latest logic for next release AB#3036
+		//"mix of Latest and uint as version value": {
+		//	config: func() configMap {
+		//		conf := Default()
+		//		m := getConfigAsMap(conf, t)
+		//		m.setAzureSEVSNPVersion("microcodeVersion", "Latest") // check uppercase also works
+		//		m.setAzureSEVSNPVersion("teeVersion", 2)
+		//		m.setAzureSEVSNPVersion("bootloaderVersion", 1)
+		//		return m
+		//	}(),
+
+		//	configName: constants.ConfigFilename,
+		//	wantResult: func() *Config {
+		//		conf := Default()
+		//		conf.Attestation.AzureSEVSNP.BootloaderVersion = AttestationVersion{
+		//			Value:    1,
+		//			IsLatest: false,
+		//		}
+		//		conf.Attestation.AzureSEVSNP.TEEVersion = AttestationVersion{
+		//			Value:    2,
+		//			IsLatest: false,
+		//		}
+		//		return conf
+		//	}(),
+		//},
+		// TODO(elchead): activate latest logic for next release AB#3036
+		"refuse invalid latest value": {
 			config: func() configMap {
 				conf := Default()
 				m := getConfigAsMap(conf, t)
-				m.setAzureSEVSNPVersion("microcodeVersion", "Latest") // check uppercase also works
-				m.setAzureSEVSNPVersion("teeVersion", 2)
-				m.setAzureSEVSNPVersion("bootloaderVersion", 1)
+				m.setAzureSEVSNPVersion("microcodeVersion", "latest")
 				return m
 			}(),
-
 			configName: constants.ConfigFilename,
-			wantResult: func() *Config {
-				conf := Default()
-				conf.Attestation.AzureSEVSNP.BootloaderVersion = AttestationVersion{
-					Value:    1,
-					IsLatest: false,
-				}
-				conf.Attestation.AzureSEVSNP.TEEVersion = AttestationVersion{
-					Value:    2,
-					IsLatest: false,
-				}
-				return conf
-			}(),
+			wantErr:    true,
 		},
 		"refuse invalid version value": {
 			config: func() configMap {
@@ -876,9 +889,9 @@ func (c configMap) setAzureSEVSNPVersion(versionType string, value interface{}) 
 	c["attestation"].(configMap)["azureSEVSNP"].(configMap)[versionType] = value
 }
 
-func (c configMap) getAzureSEVSNPVersion(versionType string) interface{} {
-	return c["attestation"].(configMap)["azureSEVSNP"].(configMap)[versionType]
-}
+//func (c configMap) getAzureSEVSNPVersion(versionType string) interface{} {
+//	return c["attestation"].(configMap)["azureSEVSNP"].(configMap)[versionType]
+//}
 
 // getConfigAsMap returns a map of the config.
 func getConfigAsMap(conf *Config, t *testing.T) (res configMap) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
don't allow "latest" value and disable user-facing version fetcher for Azure SEV SNP.
REASON: v2.8 release.
Revert after release

Co-authored-by: @derpsteb



### Related issue
[AB#3036](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3036)

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
