### PR TITLE
ci: migrate e2e lb test to bazel

### DIFF
--- a/.github/actions/e2e_lb/action.yml
+++ b/.github/actions/e2e_lb/action.yml
@@ -18,7 +18,7 @@ runs:
       run: |
         kubectl apply -f ns.yml
         kubectl apply -f lb.yml
-        go test -timeout=3h ../../../e2e/internal/lb/lb_test.go -v
+        bazel run //e2e/internal/lb:lb_test
 
     - name: Delete deployment
       if: always()

--- a/.github/actions/setup_bazel/action.yml
+++ b/.github/actions/setup_bazel/action.yml
@@ -69,10 +69,22 @@ runs:
 
     - name: Configure Bazel (readonly)
       shell: bash
-      if: inputs.useCache == 'readonly'
+      env:
+        WORKSPACE: ${{ github.workspace }}
       run: |
         echo "::group::Configure Bazel (readonly)"
         echo "build --remote_upload_local_results=false" >> "${WORKSPACE}/.bazeloverwriterc"
+        echo "::endgroup::"
+
+    - name: Disable disk cache on GitHub Actions runners
+      shell: bash
+      env:
+        WORKSPACE: ${{ github.workspace }}
+      if: startsWith(runner.name , 'GitHub Actions')
+      run: |
+        echo "::group::Configure Bazel (disk cache)"
+        echo "build --disk_cache=" >> "${WORKSPACE}/.bazeloverwriterc"
+        echo "build --repository_cache=" >> "${WORKSPACE}/.bazeloverwriterc"
         echo "::endgroup::"
 
     - name: Check bazel version

--- a/e2e/internal/lb/BUILD.bazel
+++ b/e2e/internal/lb/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//bazel/go:go_test.bzl", "go_test")
+
+go_library(
+    name = "lb",
+    srcs = ["lb.go"],
+    importpath = "github.com/edgelesssys/constellation/v2/e2e/internal/lb",
+    visibility = ["//e2e:__subpackages__"],
+)
+
+go_test(
+    name = "lb_test",
+    timeout = "eternal",  # 1 hour
+    srcs = ["lb_test.go"],
+    # keep
+    count = 1,
+    embed = [":lb"],
+    # keep
+    gotags = ["e2e"],
+    tags = ["manual"],
+    deps = [
+        "//e2e/internal/kubectl",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+        "@io_k8s_api//core/v1:core",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_client_go//kubernetes",
+    ],
+)

--- a/e2e/internal/lb/lb.go
+++ b/e2e/internal/lb/lb.go
@@ -1,0 +1,8 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+// Package lb tests that the cloud load balancer works as expected.
+package lb


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Try to migrate out of disk space errors: https://github.com/edgelesssys/constellation/actions/runs/5197845754/jobs/9373214163 by disabling the shared bazel cache on GitHub Action runners. This saves ~8 GB.

Testrun (azure, lb): https://github.com/edgelesssys/constellation/actions/runs/5221894800

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
