### PR TITLE
cli: change generate-config flag to update-config flag

### DIFF
--- a/.github/actions/constellation_iam_create/action.yml
+++ b/.github/actions/constellation_iam_create/action.yml
@@ -42,10 +42,11 @@ runs:
       shell: bash
       if: inputs.cloudProvider == 'aws'
       run: |
+        constellation config generate aws
         constellation iam create aws \
           --zone=${{ inputs.awsZone }} \
           --prefix=${{ inputs.namePrefix }} \
-          --generate-config --yes
+          --update-config --yes
 
     - name: Constellation iam create azure
       shell: bash
@@ -55,21 +56,23 @@ runs:
         if [[ $output == *"tf-log"* ]]; then
           TFFLAG="--tf-log=DEBUG"
         fi
+        constellation config generate azure
         constellation iam create azure \
           --region=${{ inputs.azureRegion }} \
           --resourceGroup="${{ inputs.namePrefix }}-rg" \
           --servicePrincipal="${{ inputs.namePrefix }}-sp" \
-          --generate-config --yes ${TFFLAG:-}
+          --update-config --yes ${TFFLAG:-}
 
     - name: Constellation iam create gcp
       shell: bash
       if: inputs.cloudProvider == 'gcp'
       run: |
+        constellation config generate gcp
         constellation iam create gcp \
           --projectID=${{ inputs.gcpProjectID }} \
           --zone=${{ inputs.gcpZone }} \
           --serviceAccountID="${{ inputs.namePrefix }}-sa" \
-          --generate-config --yes
+          --update-config --yes
 
     - name: Set existing config
       id: setExistingConfig

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -57,7 +57,8 @@ jobs:
       - name: Create IAM configuration
         shell: pwsh
         run: |
-          .\constellation.exe iam create azure --region=westus --resourceGroup=e2eWindoewsRG --servicePrincipal=e2eWindoewsSP --generate-config --debug -y
+          .\constellation.exe config generate azure
+          .\constellation.exe iam create azure --region=westus --resourceGroup=e2eWindoewsRG --servicePrincipal=e2eWindoewsSP --update-config --debug -y
 
       - name: Login to Azure (Cluster service principal)
         uses: ./.github/actions/login_azure

--- a/cli/internal/cmd/iamcreate.go
+++ b/cli/internal/cmd/iamcreate.go
@@ -22,7 +22,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"golang.org/x/mod/semver"
 )
 
 var (
@@ -60,7 +59,6 @@ func newIAMCreateCmd() *cobra.Command {
 
 	cmd.PersistentFlags().BoolP("yes", "y", false, "create the IAM configuration without further confirmation")
 	cmd.PersistentFlags().Bool("update-config", false, "automatically update the config file with the specific IAM information")
-	cmd.PersistentFlags().StringP("kubernetes", "k", semver.MajorMinor(config.Default().KubernetesVersion), "Kubernetes version to use in format MAJOR.MINOR - only usable in combination with --generate-config")
 
 	cmd.AddCommand(newIAMCreateAWSCmd())
 	cmd.AddCommand(newIAMCreateAzureCmd())
@@ -215,16 +213,13 @@ func (c *iamCreator) create(ctx context.Context) error {
 	}
 	c.log.Debugf("Using flags: %+v", flags)
 
-	if err := c.checkWorkingDir(flags); err != nil {
+	if err := c.checkWorkingDir(); err != nil {
 		return err
 	}
 
 	if !flags.yesFlag {
 		c.cmd.Printf("The following IAM configuration will be created:\n\n")
 		c.providerCreator.printConfirmValues(c.cmd, flags)
-		if flags.updateConfig {
-			c.cmd.Printf("The configuration file %s will be automatically generated and populated with the IAM values.\n", flags.configPath)
-		}
 		ok, err := askToConfirm(c.cmd, "Do you want to create the configuration?")
 		if err != nil {
 			return err
@@ -235,10 +230,16 @@ func (c *iamCreator) create(ctx context.Context) error {
 		}
 	}
 
+	var conf config.Config
+	if flags.updateConfig {
+		c.cmd.Printf("The configuration file %q will be automatically updated and populated with the IAM values.\n", flags.configPath)
+		c.log.Debugf("Parsing config %s", flags.configPath)
+		if err = c.fileHandler.ReadYAML(flags.configPath, &conf); err != nil {
+			return fmt.Errorf("error reading the configuration file: %w", err)
+		}
+	}
+
 	c.spinner.Start("Creating", false)
-
-	conf := createConfig(c.provider)
-
 	iamFile, err := c.creator.Create(ctx, c.provider, c.iamConfig)
 	c.spinner.Stop()
 	if err != nil {
@@ -254,12 +255,8 @@ func (c *iamCreator) create(ctx context.Context) error {
 
 	if flags.updateConfig {
 		c.log.Debugf("Writing IAM configuration to %s", flags.configPath)
-		c.providerCreator.writeOutputValuesToConfig(conf, flags, iamFile)
-		// Only overwrite when --generate-config && --kubernetes. Otherwise this string is empty from parseFlagsAndSetupConfig.
-		if flags.k8sVersion != "" {
-			conf.KubernetesVersion = flags.k8sVersion
-		}
-		if err := c.fileHandler.WriteYAML(flags.configPath, conf, file.OptMkdirAll); err != nil {
+		c.providerCreator.writeOutputValuesToConfig(&conf, flags, iamFile)
+		if err := c.fileHandler.WriteYAML(flags.configPath, conf, file.OptOverwrite); err != nil {
 			return err
 		}
 		c.cmd.Printf("Your IAM configuration was created and filled into %s successfully.\n", flags.configPath)
@@ -282,35 +279,15 @@ func (c *iamCreator) parseFlagsAndSetupConfig() (iamFlags, error) {
 	if err != nil {
 		return iamFlags{}, fmt.Errorf("parsing yes bool: %w", err)
 	}
-	generateConfig, err := c.cmd.Flags().GetBool("generate-config")
+	updateConfig, err := c.cmd.Flags().GetBool("update-config")
 	if err != nil {
-		return iamFlags{}, fmt.Errorf("parsing generate-config bool: %w", err)
-	}
-	k8sVersion, err := c.cmd.Flags().GetString("kubernetes")
-	if err != nil {
-		return iamFlags{}, fmt.Errorf("parsing kubernetes string: %w", err)
-	}
-
-	// This is implemented slightly differently compared to "config generate", since this flag is only respected in combination with --generate-config.
-	// Even if an invalid version is set, in case --generate-config is false, we don't overwrite the default value of the config.
-	// So we only need to validate the input to the flag when --generate-config is set.
-	// Otherwise, we return an empty string. Later, we only overwrite the value in the config when we haven't passed an empty string.
-	// Instead, we should have our validated K8s version parameter then.
-	var resolvedVersion string
-	if generateConfig {
-		resolvedVersion, err = resolveK8sVersion(k8sVersion)
-		if err != nil {
-			return iamFlags{}, fmt.Errorf("resolving kubernetes version: %w", err)
-		}
-	} else if c.cmd.Flag("kubernetes").Changed {
-		c.cmd.Println("Warning: --generate-config is not set, ignoring --kubernetes flag.")
+		return iamFlags{}, fmt.Errorf("parsing update-config bool: %w", err)
 	}
 
 	flags := iamFlags{
 		configPath:   configPath,
 		yesFlag:      yesFlag,
-		updateConfig: generateConfig,
-		k8sVersion:   resolvedVersion,
+		updateConfig: updateConfig,
 	}
 
 	flags, err = c.providerCreator.parseFlagsAndSetupConfig(c.cmd, flags, c.iamConfig)
@@ -321,15 +298,10 @@ func (c *iamCreator) parseFlagsAndSetupConfig() (iamFlags, error) {
 	return flags, nil
 }
 
-// checkWorkingDir checks if the current working directory already contains a Terraform dir or a Constellation config file.
-func (c *iamCreator) checkWorkingDir(flags iamFlags) error {
+// checkWorkingDir checks if the current working directory already contains a Terraform dir.
+func (c *iamCreator) checkWorkingDir() error {
 	if _, err := c.fileHandler.Stat(constants.TerraformIAMWorkingDir); err == nil {
 		return fmt.Errorf("the current working directory already contains the Terraform workspace directory %q. Please run the command in a different directory or destroy the existing workspace", constants.TerraformIAMWorkingDir)
-	}
-	if flags.updateConfig {
-		if _, err := c.fileHandler.Stat(flags.configPath); err == nil {
-			return fmt.Errorf("the flag --generate-config is set, but %q already exists. Please either run the command in a different directory, define another config path, or delete or move the existing configuration", flags.configPath)
-		}
 	}
 	return nil
 }
@@ -342,7 +314,6 @@ type iamFlags struct {
 	configPath   string
 	yesFlag      bool
 	updateConfig bool
-	k8sVersion   string
 }
 
 // awsFlags contains the parsed flags of the iam create aws command.

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -50,7 +50,7 @@ func newUpgradeCheckCmd() *cobra.Command {
 		RunE:  runUpgradeCheck,
 	}
 
-	cmd.Flags().BoolP("write-config", "w", false, "update the specified config file with the suggested versions")
+	cmd.Flags().BoolP("update-config", "u", false, "update the specified config file with the suggested versions")
 	cmd.Flags().String("ref", versionsapi.ReleaseRef, "the reference to use for querying new versions")
 	cmd.Flags().String("stream", "stable", "the stream to use for querying new versions")
 
@@ -109,9 +109,9 @@ func parseUpgradeCheckFlags(cmd *cobra.Command) (upgradeCheckFlags, error) {
 	if err != nil {
 		return upgradeCheckFlags{}, fmt.Errorf("parsing force bool: %w", err)
 	}
-	writeConfig, err := cmd.Flags().GetBool("write-config")
+	updateConfig, err := cmd.Flags().GetBool("update-config")
 	if err != nil {
-		return upgradeCheckFlags{}, fmt.Errorf("parsing write-config bool: %w", err)
+		return upgradeCheckFlags{}, fmt.Errorf("parsing update-config bool: %w", err)
 	}
 	ref, err := cmd.Flags().GetString("ref")
 	if err != nil {
@@ -134,7 +134,7 @@ func parseUpgradeCheckFlags(cmd *cobra.Command) (upgradeCheckFlags, error) {
 	return upgradeCheckFlags{
 		configPath:        configPath,
 		force:             force,
-		writeConfig:       writeConfig,
+		updateConfig:      updateConfig,
 		ref:               ref,
 		stream:            stream,
 		terraformLogLevel: logLevel,
@@ -257,7 +257,7 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 	// Using Print over Println as buildString already includes a trailing newline where necessary.
 	cmd.Print(updateMsg)
 
-	if flags.writeConfig {
+	if flags.updateConfig {
 		if err := upgrade.writeConfig(conf, fileHandler, flags.configPath); err != nil {
 			return fmt.Errorf("writing config: %w", err)
 		}
@@ -717,7 +717,7 @@ func (v *versionCollector) filterCompatibleCLIVersions(ctx context.Context, cliP
 type upgradeCheckFlags struct {
 	configPath        string
 	force             bool
-	writeConfig       bool
+	updateConfig      bool
 	ref               string
 	stream            string
 	terraformLogLevel terraform.LogLevel

--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -13,19 +13,47 @@ If you encounter any problem with the following steps, make sure to use the [lat
 
 ## Create a cluster
 
-1. Create the configuration file and IAM resources for your selected cloud provider
-
-    First, you need to create a [configuration file](../workflows/config.md) and an [IAM configuration](../workflows/config.md#creating-an-iam-configuration). The easiest way to do this is the following CLI command:
+1. Create the [configuration file](../workflows/config.md) for your cloud provider.
 
     <tabs groupId="csp">
 
     <tabItem value="azure" label="Azure">
 
     ```bash
-    constellation iam create azure --region=westus --resourceGroup=constellTest --servicePrincipal=spTest --generate-config
+    constellation config generate azure
     ```
 
-    This command creates IAM configuration on the Azure region `westus` creating a new resource group `constellTest` and a new service principal `spTest`. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    </tabItem>
+
+    <tabItem value="gcp" label="GCP">
+
+    ```bash
+    constellation config generate gcp
+    ```
+
+    </tabItem>
+
+    <tabItem value="aws" label="AWS">
+
+    ```bash
+    constellation config generate aws
+    ```
+
+    </tabItem>
+
+    </tabs>
+
+2. Create your [IAM configuration](../workflows/config.md#creating-an-iam-configuration).
+
+    <tabs groupId="csp">
+
+    <tabItem value="azure" label="Azure">
+
+    ```bash
+    constellation iam create azure --region=westus --resourceGroup=constellTest --servicePrincipal=spTest --update-config
+    ```
+
+    This command creates IAM configuration on the Azure region `westus` creating a new resource group `constellTest` and a new service principal `spTest`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that CVMs are currently only supported in a few regions, check [Azure's products available by region](https://azure.microsoft.com/en-us/global-infrastructure/services/?products=virtual-machines&regions=all). These are:
     * `westus`
@@ -38,10 +66,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <tabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --generate-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 
@@ -50,10 +78,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <tabItem value="aws" label="AWS">
 
     ```bash
-    constellation iam create aws --zone=us-east-2a --prefix=constellTest --generate-config
+    constellation iam create aws --zone=us-east-2a --prefix=constellTest --update-config
     ```
 
-    This command creates IAM configuration for the AWS zone `us-east-2a` using the prefix `constellTest` for all named resources being created. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration for the AWS zone `us-east-2a` using the prefix `constellTest` for all named resources being created. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Depending on the attestation variant selected on config generation, different regions are available.
     AMD SEV-SNP machines (requires the default attestation variant `awsSEVSNP`) are currently available in the following regions:
@@ -89,7 +117,7 @@ If you encounter any problem with the following steps, make sure to use the [lat
     :::
 -->
 
-2. Create the cluster with one control-plane node and two worker nodes. `constellation create` uses options set in `constellation-conf.yaml`.
+3. Create the cluster with one control-plane node and two worker nodes. `constellation create` uses options set in `constellation-conf.yaml`.
     If you want to manually use [Terraform](../reference/terraform.md) for managing the cloud resources instead, follow the corresponding instructions in the [Create workflow](../workflows/create.md).
 
     :::tip
@@ -109,7 +137,7 @@ If you encounter any problem with the following steps, make sure to use the [lat
     Your Constellation cluster was created successfully.
     ```
 
-3. Initialize the cluster
+4. Initialize the cluster.
 
     ```bash
     constellation init
@@ -140,7 +168,7 @@ If you encounter any problem with the following steps, make sure to use the [lat
 
     :::
 
-4. Configure kubectl
+5. Configure kubectl.
 
     ```bash
     export KUBECONFIG="$PWD/constellation-admin.conf"

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -416,7 +416,7 @@ constellation upgrade check [flags]
   -h, --help            help for check
       --ref string      the reference to use for querying new versions (default "-")
       --stream string   the stream to use for querying new versions (default "stable")
-  -w, --write-config    update the specified config file with the suggested versions
+  -u, --update-config   update the specified config file with the suggested versions
 ```
 
 ### Options inherited from parent commands
@@ -580,10 +580,9 @@ Create IAM configuration on a cloud platform for your Constellation cluster.
 ### Options
 
 ```
-      --generate-config     automatically generate a configuration file and fill in the required fields
-  -h, --help                help for create
-  -k, --kubernetes string   Kubernetes version to use in format MAJOR.MINOR - only usable in combination with --generate-config (default "v1.26")
-  -y, --yes                 create the IAM configuration without further confirmation
+  -h, --help            help for create
+      --update-config   automatically update the config file with the specific IAM information
+  -y, --yes             create the IAM configuration without further confirmation
 ```
 
 ### Options inherited from parent commands
@@ -619,13 +618,12 @@ constellation iam create aws [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       path to the configuration file (default "constellation-conf.yaml")
-      --debug               enable debug logging
-      --force               disable version compatibility checks - might result in corrupted clusters
-      --generate-config     automatically generate a configuration file and fill in the required fields
-  -k, --kubernetes string   Kubernetes version to use in format MAJOR.MINOR - only usable in combination with --generate-config (default "v1.26")
-      --tf-log string       sets the Terraform log level (default "NONE" - no logs) (default "NONE")
-  -y, --yes                 create the IAM configuration without further confirmation
+      --config string   path to the configuration file (default "constellation-conf.yaml")
+      --debug           enable debug logging
+      --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
+      --update-config   automatically update the config file with the specific IAM information
+  -y, --yes             create the IAM configuration without further confirmation
 ```
 
 ## constellation iam create azure
@@ -652,13 +650,12 @@ constellation iam create azure [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       path to the configuration file (default "constellation-conf.yaml")
-      --debug               enable debug logging
-      --force               disable version compatibility checks - might result in corrupted clusters
-      --generate-config     automatically generate a configuration file and fill in the required fields
-  -k, --kubernetes string   Kubernetes version to use in format MAJOR.MINOR - only usable in combination with --generate-config (default "v1.26")
-      --tf-log string       sets the Terraform log level (default "NONE" - no logs) (default "NONE")
-  -y, --yes                 create the IAM configuration without further confirmation
+      --config string   path to the configuration file (default "constellation-conf.yaml")
+      --debug           enable debug logging
+      --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
+      --update-config   automatically update the config file with the specific IAM information
+  -y, --yes             create the IAM configuration without further confirmation
 ```
 
 ## constellation iam create gcp
@@ -688,13 +685,12 @@ constellation iam create gcp [flags]
 ### Options inherited from parent commands
 
 ```
-      --config string       path to the configuration file (default "constellation-conf.yaml")
-      --debug               enable debug logging
-      --force               disable version compatibility checks - might result in corrupted clusters
-      --generate-config     automatically generate a configuration file and fill in the required fields
-  -k, --kubernetes string   Kubernetes version to use in format MAJOR.MINOR - only usable in combination with --generate-config (default "v1.26")
-      --tf-log string       sets the Terraform log level (default "NONE" - no logs) (default "NONE")
-  -y, --yes                 create the IAM configuration without further confirmation
+      --config string   path to the configuration file (default "constellation-conf.yaml")
+      --debug           enable debug logging
+      --force           disable version compatibility checks - might result in corrupted clusters
+      --tf-log string   sets the Terraform log level (default "NONE" - no logs) (default "NONE")
+      --update-config   automatically update the config file with the specific IAM information
+  -y, --yes             create the IAM configuration without further confirmation
 ```
 
 ## constellation iam destroy

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -40,10 +40,6 @@ constellation config generate aws
 
 This creates the file `constellation-conf.yaml` in the current directory.
 
-:::tip
-You can also automatically generate a configuration file by adding the `--generate-config` flag to the `constellation iam create` command when [creating an IAM configuration](#creating-an-iam-configuration).
-:::
-
 ## Choosing a VM type
 
 Constellation supports the following VM types:
@@ -92,7 +88,7 @@ See also Constellation's [Kubernetes support policy](../architecture/versions.md
 ## Creating an IAM configuration
 
 You can create an IAM configuration for your cluster automatically using the `constellation iam create` command.
-If you haven't generated a configuration file yet, you can do so by adding the `--generate-config` flag to the command. This creates a configuration file and populates it with the created IAM values.
+If you already have a constellation configuration file, you can add the `--update-config` flag to the command. This writes the needed IAM fields into your configuration.
 
 <tabs groupId="csp">
 <tabItem value="azure" label="Azure">

--- a/docs/docs/workflows/upgrade.md
+++ b/docs/docs/workflows/upgrade.md
@@ -36,10 +36,10 @@ To learn which versions the current CLI can upgrade to and what's installed in y
 constellation upgrade check
 
 # Show possible upgrades and write them to config file
-constellation upgrade check --write-config
+constellation upgrade check --update-config
 ```
 
-You can either enter the reported target versions into your config manually or run the above command with the `--write-config` flag.
+You can either enter the reported target versions into your config manually or run the above command with the `--update-config` flag.
 When using this flag, the `kubernetesVersion`, `image`, `microserviceVersion` and `attestation` fields are overwritten with the smallest available upgrade.
 
 ## Apply the upgrade

--- a/docs/screencasts/docker/configure-cluster.expect
+++ b/docs/screencasts/docker/configure-cluster.expect
@@ -23,9 +23,13 @@ spawn asciinema rec --overwrite /recordings/configure-cluster.cast
 send "\r"
 expect_prompt
 
-run_command "# Step 1: Create IAM configuration and Constellation configuration file"
+run_command "# Step 1: Create a configuration file for Constellation"
 expect_prompt
-run_command "constellation iam create gcp --generate-config --projectID constellation-331613 --serviceAccountID constellation-demo --zone europe-west3-b"
+run_command "constellation config generate gcp"
+expect_prompt
+run_command "# Step 2: Create your cluster's IAM configuration"
+expect_prompt
+run_command "constellation iam create gcp --update-config --projectID constellation-331613 --serviceAccountID constellation-demo --zone europe-west3-b"
 expect -re "y\/n"
 send "y"
 send "\r"

--- a/docs/screencasts/generate-readme-svg.sh
+++ b/docs/screencasts/generate-readme-svg.sh
@@ -10,7 +10,8 @@
 
 # Create IAM configuration
 pushd constellation || exit
-constellation iam create gcp --generate-config --projectID constellation-331613 --serviceAccountID constellation-demo --zone europe-west3-b --yes
+constellation config generate gcp
+constellation iam create gcp --update-config --projectID constellation-331613 --serviceAccountID constellation-demo --zone europe-west3-b --yes
 popd || exit
 
 docker build -t screenrecodings docker

--- a/rfc/updates.md
+++ b/rfc/updates.md
@@ -208,7 +208,7 @@ If there are still microservice updates needed with the current CLI, we need to 
 
 We also print `In newer CLI versions there are even newer versions available.` if e.g. there is a newer patch version of Kubernetes available in one of the proposed minor versions.
 
-Executing `constellation upgrade check --write-config` writes all new version values to `constellation-conf.json`.
+Executing `constellation upgrade check --update-config` updates all new version values to `constellation-conf.json`.
 This allows the user to execute `constellation upgrade apply` without manually modifying `constellation-conf.json`.
 
 ```bash


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- change `--generate-config` flag to `--update-config` in the iam create subcommand
- rename `--write-config` flag to `--update-config` in the upgrade check subcommand

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Context
<!-- Please add background information on why this PR is opened. -->
SInce we'd need to support the growing number of flags in `constellation config generate` for the `--generate-config` flag, we should change the workflow to scale better while preserving flexibility.

### Additional info
- This changes the workflow to require `constellation config generate` before `constellation iam create`

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [X] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [X] Add labels (e.g., for changelog category)
- [X] Link to Milestone
