### PR TITLE
cli: hide --insecure of config fetch-measurements

### DIFF
--- a/cli/internal/cmd/configfetchmeasurements.go
+++ b/cli/internal/cmd/configfetchmeasurements.go
@@ -37,6 +37,7 @@ func newConfigFetchMeasurementsCmd() *cobra.Command {
 	cmd.Flags().StringP("url", "u", "", "alternative URL to fetch measurements from")
 	cmd.Flags().StringP("signature-url", "s", "", "alternative URL to fetch measurements' signature from")
 	cmd.Flags().Bool("insecure", false, "skip the measurement signature verification")
+	must(cmd.Flags().MarkHidden("insecure"))
 
 	return cmd
 }

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -108,7 +108,6 @@ constellation config fetch-measurements [flags]
 
 ```
   -h, --help                   help for fetch-measurements
-      --insecure               skip the measurement signature verification
   -s, --signature-url string   alternative URL to fetch measurements' signature from
   -u, --url string             alternative URL to fetch measurements from
 ```


### PR DESCRIPTION
If I understand #1879 correctly, this doesn't need to be exposed to users, right?