### PR TITLE
config: iam create aws check zone contains availability zone

### DIFF
--- a/cli/internal/cmd/iamcreate.go
+++ b/cli/internal/cmd/iamcreate.go
@@ -79,11 +79,10 @@ func newIAMCreateAWSCmd() *cobra.Command {
 
 	cmd.Flags().String("prefix", "", "name prefix for all resources (required)")
 	must(cobra.MarkFlagRequired(cmd.Flags(), "prefix"))
-	// TODO: leave the availability zone out and should be called region if only necessary for iam creation?
 	cmd.Flags().String("zone", "", "AWS availability zone the resources will be created in, e.g. us-east-2a (required)\n"+
 		"Find available zones here: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-availability-zones. "+
 		"Note that we do not support every zone / region. You can find a list of all supported regions in our docs.")
-
+	must(cobra.MarkFlagRequired(cmd.Flags(), "zone"))
 	return cmd
 }
 
@@ -100,9 +99,9 @@ func newIAMCreateAzureCmd() *cobra.Command {
 	cmd.Flags().String("resourceGroup", "", "name prefix of the two resource groups your cluster / IAM resources will be created in (required)")
 	must(cobra.MarkFlagRequired(cmd.Flags(), "resourceGroup"))
 	cmd.Flags().String("region", "", "region the resources will be created in, e.g. westus (required)")
+	must(cobra.MarkFlagRequired(cmd.Flags(), "region"))
 	cmd.Flags().String("servicePrincipal", "", "name of the service principal that will be created (required)")
 	must(cobra.MarkFlagRequired(cmd.Flags(), "servicePrincipal"))
-
 	return cmd
 }
 
@@ -118,6 +117,7 @@ func newIAMCreateGCPCmd() *cobra.Command {
 
 	cmd.Flags().String("zone", "", "GCP zone the cluster will be deployed in (required)\n"+
 		"Find a list of available zones here: https://cloud.google.com/compute/docs/regions-zones#available.")
+	must(cobra.MarkFlagRequired(cmd.Flags(), "zone"))
 	cmd.Flags().String("serviceAccountID", "", "ID for the service account that will be created (required)\n"+
 		"Must match ^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$.")
 	must(cobra.MarkFlagRequired(cmd.Flags(), "serviceAccountID"))

--- a/cli/internal/cmd/iamcreate.go
+++ b/cli/internal/cmd/iamcreate.go
@@ -588,8 +588,8 @@ func awsZoneToRegion(zone string) (string, error) {
 	return fmt.Sprintf("%s-%s-%c", parts[0], parts[1], parts[2][0]), nil
 }
 
-// ValidateConfigWithFlagCompatibility checks if the config is compatible with the flags.
-func ValidateConfigWithFlagCompatibility(iamProvider cloudprovider.Provider, cfg config.Config, flags iamFlags) error {
+// validateConfigWithFlagCompatibility checks if the config is compatible with the flags.
+func validateConfigWithFlagCompatibility(iamProvider cloudprovider.Provider, cfg config.Config, flags iamFlags) error {
 	if !hasProviderCfg(iamProvider, cfg) {
 		return fmt.Errorf("iam provider %q seems different from config provider", iamProvider)
 	}

--- a/cli/internal/cmd/iamcreate.go
+++ b/cli/internal/cmd/iamcreate.go
@@ -235,8 +235,7 @@ func (c *iamCreator) create(ctx context.Context) error {
 		if err = c.fileHandler.ReadYAML(flags.configPath, &conf); err != nil {
 			return fmt.Errorf("error reading the configuration file: %w", err)
 		}
-		err := validateConfigWithFlagCompatibility(c.provider, conf, flags)
-		if err != nil {
+		if err := validateConfigWithFlagCompatibility(c.provider, conf, flags); err != nil {
 			return err
 		}
 		c.cmd.Printf("The configuration file %q will be automatically updated with the IAM values and zone/region information.\n", flags.configPath)

--- a/cli/internal/cmd/iamcreate.go
+++ b/cli/internal/cmd/iamcreate.go
@@ -590,16 +590,15 @@ func awsZoneToRegion(zone string) (string, error) {
 
 // validateConfigWithFlagCompatibility checks if the config is compatible with the flags.
 func validateConfigWithFlagCompatibility(iamProvider cloudprovider.Provider, cfg config.Config, flags iamFlags) error {
-	if !hasProviderCfg(iamProvider, cfg) {
-		return fmt.Errorf("iam provider %q seems different from config provider", iamProvider)
+	if !cfg.HasProvider(iamProvider) {
+		return fmt.Errorf("cloud provider from the the configuration file differs from the one provided via the command %q", iamProvider)
 	}
-
 	return checkIfCfgZoneAndFlagZoneDiffer(iamProvider, flags, cfg)
 }
 
 func checkIfCfgZoneAndFlagZoneDiffer(iamProvider cloudprovider.Provider, flags iamFlags, cfg config.Config) error {
 	flagZone := flagZoneOrAzRegion(iamProvider, flags)
-	configZone := configZoneOrAzRegion(iamProvider, cfg)
+	configZone := cfg.GetZone()
 	if configZone != "" && flagZone != configZone {
 		return fmt.Errorf("zone/region from the configuration file %q differs from the one provided via flags %q", configZone, flagZone)
 	}
@@ -616,28 +615,4 @@ func flagZoneOrAzRegion(provider cloudprovider.Provider, flags iamFlags) string 
 		return flags.gcp.zone
 	}
 	return ""
-}
-
-func configZoneOrAzRegion(provider cloudprovider.Provider, conf config.Config) string {
-	switch provider {
-	case cloudprovider.AWS:
-		return conf.Provider.AWS.Zone
-	case cloudprovider.Azure:
-		return conf.Provider.Azure.Location
-	case cloudprovider.GCP:
-		return conf.Provider.GCP.Zone
-	}
-	return ""
-}
-
-func hasProviderCfg(provider cloudprovider.Provider, cfg config.Config) bool {
-	switch provider {
-	case cloudprovider.AWS:
-		return cfg.Provider.AWS != nil
-	case cloudprovider.Azure:
-		return cfg.Provider.Azure != nil
-	case cloudprovider.GCP:
-		return cfg.Provider.GCP != nil
-	}
-	return false
 }

--- a/cli/internal/cmd/iamcreate_test.go
+++ b/cli/internal/cmd/iamcreate_test.go
@@ -939,7 +939,6 @@ func createFSWithConfig(cfg config.Config) func(require *require.Assertions, pro
 	return func(require *require.Assertions, provider cloudprovider.Provider, existingConfigFiles []string, existingDirs []string) afero.Fs {
 		fs := afero.NewMemMapFs()
 		fileHandler := file.NewHandler(fs)
-		fmt.Println("CFG", cfg.Provider.AWS)
 		for _, f := range existingConfigFiles {
 			require.NoError(fileHandler.WriteYAML(f, cfg, file.OptNone))
 		}

--- a/cli/internal/cmd/iamcreate_test.go
+++ b/cli/internal/cmd/iamcreate_test.go
@@ -8,7 +8,6 @@ package cmd
 import (
 	"bytes"
 	"encoding/base64"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -925,7 +924,7 @@ func TestValidateConfigWithFlagCompatibility(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			err := ValidateConfigWithFlagCompatibility(tc.iamProvider, tc.cfg, tc.flags)
+			err := validateConfigWithFlagCompatibility(tc.iamProvider, tc.cfg, tc.flags)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/cli/internal/cmd/iamcreate_test.go
+++ b/cli/internal/cmd/iamcreate_test.go
@@ -306,7 +306,7 @@ func TestIAMCreateAWS(t *testing.T) {
 				assert.Error(err)
 				return
 			}
-			assert.NoError(err)
+			require.NoError(err)
 
 			if tc.wantAbort {
 				assert.False(tc.creator.createCalled)

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -88,7 +88,7 @@ See also Constellation's [Kubernetes support policy](../architecture/versions.md
 ## Creating an IAM configuration
 
 You can create an IAM configuration for your cluster automatically using the `constellation iam create` command.
-If you already have a constellation configuration file, you can add the `--update-config` flag to the command. This writes the needed IAM fields into your configuration. Furthermore, the flag updates the zone/region of the configuration when it's not yet set.
+If you already have a Constellation configuration file, you can add the `--update-config` flag to the command. This writes the needed IAM fields into your configuration. Furthermore, the flag updates the zone/region of the configuration if it hasn't been set yet.
 
 <tabs groupId="csp">
 <tabItem value="azure" label="Azure">

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -88,7 +88,7 @@ See also Constellation's [Kubernetes support policy](../architecture/versions.md
 ## Creating an IAM configuration
 
 You can create an IAM configuration for your cluster automatically using the `constellation iam create` command.
-If you already have a constellation configuration file, you can add the `--update-config` flag to the command. This writes the needed IAM fields into your configuration.
+If you already have a constellation configuration file, you can add the `--update-config` flag to the command. This writes the needed IAM fields into your configuration. Furthermore, the flag updates the zone/region of the configuration when it's not yet set.
 
 <tabs groupId="csp">
 <tabItem value="azure" label="Azure">

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -110,10 +110,10 @@ type ProviderConfig struct {
 type AWSConfig struct {
 	// description: |
 	//   AWS data center region. See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
-	Region string `yaml:"region" validate:"required"`
+	Region string `yaml:"region" validate:"required,aws_region"`
 	// description: |
 	//   AWS data center zone name in defined region. See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-availability-zones
-	Zone string `yaml:"zone" validate:"required"`
+	Zone string `yaml:"zone" validate:"required,aws_zone"`
 	// description: |
 	//   VM instance type to use for Constellation nodes. Needs to support NitroTPM. See: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/enable-nitrotpm-prerequisites.html
 	InstanceType string `yaml:"instanceType" validate:"lowercase,aws_instance_type"`
@@ -762,6 +762,19 @@ func (c *Config) Validate(force bool) error {
 		return err
 	}
 	if err := validate.RegisterTranslation("more_than_one_attestation", trans, registerMoreThanOneAttestationError, c.translateMoreThanOneAttestationError); err != nil {
+		return err
+	}
+
+	if err := validate.RegisterValidation("aws_region", validateAWSRegionField); err != nil {
+		return err
+	}
+	if err := validate.RegisterValidation("aws_zone", validateAWSZoneField); err != nil {
+		return err
+	}
+	if err := validate.RegisterTranslation("aws_region", trans, registerAWSRegionError, translateAWSRegionError); err != nil {
+		return err
+	}
+	if err := validate.RegisterTranslation("aws_zone", trans, registerAWSZoneError, translateAWSZoneError); err != nil {
 		return err
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -625,6 +625,19 @@ func (c *Config) GetRegion() string {
 	return ""
 }
 
+// GetZone returns the configured zone or location for providers without zone support (Azure).
+func (c *Config) GetZone() string {
+	switch c.GetProvider() {
+	case cloudprovider.AWS:
+		return c.Provider.AWS.Zone
+	case cloudprovider.Azure:
+		return c.Provider.Azure.Location
+	case cloudprovider.GCP:
+		return c.Provider.GCP.Zone
+	}
+	return ""
+}
+
 // UpdateMAAURL updates the MAA URL in the config.
 func (c *Config) UpdateMAAURL(maaURL string) {
 	if c.Attestation.AzureSEVSNP != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -264,6 +264,7 @@ func TestFromFile(t *testing.T) {
 func TestValidate(t *testing.T) {
 	const defaultErrCount = 33 // expect this number of error messages by default because user-specific values are not set and multiple providers are defined by default
 	const azErrCount = 7
+	const awsErrCount = 6
 	const gcpErrCount = 6
 
 	// TODO(AB#3132,3u13r): refactor config validation tests
@@ -346,7 +347,37 @@ func TestValidate(t *testing.T) {
 				return cnf
 			}(),
 		},
-
+		"default AWS config is not valid": {
+			cnf: func() *Config {
+				cnf := Default()
+				cnf.RemoveProviderAndAttestationExcept(cloudprovider.AWS)
+				return cnf
+			}(),
+			wantErr:      true,
+			wantErrCount: awsErrCount,
+		},
+		"AWS config with correct region and zone format": {
+			cnf: func() *Config {
+				cnf := Default()
+				cnf.Provider.AWS.Region = "us-east-2"
+				cnf.Provider.AWS.Zone = "us-east-2a"
+				cnf.RemoveProviderAndAttestationExcept(cloudprovider.AWS)
+				return cnf
+			}(),
+			wantErr:      true,
+			wantErrCount: awsErrCount - 2,
+		},
+		"AWS config with wrong region and zone format": {
+			cnf: func() *Config {
+				cnf := Default()
+				cnf.Provider.AWS.Region = "us-west2"
+				cnf.Provider.AWS.Zone = "a"
+				cnf.RemoveProviderAndAttestationExcept(cloudprovider.AWS)
+				return cnf
+			}(),
+			wantErr:      true,
+			wantErrCount: awsErrCount,
+		},
 		"default GCP config is not valid": {
 			cnf: func() *Config {
 				cnf := Default()

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -129,7 +129,6 @@ func ValidateAWSZone(zone string) bool {
 }
 
 // ValidateAWSRegion validates that the region is in the correct format.
-// TODO create validation pkg? (lots of general functions aggregating here..)
 func ValidateAWSRegion(region string) bool {
 	awsRegionRegex := regexp.MustCompile(`^\w+-\w+-[1-9]$`)
 	return awsRegionRegex.MatchString(region)

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -113,6 +114,27 @@ func validateGCPInstanceType(fl validator.FieldLevel) bool {
 	return validInstanceTypeForProvider(fl.Field().String(), false, cloudprovider.GCP)
 }
 
+func validateAWSRegionField(fl validator.FieldLevel) bool {
+	return ValidateAWSRegion(fl.Field().String())
+}
+
+func validateAWSZoneField(fl validator.FieldLevel) bool {
+	return ValidateAWSZone(fl.Field().String())
+}
+
+// ValidateAWSZone validates that the zone is in the correct format.
+func ValidateAWSZone(zone string) bool {
+	awsZoneRegex := regexp.MustCompile(`^\w+-\w+-[1-9][abc]$`)
+	return awsZoneRegex.MatchString(zone)
+}
+
+// ValidateAWSRegion validates that the region is in the correct format.
+// TODO create validation pkg? (lots of general functions aggregating here..)
+func ValidateAWSRegion(region string) bool {
+	awsRegionRegex := regexp.MustCompile(`^\w+-\w+-[1-9]$`)
+	return awsRegionRegex.MatchString(region)
+}
+
 // validateProvider checks if zero or more than one providers are defined in the config.
 func validateProvider(sl validator.StructLevel) {
 	provider := sl.Current().Interface().(ProviderConfig)
@@ -179,6 +201,26 @@ func translateNoAttestationError(ut ut.Translator, fe validator.FieldError) stri
 
 func registerNoAttestationError(ut ut.Translator) error {
 	return ut.Add("no_attestation", "{0}: No attestation has been defined (requires either awsSEVSNP, awsNitroTPM, azureSEVSNP, azureTrustedLaunch, gcpSEVES, or qemuVTPM)", true)
+}
+
+func registerAWSRegionError(ut ut.Translator) error {
+	return ut.Add("aws_region", "{0}: has invalid format: {1}", true)
+}
+
+func translateAWSRegionError(ut ut.Translator, fe validator.FieldError) string {
+	t, _ := ut.T("aws_region", fe.Field(), "field must be of format eu-central-1")
+
+	return t
+}
+
+func translateAWSZoneError(ut ut.Translator, fe validator.FieldError) string {
+	t, _ := ut.T("aws_zone", fe.Field(), "field must be of format eu-central-1a")
+
+	return t
+}
+
+func registerAWSZoneError(ut ut.Translator) error {
+	return ut.Add("aws_zone", "{0}: has invalid format: {1}", true)
 }
 
 func registerMoreThanOneAttestationError(ut ut.Translator) error {


### PR DESCRIPTION
**Why?**
```sh
constellation create --control-plane-nodes 1 --worker-nodes 1
Configured image doesn't look like a released production image. Double check image before deploying to production.

The following Constellation cluster will be created:
1 control-plane node of type m6a.xlarge will be created.
1 worker node of type m6a.xlarge will be created.
Do you want to create this cluster? [y/n]: y
Creating
An error occurred: terraform apply: exit status 1

Error: creating EC2 Subnet: InvalidParameterValue: Value (eu-central-1) for parameter availabilityZone is invalid. Subnets can currently only be created in the following availability zones: eu-central-1a, eu-central-1b, eu-central-1c.
	status code: 400, request id: 225f1583-b2d8-4278-aacd-23113226d00d

  with module.public_private_subnet.aws_subnet.private,
  on modules/public_private_subnet/main.tf line 15, in resource "aws_subnet" "private":
  15: resource "aws_subnet" "private" {


Error: creating EC2 Subnet: InvalidParameterValue: Value (eu-central-1) for parameter availabilityZone is invalid. Subnets can currently only be created in the following availability zones: eu-central-1a, eu-central-1b, eu-central-1c.
	status code: 400, request id: 1c1e558f-9c14-46bd-96e7-60af26b8d965

  with module.public_private_subnet.aws_subnet.public,
  on modules/public_private_subnet/main.tf line 22, in resource "aws_subnet" "public":
  22: resource "aws_subnet" "public" {


Attempting to roll back.
```
fails because config was generated without availability zone.

(Problem still persists with new `--update-config`)


<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
- info that `--update-config` also updates the zone/region if it's not yet written in the file
<!-- Please provide a description of the change(s) here. -->
- check for AWS suffix when parsing the flag
- for `--update-config` check if config provider and iam provider are the same and that the config zone is either empty or the same as the flag value

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
