### PR TITLE
cli: store upgrade files in versioned folders

### DIFF
--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -62,7 +62,7 @@ func runUpgradeApply(cmd *cobra.Command, _ []string) error {
 	defer log.Sync()
 
 	fileHandler := file.NewHandler(afero.NewOsFs())
-	upgrader, err := kubernetes.NewUpgrader(cmd.Context(), cmd.OutOrStdout(), log)
+	upgrader, err := kubernetes.NewUpgrader(cmd.Context(), cmd.OutOrStdout(), log, false)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -149,7 +149,7 @@ func (u *upgradeApplyCmd) migrateTerraform(cmd *cobra.Command, file file.Handler
 		return fmt.Errorf("checking workspace: %w", err)
 	}
 
-	targets, vars, err := u.parseUpgradeVars(cmd, conf, fetcher)
+	targets, vars, err := parseTerraformUpgradeVars(cmd, conf, fetcher)
 	if err != nil {
 		return fmt.Errorf("parsing upgrade variables: %w", err)
 	}
@@ -200,7 +200,8 @@ func (u *upgradeApplyCmd) migrateTerraform(cmd *cobra.Command, file file.Handler
 	return nil
 }
 
-func (u *upgradeApplyCmd) parseUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher imageFetcher) ([]string, terraform.Variables, error) {
+// parseTerraformUpgradeVars parses the variables required to execute the Terraform script with.
+func parseTerraformUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher imageFetcher) ([]string, terraform.Variables, error) {
 	// Fetch variables to execute Terraform script with
 	provider := conf.GetProvider()
 	attestationVariant := conf.GetAttestationConfig().GetVariant()

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -62,7 +62,7 @@ func runUpgradeApply(cmd *cobra.Command, _ []string) error {
 	defer log.Sync()
 
 	fileHandler := file.NewHandler(afero.NewOsFs())
-	upgrader, err := kubernetes.NewUpgrader(cmd.Context(), cmd.OutOrStdout(), log, false)
+	upgrader, err := kubernetes.NewUpgrader(cmd.Context(), cmd.OutOrStdout(), log, kubernetes.UpgradeCmdKindApply)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -18,6 +18,8 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/featureset"
 	"github.com/edgelesssys/constellation/v2/cli/internal/helm"
 	"github.com/edgelesssys/constellation/v2/cli/internal/kubernetes"
+	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
+	"github.com/edgelesssys/constellation/v2/cli/internal/upgrade"
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfigapi"
 	"github.com/edgelesssys/constellation/v2/internal/api/fetcher"
 	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
@@ -28,6 +30,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
+	"github.com/edgelesssys/constellation/v2/internal/imagefetcher"
 	"github.com/edgelesssys/constellation/v2/internal/kubernetes/kubectl"
 	conSemver "github.com/edgelesssys/constellation/v2/internal/semver"
 	"github.com/edgelesssys/constellation/v2/internal/sigstore"
@@ -89,7 +92,9 @@ func runUpgradeCheck(cmd *cobra.Command, _ []string) error {
 			log:            log,
 			versionsapi:    versionfetcher,
 		},
-		log: log,
+		checker:      checker,
+		imagefetcher: imagefetcher.New(),
+		log:          log,
 	}
 
 	return up.upgradeCheck(cmd, fileHandler, attestationconfigapi.NewFetcher(), flags)
@@ -98,36 +103,49 @@ func runUpgradeCheck(cmd *cobra.Command, _ []string) error {
 func parseUpgradeCheckFlags(cmd *cobra.Command) (upgradeCheckFlags, error) {
 	configPath, err := cmd.Flags().GetString("config")
 	if err != nil {
-		return upgradeCheckFlags{}, err
+		return upgradeCheckFlags{}, fmt.Errorf("parsing config string: %w", err)
 	}
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
-		return upgradeCheckFlags{}, err
+		return upgradeCheckFlags{}, fmt.Errorf("parsing force bool: %w", err)
 	}
 	writeConfig, err := cmd.Flags().GetBool("write-config")
 	if err != nil {
-		return upgradeCheckFlags{}, err
+		return upgradeCheckFlags{}, fmt.Errorf("parsing write-config bool: %w", err)
 	}
 	ref, err := cmd.Flags().GetString("ref")
 	if err != nil {
-		return upgradeCheckFlags{}, err
+		return upgradeCheckFlags{}, fmt.Errorf("parsing ref string: %w", err)
 	}
 	stream, err := cmd.Flags().GetString("stream")
 	if err != nil {
-		return upgradeCheckFlags{}, err
+		return upgradeCheckFlags{}, fmt.Errorf("parsing stream string: %w", err)
 	}
+
+	logLevelString, err := cmd.Flags().GetString("tf-log")
+	if err != nil {
+		return upgradeCheckFlags{}, fmt.Errorf("parsing tf-log string: %w", err)
+	}
+	logLevel, err := terraform.ParseLogLevel(logLevelString)
+	if err != nil {
+		return upgradeCheckFlags{}, fmt.Errorf("parsing Terraform log level %s: %w", logLevelString, err)
+	}
+
 	return upgradeCheckFlags{
-		configPath:  configPath,
-		force:       force,
-		writeConfig: writeConfig,
-		ref:         ref,
-		stream:      stream,
+		configPath:        configPath,
+		force:             force,
+		writeConfig:       writeConfig,
+		ref:               ref,
+		stream:            stream,
+		terraformLogLevel: logLevel,
 	}, nil
 }
 
 type upgradeCheckCmd struct {
 	canUpgradeCheck bool
 	collect         collector
+	checker         upgradeChecker
+	imagefetcher    imageFetcher
 	log             debugLog
 }
 
@@ -182,6 +200,44 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 	newImages, err := u.collect.newMeasurements(cmd.Context(), csp, attestationVariant, supported.image)
 	if err != nil {
 		return err
+	}
+
+	u.log.Debugf("Planning Terraform migrations")
+
+	if err := u.checker.CheckTerraformMigrations(fileHandler); err != nil {
+		return fmt.Errorf("checking workspace: %w", err)
+	}
+
+	targets, vars, err := parseTerraformUpgradeVars(cmd, conf, u.imagefetcher)
+	if err != nil {
+		return fmt.Errorf("parsing upgrade variables: %w", err)
+	}
+	u.log.Debugf("Using migration targets:\n%v", targets)
+	u.log.Debugf("Using Terraform variables:\n%v", vars)
+
+	opts := upgrade.TerraformUpgradeOptions{
+		LogLevel:   flags.terraformLogLevel,
+		CSP:        conf.GetProvider(),
+		Vars:       vars,
+		Targets:    targets,
+		OutputFile: constants.TerraformMigrationOutputFile,
+	}
+
+	cmd.Println("The following Teraform migrations are available with this CLI:")
+
+	// Check if there are any Terraform migrations
+	hasDiff, err := u.checker.PlanTerraformMigrations(cmd.Context(), opts)
+	if err != nil {
+		return fmt.Errorf("planning terraform migrations: %w", err)
+	}
+	defer func() {
+		if err := u.checker.CleanUpTerraformMigrations(fileHandler); err != nil {
+			u.log.Debugf("Failed to clean up Terraform migrations: %v", err)
+		}
+	}()
+
+	if !hasDiff {
+		cmd.Println("  No Terraform migrations are available.")
 	}
 
 	upgrade := versionUpgrade{
@@ -661,16 +717,20 @@ func (v *versionCollector) filterCompatibleCLIVersions(ctx context.Context, cliP
 }
 
 type upgradeCheckFlags struct {
-	configPath  string
-	force       bool
-	writeConfig bool
-	ref         string
-	stream      string
+	configPath        string
+	force             bool
+	writeConfig       bool
+	ref               string
+	stream            string
+	terraformLogLevel terraform.LogLevel
 }
 
 type upgradeChecker interface {
 	CurrentImage(ctx context.Context) (string, error)
 	CurrentKubernetesVersion(ctx context.Context) (string, error)
+	PlanTerraformMigrations(ctx context.Context, opts upgrade.TerraformUpgradeOptions) (bool, error)
+	CheckTerraformMigrations(fileHandler file.Handler) error
+	CleanUpTerraformMigrations(fileHandler file.Handler) error
 }
 
 type versionListFetcher interface {

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -65,7 +65,7 @@ func runUpgradeCheck(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	checker, err := kubernetes.NewUpgrader(cmd.Context(), cmd.OutOrStdout(), log)
+	checker, err := kubernetes.NewUpgrader(cmd.Context(), cmd.OutOrStdout(), log, true)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -65,7 +65,7 @@ func runUpgradeCheck(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	checker, err := kubernetes.NewUpgrader(cmd.Context(), cmd.OutOrStdout(), log, true)
+	checker, err := kubernetes.NewUpgrader(cmd.Context(), cmd.OutOrStdout(), log, kubernetes.UpgradeCmdKindCheck)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -102,7 +102,7 @@ func (c *Client) shouldUpgrade(releaseName, newVersion string) error {
 // Upgrade runs a helm-upgrade on all deployments that are managed via Helm.
 // If the CLI receives an interrupt signal it will cancel the context.
 // Canceling the context will prompt helm to abort and roll back the ongoing upgrade.
-func (c *Client) Upgrade(ctx context.Context, config *config.Config, timeout time.Duration, allowDestructive bool) error {
+func (c *Client) Upgrade(ctx context.Context, config *config.Config, timeout time.Duration, allowDestructive bool, upgradeID string) error {
 	upgradeErrs := []error{}
 	upgradeReleases := []*chart.Chart{}
 	invalidUpgrade := &compatibility.InvalidUpgradeError{}
@@ -138,11 +138,11 @@ func (c *Client) Upgrade(ctx context.Context, config *config.Config, timeout tim
 		return errors.Join(upgradeErrs...)
 	}
 
-	crds, err := c.backupCRDs(ctx)
+	crds, err := c.backupCRDs(ctx, upgradeID)
 	if err != nil {
 		return fmt.Errorf("creating CRD backup: %w", err)
 	}
-	if err := c.backupCRs(ctx, crds); err != nil {
+	if err := c.backupCRs(ctx, crds, upgradeID); err != nil {
 		return fmt.Errorf("creating CR backup: %w", err)
 	}
 

--- a/cli/internal/kubernetes/BUILD.bazel
+++ b/cli/internal/kubernetes/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//internal/versions",
         "//internal/versions/components",
         "//operators/constellation-node-operator/api/v1alpha1",
+        "@com_github_google_uuid//:uuid",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apimachinery//pkg/api/errors",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",

--- a/cli/internal/kubernetes/upgrade.go
+++ b/cli/internal/kubernetes/upgrade.go
@@ -45,7 +45,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// UpgradeCmdKind is the kind of the upgrade command. (check, apply)
+// UpgradeCmdKind is the kind of the upgrade command (check, apply).
 type UpgradeCmdKind int
 
 const (

--- a/cli/internal/kubernetes/upgrade.go
+++ b/cli/internal/kubernetes/upgrade.go
@@ -105,7 +105,7 @@ func NewUpgrader(ctx context.Context, outWriter io.Writer, log debugLog, upgrade
 	if upgradeCmdKind == UpgradeCmdKindCheck {
 		upgradeID += "-check"
 	}
-	
+
 	u := &Upgrader{
 		imageFetcher: imagefetcher.New(),
 		outWriter:    outWriter,

--- a/cli/internal/kubernetes/upgrade.go
+++ b/cli/internal/kubernetes/upgrade.go
@@ -103,7 +103,10 @@ type Upgrader struct {
 func NewUpgrader(ctx context.Context, outWriter io.Writer, log debugLog, upgradeCmdKind UpgradeCmdKind) (*Upgrader, error) {
 	upgradeID := "upgrade-" + time.Now().Format("20060102150405") + "-" + strings.Split(uuid.New().String(), "-")[0]
 	if upgradeCmdKind == UpgradeCmdKindCheck {
-		upgradeID += "-check"
+		// When performing an upgrade check, the upgrade directory will only be used temporarily to store the
+		// Terraform state. The directory is deleted after the check is finished.
+		// Therefore, add a tmp-suffix to the upgrade ID to indicate that the directory will be cleared after the check.
+		upgradeID += "-tmp"
 	}
 
 	u := &Upgrader{

--- a/cli/internal/terraform/loader.go
+++ b/cli/internal/terraform/loader.go
@@ -16,7 +16,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/spf13/afero"
 )
@@ -36,11 +35,11 @@ func prepareWorkspace(rootDir string, fileHandler file.Handler, workingDir strin
 
 // prepareUpgradeWorkspace takes the Terraform state file from the old workspace and the
 // embedded Terraform files and writes them into the new workspace.
-func prepareUpgradeWorkspace(rootDir string, fileHandler file.Handler, oldWorkingDir, newWorkingDir string) error {
+func prepareUpgradeWorkspace(rootDir string, fileHandler file.Handler, oldWorkingDir, newWorkingDir, backupDir string) error {
 	// backup old workspace
 	if err := fileHandler.CopyDir(
 		oldWorkingDir,
-		filepath.Join(constants.UpgradeDir, constants.TerraformUpgradeBackupDir),
+		backupDir,
 	); err != nil {
 		return fmt.Errorf("backing up old workspace: %w", err)
 	}

--- a/cli/internal/terraform/loader_test.go
+++ b/cli/internal/terraform/loader_test.go
@@ -133,6 +133,7 @@ func TestPrepareUpgradeWorkspace(t *testing.T) {
 		provider            cloudprovider.Provider
 		oldWorkingDir       string
 		newWorkingDir       string
+		backupDir           string
 		oldWorkspaceFiles   []string
 		newWorkspaceFiles   []string
 		expectedFiles       []string
@@ -144,6 +145,7 @@ func TestPrepareUpgradeWorkspace(t *testing.T) {
 			provider:          cloudprovider.AWS,
 			oldWorkingDir:     "old",
 			newWorkingDir:     "new",
+			backupDir:         "backup",
 			oldWorkspaceFiles: []string{"terraform.tfstate"},
 			expectedFiles: []string{
 				"main.tf",
@@ -158,6 +160,7 @@ func TestPrepareUpgradeWorkspace(t *testing.T) {
 			provider:          cloudprovider.AWS,
 			oldWorkingDir:     "old",
 			newWorkingDir:     "new",
+			backupDir:         "backup",
 			oldWorkspaceFiles: []string{},
 			expectedFiles:     []string{},
 			wantErr:           true,
@@ -167,6 +170,7 @@ func TestPrepareUpgradeWorkspace(t *testing.T) {
 			provider:          cloudprovider.AWS,
 			oldWorkingDir:     "old",
 			newWorkingDir:     "new",
+			backupDir:         "backup",
 			oldWorkspaceFiles: []string{"terraform.tfstate"},
 			newWorkspaceFiles: []string{"main.tf"},
 			wantErr:           true,
@@ -185,7 +189,7 @@ func TestPrepareUpgradeWorkspace(t *testing.T) {
 			createFiles(t, file, tc.oldWorkspaceFiles, tc.oldWorkingDir)
 			createFiles(t, file, tc.newWorkspaceFiles, tc.newWorkingDir)
 
-			err := prepareUpgradeWorkspace(path, file, tc.oldWorkingDir, tc.newWorkingDir)
+			err := prepareUpgradeWorkspace(path, file, tc.oldWorkingDir, tc.newWorkingDir, tc.backupDir)
 
 			if tc.wantErr {
 				require.Error(err)
@@ -194,7 +198,7 @@ func TestPrepareUpgradeWorkspace(t *testing.T) {
 			}
 			checkFiles(t, file, func(err error) { assert.NoError(err) }, tc.newWorkingDir, tc.expectedFiles)
 			checkFiles(t, file, func(err error) { assert.NoError(err) },
-				filepath.Join(constants.UpgradeDir, constants.TerraformUpgradeBackupDir),
+				tc.backupDir,
 				tc.oldWorkspaceFiles,
 			)
 		})

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -87,8 +87,8 @@ func (c *Client) PrepareWorkspace(path string, vars Variables) error {
 
 // PrepareUpgradeWorkspace prepares a Terraform workspace for a Constellation version upgrade.
 // It copies the Terraform state from the old working dir and the embedded Terraform files into the new working dir.
-func (c *Client) PrepareUpgradeWorkspace(path, oldWorkingDir, newWorkingDir string, vars Variables) error {
-	if err := prepareUpgradeWorkspace(path, c.file, oldWorkingDir, newWorkingDir); err != nil {
+func (c *Client) PrepareUpgradeWorkspace(path, oldWorkingDir, newWorkingDir, backupDir string, vars Variables) error {
+	if err := prepareUpgradeWorkspace(path, c.file, oldWorkingDir, newWorkingDir, backupDir); err != nil {
 		return fmt.Errorf("prepare upgrade workspace: %w", err)
 	}
 

--- a/cli/internal/upgrade/terraform.go
+++ b/cli/internal/upgrade/terraform.go
@@ -120,8 +120,7 @@ func (u *TerraformUpgrader) PlanTerraformMigrations(ctx context.Context, opts Te
 // aborted by the user.
 func (u *TerraformUpgrader) CleanUpTerraformMigrations(fileHandler file.Handler, upgradeID string) error {
 	cleanupFiles := []string{
-		filepath.Join(constants.UpgradeDir, upgradeID, constants.TerraformUpgradeBackupDir),
-		filepath.Join(constants.UpgradeDir, upgradeID, constants.TerraformUpgradeWorkingDir),
+		filepath.Join(constants.UpgradeDir, upgradeID),
 	}
 
 	for _, f := range cleanupFiles {

--- a/cli/internal/upgrade/terraform_test.go
+++ b/cli/internal/upgrade/terraform_test.go
@@ -265,38 +265,47 @@ func TestCleanUpTerraformMigrations(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		upgradeID string
-		workspace file.Handler
-		wantFiles []string
-		wantErr   bool
+		upgradeID      string
+		workspaceFiles []string
+		wantFiles      []string
+		wantErr        bool
 	}{
 		"no files": {
-			upgradeID: "1234",
-			workspace: workspace(nil),
-			wantFiles: []string{},
+			upgradeID:      "1234",
+			workspaceFiles: nil,
+			wantFiles:      []string{},
 		},
 		"clean backup dir": {
 			upgradeID: "1234",
-			workspace: workspace([]string{
+			workspaceFiles: []string{
 				filepath.Join(constants.UpgradeDir, "1234", constants.TerraformUpgradeBackupDir),
-			}),
+			},
 			wantFiles: []string{},
 		},
 		"clean working dir": {
 			upgradeID: "1234",
-			workspace: workspace([]string{
+			workspaceFiles: []string{
 				filepath.Join(constants.UpgradeDir, "1234", constants.TerraformUpgradeWorkingDir),
-			}),
+			},
 			wantFiles: []string{},
 		},
-		"clean backup dir leave other files": {
+		"clean all": {
 			upgradeID: "1234",
-			workspace: workspace([]string{
+			workspaceFiles: []string{
 				filepath.Join(constants.UpgradeDir, "1234", constants.TerraformUpgradeBackupDir),
-				filepath.Join(constants.UpgradeDir, "1234", "someFile"),
-			}),
+				filepath.Join(constants.UpgradeDir, "1234", constants.TerraformUpgradeWorkingDir),
+				filepath.Join(constants.UpgradeDir, "1234", "abc"),
+			},
+			wantFiles: []string{},
+		},
+		"leave other files": {
+			upgradeID: "1234",
+			workspaceFiles: []string{
+				filepath.Join(constants.UpgradeDir, "1234", constants.TerraformUpgradeBackupDir),
+				filepath.Join(constants.UpgradeDir, "other"),
+			},
 			wantFiles: []string{
-				filepath.Join(constants.UpgradeDir, "1234", "someFile"),
+				filepath.Join(constants.UpgradeDir, "other"),
 			},
 		},
 	}
@@ -305,8 +314,10 @@ func TestCleanUpTerraformMigrations(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 
+			workspace := workspace(tc.workspaceFiles)
 			u := upgrader()
-			err := u.CleanUpTerraformMigrations(tc.workspace, tc.upgradeID)
+
+			err := u.CleanUpTerraformMigrations(workspace, tc.upgradeID)
 			if tc.wantErr {
 				require.Error(err)
 				return
@@ -314,9 +325,16 @@ func TestCleanUpTerraformMigrations(t *testing.T) {
 
 			require.NoError(err)
 
-			for _, f := range tc.wantFiles {
-				_, err := tc.workspace.Stat(f)
-				require.NoError(err, "file %s should exist", f)
+			for _, haveFile := range tc.workspaceFiles {
+				for _, wantFile := range tc.wantFiles {
+					if haveFile == wantFile {
+						_, err := workspace.Stat(wantFile)
+						require.NoError(err, "file %s should exist", wantFile)
+					} else {
+						_, err := workspace.Stat(haveFile)
+						require.Error(err, "file %s should not exist", haveFile)
+					}
+				}
 			}
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Implement versioning of Constellation upgrades, so that a user can perform multiple upgrades without cleaning the `constellation-upgrade` directory. Each upgrade is marked by a timestamp string and a unique identifier and the corresponding files get placed into a unique subdirectory for their upgrade ID. (e.g. `constellation-upgrade/upgrade-20230614105831-976b92d0`)

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [Upgrade e2e test](https://github.com/edgelesssys/constellation/actions/runs/5265731418)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
