### PR TITLE
cli: improve user warning / information

### DIFF
--- a/cli/internal/cmd/configfetchmeasurements.go
+++ b/cli/internal/cmd/configfetchmeasurements.go
@@ -161,6 +161,7 @@ func (cfm *configFetchMeasurementsCmd) configFetchMeasurements(
 		return err
 	}
 	cfm.log.Debugf("Configuration written to %s", flags.configPath)
+	cmd.Print("Successfully fetched measurements and updated Configuration\n")
 	return nil
 }
 

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -91,7 +91,7 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 		printedAWarning = true
 	}
 
-	if conf.IsDebugImage() && !conf.IsDebugCluster() {
+	if conf.IsNamedLikeDebugImage() && !conf.IsDebugCluster() {
 		cmd.PrintErrln("WARNING: A debug image is used but debugCluster is false.")
 		printedAWarning = true
 	}

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -91,6 +91,11 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 		printedAWarning = true
 	}
 
+	if conf.IsDebugImage() && !conf.IsDebugCluster() {
+		cmd.PrintErrln("WARNING: A debug image is used but debugCluster is false.")
+		printedAWarning = true
+	}
+
 	if conf.IsDebugCluster() {
 		cmd.PrintErrln("WARNING: Creating a debug cluster. This cluster is not secure and should only be used for debugging purposes.")
 		cmd.PrintErrln("DO NOT USE THIS CLUSTER IN PRODUCTION.")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,6 +36,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfigapi"
+	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/idkeydigest"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
@@ -544,7 +545,11 @@ func (c *Config) IsReleaseImage() bool {
 
 // IsDebugImage checks whether image name looks like a debug image.
 func (c *Config) IsDebugImage() bool {
-	return strings.Contains(c.Image, "debug")
+	v, err := versionsapi.NewVersionFromShortPath(c.Image, versionsapi.VersionKindImage)
+	if err != nil {
+		return false
+	}
+	return v.Stream == "debug"
 }
 
 // GetProvider returns the configured cloud provider.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -543,8 +543,8 @@ func (c *Config) IsReleaseImage() bool {
 	return strings.HasPrefix(c.Image, "v")
 }
 
-// IsDebugImage checks whether image name looks like a debug image.
-func (c *Config) IsDebugImage() bool {
+// IsNamedLikeDebugImage checks whether image name looks like a debug image.
+func (c *Config) IsNamedLikeDebugImage() bool {
 	v, err := versionsapi.NewVersionFromShortPath(c.Image, versionsapi.VersionKindImage)
 	if err != nil {
 		return false

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -542,6 +542,11 @@ func (c *Config) IsReleaseImage() bool {
 	return strings.HasPrefix(c.Image, "v")
 }
 
+// IsDebugImage checks whether image name looks like a debug image.
+func (c *Config) IsDebugImage() bool {
+	return strings.Contains(c.Image, "debug")
+}
+
 // GetProvider returns the configured cloud provider.
 func (c *Config) GetProvider() cloudprovider.Provider {
 	if c.Provider.AWS != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -867,7 +867,7 @@ func TestIsDebugImage(t *testing.T) {
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
 			c := &Config{Image: tc.image}
-			assert.Equal(t, tc.expected, c.IsDebugImage())
+			assert.Equal(t, tc.expected, c.IsNamedLikeDebugImage())
 		})
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -854,6 +854,24 @@ func TestConfigVersionCompatibility(t *testing.T) {
 	}
 }
 
+func TestIsDebugImage(t *testing.T) {
+	cases := map[string]struct {
+		image    string
+		expected bool
+	}{
+		"debug image":   {"ref/test/stream/debug/v2.9.0-pre.0.20230613084544-eeea7b1f56f4", true},
+		"release image": {"v2.8.0", false},
+		"empty image":   {"", false},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			c := &Config{Image: tc.image}
+			assert.Equal(t, tc.expected, c.IsDebugImage())
+		})
+	}
+}
+
 func TestIsAppClientIDError(t *testing.T) {
 	testCases := map[string]struct {
 		err      error


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Currently there is no useful output that indicates success to the user:
```

./constellation config fetch-measurements --insecure
Configured image doesn't look like a released production image. Double check image before deploying to production.

```
We also discussed printing a diff of the updated measurements, but comparing the `measurement.M` object seems tricky and is not worth the effort.

---

We should issue a warning on cluster creation with debug image and `debugCluster: false`:
```
../constellation create --control-plane-nodes 1 --worker-nodes 1 -y
Configured image doesn't look like a released production image. Double check image before deploying to production.

Creating
Your Constellation cluster was created successfully.
15.92s user 5.14s system 16% cpu 2:06.29s total
```
Otherwise the user will get stuck at `init`.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- print success on fetch-measurements
- print warning for isDebugImg && !isDebugCluster 
- 
<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Link to Milestone
