### PR TITLE
nix: add python toolchain deps

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,7 @@
     pkgs.glibc
     pkgs.gcc
     pkgs.jdk11 # TODO(katexochen): investigate why our build chain doesn't work on NixOS
+    pkgs.libxcrypt-legacy # TODO(malt3): python toolchain depends on this. Remove once https://github.com/bazelbuild/rules_python/issues/1211 is resolved
   ];
 })
 .env


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Bazel's rules_python installs a python toolchain that depends on libcrypt.so.1. This change provides the required library on nixOS. Added a TODO to remove the dep as soon as rules_python toolchains are fully hermetic.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- nix: add python toolchain deps

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
