### PR TITLE
cli: dry-run Terraform migrations on `upgrade check`

### DIFF
--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -149,7 +149,7 @@ func (u *upgradeApplyCmd) migrateTerraform(cmd *cobra.Command, file file.Handler
 		return fmt.Errorf("checking workspace: %w", err)
 	}
 
-	targets, vars, err := u.parseUpgradeVars(cmd, conf, fetcher)
+	targets, vars, err := parseTerraformUpgradeVars(cmd, conf, fetcher)
 	if err != nil {
 		return fmt.Errorf("parsing upgrade variables: %w", err)
 	}
@@ -200,7 +200,8 @@ func (u *upgradeApplyCmd) migrateTerraform(cmd *cobra.Command, file file.Handler
 	return nil
 }
 
-func (u *upgradeApplyCmd) parseUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher imageFetcher) ([]string, terraform.Variables, error) {
+// parseTerraformUpgradeVars parses the variables required to execute the Terraform script with.
+func parseTerraformUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher imageFetcher) ([]string, terraform.Variables, error) {
 	// Fetch variables to execute Terraform script with
 	provider := conf.GetProvider()
 	attestationVariant := conf.GetAttestationConfig().GetVariant()

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -106,7 +106,7 @@ func parseUpgradeCheckFlags(cmd *cobra.Command) (upgradeCheckFlags, error) {
 	}
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
-		fmt.Errorf("parsing force bool: %w", err)
+		return upgradeCheckFlags{}, fmt.Errorf("parsing force bool: %w", err)
 	}
 	writeConfig, err := cmd.Flags().GetBool("write-config")
 	if err != nil {

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -92,8 +92,9 @@ func runUpgradeCheck(cmd *cobra.Command, _ []string) error {
 			log:            log,
 			versionsapi:    versionfetcher,
 		},
-		checker: checker,
-		log:     log,
+		checker:      checker,
+		imagefetcher: imagefetcher.New(),
+		log:          log,
 	}
 
 	return up.upgradeCheck(cmd, fileHandler, attestationconfigapi.NewFetcher(), flags)
@@ -144,6 +145,7 @@ type upgradeCheckCmd struct {
 	canUpgradeCheck bool
 	collect         collector
 	checker         upgradeChecker
+	imagefetcher    imageFetcher
 	log             debugLog
 }
 
@@ -206,7 +208,7 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 		return fmt.Errorf("checking workspace: %w", err)
 	}
 
-	targets, vars, err := parseTerraformUpgradeVars(cmd, conf, imagefetcher.New())
+	targets, vars, err := parseTerraformUpgradeVars(cmd, conf, u.imagefetcher)
 	if err != nil {
 		return fmt.Errorf("parsing upgrade variables: %w", err)
 	}

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -228,6 +228,11 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 	if err != nil {
 		return fmt.Errorf("planning terraform migrations: %w", err)
 	}
+	defer func() {
+		if err := u.checker.CleanUpTerraformMigrations(fileHandler); err != nil {
+			u.log.Debugf("Failed to clean up Terraform migrations: %v", err)
+		}
+	}()
 
 	if !hasDiff {
 		cmd.Println("  No Terraform migrations are available.")

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -368,19 +368,19 @@ func (u stubUpgradeChecker) CurrentImage(context.Context) (string, error) {
 	return u.image, u.err
 }
 
-func (u stubUpgradeChecker) CurrentKubernetesVersion(_ context.Context) (string, error) {
+func (u stubUpgradeChecker) CurrentKubernetesVersion(context.Context) (string, error) {
 	return u.k8sVersion, u.err
 }
 
-func (u stubUpgradeChecker) PlanTerraformMigrations(ctx context.Context, opts upgrade.TerraformUpgradeOptions) (bool, error) {
+func (u stubUpgradeChecker) PlanTerraformMigrations(context.Context, upgrade.TerraformUpgradeOptions) (bool, error) {
 	return u.tfDiff, u.err
 }
 
-func (u stubUpgradeChecker) CheckTerraformMigrations(_ file.Handler) error {
+func (u stubUpgradeChecker) CheckTerraformMigrations(file.Handler) error {
 	return u.err
 }
 
-func (u stubUpgradeChecker) CleanUpTerraformMigrations(_ file.Handler) error {
+func (u stubUpgradeChecker) CleanUpTerraformMigrations(file.Handler) error {
 	return u.err
 }
 

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/edgelesssys/constellation/v2/cli/internal/upgrade"
 	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
@@ -338,6 +339,7 @@ func (s *stubVersionCollector) filterCompatibleCLIVersions(_ context.Context, _ 
 type stubUpgradeChecker struct {
 	image      string
 	k8sVersion string
+	tfDiff     bool
 	err        error
 }
 
@@ -347,6 +349,18 @@ func (u stubUpgradeChecker) CurrentImage(context.Context) (string, error) {
 
 func (u stubUpgradeChecker) CurrentKubernetesVersion(_ context.Context) (string, error) {
 	return u.k8sVersion, u.err
+}
+
+func (u stubUpgradeChecker) PlanTerraformMigrations(ctx context.Context, opts upgrade.TerraformUpgradeOptions) (bool, error) {
+	return u.tfDiff, u.err
+}
+
+func (u stubUpgradeChecker) CheckTerraformMigrations(fileHandler file.Handler) error {
+	return u.err
+}
+
+func (u stubUpgradeChecker) CleanUpTerraformMigrations(fileHandler file.Handler) error {
+	return u.err
 }
 
 func TestNewCLIVersions(t *testing.T) {

--- a/cli/internal/upgrade/terraform.go
+++ b/cli/internal/upgrade/terraform.go
@@ -120,8 +120,7 @@ func (u *TerraformUpgrader) PlanTerraformMigrations(ctx context.Context, opts Te
 // aborted by the user.
 func (u *TerraformUpgrader) CleanUpTerraformMigrations(fileHandler file.Handler, upgradeID string) error {
 	cleanupFiles := []string{
-		filepath.Join(constants.UpgradeDir, upgradeID, constants.TerraformUpgradeBackupDir),
-		filepath.Join(constants.UpgradeDir, upgradeID, constants.TerraformUpgradeWorkingDir),
+		filepath.Join(constants.UpgradeDir, upgradeID),
 	}
 
 	for _, f := range cleanupFiles {

--- a/cli/internal/upgrade/terraform_test.go
+++ b/cli/internal/upgrade/terraform_test.go
@@ -289,14 +289,23 @@ func TestCleanUpTerraformMigrations(t *testing.T) {
 			}),
 			wantFiles: []string{},
 		},
-		"clean backup dir leave other files": {
+		"clean all": {
 			upgradeID: "1234",
 			workspace: workspace([]string{
 				filepath.Join(constants.UpgradeDir, "1234", constants.TerraformUpgradeBackupDir),
-				filepath.Join(constants.UpgradeDir, "1234", "someFile"),
+				filepath.Join(constants.UpgradeDir, "1234", constants.TerraformUpgradeWorkingDir),
+				filepath.Join(constants.UpgradeDir, "1234", "abc"),
+			}),
+			wantFiles: []string{},
+		},
+		"leave other files": {
+			upgradeID: "1234",
+			workspace: workspace([]string{
+				filepath.Join(constants.UpgradeDir, "1234", constants.TerraformUpgradeBackupDir),
+				filepath.Join(constants.UpgradeDir, "other"),
 			}),
 			wantFiles: []string{
-				filepath.Join(constants.UpgradeDir, "1234", "someFile"),
+				filepath.Join(constants.UpgradeDir, "other"),
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).
-->

### Context
- The `upgrade check` command used not to take the Terraform migrations into account that would happen within the checked upgrade. This should be changed in this PR.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- The `upgrade check` command should perform a dry-run of the Terraform migrations that will be applied within the update, to show the user which actions on cloud resources will be taken upon the update.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Right now, the `parseTerraformUpgradeVars` function is shared between both the `upgrade check` and the `upgrade apply` command. This is certainly not a great dependency model and it should likely be factored out. I was unsure about what an appropriate place might be.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
