### PR TITLE
ci: download bootlogs in correct aws region

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -291,7 +291,7 @@ runs:
             ./.github/actions/constellation_create/gcp-logs.sh
             ;;
           aws)
-            ./.github/actions/constellation_create/aws-logs.sh eu-central-1
+            ./.github/actions/constellation_create/aws-logs.sh eu-west-1
             ;;
         esac
         echo "::endgroup::"


### PR DESCRIPTION

### Context
We changed the default region on AWS for our e2e tests since we are using SNP machines on AWS in the past. They are currently only available in `eu-west-1` in Europe. 

### Proposed change(s)
- Update region argument for bootlog download script to be the same region as the cluster is created in.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
