### PR TITLE
terraform: always use uniform role names

### DIFF
--- a/cli/internal/cloudcmd/create.go
+++ b/cli/internal/cloudcmd/create.go
@@ -170,7 +170,7 @@ func (c *Creator) createGCP(ctx context.Context, cl terraformClient, opts Create
 		Name: opts.Config.Name,
 		NodeGroups: map[string]terraform.GCPNodeGroup{
 			"control_plane_default": {
-				Role:            "ControlPlane",
+				Role:            role.ControlPlane.TFString(),
 				StateDiskSizeGB: opts.Config.StateDiskSizeGB,
 				InitialCount:    opts.ControlPlaneCount,
 				Zone:            opts.Config.Provider.GCP.Zone,
@@ -178,7 +178,7 @@ func (c *Creator) createGCP(ctx context.Context, cl terraformClient, opts Create
 				DiskType:        opts.Config.Provider.GCP.StateDiskType,
 			},
 			"worker_default": {
-				Role:            "Worker",
+				Role:            role.Worker.TFString(),
 				StateDiskSizeGB: opts.Config.StateDiskSizeGB,
 				InitialCount:    opts.WorkerCount,
 				Zone:            opts.Config.Provider.GCP.Zone,

--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -74,6 +74,7 @@ go_library(
         "//internal/license",
         "//internal/logger",
         "//internal/retry",
+        "//internal/role",
         "//internal/semver",
         "//internal/sigstore",
         "//internal/versions",

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -27,6 +27,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/imagefetcher"
+	"github.com/edgelesssys/constellation/v2/internal/role"
 	"github.com/edgelesssys/constellation/v2/internal/versions"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -282,14 +283,14 @@ func parseTerraformUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher 
 			Name: conf.Name,
 			NodeGroups: map[string]terraform.GCPNodeGroup{
 				"control_plane_default": {
-					Role:            "ControlPlane",
+					Role:            role.ControlPlane.TFString(),
 					StateDiskSizeGB: conf.StateDiskSizeGB,
 					Zone:            conf.Provider.GCP.Zone,
 					InstanceType:    conf.Provider.GCP.InstanceType,
 					DiskType:        conf.Provider.GCP.StateDiskType,
 				},
 				"worker_default": {
-					Role:            "Worker",
+					Role:            role.Worker.TFString(),
 					StateDiskSizeGB: conf.StateDiskSizeGB,
 					Zone:            conf.Provider.GCP.Zone,
 					InstanceType:    conf.Provider.GCP.InstanceType,

--- a/cli/internal/terraform/terraform/aws/modules/instance_group/variables.tf
+++ b/cli/internal/terraform/terraform/aws/modules/instance_group/variables.tf
@@ -5,7 +5,11 @@ variable "name" {
 
 variable "role" {
   type        = string
-  description = "The role of the instance group. Has to be 'ControlPlane' or 'Worker'."
+  description = "The role of the instance group."
+  validation {
+    condition     = contains(["control-plane", "worker"], var.role)
+    error_message = "The role has to be 'control-plane' or 'worker'."
+  }
 }
 
 variable "uid" {

--- a/cli/internal/terraform/terraform/azure/modules/scale_set/main.tf
+++ b/cli/internal/terraform/terraform/azure/modules/scale_set/main.tf
@@ -18,7 +18,7 @@ locals {
     { constellation-node-group = var.node_group_name },
   )
   group_uid = random_id.uid.hex
-  name      = "${var.base_name}-${var.role}${local.group_uid}"
+  name      = "${var.base_name}-${var.role}-${local.group_uid}"
 }
 
 resource "random_id" "uid" {

--- a/cli/internal/terraform/terraform/gcp/main.tf
+++ b/cli/internal/terraform/terraform/gcp/main.tf
@@ -56,7 +56,7 @@ locals {
     for name, node_group in var.node_groups : node_group.role => name...
   }
   control_plane_instance_groups = [
-    for control_plane in local.node_groups_by_role["ControlPlane"] : module.instance_group[control_plane].instance_group
+    for control_plane in local.node_groups_by_role["control-plane"] : module.instance_group[control_plane].instance_group
   ]
 }
 
@@ -167,7 +167,7 @@ module "instance_group" {
   alias_ip_range_name = google_compute_subnetwork.vpc_subnetwork.secondary_ip_range[0].range_name
   kube_env            = local.kube_env
   debug               = var.debug
-  named_ports         = each.value.role == "ControlPlane" ? local.control_plane_named_ports : []
+  named_ports         = each.value.role == "control-plane" ? local.control_plane_named_ports : []
   labels              = local.labels
   init_secret_hash    = local.initSecretHash
 }

--- a/cli/internal/terraform/terraform/gcp/modules/instance_group/variables.tf
+++ b/cli/internal/terraform/terraform/gcp/modules/instance_group/variables.tf
@@ -12,8 +12,8 @@ variable "role" {
   type        = string
   description = "The role of the instance group."
   validation {
-    condition     = contains(["ControlPlane", "Worker"], var.role)
-    error_message = "The role has to be 'ControlPlane' or 'Worker'."
+    condition     = contains(["control-plane", "worker"], var.role)
+    error_message = "The role has to be 'control-plane' or 'worker'."
   }
 }
 

--- a/cli/internal/terraform/terraform/gcp/variables.tf
+++ b/cli/internal/terraform/terraform/gcp/variables.tf
@@ -14,6 +14,10 @@ variable "node_groups" {
     initial_count = number
   }))
   description = "A map of node group names to node group configurations."
+  validation {
+    condition     = can([for group in var.node_groups : group.role == "control-plane" || group.role == "worker"])
+    error_message = "The role has to be 'control-plane' or 'worker'."
+  }
 }
 
 variable "project" {

--- a/cli/internal/terraform/terraform/openstack/main.tf
+++ b/cli/internal/terraform/terraform/openstack/main.tf
@@ -161,7 +161,7 @@ resource "openstack_compute_secgroup_v2" "vpc_secgroup" {
 module "instance_group_control_plane" {
   source                     = "./modules/instance_group"
   name                       = local.name
-  role                       = "ControlPlane"
+  role                       = "control-plane"
   instance_count             = var.control_plane_count
   image_id                   = openstack_images_image_v2.constellation_os_image.image_id
   flavor_id                  = var.flavor_id
@@ -182,7 +182,7 @@ module "instance_group_control_plane" {
 module "instance_group_worker" {
   source                     = "./modules/instance_group"
   name                       = local.name
-  role                       = "Worker"
+  role                       = "worker"
   instance_count             = var.worker_count
   image_id                   = openstack_images_image_v2.constellation_os_image.image_id
   flavor_id                  = var.flavor_id

--- a/cli/internal/terraform/terraform/openstack/modules/instance_group/main.tf
+++ b/cli/internal/terraform/terraform/openstack/modules/instance_group/main.tf
@@ -8,9 +8,8 @@ terraform {
 }
 
 locals {
-  role_dashed = var.role == "ControlPlane" ? "control-plane" : "worker"
-  name        = "${var.name}-${local.role_dashed}"
-  tags        = distinct(sort(concat(var.tags, ["constellation-role-${local.role_dashed}"])))
+  name = "${var.name}-${var.role}"
+  tags = distinct(sort(concat(var.tags, ["constellation-role-${var.role}"])))
 }
 
 # TODO(malt3): get this API enabled in the test environment
@@ -49,7 +48,7 @@ resource "openstack_compute_instance_v2" "instance_group_member" {
     delete_on_termination = true
   }
   metadata = {
-    constellation-role             = local.role_dashed
+    constellation-role             = var.role
     constellation-uid              = var.uid
     constellation-init-secret-hash = var.init_secret_hash
     openstack-auth-url             = var.identity_internal_url

--- a/cli/internal/terraform/terraform/openstack/modules/instance_group/variables.tf
+++ b/cli/internal/terraform/terraform/openstack/modules/instance_group/variables.tf
@@ -12,8 +12,8 @@ variable "role" {
   type        = string
   description = "The role of the instance group."
   validation {
-    condition     = contains(["ControlPlane", "Worker"], var.role)
-    error_message = "The role has to be 'ControlPlane' or 'Worker'."
+    condition     = contains(["control-plane", "worker"], var.role)
+    error_message = "The role has to be 'control-plane' or 'worker'."
   }
 }
 

--- a/cli/internal/terraform/variables_test.go
+++ b/cli/internal/terraform/variables_test.go
@@ -75,7 +75,7 @@ func TestGCPClusterVariables(t *testing.T) {
 		Debug:   true,
 		NodeGroups: map[string]GCPNodeGroup{
 			"control_plane_default": {
-				Role:            "ControlPlane",
+				Role:            "control-plane",
 				StateDiskSizeGB: 30,
 				InitialCount:    1,
 				Zone:            "eu-central-1a",
@@ -83,7 +83,7 @@ func TestGCPClusterVariables(t *testing.T) {
 				DiskType:        "pd-ssd",
 			},
 			"worker_default": {
-				Role:            "Worker",
+				Role:            "worker",
 				StateDiskSizeGB: 10,
 				InitialCount:    1,
 				Zone:            "eu-central-1b",
@@ -106,7 +106,7 @@ node_groups = {
     disk_type     = "pd-ssd"
     initial_count = 1
     instance_type = "n2d-standard-4"
-    role          = "ControlPlane"
+    role          = "control-plane"
     zone          = "eu-central-1a"
   }
   worker_default = {
@@ -114,7 +114,7 @@ node_groups = {
     disk_type     = "pd-ssd"
     initial_count = 1
     instance_type = "n2d-standard-8"
-    role          = "Worker"
+    role          = "worker"
     zone          = "eu-central-1b"
   }
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

terraform.tfvars should use the following role names to refer to roles:

"control-plane", "worker"

Go code uses a `Role` type that has the string constants `ControlPlane` and `Worker`. From now on, the CLI should convert the role names when writing the terraform.tfvars file.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- terraform: always use uniform role names

<!-- (uncomment if applicable)
### Related issue
- [AB#3240](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3240)
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
- [x] Perform manual tests to ensure nothing breaks