### PR TITLE
ci: parse ovmf binaries from metadata

### DIFF
--- a/.github/workflows/aws-snp-launchmeasurement.yml
+++ b/.github/workflows/aws-snp-launchmeasurement.yml
@@ -54,6 +54,12 @@ jobs:
         ref: main
         path: sev-snp-measure
 
+    - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # tag=v3.5.2
+      with:
+        repository: edgelesssys/sev-snp-measure-go.git
+        ref: main
+        path: sev-snp-measure-go
+
     - name: Run sev-snp-measure
       shell: bash
       run: |
@@ -69,3 +75,21 @@ jobs:
         done
 
         jq < measurements.json
+        popd || exit 1
+
+    - name: Test equivalence sevsnpmeasure & sev-snp-measure
+      shell: bash
+      run: |
+        pushd sev-snp-measure-go/e2e || exit 1
+        go test --expected-values ../../sev-snp-measure/measurements.json --ovmf ${{ steps.build-uefi.outputs.ovmfPath }}
+        popd || exit 1
+
+    - name: Generate API objects
+      shell: bash
+      run: |
+        pushd sev-snp-measure-go/sevsnpmeasure || exit 1
+        go build .
+
+        ./sevsnpmeasure parse-metadata ${{ steps.build-uefi.outputs.ovmfPath }} -o metadata.json
+
+        jq < metadata.json

--- a/.github/workflows/aws-snp-launchmeasurement.yml
+++ b/.github/workflows/aws-snp-launchmeasurement.yml
@@ -47,42 +47,12 @@ jobs:
         ovmfPath=$(realpath result/ovmf_img.fd)
         echo "ovmfPath=${ovmfPath}" | tee -a "$GITHUB_OUTPUT"
 
-
-    - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-      with:
-        repository: IBM/sev-snp-measure.git
-        ref: main
-        path: sev-snp-measure
-
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # tag=v3.5.2
       with:
         repository: edgelesssys/sev-snp-measure-go.git
         ref: main
         path: sev-snp-measure-go
 
-    - name: Run sev-snp-measure
-      shell: bash
-      run: |
-        pushd sev-snp-measure || exit 1
-        echo '[]' > intermediate.json
-
-        for vcpus in 2 4 8 16 32 48 64;
-        do
-          measurement="$(./sev-snp-measure.py --mode snp --vmm-type=ec2 --vcpus="$vcpus" --ovmf=${{ steps.build-uefi.outputs.ovmfPath }})"
-
-          jq --arg vcpus "$vcpus" --arg measurement "$measurement" '. += [{"vcpus": $vcpus, "measurement": $measurement}]' intermediate.json > measurements.json
-          cp measurements.json intermediate.json
-        done
-
-        jq < measurements.json
-        popd || exit 1
-
-    - name: Test equivalence sevsnpmeasure & sev-snp-measure
-      shell: bash
-      run: |
-        pushd sev-snp-measure-go/e2e || exit 1
-        go test --expected-values ../../sev-snp-measure/measurements.json --ovmf ${{ steps.build-uefi.outputs.ovmfPath }}
-        popd || exit 1
 
     - name: Generate API objects
       shell: bash


### PR DESCRIPTION
### Context
AWS SNP attestation should verify the launch measurement from the SNP report. The launch measurement should be configurable by the user through the constellation config. As the launch measurement differs depending on the number of vCPUs of a machine we would have to provide multiple launch measurements in the config, one for each possible VM size. To avoid this we will soon start using [this](https://github.com/edgelesssys/sev-snp-measure-go) library to pre-calculate launchmeasurements during runtime. The input for that calculation is produced as part of the pipeline changes in this PR.

### Proposed change(s)
- Build sev-snp-measure-go.
- Run equivalence test between sev-snp-measure-go and it's [upstream](https://github.com/IBM/sev-snp-measure).
- Generate MetadataWrapper object.

### Additional info
- Saving the files to the API will be added in a second PR.
- [Testrun](https://github.com/edgelesssys/constellation/actions/runs/5353628310/jobs/9709705054) :green_circle: 

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
