### PR TITLE
Use term "attestation variant" consistently

### DIFF
--- a/cli/internal/cmd/configgenerate_test.go
+++ b/cli/internal/cmd/configgenerate_test.go
@@ -193,7 +193,7 @@ func TestNoValidProviderAttestationCombination(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			_, err := createConfigWithAttestationType(test.provider, "", test.attestation)
+			_, err := createConfigWithAttestationVariant(test.provider, "", test.attestation)
 			assert.Error(err)
 		})
 	}
@@ -244,7 +244,7 @@ func TestValidProviderAttestationCombination(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("Provider:%s,Attestation:%s", test.provider, test.attestation), func(t *testing.T) {
-			sut, err := createConfigWithAttestationType(test.provider, "", test.attestation)
+			sut, err := createConfigWithAttestationVariant(test.provider, "", test.attestation)
 			assert := assert.New(t)
 			assert.NoError(err)
 			assert.Equal(test.expected, sut.Attestation)

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -73,7 +73,7 @@ The Constellation CLI can also print the supported instance types with: `constel
 
 :::caution
 Due to a bug in AWS's SNP implementation, SNP report generation currently fails in unforeseeable circumstances.
-Therefore, even if you select attestation type `awsSEVSNP`, Constellation still uses NitroTPM-based attestation.
+Therefore, even if you select attestation variant `awsSEVSNP`, Constellation still uses NitroTPM-based attestation.
 Nonetheless, runtime encryption is enabled.
 AWS is currently investigating the issue.
 SNP-based attestation will be enabled as soon as a fix is verified.

--- a/internal/api/attestationconfigapi/client.go
+++ b/internal/api/attestationconfigapi/client.go
@@ -71,7 +71,7 @@ func (a Client) DeleteAzureSEVSNPVersion(ctx context.Context, versionStr string)
 	return executeAllCmds(ctx, a.s3Client, ops)
 }
 
-// List returns the list of versions for the given attestation type.
+// List returns the list of versions for the given attestation variant.
 func (a Client) List(ctx context.Context, attestation variant.Variant) ([]string, error) {
 	if attestation.Equal(variant.AzureSEVSNP{}) {
 		versions, err := apiclient.Fetch(ctx, a.s3Client, AzureSEVSNPVersionList{})
@@ -80,7 +80,7 @@ func (a Client) List(ctx context.Context, attestation variant.Variant) ([]string
 		}
 		return versions, nil
 	}
-	return nil, fmt.Errorf("unsupported attestation type: %s", attestation)
+	return nil, fmt.Errorf("unsupported attestation variant: %s", attestation)
 }
 
 func (a Client) deleteAzureSEVSNPVersion(versions AzureSEVSNPVersionList, versionStr string) (ops []crudCmd, err error) {

--- a/internal/attestation/variant/variant.go
+++ b/internal/attestation/variant/variant.go
@@ -58,7 +58,7 @@ var providerAttestationMapping = map[cloudprovider.Provider][]Variant{
 	cloudprovider.OpenStack: {QEMUVTPM{}},
 }
 
-// GetDefaultAttestation returns the default attestation type for the given provider. If not found, it returns the default variant.
+// GetDefaultAttestation returns the default attestation variant for the given provider. If not found, it returns the default variant.
 func GetDefaultAttestation(provider cloudprovider.Provider) Variant {
 	res, ok := providerAttestationMapping[provider]
 	if ok {
@@ -67,8 +67,8 @@ func GetDefaultAttestation(provider cloudprovider.Provider) Variant {
 	return Dummy{}
 }
 
-// GetAvailableAttestationTypes returns the available attestation types.
-func GetAvailableAttestationTypes() []Variant {
+// GetAvailableAttestationVariants returns the available attestation variants.
+func GetAvailableAttestationVariants() []Variant {
 	var res []Variant
 
 	// assumes that cloudprovider.Provider is a uint32 to sort the providers and get a consistent order
@@ -121,7 +121,7 @@ func FromString(oid string) (Variant, error) {
 	return nil, fmt.Errorf("unknown OID: %q", oid)
 }
 
-// ValidProvider returns true if the attestation type is valid for the given provider.
+// ValidProvider returns true if the attestation variants is valid for the given provider.
 func ValidProvider(provider cloudprovider.Provider, variant Variant) bool {
 	validTypes, ok := providerAttestationMapping[provider]
 	if ok {


### PR DESCRIPTION
### Context
There are some places where "attestation variant" is called "attestation type". We should use the term consistently.

### Proposed change(s)
- Replace "attestation type" with "attestation variant" in user-facing strings as well as in identifiers
