### PR TITLE
cli: remove Terraform targets

### DIFF
--- a/cli/internal/cloudcmd/clients.go
+++ b/cli/internal/cloudcmd/clients.go
@@ -26,7 +26,7 @@ type imageFetcher interface {
 
 type terraformClient interface {
 	PrepareWorkspace(path string, input terraform.Variables) error
-	CreateCluster(ctx context.Context, logLevel terraform.LogLevel, targets ...string) (terraform.CreateOutput, error)
+	CreateCluster(ctx context.Context, logLevel terraform.LogLevel) (terraform.CreateOutput, error)
 	CreateIAMConfig(ctx context.Context, provider cloudprovider.Provider, logLevel terraform.LogLevel) (terraform.IAMOutput, error)
 	Destroy(ctx context.Context, logLevel terraform.LogLevel) error
 	CleanUpWorkspace() error

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -45,7 +45,7 @@ type stubTerraformClient struct {
 	showErr                error
 }
 
-func (c *stubTerraformClient) CreateCluster(_ context.Context, _ terraform.LogLevel, _ ...string) (terraform.CreateOutput, error) {
+func (c *stubTerraformClient) CreateCluster(_ context.Context, _ terraform.LogLevel) (terraform.CreateOutput, error) {
 	return terraform.CreateOutput{
 		IP:             c.ip,
 		Secret:         c.initSecret,

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -153,22 +153,16 @@ func (u *upgradeApplyCmd) migrateTerraform(cmd *cobra.Command, file file.Handler
 		return fmt.Errorf("checking workspace: %w", err)
 	}
 
-	targets, vars, err := parseTerraformUpgradeVars(cmd, conf, fetcher)
+	vars, err := parseTerraformUpgradeVars(cmd, conf, fetcher)
 	if err != nil {
 		return fmt.Errorf("parsing upgrade variables: %w", err)
 	}
-	if len(targets) == 0 {
-		u.log.Debugf("No targets specified. Skipping Terraform migration")
-		return nil
-	}
-	u.log.Debugf("Using migration targets:\n%v", targets)
 	u.log.Debugf("Using Terraform variables:\n%v", vars)
 
 	opts := upgrade.TerraformUpgradeOptions{
 		LogLevel:   flags.terraformLogLevel,
 		CSP:        conf.GetProvider(),
 		Vars:       vars,
-		Targets:    targets,
 		OutputFile: constants.TerraformMigrationOutputFile,
 	}
 
@@ -210,14 +204,14 @@ func (u *upgradeApplyCmd) migrateTerraform(cmd *cobra.Command, file file.Handler
 }
 
 // parseTerraformUpgradeVars parses the variables required to execute the Terraform script with.
-func parseTerraformUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher imageFetcher) ([]string, terraform.Variables, error) {
+func parseTerraformUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher imageFetcher) (terraform.Variables, error) {
 	// Fetch variables to execute Terraform script with
 	provider := conf.GetProvider()
 	attestationVariant := conf.GetAttestationConfig().GetVariant()
 	region := conf.GetRegion()
 	imageRef, err := fetcher.FetchReference(cmd.Context(), provider, attestationVariant, conf.Image, region)
 	if err != nil {
-		return nil, nil, fmt.Errorf("fetching image reference: %w", err)
+		return nil, fmt.Errorf("fetching image reference: %w", err)
 	}
 
 	commonVariables := terraform.CommonVariables{
@@ -229,8 +223,6 @@ func parseTerraformUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher 
 
 	switch conf.GetProvider() {
 	case cloudprovider.AWS:
-		targets := []string{}
-
 		vars := &terraform.AWSClusterVariables{
 			CommonVariables:        commonVariables,
 			StateDiskType:          conf.Provider.AWS.StateDiskType,
@@ -242,10 +234,8 @@ func parseTerraformUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher 
 			IAMProfileWorkerNodes:  conf.Provider.AWS.IAMProfileWorkerNodes,
 			Debug:                  conf.IsDebugCluster(),
 		}
-		return targets, vars, nil
+		return vars, nil
 	case cloudprovider.Azure:
-		targets := []string{"azurerm_attestation_provider.attestation_provider", "module.scale_set_group", "module.scale_set_control_plane", "module.scale_set_worker"}
-
 		// Azure Terraform provider is very strict about it's casing
 		imageRef = strings.Replace(imageRef, "CommunityGalleries", "communityGalleries", 1)
 		imageRef = strings.Replace(imageRef, "Images", "images", 1)
@@ -275,10 +265,8 @@ func parseTerraformUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher 
 			CreateMAA:  toPtr(conf.GetAttestationConfig().GetVariant().Equal(variant.AzureSEVSNP{})),
 			Debug:      toPtr(conf.IsDebugCluster()),
 		}
-		return targets, vars, nil
+		return vars, nil
 	case cloudprovider.GCP:
-		targets := []string{}
-
 		vars := &terraform.GCPClusterVariables{
 			Name: conf.Name,
 			NodeGroups: map[string]terraform.GCPNodeGroup{
@@ -303,9 +291,9 @@ func parseTerraformUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher 
 			ImageID: imageRef,
 			Debug:   conf.IsDebugCluster(),
 		}
-		return targets, vars, nil
+		return vars, nil
 	default:
-		return nil, nil, fmt.Errorf("unsupported provider: %s", conf.GetProvider())
+		return nil, fmt.Errorf("unsupported provider: %s", conf.GetProvider())
 	}
 }
 

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -208,18 +208,16 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 		return fmt.Errorf("checking workspace: %w", err)
 	}
 
-	targets, vars, err := parseTerraformUpgradeVars(cmd, conf, u.imagefetcher)
+	vars, err := parseTerraformUpgradeVars(cmd, conf, u.imagefetcher)
 	if err != nil {
 		return fmt.Errorf("parsing upgrade variables: %w", err)
 	}
-	u.log.Debugf("Using migration targets:\n%v", targets)
 	u.log.Debugf("Using Terraform variables:\n%v", vars)
 
 	opts := upgrade.TerraformUpgradeOptions{
 		LogLevel:   flags.terraformLogLevel,
 		CSP:        conf.GetProvider(),
 		Vars:       vars,
-		Targets:    targets,
 		OutputFile: constants.TerraformMigrationOutputFile,
 	}
 

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -96,7 +96,7 @@ func (c *Client) PrepareUpgradeWorkspace(path, oldWorkingDir, newWorkingDir, bac
 }
 
 // CreateCluster creates a Constellation cluster using Terraform.
-func (c *Client) CreateCluster(ctx context.Context, logLevel LogLevel, targets ...string) (CreateOutput, error) {
+func (c *Client) CreateCluster(ctx context.Context, logLevel LogLevel) (CreateOutput, error) {
 	if err := c.setLogLevel(logLevel); err != nil {
 		return CreateOutput{}, fmt.Errorf("set terraform log level %s: %w", logLevel.String(), err)
 	}
@@ -105,12 +105,7 @@ func (c *Client) CreateCluster(ctx context.Context, logLevel LogLevel, targets .
 		return CreateOutput{}, fmt.Errorf("terraform init: %w", err)
 	}
 
-	opts := []tfexec.ApplyOption{}
-	for _, target := range targets {
-		opts = append(opts, tfexec.Target(target))
-	}
-
-	if err := c.tf.Apply(ctx, opts...); err != nil {
+	if err := c.tf.Apply(ctx); err != nil {
 		return CreateOutput{}, fmt.Errorf("terraform apply: %w", err)
 	}
 
@@ -292,7 +287,7 @@ func (c *Client) CreateIAMConfig(ctx context.Context, provider cloudprovider.Pro
 
 // Plan determines the diff that will be applied by Terraform. The plan output is written to the planFile.
 // If there is a diff, the returned bool is true. Otherwise, it is false.
-func (c *Client) Plan(ctx context.Context, logLevel LogLevel, planFile string, targets ...string) (bool, error) {
+func (c *Client) Plan(ctx context.Context, logLevel LogLevel, planFile string) (bool, error) {
 	if err := c.setLogLevel(logLevel); err != nil {
 		return false, fmt.Errorf("set terraform log level %s: %w", logLevel.String(), err)
 	}
@@ -303,9 +298,6 @@ func (c *Client) Plan(ctx context.Context, logLevel LogLevel, planFile string, t
 
 	opts := []tfexec.PlanOption{
 		tfexec.Out(planFile),
-	}
-	for _, target := range targets {
-		opts = append(opts, tfexec.Target(target))
 	}
 	return c.tf.Plan(ctx, opts...)
 }

--- a/cli/internal/upgrade/terraform.go
+++ b/cli/internal/upgrade/terraform.go
@@ -46,8 +46,6 @@ type TerraformUpgradeOptions struct {
 	CSP cloudprovider.Provider
 	// Vars are the Terraform variables used for the upgrade.
 	Vars terraform.Variables
-	// Targets are the Terraform targets used for the upgrade.
-	Targets []string
 	// OutputFile is the file to write the Terraform output to.
 	OutputFile string
 }
@@ -102,7 +100,7 @@ func (u *TerraformUpgrader) PlanTerraformMigrations(ctx context.Context, opts Te
 		return false, fmt.Errorf("preparing terraform workspace: %w", err)
 	}
 
-	hasDiff, err := u.tf.Plan(ctx, opts.LogLevel, constants.TerraformUpgradePlanFile, opts.Targets...)
+	hasDiff, err := u.tf.Plan(ctx, opts.LogLevel, constants.TerraformUpgradePlanFile)
 	if err != nil {
 		return false, fmt.Errorf("terraform plan: %w", err)
 	}
@@ -137,7 +135,7 @@ func (u *TerraformUpgrader) CleanUpTerraformMigrations(fileHandler file.Handler,
 // In case of a successful upgrade, the output will be written to the specified file and the old Terraform directory is replaced
 // By the new one.
 func (u *TerraformUpgrader) ApplyTerraformMigrations(ctx context.Context, fileHandler file.Handler, opts TerraformUpgradeOptions, upgradeID string) error {
-	tfOutput, err := u.tf.CreateCluster(ctx, opts.LogLevel, opts.Targets...)
+	tfOutput, err := u.tf.CreateCluster(ctx, opts.LogLevel)
 	if err != nil {
 		return fmt.Errorf("terraform apply: %w", err)
 	}
@@ -180,8 +178,8 @@ func (u *TerraformUpgrader) ApplyTerraformMigrations(ctx context.Context, fileHa
 type tfClient interface {
 	PrepareUpgradeWorkspace(path, oldWorkingDir, newWorkingDir, upgradeID string, vars terraform.Variables) error
 	ShowPlan(ctx context.Context, logLevel terraform.LogLevel, planFilePath string, output io.Writer) error
-	Plan(ctx context.Context, logLevel terraform.LogLevel, planFile string, targets ...string) (bool, error)
-	CreateCluster(ctx context.Context, logLevel terraform.LogLevel, targets ...string) (terraform.CreateOutput, error)
+	Plan(ctx context.Context, logLevel terraform.LogLevel, planFile string) (bool, error)
+	CreateCluster(ctx context.Context, logLevel terraform.LogLevel) (terraform.CreateOutput, error)
 }
 
 // policyPatcher interacts with the CSP (currently only applies for Azure) to update the attestation policy.

--- a/cli/internal/upgrade/terraform_test.go
+++ b/cli/internal/upgrade/terraform_test.go
@@ -356,11 +356,11 @@ func (u *stubTerraformClient) ShowPlan(context.Context, terraform.LogLevel, stri
 	return u.showErr
 }
 
-func (u *stubTerraformClient) Plan(context.Context, terraform.LogLevel, string, ...string) (bool, error) {
+func (u *stubTerraformClient) Plan(context.Context, terraform.LogLevel, string) (bool, error) {
 	return u.hasDiff, u.planErr
 }
 
-func (u *stubTerraformClient) CreateCluster(context.Context, terraform.LogLevel, ...string) (terraform.CreateOutput, error) {
+func (u *stubTerraformClient) CreateCluster(context.Context, terraform.LogLevel) (terraform.CreateOutput, error) {
 	return terraform.CreateOutput{}, u.CreateClusterErr
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Terraform migrations on Constellation upgrades used to target resources explicitly as otherwise Terraform would destroy non-updatable resources such as instance groups if they have been changed (e.g. due to autoscaling) outside of Terraform. The explicit targeting will fail when a user edits a non-targeted resource outside of Terraform as Terraform receives an unexpected state drift.
 
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
-  Remove the resource targeting.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Before releasing v2.9.0, we will need to check the migrations happening with the release (most likely only node groups) thoroughly and add the required `lifecycle { ignore_changes ... }` meta-argument in the Terraform config.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
