### PR TITLE
cli: fail fast when CLI and Constellation versions don't match

### DIFF
--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -14,11 +14,13 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfigapi"
+	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
+	"github.com/edgelesssys/constellation/v2/internal/semver"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -81,6 +83,9 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 		cmd.PrintErrln(configValidationErr.LongMessage())
 	}
 	if err != nil {
+		return err
+	}
+	if err := validateCLIandConstellationVersionCompatibility(constants.VersionInfo(), conf.Image, conf.MicroserviceVersion); err != nil {
 		return err
 	}
 
@@ -170,6 +175,33 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 	}
 
 	cmd.Println("Your Constellation cluster was created successfully.")
+	return nil
+}
+
+func validateCLIandConstellationVersionCompatibility(cliVersion, imageVersion, microserviceVersion string) error {
+	parsedImageVersion, err := versionsapi.NewVersionFromShortPath(imageVersion, versionsapi.VersionKindImage)
+	if err != nil {
+		return fmt.Errorf("parsing image version: %w", err)
+	}
+
+	semImage, err := semver.New(parsedImageVersion.Version)
+	if err != nil {
+		return fmt.Errorf("parsing image semantical version: %w", err)
+	}
+
+	semMicro, err := semver.New(microserviceVersion)
+	if err != nil {
+		return fmt.Errorf("parsing microservice version: %w", err)
+	}
+
+	semCLI, err := semver.New(cliVersion)
+	if err != nil {
+		return fmt.Errorf("parsing binary version: %w", err)
+	}
+
+	if semCLI.Compare(semImage) != 0 || semCLI.Compare(semMicro) != 0 {
+		return fmt.Errorf("cli version %q does not match microservice version %q or image %q", semCLI.String(), semMicro.String(), semImage.String())
+	}
 	return nil
 }
 

--- a/cli/internal/cmd/create_test.go
+++ b/cli/internal/cmd/create_test.go
@@ -270,6 +270,57 @@ func TestCheckDirClean(t *testing.T) {
 	}
 }
 
+func TestValidateCLIandConstellationVersionCompatibility(t *testing.T) {
+	testCases := map[string]struct {
+		imageVersion        string
+		microServiceVersion string
+		cliVersion          string
+		wantErr             bool
+	}{
+		"empty": {
+			imageVersion:        "",
+			microServiceVersion: "",
+			cliVersion:          "",
+			wantErr:             true,
+		},
+		"invalid when image < CLI": {
+			imageVersion:        "v2.7.1",
+			microServiceVersion: "v2.8.0",
+			cliVersion:          "v2.8.0",
+			wantErr:             true,
+		},
+		"invalid when microservice < CLI": {
+			imageVersion:        "v2.8.0",
+			microServiceVersion: "v2.7.1",
+			cliVersion:          "v2.8.0",
+			wantErr:             true,
+		},
+		"valid release version": {
+			imageVersion:        "v2.9.0",
+			microServiceVersion: "v2.9.0",
+			cliVersion:          "2.9.0",
+		},
+		"valid pre-version": {
+			imageVersion:        "ref/main/stream/nightly/v2.9.0-pre.0.20230626150512-0a36ce61719f",
+			microServiceVersion: "v2.9.0-pre.0.20230626150512-0a36ce61719f",
+			cliVersion:          "2.9.0-pre.0.20230626150512-0a36ce61719f",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			err := validateCLIandConstellationVersionCompatibility(tc.cliVersion, tc.imageVersion, tc.microServiceVersion)
+
+			if tc.wantErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
 func intPtr(i int) *int {
 	return &i
 }

--- a/cli/internal/cmd/create_test.go
+++ b/cli/internal/cmd/create_test.go
@@ -310,7 +310,7 @@ func TestValidateCLIandConstellationVersionCompatibility(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			err := validateCLIandConstellationVersionCompatibility(tc.cliVersion, tc.imageVersion, tc.microServiceVersion)
+			err := validateCLIandConstellationVersionAreEqual(tc.cliVersion, tc.imageVersion, tc.microServiceVersion)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -121,7 +121,7 @@ func (i *initCmd) initialize(cmd *cobra.Command, newDialer func(validator atls.V
 	if err != nil {
 		return err
 	}
-	if err := validateCLIandConstellationVersionCompatibility(constants.VersionInfo(), conf.Image, conf.MicroserviceVersion); err != nil {
+	if err := validateCLIandConstellationVersionAreEqual(constants.VersionInfo(), conf.Image, conf.MicroserviceVersion); err != nil {
 		return err
 	}
 	if conf.GetAttestationConfig().GetVariant().Equal(variant.AWSSEVSNP{}) {

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -121,7 +121,9 @@ func (i *initCmd) initialize(cmd *cobra.Command, newDialer func(validator atls.V
 	if err != nil {
 		return err
 	}
-
+	if err := validateCLIandConstellationVersionCompatibility(constants.VersionInfo(), conf.Image, conf.MicroserviceVersion); err != nil {
+		return err
+	}
 	if conf.GetAttestationConfig().GetVariant().Equal(variant.AWSSEVSNP{}) {
 		cmd.PrintErrln("WARNING: SNP based attestation is still under active development. Please do not use in production.")
 	}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We don't support creating e.g. a 2.7.1 Constellation with e.g. the 2.8.0. CLI.
More precisely: The to-be-created Constellation version must always match the CLI's version, down to the patch version.

We don't want to forbid using/loading an old config since this is needed for e.g. the upgrade process.
But we want to fail fast if the user tries to `constellation create` or `constellation init` a Constellation.

Mismatches can be found by comparing the CLI's version against the `microserviceVersion` and `image` version of the config. Then we want to fail hard on `constellation create` and `constellation init` with a corresponding error which states that there is a mismatch and that the corresponding version to the config must be downloaded or the version in the config must be updated.

Creating a Constellation v2.7.1 (nodes and microservices) with a v2.8.0 CLI (Darwin, ARM64) gives the following errror:
``` sh
➜  demo constellation config fetch-measurements 
➜  demo constellation create -c 1 -w 2 -y   
Creating  
Your Constellation cluster was created successfully.
➜  demo constellation init               
Using community license.
Unable to contact license server.
Please keep your vCPU quota in mind.
Your Constellation master secret was successfully written to ./constellation-mastersecret.json
Note: If you just created the cluster, it can take a few minutes to connect.
Connecting   
Initializing cluster   
Cluster initialization failed. This error is not recoverable.
Terminate your cluster and try again.
The cluster logs were saved to "constellation-cluster.log"
Error: rpc error: code = Internal desc = grpc: failed to unmarshal the received message: proto: cannot parse invalid wire-format data
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add a validation check for `create` and `init` to fail early when the versions don't match.


### Related issue
- AB#3236

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
