### PR TITLE
config: improve usage and meaning of validate

### DIFF
--- a/cli/internal/cmd/miniup.go
+++ b/cli/internal/cmd/miniup.go
@@ -143,7 +143,7 @@ func (m *miniUpCmd) prepareConfig(cmd *cobra.Command, fileHandler file.Handler, 
 			return nil, errors.New("not overwriting existing config")
 		}
 	}
-	if featureset.CurrentEdition != featureset.EditionEnterprise {
+	if !featureset.CanUseEmbeddedMeasurmentsAndImage {
 		cmd.PrintErrln("Generating a valid default config is not supported in the OSS build of the Constellation CLI. Consult the documentation for instructions on where to download the enterprise version.")
 		return nil, errors.New("cannot create a mini cluster without a config file in the OSS build")
 	}

--- a/cli/internal/cmd/miniup.go
+++ b/cli/internal/cmd/miniup.go
@@ -143,15 +143,16 @@ func (m *miniUpCmd) prepareConfig(cmd *cobra.Command, fileHandler file.Handler, 
 		}
 	}
 
-	config := config.Default()
-	config.Name = constants.MiniConstellationUID
-	config.RemoveProviderAndAttestationExcept(cloudprovider.QEMU)
-	config.StateDiskSizeGB = 8
-
+	// TODO: Should we allow this at all?  It seems more logical to follow the usage pattern for the other providers: constellation config generate mini -> constellation init. But maybe it's more user friendly to not persist a config file in the workspace for a testing cluster?
+	config := config.MiniDefault()
 	// only release images (e.g. v2.7.0) use the production NVRAM
 	if !config.IsReleaseImage() {
 		config.Provider.QEMU.NVRAM = "testing"
 	}
+	// TODO: this validation would fail since no image nor measurements are set; we create a cluster with what we call invalid?
+	//if err := config.Validate(flags.force); err != nil {
+	//	return nil, fmt.Errorf("validating config: %w", err)
+	//}
 
 	m.log.Debugf("Prepared configuration")
 

--- a/cli/internal/cmd/miniup.go
+++ b/cli/internal/cmd/miniup.go
@@ -143,19 +143,14 @@ func (m *miniUpCmd) prepareConfig(cmd *cobra.Command, fileHandler file.Handler, 
 			return nil, errors.New("not overwriting existing config")
 		}
 	}
-	if featureset.CurrentEdition != featureset.EditionEnterprise { // TODO: or !featureset.CanFetchMeasurements? image is also needed..
+	if featureset.CurrentEdition != featureset.EditionEnterprise {
 		cmd.PrintErrln("Generating a valid default config is not supported in the OSS build of the Constellation CLI. Consult the documentation for instructions on where to download the enterprise version.")
 		return nil, errors.New("cannot create a mini cluster without a config file in the OSS build")
 	}
-	config := config.MiniDefault()
-	// only release images (e.g. v2.7.0) use the production NVRAM
-	if !config.IsReleaseImage() {
-		config.Provider.QEMU.NVRAM = "testing"
+	config, err := config.MiniDefault()
+	if err != nil {
+		return nil, fmt.Errorf("mini default config is invalid: %v", err)
 	}
-	if err := config.Validate(flags.force); err != nil {
-		return nil, fmt.Errorf("validating config: %w", err)
-	}
-
 	m.log.Debugf("Prepared configuration")
 
 	return config, fileHandler.WriteYAML(constants.ConfigFilename, config, file.OptOverwrite)

--- a/cli/internal/featureset/featureset.go
+++ b/cli/internal/featureset/featureset.go
@@ -20,6 +20,9 @@ const (
 // CanFetchMeasurements returns whether the current build can fetch measurements.
 const CanFetchMeasurements = canFetchMeasurements
 
+// CanUseEmbeddedMeasurmentsAndImage returns whether the current build can use embedded measurements and can provide a node image.
+const CanUseEmbeddedMeasurmentsAndImage = canUseEmbeddedMeasurmentsAndImage
+
 // CanUpgradeCheck returns whether the current build can check for upgrades.
 // This also includes fetching new measurements.
 const CanUpgradeCheck = canUpgradeCheck

--- a/cli/internal/featureset/featureset_enterprise.go
+++ b/cli/internal/featureset/featureset_enterprise.go
@@ -9,7 +9,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 package featureset
 
 const (
-	edition              = EditionEnterprise
-	canFetchMeasurements = true
-	canUpgradeCheck      = true
+	edition                           = EditionEnterprise
+	canFetchMeasurements              = true
+	canUpgradeCheck                   = true
+	canUseEmbeddedMeasurmentsAndImage = true
 )

--- a/cli/internal/featureset/featureset_oss.go
+++ b/cli/internal/featureset/featureset_oss.go
@@ -9,7 +9,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 package featureset
 
 const (
-	edition              = EditionOSS
-	canFetchMeasurements = false
-	canUpgradeCheck      = false
+	edition                           = EditionOSS
+	canFetchMeasurements              = false
+	canUpgradeCheck                   = false
+	canUseEmbeddedMeasurmentsAndImage = false
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -297,7 +297,8 @@ type AttestationConfig struct {
 	QEMUVTPM *QEMUVTPM `yaml:"qemuVTPM,omitempty" validate:"omitempty,dive"`
 }
 
-// Default returns a struct with the default config. IMPORTANT: Ensure that any state mutation is followed by a call to Validate() to ensure that the config is always in a valid state. Avoid usage outside of tests.
+// Default returns a struct with the default config.
+// IMPORTANT: Ensure that any state mutation is followed by a call to Validate() to ensure that the config is always in a valid state. Avoid usage outside of tests.
 func Default() *Config {
 	return &Config{
 		Version:             Version3,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -297,7 +297,7 @@ type AttestationConfig struct {
 	QEMUVTPM *QEMUVTPM `yaml:"qemuVTPM,omitempty" validate:"omitempty,dive"`
 }
 
-// Default returns a struct with the default config.
+// Default returns a struct with the default config. IMPORTANT: Ensure that any state mutation is followed by a call to Validate() to ensure that the config is always in a valid state. Avoid usage outside of tests.
 func Default() *Config {
 	return &Config{
 		Version:             Version3,
@@ -365,6 +365,15 @@ func Default() *Config {
 			QEMUVTPM:           &QEMUVTPM{Measurements: measurements.DefaultsFor(cloudprovider.QEMU, variant.QEMUVTPM{})},
 		},
 	}
+}
+
+// MiniDefault returns a default config for a mini cluster.
+func MiniDefault() *Config {
+	config := Default()
+	config.Name = constants.MiniConstellationUID
+	config.RemoveProviderAndAttestationExcept(cloudprovider.QEMU)
+	config.StateDiskSizeGB = 8
+	return config
 }
 
 // fromFile returns config file with `name` read from `fileHandler` by parsing

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -369,12 +369,16 @@ func Default() *Config {
 }
 
 // MiniDefault returns a default config for a mini cluster.
-func MiniDefault() *Config {
+func MiniDefault() (*Config, error) {
 	config := Default()
 	config.Name = constants.MiniConstellationUID
 	config.RemoveProviderAndAttestationExcept(cloudprovider.QEMU)
 	config.StateDiskSizeGB = 8
-	return config
+	// only release images (e.g. v2.7.0) use the production NVRAM
+	if !config.IsReleaseImage() {
+		config.Provider.QEMU.NVRAM = "testing"
+	}
+	return config, config.Validate(false)
 }
 
 // fromFile returns config file with `name` read from `fileHandler` by parsing

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -378,8 +378,8 @@ func TestValidate(t *testing.T) {
 		},
 		"miniup default config is not valid because image and measurements are missing in OSS": {
 			cnf: func() *Config {
-				config, err := MiniDefault()
-				require.Error(t, err)
+				config, _ := MiniDefault()
+				require.NotNil(t, config)
 				return config
 			}(),
 			wantErr:      true,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -397,8 +397,7 @@ func TestValidate(t *testing.T) {
 				assert.Error(err)
 				var valErr *ValidationError
 				require.ErrorAs(err, &valErr)
-				t.Log("validation err:", valErr.LongMessage()) // TODO: Why don't we keep this log for better debugging on failure?
-				assert.Equal(tc.wantErrCount, valErr.messagesCount())
+				assert.Equalf(tc.wantErrCount, valErr.messagesCount(), "Got unexpected error count: %d: %s", valErr.messagesCount(), valErr.LongMessage())
 				return
 			}
 			assert.NoError(err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -376,6 +376,14 @@ func TestValidate(t *testing.T) {
 				return cnf
 			}(),
 		},
+		"miniup default config is not valid because image and measurements are missing": {
+			cnf: func() *Config {
+				config := MiniDefault()
+				return config
+			}(),
+			wantErr:      true,
+			wantErrCount: 2,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -389,6 +397,7 @@ func TestValidate(t *testing.T) {
 				assert.Error(err)
 				var valErr *ValidationError
 				require.ErrorAs(err, &valErr)
+				t.Log("validation err:", valErr.LongMessage()) // TODO: Why don't we keep this log for better debugging on failure?
 				assert.Equal(tc.wantErrCount, valErr.messagesCount())
 				return
 			}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -376,9 +376,10 @@ func TestValidate(t *testing.T) {
 				return cnf
 			}(),
 		},
-		"miniup default config is not valid because image and measurements are missing": {
+		"miniup default config is not valid because image and measurements are missing in OSS": {
 			cnf: func() *Config {
-				config := MiniDefault()
+				config, err := MiniDefault()
+				require.Error(t, err)
 				return config
 			}(),
 			wantErr:      true,


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We want to make sure that a consumer of the config can rely on it being in a valid state (as verified in `config.Validate`).
Currently, the usage is not consistent and better documentation should discourage mutation of a config object without subsequent validation.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- discourage use of config.Default + mutation
- discuss violating usage in miniup

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [x] Link to Milestone
