### PR TITLE
terraform: aws node groups

### DIFF
--- a/cli/internal/cloudcmd/create.go
+++ b/cli/internal/cloudcmd/create.go
@@ -130,16 +130,27 @@ func (c *Creator) Create(ctx context.Context, opts CreateOptions) (clusterid.Fil
 
 func (c *Creator) createAWS(ctx context.Context, cl terraformClient, opts CreateOptions) (idFile clusterid.File, retErr error) {
 	vars := terraform.AWSClusterVariables{
-		CommonVariables: terraform.CommonVariables{
-			Name:               opts.Config.Name,
-			CountControlPlanes: opts.ControlPlaneCount,
-			CountWorkers:       opts.WorkerCount,
-			StateDiskSizeGB:    opts.Config.StateDiskSizeGB,
+		Name: opts.Config.Name,
+		NodeGroups: map[string]terraform.AWSNodeGroup{
+			"control_plane_default": {
+				Role:            role.ControlPlane.TFString(),
+				StateDiskSizeGB: opts.Config.StateDiskSizeGB,
+				InitialCount:    opts.ControlPlaneCount,
+				Zone:            opts.Config.Provider.AWS.Zone,
+				InstanceType:    opts.InsType,
+				DiskType:        opts.Config.Provider.AWS.StateDiskType,
+			},
+			"worker_default": {
+				Role:            role.Worker.TFString(),
+				StateDiskSizeGB: opts.Config.StateDiskSizeGB,
+				InitialCount:    opts.WorkerCount,
+				Zone:            opts.Config.Provider.AWS.Zone,
+				InstanceType:    opts.InsType,
+				DiskType:        opts.Config.Provider.AWS.StateDiskType,
+			},
 		},
-		StateDiskType:          opts.Config.Provider.AWS.StateDiskType,
 		Region:                 opts.Config.Provider.AWS.Region,
 		Zone:                   opts.Config.Provider.AWS.Zone,
-		InstanceType:           opts.InsType,
 		AMIImageID:             opts.image,
 		IAMProfileControlPlane: opts.Config.Provider.AWS.IAMProfileControlPlane,
 		IAMProfileWorkerNodes:  opts.Config.Provider.AWS.IAMProfileWorkerNodes,

--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "iamdestroy.go",
         "init.go",
         "log.go",
+        "manualtfstatemigration.go",
         "mini.go",
         "minidown.go",
         "miniup.go",

--- a/cli/internal/cmd/manualtfstatemigration.go
+++ b/cli/internal/cmd/manualtfstatemigration.go
@@ -1,0 +1,78 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
+	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
+)
+
+// terraformMigrationAWSNodeGroups migrates the AWS node groups from the old state to the new state.
+// TODO(AB#3248): Remove this migration after we can assume that all existing clusters have been migrated.
+func terraformMigrationAWSNodeGroups(csp cloudprovider.Provider, zone string) []terraform.StateMigration {
+	if csp != cloudprovider.AWS {
+		return nil
+	}
+	return []terraform.StateMigration{
+		{
+			DisplayName: "AWS node groups",
+			Hook: func(ctx context.Context, tfClient terraform.TFMigrator) error {
+				fromTo := []struct {
+					from string
+					to   string
+				}{
+					{
+						from: "aws_eip.lb",
+						to:   fmt.Sprintf("aws_eip.lb[%q]", zone),
+					},
+					{
+						from: "module.public_private_subnet.aws_eip.nat",
+						to:   fmt.Sprintf("module.public_private_subnet.aws_eip.nat[%q]", zone),
+					},
+					{
+						from: "module.public_private_subnet.aws_nat_gateway.gw",
+						to:   fmt.Sprintf("module.public_private_subnet.aws_nat_gateway.gw[%q]", zone),
+					},
+					{
+						from: "module.public_private_subnet.aws_route_table.private_nat",
+						to:   fmt.Sprintf("module.public_private_subnet.aws_route_table.private_nat[%q]", zone),
+					},
+					{
+						from: "module.public_private_subnet.aws_route_table.public_igw",
+						to:   fmt.Sprintf("module.public_private_subnet.aws_route_table.public_igw[%q]", zone),
+					},
+					{
+						from: "module.public_private_subnet.aws_route_table_association.private-nat",
+						to:   fmt.Sprintf("module.public_private_subnet.aws_route_table_association.private_nat[%q]", zone),
+					},
+					{
+						from: "module.public_private_subnet.aws_route_table_association.route_to_internet",
+						to:   fmt.Sprintf("module.public_private_subnet.aws_route_table_association.route_to_internet[%q]", zone),
+					},
+					{
+						from: "module.public_private_subnet.aws_subnet.private",
+						to:   fmt.Sprintf("module.public_private_subnet.aws_subnet.private[%q]", zone),
+					},
+					{
+						from: "module.public_private_subnet.aws_subnet.public",
+						to:   fmt.Sprintf("module.public_private_subnet.aws_subnet.public[%q]", zone),
+					},
+				}
+
+				for _, move := range fromTo {
+					// we need to drop the error here, because the migration has to be idempotent
+					// and state mv will fail if the state is already migrated
+					_ = tfClient.StateMv(ctx, move.from, move.to)
+				}
+				return nil
+			},
+		},
+	}
+}

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/kubernetes"
+	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/cli/internal/upgrade"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
@@ -194,6 +195,12 @@ func (u stubUpgrader) PlanTerraformMigrations(context.Context, upgrade.Terraform
 
 func (u stubUpgrader) ApplyTerraformMigrations(context.Context, file.Handler, upgrade.TerraformUpgradeOptions) error {
 	return u.applyTerraformErr
+}
+
+// AddManualStateMigration is not used in this test.
+// TODO(AB#3248): remove this method together with the definition in the interfaces.
+func (u stubUpgrader) AddManualStateMigration(_ terraform.StateMigration) {
+	panic("unused")
 }
 
 type stubImageFetcher struct {

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/cli/internal/upgrade"
 	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
@@ -382,6 +383,12 @@ func (u stubUpgradeChecker) CheckTerraformMigrations(file.Handler) error {
 
 func (u stubUpgradeChecker) CleanUpTerraformMigrations(file.Handler) error {
 	return u.err
+}
+
+// AddManualStateMigration is not used in this test.
+// TODO(AB#3248): remove this method together with the definition in the interfaces.
+func (u stubUpgradeChecker) AddManualStateMigration(_ terraform.StateMigration) {
+	panic("unused")
 }
 
 func TestNewCLIVersions(t *testing.T) {

--- a/cli/internal/terraform/BUILD.bazel
+++ b/cli/internal/terraform/BUILD.bazel
@@ -103,6 +103,7 @@ go_test(
         "//internal/cloud/cloudprovider",
         "//internal/constants",
         "//internal/file",
+        "//internal/role",
         "@com_github_azure_azure_sdk_for_go_sdk_azcore//to",
         "@com_github_hashicorp_terraform_exec//tfexec",
         "@com_github_hashicorp_terraform_json//:terraform-json",

--- a/cli/internal/terraform/terraform/aws/main.tf
+++ b/cli/internal/terraform/terraform/aws/main.tf
@@ -89,7 +89,12 @@ resource "aws_lb" "front_end" {
   tags               = local.tags
 
   dynamic "subnet_mapping" {
-    for_each = toset(module.public_private_subnet.all_zones)
+    # TODO(malt3): use for_each = toset(module.public_private_subnet.all_zones)
+    # in a future version to support all availability zones in the chosen region
+    # without needing to constantly replace the loadbalancer.
+    # This has to wait until the bootstrapper that we upgrade from (source version) can handle multiple AZs
+    # for_each = toset(module.public_private_subnet.all_zones)
+    for_each = toset(local.zones)
     content {
       subnet_id     = module.public_private_subnet.public_subnet_id[subnet_mapping.key]
       allocation_id = aws_eip.lb[subnet_mapping.key].id

--- a/cli/internal/terraform/terraform/aws/modules/instance_group/main.tf
+++ b/cli/internal/terraform/terraform/aws/modules/instance_group/main.tf
@@ -4,13 +4,21 @@ terraform {
       source  = "hashicorp/aws"
       version = "5.1.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.5.1"
+    }
   }
 }
 
 locals {
-  name = "${var.name}-${lower(var.role)}"
+  group_uid = random_id.uid.hex
+  name      = "${var.base_name}-${lower(var.role)}-${local.group_uid}"
 }
 
+resource "random_id" "uid" {
+  byte_length = 4
+}
 
 resource "aws_launch_template" "launch_template" {
   name_prefix   = local.name
@@ -37,17 +45,22 @@ resource "aws_launch_template" "launch_template" {
     }
   }
 
+  # See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template#cpu-options
+  cpu_options {
+    # use "enabled" to enable SEV-SNP
+    # use "disabled" to disable SEV-SNP (but still require SNP-capable hardware)
+    # use null to leave the setting unset (allows non-SNP-capable hardware to be used)
+    amd_sev_snp = var.enable_snp ? "enabled" : null
+  }
+
   lifecycle {
     create_before_destroy = true
     ignore_changes = [
+      cpu_options,     # required. we cannot change the CPU options of a launch template
+      name_prefix,     # required. Allow legacy scale sets to keep their old names
       default_version, # required. update procedure creates new versions of the launch template
       image_id,        # required. update procedure modifies the image id externally
     ]
-  }
-
-  # See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template#cpu-options
-  cpu_options {
-    amd_sev_snp = var.enable_snp ? "enabled" : "disabled"
   }
 }
 
@@ -74,6 +87,7 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   lifecycle {
     create_before_destroy = true
     ignore_changes = [
+      name,                      # required. Allow legacy scale sets to keep their old names
       launch_template.0.version, # required. update procedure creates new versions of the launch template
       min_size,                  # required. autoscaling modifies the instance count externally
       max_size,                  # required. autoscaling modifies the instance count externally

--- a/cli/internal/terraform/terraform/aws/modules/instance_group/variables.tf
+++ b/cli/internal/terraform/terraform/aws/modules/instance_group/variables.tf
@@ -1,6 +1,11 @@
-variable "name" {
+variable "base_name" {
   type        = string
   description = "Base name of the instance group."
+}
+
+variable "node_group_name" {
+  type        = string
+  description = "Constellation name for the node group (used for configuration and CSP-independent naming)."
 }
 
 variable "role" {
@@ -71,4 +76,9 @@ variable "enable_snp" {
   type        = bool
   default     = true
   description = "Enable AMD SEV SNP. Setting this to true sets the cpu-option AmdSevSnp to enable."
+}
+
+variable "zone" {
+  type        = string
+  description = "Zone to deploy the instance group in."
 }

--- a/cli/internal/terraform/terraform/aws/modules/public_private_subnet/main.tf
+++ b/cli/internal/terraform/terraform/aws/modules/public_private_subnet/main.tf
@@ -7,23 +7,70 @@ terraform {
   }
 }
 
+locals {
+  # az_number is a stable mapping of az suffix to a number used for calculating the subnet cidr
+  az_number = {
+    # we start counting at 2 to have the legacy subnet before the first newly created networks
+    # the legacy subnet did not start at a /20 boundary
+    # 0 => 192.168.176.0/24 (unused private subnet cidr)
+    # 1 => 192.168.177.0/24 (unused private subnet cidr)
+    legacy = 2 # => 192.168.178.0/24 (legacy private subnet)
+    a      = 3 # => 192.168.178.1/24 (first newly created zonal private subnet)
+    b      = 4
+    c      = 5
+    d      = 6
+    e      = 7
+    f      = 8
+    g      = 9
+    h      = 10
+    i      = 11
+    j      = 12
+    k      = 13
+    l      = 14
+    m      = 15 # => 192.168.191.0/24 (last reserved zonal private subnet cidr). In reality, AWS doesn't have that many zones in a region.
+  }
+}
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+data "aws_availability_zone" "all" {
+  for_each = toset(data.aws_availability_zones.available.names)
+
+  name = each.key
+}
+
 resource "aws_eip" "nat" {
-  domain = "vpc"
-  tags   = var.tags
+  for_each = toset(var.zones)
+  domain   = "vpc"
+  tags     = var.tags
 }
 
 resource "aws_subnet" "private" {
+  for_each          = data.aws_availability_zone.all
   vpc_id            = var.vpc_id
-  cidr_block        = var.cidr_vpc_subnet_nodes
-  availability_zone = var.zone
+  cidr_block        = cidrsubnet(var.cidr_vpc_subnet_nodes, 4, local.az_number[each.value.name_suffix])
+  availability_zone = each.key
   tags              = merge(var.tags, { Name = "${var.name}-subnet-nodes" })
+  lifecycle {
+    ignore_changes = [
+      cidr_block, # required. Legacy subnets used fixed cidr blocks for the single zone that don't match the new scheme.
+    ]
+  }
 }
 
 resource "aws_subnet" "public" {
+  for_each          = data.aws_availability_zone.all
   vpc_id            = var.vpc_id
-  cidr_block        = var.cidr_vpc_subnet_internet
-  availability_zone = var.zone
+  cidr_block        = cidrsubnet(var.cidr_vpc_subnet_internet, 4, local.az_number[each.value.name_suffix])
+  availability_zone = each.key
   tags              = merge(var.tags, { Name = "${var.name}-subnet-internet" })
+  lifecycle {
+    ignore_changes = [
+      cidr_block, # required. Legacy subnets used fixed cidr blocks for the single zone that don't match the new scheme.
+    ]
+  }
 }
 
 resource "aws_internet_gateway" "gw" {
@@ -32,24 +79,27 @@ resource "aws_internet_gateway" "gw" {
 }
 
 resource "aws_nat_gateway" "gw" {
-  subnet_id     = aws_subnet.public.id
-  allocation_id = aws_eip.nat.id
+  for_each      = toset(var.zones)
+  subnet_id     = aws_subnet.public[each.key].id
+  allocation_id = aws_eip.nat[each.key].id
   tags          = merge(var.tags, { Name = "${var.name}-nat-gateway" })
 }
 
 resource "aws_route_table" "private_nat" {
-  vpc_id = var.vpc_id
-  tags   = merge(var.tags, { Name = "${var.name}-private-nat" })
+  for_each = toset(var.zones)
+  vpc_id   = var.vpc_id
+  tags     = merge(var.tags, { Name = "${var.name}-private-nat" })
 
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.gw.id
+    nat_gateway_id = aws_nat_gateway.gw[each.key].id
   }
 }
 
 resource "aws_route_table" "public_igw" {
-  vpc_id = var.vpc_id
-  tags   = merge(var.tags, { Name = "${var.name}-public-igw" })
+  for_each = toset(var.zones)
+  vpc_id   = var.vpc_id
+  tags     = merge(var.tags, { Name = "${var.name}-public-igw" })
 
   route {
     cidr_block = "0.0.0.0/0"
@@ -57,12 +107,14 @@ resource "aws_route_table" "public_igw" {
   }
 }
 
-resource "aws_route_table_association" "private-nat" {
-  subnet_id      = aws_subnet.private.id
-  route_table_id = aws_route_table.private_nat.id
+resource "aws_route_table_association" "private_nat" {
+  for_each       = toset(var.zones)
+  subnet_id      = aws_subnet.private[each.key].id
+  route_table_id = aws_route_table.private_nat[each.key].id
 }
 
 resource "aws_route_table_association" "route_to_internet" {
-  subnet_id      = aws_subnet.public.id
-  route_table_id = aws_route_table.public_igw.id
+  for_each       = toset(var.zones)
+  subnet_id      = aws_subnet.public[each.key].id
+  route_table_id = aws_route_table.public_igw[each.key].id
 }

--- a/cli/internal/terraform/terraform/aws/modules/public_private_subnet/output.tf
+++ b/cli/internal/terraform/terraform/aws/modules/public_private_subnet/output.tf
@@ -1,7 +1,19 @@
 output "private_subnet_id" {
-  value = aws_subnet.private.id
+  value = {
+    for az in data.aws_availability_zone.all :
+    az.name => aws_subnet.private[az.name].id
+  }
 }
 
 output "public_subnet_id" {
-  value = aws_subnet.public.id
+  value = {
+    for az in data.aws_availability_zone.all :
+    az.name => aws_subnet.public[az.name].id
+  }
+}
+
+# all_zones is a list of all availability zones in the region
+# it also contains zones that are not currently used by node groups (but might be in the future)
+output "all_zones" {
+  value = distinct(sort([for az in data.aws_availability_zone.all : az.name]))
 }

--- a/cli/internal/terraform/terraform/aws/modules/public_private_subnet/variables.tf
+++ b/cli/internal/terraform/terraform/aws/modules/public_private_subnet/variables.tf
@@ -10,7 +10,12 @@ variable "vpc_id" {
 
 variable "zone" {
   type        = string
-  description = "Availability zone."
+  description = "Main availability zone. Only used for legacy reasons."
+}
+
+variable "zones" {
+  type        = list(string)
+  description = "Availability zones."
 }
 
 variable "cidr_vpc_subnet_nodes" {

--- a/cli/internal/terraform/terraform/aws/outputs.tf
+++ b/cli/internal/terraform/terraform/aws/outputs.tf
@@ -1,5 +1,5 @@
 output "ip" {
-  value = aws_eip.lb.public_ip
+  value = aws_eip.lb[var.zone].public_ip
 }
 
 output "uid" {

--- a/cli/internal/terraform/terraform/aws/variables.tf
+++ b/cli/internal/terraform/terraform/aws/variables.tf
@@ -1,10 +1,25 @@
 variable "name" {
   type        = string
-  default     = "constell"
   description = "Name of your Constellation"
   validation {
     condition     = length(var.name) < 10
     error_message = "The name of the Constellation must be shorter than 10 characters"
+  }
+}
+
+variable "node_groups" {
+  type = map(object({
+    role           = string
+    instance_count = optional(number)
+    instance_type  = string
+    disk_size      = number
+    disk_type      = string
+    zone           = string
+  }))
+  description = "A map of node group names to node group configurations."
+  validation {
+    condition     = can([for group in var.node_groups : group.role == "control-plane" || group.role == "worker"])
+    error_message = "The role has to be 'control-plane' or 'worker'."
   }
 }
 
@@ -16,33 +31,6 @@ variable "iam_instance_profile_worker_nodes" {
 variable "iam_instance_profile_control_plane" {
   type        = string
   description = "Name of the IAM instance profile for control plane nodes"
-}
-
-variable "instance_type" {
-  type        = string
-  description = "Instance type for worker nodes"
-}
-
-variable "state_disk_type" {
-  type        = string
-  default     = "gp2"
-  description = "EBS disk type for the state disk of the nodes"
-}
-
-variable "state_disk_size" {
-  type        = number
-  default     = 30
-  description = "Disk size for the state disk of the nodes [GB]"
-}
-
-variable "control_plane_count" {
-  type        = number
-  description = "Number of control plane nodes"
-}
-
-variable "worker_count" {
-  type        = number
-  description = "Number of worker nodes"
 }
 
 variable "ami" {

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -1072,6 +1072,7 @@ type stubTerraform struct {
 	setLogPathErr   error
 	planJSONErr     error
 	showPlanFileErr error
+	stateMvErr      error
 	showState       *tfjson.State
 }
 
@@ -1105,4 +1106,8 @@ func (s *stubTerraform) SetLog(_ string) error {
 
 func (s *stubTerraform) SetLogPath(_ string) error {
 	return s.setLogPathErr
+}
+
+func (s *stubTerraform) StateMv(_ context.Context, _, _ string, _ ...tfexec.StateMvCmdOption) error {
+	return s.stateMvErr
 }

--- a/cli/internal/terraform/variables.go
+++ b/cli/internal/terraform/variables.go
@@ -44,42 +44,46 @@ func (v *CommonVariables) String() string {
 
 // AWSClusterVariables is user configuration for creating a cluster with Terraform on AWS.
 type AWSClusterVariables struct {
-	// CommonVariables contains common variables.
-	CommonVariables
+	// Name of the cluster.
+	Name string `hcl:"name" cty:"name"`
 	// Region is the AWS region to use.
-	Region string
+	Region string `hcl:"region" cty:"region"`
 	// Zone is the AWS zone to use in the given region.
-	Zone string
+	Zone string `hcl:"zone" cty:"zone"`
 	// AMIImageID is the ID of the AMI image to use.
-	AMIImageID string
-	// InstanceType is the type of the EC2 instance to use.
-	InstanceType string
-	// StateDiskType is the EBS disk type to use for the state disk.
-	StateDiskType string
+	AMIImageID string `hcl:"ami" cty:"ami"`
 	// IAMGroupControlPlane is the IAM group to use for the control-plane nodes.
-	IAMProfileControlPlane string
+	IAMProfileControlPlane string `hcl:"iam_instance_profile_control_plane" cty:"iam_instance_profile_control_plane"`
 	// IAMGroupWorkerNodes is the IAM group to use for the worker nodes.
-	IAMProfileWorkerNodes string
+	IAMProfileWorkerNodes string `hcl:"iam_instance_profile_worker_nodes" cty:"iam_instance_profile_worker_nodes"`
 	// Debug is true if debug mode is enabled.
-	Debug bool
+	Debug bool `hcl:"debug" cty:"debug"`
 	// EnableSNP controls enablement of the EC2 cpu-option "AmdSevSnp".
-	EnableSNP bool
+	EnableSNP bool `hcl:"enable_snp" cty:"enable_snp"`
+	// NodeGroups is a map of node groups to create.
+	NodeGroups map[string]AWSNodeGroup `hcl:"node_groups" cty:"node_groups"`
+}
+
+// AWSNodeGroup is a node group to create on AWS.
+type AWSNodeGroup struct {
+	// Role is the role of the node group.
+	Role string `hcl:"role" cty:"role"`
+	// StateDiskSizeGB is the size of the state disk to allocate to each node, in GB.
+	StateDiskSizeGB int `hcl:"disk_size" cty:"disk_size"`
+	// InitialCount is the initial number of nodes to create in the node group.
+	InitialCount int `hcl:"initial_count" cty:"initial_count"`
+	// Zone is the AWS availability-zone to use in the given region.
+	Zone string `hcl:"zone" cty:"zone"`
+	// InstanceType is the type of the EC2 instance to use.
+	InstanceType string `hcl:"instance_type" cty:"instance_type"`
+	// DiskType is the EBS disk type to use for the state disk.
+	DiskType string `hcl:"disk_type" cty:"disk_type"`
 }
 
 func (v *AWSClusterVariables) String() string {
-	b := &strings.Builder{}
-	b.WriteString(v.CommonVariables.String())
-	writeLinef(b, "region = %q", v.Region)
-	writeLinef(b, "zone = %q", v.Zone)
-	writeLinef(b, "ami = %q", v.AMIImageID)
-	writeLinef(b, "instance_type = %q", v.InstanceType)
-	writeLinef(b, "state_disk_type = %q", v.StateDiskType)
-	writeLinef(b, "iam_instance_profile_control_plane = %q", v.IAMProfileControlPlane)
-	writeLinef(b, "iam_instance_profile_worker_nodes = %q", v.IAMProfileWorkerNodes)
-	writeLinef(b, "debug = %t", v.Debug)
-	writeLinef(b, "enable_snp = %t", v.EnableSNP)
-
-	return b.String()
+	f := hclwrite.NewEmptyFile()
+	gohcl.EncodeIntoBody(v, f.Body())
+	return string(f.Bytes())
 }
 
 // AWSIAMVariables is user configuration for creating the IAM configuration with Terraform on Microsoft Azure.

--- a/cli/internal/terraform/variables_test.go
+++ b/cli/internal/terraform/variables_test.go
@@ -10,22 +10,34 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/edgelesssys/constellation/v2/internal/role"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestAWSClusterVariables(t *testing.T) {
 	vars := AWSClusterVariables{
-		CommonVariables: CommonVariables{
-			Name:               "cluster-name",
-			CountControlPlanes: 1,
-			CountWorkers:       2,
-			StateDiskSizeGB:    30,
+		Name: "cluster-name",
+		NodeGroups: map[string]AWSNodeGroup{
+			"control_plane_default": {
+				Role:            role.ControlPlane.TFString(),
+				StateDiskSizeGB: 30,
+				InitialCount:    1,
+				Zone:            "eu-central-1b",
+				InstanceType:    "x1.foo",
+				DiskType:        "foodisk",
+			},
+			"worker_default": {
+				Role:            role.Worker.TFString(),
+				StateDiskSizeGB: 30,
+				InitialCount:    2,
+				Zone:            "eu-central-1c",
+				InstanceType:    "x1.bar",
+				DiskType:        "bardisk",
+			},
 		},
 		Region:                 "eu-central-1",
 		Zone:                   "eu-central-1a",
 		AMIImageID:             "ami-0123456789abcdef",
-		InstanceType:           "x1.foo",
-		StateDiskType:          "bardisk",
 		IAMProfileControlPlane: "arn:aws:iam::123456789012:instance-profile/cluster-name-controlplane",
 		IAMProfileWorkerNodes:  "arn:aws:iam::123456789012:instance-profile/cluster-name-worker",
 		Debug:                  true,
@@ -33,19 +45,32 @@ func TestAWSClusterVariables(t *testing.T) {
 	}
 
 	// test that the variables are correctly rendered
-	want := `name = "cluster-name"
-control_plane_count = 1
-worker_count = 2
-state_disk_size = 30
-region = "eu-central-1"
-zone = "eu-central-1a"
-ami = "ami-0123456789abcdef"
-instance_type = "x1.foo"
-state_disk_type = "bardisk"
+	want := `name                               = "cluster-name"
+region                             = "eu-central-1"
+zone                               = "eu-central-1a"
+ami                                = "ami-0123456789abcdef"
 iam_instance_profile_control_plane = "arn:aws:iam::123456789012:instance-profile/cluster-name-controlplane"
-iam_instance_profile_worker_nodes = "arn:aws:iam::123456789012:instance-profile/cluster-name-worker"
-debug = true
-enable_snp = true
+iam_instance_profile_worker_nodes  = "arn:aws:iam::123456789012:instance-profile/cluster-name-worker"
+debug                              = true
+enable_snp                         = true
+node_groups = {
+  control_plane_default = {
+    disk_size     = 30
+    disk_type     = "foodisk"
+    initial_count = 1
+    instance_type = "x1.foo"
+    role          = "control-plane"
+    zone          = "eu-central-1b"
+  }
+  worker_default = {
+    disk_size     = 30
+    disk_type     = "bardisk"
+    initial_count = 2
+    instance_type = "x1.bar"
+    role          = "worker"
+    zone          = "eu-central-1c"
+  }
+}
 `
 	got := vars.String()
 	assert.Equal(t, want, got)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context

Refactor terraform code for AWS provider to go from two node groups (1x control plane, 1x worker) to arbitrary node groups.
On AWS, this is especially hard to do, since most network resources are zone-scoped, which means that we have to duplicate the networking resource for every zone.
This is handled differently for two categories of resources:

- Cheap resources are created for every zone in the chosen region. This ensures we can depend on those resources for loadbalancing and can add / remove node groups in every region without downtime.
- Expensive resources (nat gateways) are only created in a region when there is at least one node group in that region.

Additionally, some terraform migrations have to be performed by the cli directly. [Terraform does not yet support moving resources where the target name is dynamic](https://github.com/hashicorp/terraform/issues/31335), so moving `aws_eip.lb` -> `aws_eip[var.zone]` is not possible with `moved` blocks.

#### Future migrations

The bootstrapper needs a fix to support loadbalancers in multiple regions. This fix is included in this PR. We need to wait one release so that every bootstrapper in existing clusters can handle multiple loadbalancers before we can add every zone of the regions as a target zone of the loadbalancer. The terraform code has a TODO that explains this as well.
A final issue I still need to solve is that the upgrade where we actually want to enable multiple zones needs to recreate the loadbalancer.
This will lead to a short time where the kubernetes API is unreachable. This is especially problematic since it leads to failed upgrade steps after the terraform migration whenever a connection to the cluster is used.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- terraform: aws node groups
- manual terraform state transitions for AWS

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### How to test (upgrade)

- Create an AWS cluster on v2.8
- Upgrade using the CLI on this branch
- You should see some new resources and replacement of the loadbalancer
- Otherwise, nothing should be replaced (most important: the existing scale sets stay intact)

### How to test (multi-zone)

- Create an AWS **debug** cluster using the CLI on this branch
- Manually add a node group to the terraform.tfvars file
- run `terraform apply` in the constellation-terraform folder
- check that the new node group can join the cluster

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
- [x] Make AWS metadata code work with multiple AZs


### TODOs for future PRs

- [ ] Enable multi-zone support (including a change to the LB to target every availability zone of the chosen region)
- [ ] Work around control plane being unreachable for a short time when enabling multi-zone LB