### PR TITLE
bootstraper: delete helm chart on installation failure before retrying installation

### DIFF
--- a/bootstrapper/internal/helm/helm.go
+++ b/bootstrapper/internal/helm/helm.go
@@ -214,7 +214,7 @@ func (i installDoer) Do(ctx context.Context) error {
 	i.log.With(zap.String("chart", i.chart.Name())).Infof("Trying to install Helm chart")
 
 	if _, err := i.client.RunWithContext(ctx, i.chart, i.values); err != nil {
-		i.log.With(zap.Error(err)).Errorf("Helm chart installation failed")
+		i.log.With(zap.Error(err), zap.String("chart", i.chart.Name())).Errorf("Helm chart installation failed")
 		return err
 	}
 

--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -168,7 +168,7 @@ func (i *ChartLoader) loadRelease(info chartInfo) (helm.Release, error) {
 		return helm.Release{}, fmt.Errorf("packaging %s chart: %w", info.releaseName, err)
 	}
 
-	return helm.Release{Chart: chartRaw, Values: values, ReleaseName: info.releaseName, Wait: false}, nil
+	return helm.Release{Chart: chartRaw, Values: values, ReleaseName: info.releaseName}, nil
 }
 
 // loadCiliumValues is used to separate the marshalling step from the loading step.

--- a/internal/deploy/helm/helm.go
+++ b/internal/deploy/helm/helm.go
@@ -12,7 +12,6 @@ type Release struct {
 	Chart       []byte
 	Values      map[string]any
 	ReleaseName string
-	Wait        bool
 }
 
 // Releases bundles all helm releases to be deployed to Constellation.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Context

When installing helm charts during `constellation init`, the bootstrapper will retry an installation on error.
Because of how the retry loop and installation is set up, the chart is not cleaned up if the error didn't occur immediately, but later during the installation, e.g. a startup check fails after 3 minutes into the installation.
This in turn will cause an error when the installation is retried because the name of the installation is still in use.

For example, the installation of cert-manager may fail due to timeouts during the start up check.
The retry will then fail with the following error:

```text
installing cert-manager: helm install: cannot re-use a name that is still in use
```

### Proposed change(s)

- Install all charts with the `Atomic` flag set
  -  This causes the chart to be uninstalled on failure, e.g. install context cancelled or start up checks failed
- Move manual setting of the `Wait` flag from the various `InstallXXX` functions to the constructor of the helm client, since it was set for all functions
- Log installation failures in the retrier

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

