### PR TITLE
ci: fix expected value for PCR7 on AWS

### DIFF
--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -609,7 +609,7 @@ jobs:
                 .measurements.6.warnOnly = true |
                 .measurements.6.expected = "3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969" |
                 .measurements.7.warnOnly = true |
-                .measurements.7.expected = "120e498db2a224bd512b6efc9b0234f843e10bf061eb7a76ecca5509a2238901" |
+                .measurements.7.expected = "fb71e5e55cefba9e2b396d17604de0fe6e1841a76758856a120833e3ad1c40a3" |
                 .measurements.8.warnOnly = false |
                 .measurements.9.warnOnly = false |
                 .measurements.11.warnOnly = false |


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

PCR[7] has changed when upgrading to Fedora 38.
It didn't surface as a bug since the PCR is marked as warnOnly.
It's questionable if we should even try to pin PCR[7] since the contents can probably change without any change from our side (when the CSP decides to change the firmware).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: fix expected value for PCR7 on AWS

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
