### PR TITLE
bazel: add yq to PATH in go generate

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -153,9 +153,12 @@ oci_register_toolchains(
     crane_version = LATEST_CRANE_VERSION,
 )
 
+load("@aspect_bazel_lib//lib:repositories.bzl", "register_yq_toolchains")
 load("//bazel/toolchains:container_images.bzl", "containter_image_deps")
 
 containter_image_deps()
+
+register_yq_toolchains()
 
 # Multirun
 load("//bazel/toolchains:multirun_deps.bzl", "multirun_deps")

--- a/bazel/ci/BUILD.bazel
+++ b/bazel/ci/BUILD.bazel
@@ -320,6 +320,7 @@ sh_template(
         "//internal/versions/hash-generator",
         "@go_sdk//:bin/go",
         "@org_golang_x_tools//cmd/stringer",
+        "@yq_toolchains//:resolved_toolchain",
     ],
     substitutions = {
         "@@DOCGEN@@": "$(rootpath :com_github_siderolabs_talos_hack_docgen)",
@@ -328,8 +329,10 @@ sh_template(
         "@@HELM@@": "$(rootpath :com_github_helm_helm)",
         "@@MEASUREMENT_GENERATOR@@": "$(rootpath //internal/attestation/measurements/measurement-generator:measurement-generator)",
         "@@STRINGER@@": "$(rootpath @org_golang_x_tools//cmd/stringer:stringer)",
+        "@@YQ@@": "$(YQ_BIN)",
     },
     template = "go_generate.sh.in",
+    toolchains = ["@yq_toolchains//:resolved_toolchain"],
 )
 
 # deps_mirror_fix fixes bazel workspace rules for external dependencies.

--- a/bazel/ci/go_generate.sh.in
+++ b/bazel/ci/go_generate.sh.in
@@ -23,6 +23,8 @@ hash_generator=$(realpath @@HASH_GENERATOR@@)
 stat "${hash_generator}" >> /dev/null
 measurement_generator=$(realpath @@MEASUREMENT_GENERATOR@@)
 stat "${measurement_generator}" >> /dev/null
+yq=$(realpath @@YQ@@)
+stat "${yq}" >> /dev/null
 
 cd "${BUILD_WORKSPACE_DIRECTORY}"
 
@@ -34,6 +36,7 @@ PATH=$(dirname "${docgen}"):${PATH}
 PATH=$(dirname "${helm}"):${PATH}
 PATH=$(dirname "${hash_generator}"):${PATH}
 PATH=$(dirname "${measurement_generator}"):${PATH}
+PATH=$(dirname "${yq}"):${PATH}
 export PATH
 
 submodules=$(${go} list -f '{{.Dir}}' -m)

--- a/bazel/sh/def.bzl
+++ b/bazel/sh/def.bzl
@@ -8,6 +8,7 @@ def _sh_template_impl(ctx):
     substitutions = {}
     for k, v in ctx.attr.substitutions.items():
         sub = ctx.expand_location(v, ctx.attr.data)
+        sub = ctx.expand_make_variables("substitutions", sub, {})
         substitutions[k] = sub
 
     ctx.actions.expand_template(
@@ -50,6 +51,7 @@ def sh_template(name, **kwargs):
     substitutions = kwargs.pop("substitutions", [])
     substitutions["@@BASE_LIB@@"] = "$(rootpath //bazel/sh:base_lib)"
     template = kwargs.pop("template", [])
+    toolchains = kwargs.pop("toolchains", [])
 
     _sh_template(
         name = script_name,
@@ -57,6 +59,7 @@ def sh_template(name, **kwargs):
         data = data,
         substitutions = substitutions,
         template = template,
+        toolchains = toolchains,
     )
 
     native.sh_binary(


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
This makes `yq` work in go generate scripts hermetically. We depend on it [in this PR](https://github.com/edgelesssys/constellation/pull/1973).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bazel: add yq to PATH in go generate

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
