### PR TITLE
terraform: use single zone loadbalancer frontend on AWS

### DIFF
--- a/cli/internal/terraform/terraform/aws/modules/public_private_subnet/main.tf
+++ b/cli/internal/terraform/terraform/aws/modules/public_private_subnet/main.tf
@@ -15,7 +15,7 @@ locals {
     # 0 => 192.168.176.0/24 (unused private subnet cidr)
     # 1 => 192.168.177.0/24 (unused private subnet cidr)
     legacy = 2 # => 192.168.178.0/24 (legacy private subnet)
-    a      = 3 # => 192.168.178.1/24 (first newly created zonal private subnet)
+    a      = 3 # => 192.168.179.0/24 (first newly created zonal private subnet)
     b      = 4
     c      = 5
     d      = 6


### PR DESCRIPTION
### Context

This change is required to ensure we have no tls handshake errors when connecting to the kubernetes api. Currently, the certificates used by kube-apiserver pods contain a SAN field with the (single) public ip of the loadbalancer. If we would allow multiple loadbalancer frontend ips, we could encounter cases where the certificate is only valid for one public ip, while we try to connect to a different ip.
To prevent this, we consciously disable support for the multi-zone loadbalancer frontend on AWS for now. This will be re-enabled in the future.

[See also](https://gist.github.com/malt3/f3c2d004ed0c046edcd218fa5dcc9652)

### Proposed change(s)
- terraform: use single zone loadbalancer frontend on AWS

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
