### PR TITLE
ci: conditionally use generate-config flag for old versions of Constellation CLI

### DIFF
--- a/.github/actions/constellation_iam_create/action.yml
+++ b/.github/actions/constellation_iam_create/action.yml
@@ -43,10 +43,18 @@ runs:
       if: inputs.cloudProvider == 'aws'
       run: |
         constellation config generate aws
+        iam_conf_flag="--update-config"
+
+        output=$(constellation iam create --help)
+        if [[ $output == *"generate-config"* ]]; then
+          rm constellation-conf.yaml
+          iam_conf_flag="--generate-config"
+        fi
+
         constellation iam create aws \
           --zone=${{ inputs.awsZone }} \
           --prefix=${{ inputs.namePrefix }} \
-          --update-config --yes
+          ${iam_conf_flag} --yes
 
     - name: Constellation iam create azure
       shell: bash
@@ -57,22 +65,38 @@ runs:
           TFFLAG="--tf-log=DEBUG"
         fi
         constellation config generate azure
+        iam_conf_flag="--update-config"
+
+        output=$(constellation iam create --help)
+        if [[ $output == *"generate-config"* ]]; then
+          rm constellation-conf.yaml
+          iam_conf_flag="--generate-config"
+        fi
+
         constellation iam create azure \
           --region=${{ inputs.azureRegion }} \
           --resourceGroup="${{ inputs.namePrefix }}-rg" \
           --servicePrincipal="${{ inputs.namePrefix }}-sp" \
-          --update-config --yes ${TFFLAG:-}
+          ${iam_conf_flag} --yes ${TFFLAG:-}
 
     - name: Constellation iam create gcp
       shell: bash
       if: inputs.cloudProvider == 'gcp'
       run: |
         constellation config generate gcp
+        iam_conf_flag="--update-config"
+
+        output=$(constellation iam create --help)
+        if [[ $output == *"generate-config"* ]]; then
+          rm constellation-conf.yaml
+          iam_conf_flag="--generate-config"
+        fi
+
         constellation iam create gcp \
           --projectID=${{ inputs.gcpProjectID }} \
           --zone=${{ inputs.gcpZone }} \
           --serviceAccountID="${{ inputs.namePrefix }}-sa" \
-          --update-config --yes
+          ${iam_conf_flag} --yes
 
     - name: Set existing config
       id: setExistingConfig


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Our e2e tests also run using the CLI/image of the latest release.
Currently, the IAM creation fails because of a change in flags for the `constellation iam create` command.

### Proposed change(s)
- Conditionally use either the new `--update-config`, or the older `--generate-config` flag in the e2e tests for `constellation iam create` depending on which flag is supported by the CLI

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

GCP e2e test with release image from v2.8.0: https://github.com/edgelesssys/constellation/actions/runs/5411009653

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [x] Link to Milestone
