### PR TITLE
ci: update aws asg resource selector

### DIFF
--- a/.github/actions/constellation_create/aws-logs.sh
+++ b/.github/actions/constellation_create/aws-logs.sh
@@ -12,13 +12,13 @@ CP_SELECTOR="module.instance_group_control_plane"
 W_SELECTOR="module.instance_group_worker_nodes"
 if [[ $(./constellation version) != *"2.8.0"* ]]; then
   echo "Constellation version is not 2.8.0, using updated ASG selectors"
-  CP_SELECTOR="module.instance_group[\"control_plane_default\"]"
-  W_SELECTOR="module.instance_group[\"worker_default\"]"
+  CP_SELECTOR='module.instance_group["control_plane_default"]'
+  W_SELECTOR='module.instance_group["worker_default"]'
 fi
 
 pushd constellation-terraform
 controlAutoscalingGroup=$(
-   terraform show -json |
+  terraform show -json |
     jq --arg selector $CP_SELECTOR \
       -r .'values.root_module.child_modules[] |
       select(.address == $selector) |

--- a/.github/actions/constellation_create/aws-logs.sh
+++ b/.github/actions/constellation_create/aws-logs.sh
@@ -7,18 +7,29 @@ shopt -s inherit_errexit
 
 echo "Using AWS region: ${1}"
 
+# TODO(msanft): Remove once 2.9.0 is released
+CP_SELECTOR="module.instance_group_control_plane"
+W_SELECTOR="module.instance_group_worker_nodes"
+if [[ $(./constellation version) != *"2.8.0"* ]]; then
+  echo "Constellation version is not 2.8.0, using updated ASG selectors"
+  CP_SELECTOR="module.instance_group[\"control_plane_default\"]"
+  W_SELECTOR="module.instance_group[\"worker_default\"]"
+fi
+
 pushd constellation-terraform
 controlAutoscalingGroup=$(
-  terraform show -json |
-    jq -r .'values.root_module.child_modules[] |
-        select(.address == "module.instance_group_control_plane") |
-        .resources[0].values.name'
+   terraform show -json |
+    jq --arg selector $CP_SELECTOR \
+      -r .'values.root_module.child_modules[] |
+      select(.address == $selector) |
+      .resources[0].values.name'
 )
 workerAutoscalingGroup=$(
   terraform show -json |
-    jq -r .'values.root_module.child_modules[] |
-        select(.address == "module.instance_group_worker_nodes") |
-        .resources[0].values.name'
+    jq --arg selector $W_SELECTOR \
+      -r .'values.root_module.child_modules[] |
+      select(.address == $selector) |
+      .resources[0].values.name'
 )
 popd
 

--- a/.github/actions/constellation_create/aws-logs.sh
+++ b/.github/actions/constellation_create/aws-logs.sh
@@ -12,8 +12,8 @@ CP_SELECTOR="module.instance_group_control_plane"
 W_SELECTOR="module.instance_group_worker_nodes"
 if [[ $(./constellation version) != *"2.8.0"* ]]; then
   echo "Constellation version is not 2.8.0, using updated ASG selectors"
-  CP_SELECTOR="module.instance_group[\"control_plane_default\"]"
-  W_SELECTOR="module.instance_group[\"worker_default\"]"
+  CP_SELECTOR='module.instance_group["control_plane_default"]'
+  W_SELECTOR='module.instance_group["worker_default"]'
 fi
 
 pushd constellation-terraform

--- a/.github/actions/constellation_create/aws-logs.sh
+++ b/.github/actions/constellation_create/aws-logs.sh
@@ -12,21 +12,21 @@ CP_SELECTOR="module.instance_group_control_plane"
 W_SELECTOR="module.instance_group_worker_nodes"
 if [[ $(./constellation version) != *"2.8.0"* ]]; then
   echo "Constellation version is not 2.8.0, using updated ASG selectors"
-  CP_SELECTOR='module.instance_group["control_plane_default"]'
-  W_SELECTOR='module.instance_group["worker_default"]'
+  CP_SELECTOR="module.instance_group[\"control_plane_default\"]"
+  W_SELECTOR="module.instance_group[\"worker_default\"]"
 fi
 
 pushd constellation-terraform
 controlAutoscalingGroup=$(
   terraform show -json |
-    jq --arg selector $CP_SELECTOR \
+    jq --arg selector "$CP_SELECTOR" \
       -r .'values.root_module.child_modules[] |
       select(.address == $selector) |
       .resources[0].values.name'
 )
 workerAutoscalingGroup=$(
   terraform show -json |
-    jq --arg selector $W_SELECTOR \
+    jq --arg selector "$W_SELECTOR" \
       -r .'values.root_module.child_modules[] |
       select(.address == $selector) |
       .resources[0].values.name'


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The introduction of node groups also brought a naming change (i.e. change of explicit module instances to a map of an arbitrary amount of module instances) which broke the seleciton of the control plane and worker instance group name in the boot log collection. 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix the boot log collection resource selectors.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
