### PR TITLE
helm: fix upgrade command skipping all service upgrades

### DIFF
--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -116,13 +116,10 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, fileHandler file.Hand
 	}
 
 	if conf.GetProvider() == cloudprovider.Azure || conf.GetProvider() == cloudprovider.GCP || conf.GetProvider() == cloudprovider.AWS {
+		var upgradeErr *compatibility.InvalidUpgradeError
 		err = u.handleServiceUpgrade(cmd, conf, flags)
-		upgradeErr := &compatibility.InvalidUpgradeError{}
-		noUpgradeRequiredError := &helm.NoUpgradeRequiredError{}
 		switch {
-		case errors.As(err, upgradeErr):
-			cmd.PrintErrln(err)
-		case errors.As(err, noUpgradeRequiredError):
+		case errors.As(err, &upgradeErr):
 			cmd.PrintErrln(err)
 		case err != nil:
 			return fmt.Errorf("upgrading services: %w", err)
@@ -132,7 +129,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, fileHandler file.Hand
 		switch {
 		case errors.Is(err, kubernetes.ErrInProgress):
 			cmd.PrintErrln("Skipping image and Kubernetes upgrades. Another upgrade is in progress.")
-		case errors.As(err, upgradeErr):
+		case errors.As(err, &upgradeErr):
 			cmd.PrintErrln(err)
 		case err != nil:
 			return fmt.Errorf("upgrading NodeVersion: %w", err)

--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -85,10 +85,6 @@ func (c *Client) shouldUpgrade(releaseName, newVersion string, force bool) error
 
 	// This may break for cert-manager or cilium if we decide to upgrade more than one minor version at a time.
 	// Leaving it as is since it is not clear to me what kind of sanity check we could do.
-	if currentVersion == newVersion {
-		return NoUpgradeRequiredError{}
-	}
-
 	if !force {
 		if err := compatibility.IsValidUpgrade(currentVersion, newVersion); err != nil {
 			return err
@@ -105,20 +101,12 @@ func (c *Client) shouldUpgrade(releaseName, newVersion string, force bool) error
 	return nil
 }
 
-// NoUpgradeRequiredError is returned if the current version is the same as the target version.
-type NoUpgradeRequiredError struct{}
-
-func (e NoUpgradeRequiredError) Error() string {
-	return "no upgrade required since current version is the same as the target version"
-}
-
 // Upgrade runs a helm-upgrade on all deployments that are managed via Helm.
 // If the CLI receives an interrupt signal it will cancel the context.
 // Canceling the context will prompt helm to abort and roll back the ongoing upgrade.
 func (c *Client) Upgrade(ctx context.Context, config *config.Config, timeout time.Duration, allowDestructive, force bool, upgradeID string) error {
 	upgradeErrs := []error{}
 	upgradeReleases := []*chart.Chart{}
-	invalidUpgrade := &compatibility.InvalidUpgradeError{}
 
 	for _, info := range []chartInfo{ciliumInfo, certManagerInfo, constellationOperatorsInfo, constellationServicesInfo} {
 		chart, err := loadChartsDir(helmFS, info.path)
@@ -136,12 +124,10 @@ func (c *Client) Upgrade(ctx context.Context, config *config.Config, timeout tim
 			upgradeVersion = chart.Metadata.Version
 		}
 
+		var invalidUpgrade *compatibility.InvalidUpgradeError
 		err = c.shouldUpgrade(info.releaseName, upgradeVersion, force)
-		noUpgradeRequired := &NoUpgradeRequiredError{}
 		switch {
 		case errors.As(err, &invalidUpgrade):
-			upgradeErrs = append(upgradeErrs, fmt.Errorf("skipping %s upgrade: %w", info.releaseName, err))
-		case errors.As(err, &noUpgradeRequired):
 			upgradeErrs = append(upgradeErrs, fmt.Errorf("skipping %s upgrade: %w", info.releaseName, err))
 		case err != nil:
 			return fmt.Errorf("should upgrade %s: %w", info.releaseName, err)

--- a/cli/internal/helm/client_test.go
+++ b/cli/internal/helm/client_test.go
@@ -32,7 +32,7 @@ func TestShouldUpgrade(t *testing.T) {
 		"not a valid upgrade": {
 			version: "1.0.0",
 			assertCorrectError: func(t *testing.T, err error) bool {
-				target := &compatibility.InvalidUpgradeError{}
+				var target *compatibility.InvalidUpgradeError
 				return assert.ErrorAs(t, err, &target)
 			},
 			wantError: true,

--- a/cli/internal/kubernetes/upgrade.go
+++ b/cli/internal/kubernetes/upgrade.go
@@ -217,7 +217,7 @@ func (u *Upgrader) UpgradeNodeVersion(ctx context.Context, conf *config.Config, 
 	}
 
 	upgradeErrs := []error{}
-	upgradeErr := &compatibility.InvalidUpgradeError{}
+	var upgradeErr *compatibility.InvalidUpgradeError
 
 	err = u.updateImage(&nodeVersion, imageReference, imageVersion.Version, force)
 	switch {

--- a/cli/internal/kubernetes/upgrade_test.go
+++ b/cli/internal/kubernetes/upgrade_test.go
@@ -187,7 +187,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			wantUpdate: true,
 			wantErr:    true,
 			assertCorrectError: func(t *testing.T, err error) bool {
-				upgradeErr := &compatibility.InvalidUpgradeError{}
+				var upgradeErr *compatibility.InvalidUpgradeError
 				return assert.ErrorAs(t, err, &upgradeErr)
 			},
 		},

--- a/internal/compatibility/compatibility.go
+++ b/internal/compatibility/compatibility.go
@@ -41,12 +41,12 @@ func NewInvalidUpgradeError(from string, to string, innerErr error) *InvalidUpgr
 }
 
 // Unwrap returns the inner error, which is nil in this case.
-func (e InvalidUpgradeError) Unwrap() error {
+func (e *InvalidUpgradeError) Unwrap() error {
 	return e.innerErr
 }
 
 // Error returns the String representation of this error.
-func (e InvalidUpgradeError) Error() string {
+func (e *InvalidUpgradeError) Error() string {
 	return fmt.Sprintf("upgrading from %s to %s is not a valid upgrade: %s", e.from, e.to, e.innerErr)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -159,7 +159,7 @@ func TestReadConfigFile(t *testing.T) {
 				return m
 			}(),
 			configName:    constants.ConfigFilename,
-			wantedErrType: UnsupportedAppRegistrationError{},
+			wantedErrType: &UnsupportedAppRegistrationError{},
 		},
 	}
 	for name, tc := range testCases {

--- a/internal/staticupload/staticupload_test.go
+++ b/internal/staticupload/staticupload_test.go
@@ -108,12 +108,13 @@ func TestUpload(t *testing.T) {
 			}
 			_, err := client.Upload(context.Background(), tc.in)
 
+			var invalidationErr *InvalidationError
 			if tc.wantCacheInvalidationErr {
-				assert.ErrorAs(err, &InvalidationError{})
+				assert.ErrorAs(err, &invalidationErr)
 				return
 			}
 			if tc.wantErr {
-				assert.False(errors.As(err, &InvalidationError{}))
+				assert.False(errors.As(err, &invalidationErr))
 				assert.Error(err)
 				return
 			}
@@ -218,12 +219,13 @@ func TestDeleteObject(t *testing.T) {
 			}
 			_, err := client.DeleteObject(context.Background(), newObjectInput(tc.nilInput, tc.nilKey))
 
+			var invalidationErr *InvalidationError
 			if tc.wantCacheInvalidationErr {
-				assert.ErrorAs(err, &InvalidationError{})
+				assert.ErrorAs(err, &invalidationErr)
 				return
 			}
 			if tc.wantErr {
-				assert.False(errors.As(err, &InvalidationError{}))
+				assert.False(errors.As(err, &invalidationErr))
 				assert.Error(err)
 				return
 			}
@@ -255,12 +257,13 @@ func TestDeleteObject(t *testing.T) {
 			}
 			_, err := client.DeleteObjects(context.Background(), newObjectsInput(tc.nilInput, tc.nilKey))
 
+			var invalidationErr *InvalidationError
 			if tc.wantCacheInvalidationErr {
-				assert.ErrorAs(err, &InvalidationError{})
+				assert.ErrorAs(err, &invalidationErr)
 				return
 			}
 			if tc.wantErr {
-				assert.False(errors.As(err, &InvalidationError{}))
+				assert.False(errors.As(err, &invalidationErr))
 				assert.Error(err)
 				return
 			}
@@ -396,7 +399,8 @@ func TestFlush(t *testing.T) {
 			err := client.Flush(context.Background())
 
 			if tc.wantCacheInvalidationErr {
-				assert.ErrorAs(err, &InvalidationError{})
+				var invalidationErr *InvalidationError
+				assert.ErrorAs(err, &invalidationErr)
 				return
 			}
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Context
`constellation upgrade apply` should go over a list of all available charts and only skip a single chart if it is already up to date. Other charts should still be upgraded if one doesn't need to.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- correctly use `errors.As` to not skip other service upgrades during `upgrade apply`
- correctly use `errors.As` to not return an error (only print it) if the node version is the same as the upgrade target

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- should be merged before v2.9 to not break upgrades

