### PR TITLE
bootstrapper: skip waiting for helm deployments

### DIFF
--- a/bootstrapper/internal/helm/helm.go
+++ b/bootstrapper/internal/helm/helm.go
@@ -57,8 +57,10 @@ func New(log *logger.Logger) (*Client, error) {
 	action := action.NewInstall(actionConfig)
 	action.Namespace = constants.HelmNamespace
 	action.Timeout = timeout
-	action.Atomic = true
-	action.Wait = true
+	// TODO(malt3): Enable "Wait" once every service gets ready with only
+	// one control-plane node and no worker nodes.
+	action.Atomic = false
+	action.Wait = false
 
 	return &Client{
 		action,

--- a/bootstrapper/internal/kubernetes/kubernetes.go
+++ b/bootstrapper/internal/kubernetes/kubernetes.go
@@ -226,14 +226,14 @@ func (k *KubeWrapper) InitCluster(
 		return nil, fmt.Errorf("setting up extraVals: %w", err)
 	}
 
-	log.Infof("Installing Constellation microservices")
-	if err = k.helmClient.InstallConstellationServices(ctx, helmReleases.ConstellationServices, extraVals); err != nil {
-		return nil, fmt.Errorf("installing constellation-services: %w", err)
-	}
-
 	log.Infof("Setting up internal-config ConfigMap")
 	if err := k.setupInternalConfigMap(ctx); err != nil {
 		return nil, fmt.Errorf("failed to setup internal ConfigMap: %w", err)
+	}
+
+	log.Infof("Installing Constellation microservices")
+	if err = k.helmClient.InstallConstellationServices(ctx, helmReleases.ConstellationServices, extraVals); err != nil {
+		return nil, fmt.Errorf("installing constellation-services: %w", err)
 	}
 
 	// cert-manager is necessary for our operator deployments.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Not all helm charts we deploy can be deployed successfully with only one control-plane node and no workers.
Disable waiting for helm deployments to be ready until we fixed the individual deployments.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bootstrapper: skip waiting for helm deployments

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
