### PR TITLE
bazel: fill microservice version on `devbuild` target

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -153,9 +153,12 @@ oci_register_toolchains(
     crane_version = LATEST_CRANE_VERSION,
 )
 
+load("@aspect_bazel_lib//lib:repositories.bzl", "register_yq_toolchains")
 load("//bazel/toolchains:container_images.bzl", "containter_image_deps")
 
 containter_image_deps()
+
+register_yq_toolchains()
 
 # Multirun
 load("//bazel/toolchains:multirun_deps.bzl", "multirun_deps")

--- a/bazel/devbuild/BUILD.bazel
+++ b/bazel/devbuild/BUILD.bazel
@@ -29,4 +29,3 @@ sh_template(
 cli_edition(
     name = "devbuild_cli_edition",
 )
-∏

--- a/bazel/devbuild/BUILD.bazel
+++ b/bazel/devbuild/BUILD.bazel
@@ -10,6 +10,7 @@ sh_template(
         "//cli:cli_edition_host",
         "//debugd/cmd/cdbg:cdbg_host",
         "//upgrade-agent/cmd:upgrade_agent_linux_amd64",
+        "@yq_toolchains//:resolved_toolchain",
     ],
     substitutions = {
         "@@BOOTSTRAPPER@@": "$(rootpath //bootstrapper/cmd/bootstrapper:bootstrapper_linux_amd64)",
@@ -18,11 +19,14 @@ sh_template(
         "@@CONTAINER_SUMS@@": "$(rootpath //bazel/release:container_sums)",
         "@@EDITION@@": "$(rootpath :devbuild_cli_edition)",
         "@@UPGRADE_AGENT@@": "$(rootpath //upgrade-agent/cmd:upgrade_agent_linux_amd64)",
+        "@@YQ@@": "$(YQ_BIN)",
     },
     template = "prepare_developer_workspace.sh.in",
+    toolchains = ["@yq_toolchains//:resolved_toolchain"],
     visibility = ["//visibility:public"],
 )
 
 cli_edition(
     name = "devbuild_cli_edition",
 )
+∏

--- a/bazel/devbuild/prepare_developer_workspace.sh.in
+++ b/bazel/devbuild/prepare_developer_workspace.sh.in
@@ -59,3 +59,12 @@ ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${upgrade_agent}")"
 ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${cdbg}")" "${workdir}/cdbg"
 ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${container_sums}")" "${workdir}/container_sums.sha256"
 ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${cli}")" "${workdir}/constellation"
+
+build_version=$("${workdir}"/constellation version | grep ^Version: | awk '{print $2}')
+if [[ ! -f "${workdir}/constellation-conf.yaml" ]]; then
+  echo "constellation-conf.yaml not present in workspace"
+  echo "Build version: ${build_version}"
+else
+  @@YQ@@ -i eval ".microserviceVersion=\"${build_version}\"" ./constellation-conf.yaml
+  echo "Microservice version updated to ${build_version} in constellation-conf.yaml"
+fi

--- a/bazel/devbuild/prepare_developer_workspace.sh.in
+++ b/bazel/devbuild/prepare_developer_workspace.sh.in
@@ -8,6 +8,9 @@
 lib=$(realpath @@BASE_LIB@@) || exit 1
 stat "${lib}" >> /dev/null || exit 1
 
+yq=$(realpath @@YQ@@)
+stat "${yq}" >> /dev/null
+
 # shellcheck source=../sh/lib.bash
 if ! source "${lib}"; then
   echo "Error: could not find import"
@@ -65,6 +68,6 @@ if [[ ! -f "${workdir}/constellation-conf.yaml" ]]; then
   echo "constellation-conf.yaml not present in workspace"
   echo "Build version: ${build_version}"
 else
-  @@YQ@@ -i eval ".microserviceVersion=\"${build_version}\"" ./constellation-conf.yaml
+  $yq -i eval ".microserviceVersion=\"${build_version}\"" ./constellation-conf.yaml
   echo "Microservice version updated to ${build_version} in constellation-conf.yaml"
 fi

--- a/bazel/sh/def.bzl
+++ b/bazel/sh/def.bzl
@@ -8,6 +8,7 @@ def _sh_template_impl(ctx):
     substitutions = {}
     for k, v in ctx.attr.substitutions.items():
         sub = ctx.expand_location(v, ctx.attr.data)
+        sub = ctx.expand_make_variables("substitutions", sub, {})
         substitutions[k] = sub
 
     ctx.actions.expand_template(
@@ -50,6 +51,7 @@ def sh_template(name, **kwargs):
     substitutions = kwargs.pop("substitutions", [])
     substitutions["@@BASE_LIB@@"] = "$(rootpath //bazel/sh:base_lib)"
     template = kwargs.pop("template", [])
+    toolchains = kwargs.pop("toolchains", [])
 
     _sh_template(
         name = script_name,
@@ -57,6 +59,7 @@ def sh_template(name, **kwargs):
         data = data,
         substitutions = substitutions,
         template = template,
+        toolchains = toolchains,
     )
 
     native.sh_binary(


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Constellation now requires an exact match between the version of the CLI and the version of the microservices. `bazel run //:devbuild` should take care of this to speed up the development workflow.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Let `devbuild` replace the microservice version in the config, if present. If no config is present, just print the microservice version so it can be copied by hand.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
