### PR TITLE
bootstrapper: install internal-config cm before constellation-services

### DIFF
--- a/bootstrapper/internal/kubernetes/kubernetes.go
+++ b/bootstrapper/internal/kubernetes/kubernetes.go
@@ -226,14 +226,14 @@ func (k *KubeWrapper) InitCluster(
 		return nil, fmt.Errorf("setting up extraVals: %w", err)
 	}
 
-	log.Infof("Installing Constellation microservices")
-	if err = k.helmClient.InstallConstellationServices(ctx, helmReleases.ConstellationServices, extraVals); err != nil {
-		return nil, fmt.Errorf("installing constellation-services: %w", err)
-	}
-
 	log.Infof("Setting up internal-config ConfigMap")
 	if err := k.setupInternalConfigMap(ctx); err != nil {
 		return nil, fmt.Errorf("failed to setup internal ConfigMap: %w", err)
+	}
+
+	log.Infof("Installing Constellation microservices")
+	if err = k.helmClient.InstallConstellationServices(ctx, helmReleases.ConstellationServices, extraVals); err != nil {
+		return nil, fmt.Errorf("installing constellation-services: %w", err)
 	}
 
 	// cert-manager is necessary for our operator deployments.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context

The `constellation-services` helm chart (or more precisely the join-service) depends on the `internal-config` configmap.
Deploy the configmap before deploying the services.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bootstrapper: install internal-config cm before constellation-services

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
