### PR TITLE
ci: use strict semver for gcp guest agent image

### DIFF
--- a/.github/workflows/build-gcp-guest-agent.yml
+++ b/.github/workflows/build-gcp-guest-agent.yml
@@ -30,7 +30,7 @@ jobs:
           beforeDot="${semver%%.*}"
           afterDot="${semver#*.}"
           afterDotEvaluated=$((afterDot))
-          semver="$beforeDot.$afterDotEvaluated"
+          semver="v${beforeDot}.${afterDotEvaluated}.0"
           echo "Semver tag of guest-agent is $semver"
           echo "latest=$semver" | tee -a "$GITHUB_OUTPUT"
 
@@ -100,7 +100,7 @@ jobs:
       - name: Log in to the Container registry
         id: docker-login
         if: steps.needs-build.outputs.out == 'true'
-        uses: ./.github/actions/container_registry_login
+        uses: ./constellation/.github/actions/container_registry_login
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -94,7 +94,7 @@ const (
 	KonnectivityServerImage = "registry.k8s.io/kas-network-proxy/proxy-server:v0.1.2@sha256:79933c3779bc30e33bb7509dff913e70f6ba78ad441f4827f0f3e840ce5f3ddb" // renovate:container
 	// GcpGuestImage image for GCP guest agent.
 	// Check for new versions at https://github.com/GoogleCloudPlatform/guest-agent/releases and update in /.github/workflows/build-gcp-guest-agent.yml.
-	GcpGuestImage = "ghcr.io/edgelesssys/gcp-guest-agent:20230221.0@sha256:8be328a5d8d601170b82481d413cf326b20c5219c016633f1651e35d95f1d6f1" // renovate:container
+	GcpGuestImage = "ghcr.io/edgelesssys/gcp-guest-agent:v20230221.0.0@sha256:8be328a5d8d601170b82481d413cf326b20c5219c016633f1651e35d95f1d6f1" // renovate:container
 	// NodeMaintenanceOperatorImage is the image for the node maintenance operator.
 	NodeMaintenanceOperatorImage = "quay.io/medik8s/node-maintenance-operator:v0.14.0@sha256:2dffb6ffdbbe997d317799fc709baf030d678bde0be0264931ff6b3e94fd89ab" // renovate:container
 	// LogstashImage is the container image of logstash, used for log collection by debugd.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Renovate bot isn't picking up updates of the gcp-guest-agent container image for some time.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Making the version a valid semver should help renovate to handle it

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->

- [x] Add labels (e.g., for changelog category)
