### PR TITLE
bootstrapper: use atomics in nodelock

### DIFF
--- a/bootstrapper/internal/nodelock/BUILD.bazel
+++ b/bootstrapper/internal/nodelock/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//bazel/go:go_test.bzl", "go_test")
 
 go_library(
     name = "nodelock",
@@ -8,5 +9,15 @@ go_library(
     deps = [
         "//internal/attestation/initialize",
         "//internal/attestation/vtpm",
+    ],
+)
+
+go_test(
+    name = "nodelock_test",
+    srcs = ["nodelock_test.go"],
+    embed = [":nodelock"],
+    deps = [
+        "//internal/attestation/vtpm",
+        "@com_github_stretchr_testify//assert",
     ],
 )

--- a/bootstrapper/internal/nodelock/nodelock.go
+++ b/bootstrapper/internal/nodelock/nodelock.go
@@ -40,8 +40,8 @@ func New(tpm vtpm.TPMOpenFunc) *Lock {
 // returns false. If the node is unlocked, it locks it and returns true.
 func (l *Lock) TryLockOnce(clusterID []byte) (bool, error) {
 	// CompareAndSwap first checks if the node is currently unlocked.
-	// It it was already locked, it returns early.
-	// It it is unlocked, it swaps the value to locked atomically and continues.
+	// If it was already locked, it returns early.
+	// If it is unlocked, it swaps the value to locked atomically and continues.
 	if !l.inner.CompareAndSwap(unlocked, locked) {
 		return false, nil
 	}

--- a/bootstrapper/internal/nodelock/nodelock.go
+++ b/bootstrapper/internal/nodelock/nodelock.go
@@ -24,7 +24,7 @@ import (
 // locked.
 type Lock struct {
 	tpm    vtpm.TPMOpenFunc
-	marker tpmMarker
+	marker markAsBootstrapped
 	inner  atomic.Bool
 }
 
@@ -49,8 +49,8 @@ func (l *Lock) TryLockOnce(clusterID []byte) (bool, error) {
 	return true, l.marker(l.tpm, clusterID)
 }
 
-// tpmMarker is a function that marks the node as bootstrapped in the TPM.
-type tpmMarker func(openDevice func() (io.ReadWriteCloser, error), clusterID []byte) error
+// markAsBootstrapped is a function that marks the node as bootstrapped in the TPM.
+type markAsBootstrapped func(openDevice func() (io.ReadWriteCloser, error), clusterID []byte) error
 
 const (
 	unlocked = false

--- a/bootstrapper/internal/nodelock/nodelock_test.go
+++ b/bootstrapper/internal/nodelock/nodelock_test.go
@@ -1,0 +1,60 @@
+package nodelock
+
+import (
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/edgelesssys/constellation/v2/internal/attestation/vtpm"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTryLockOnce(t *testing.T) {
+	t.Run("should lock exactly once", func(t *testing.T) {
+		assert := assert.New(t)
+		tpm := spyTPM{}
+		lock := Lock{
+			tpm:    tpm.Opener(),
+			marker: stubMarker,
+		}
+		locked, err := lock.TryLockOnce(nil)
+		assert.NoError(err)
+		assert.True(locked)
+
+		wg := sync.WaitGroup{}
+		tryLock := func() {
+			defer wg.Done()
+			locked, err := lock.TryLockOnce(nil)
+			assert.NoError(err)
+			assert.False(locked)
+		}
+
+		for i := 0; i < 10; i++ {
+			wg.Add(1)
+			go tryLock()
+		}
+
+		wg.Wait()
+
+		assert.EqualValues(1, tpm.counter.Load())
+	})
+}
+
+type spyTPM struct {
+	counter atomic.Uint64
+}
+
+func (s *spyTPM) Opener() vtpm.TPMOpenFunc {
+	return func() (io.ReadWriteCloser, error) {
+		s.counter.Add(1)
+		return nil, nil
+	}
+}
+
+func stubMarker(openDevice func() (io.ReadWriteCloser, error), _ []byte) error {
+	// this only needs to invoke the openDevice function
+	// so that the spyTPM counter is incremented
+	_, _ = openDevice()
+	return nil
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

The nodelock used a mutex in unintended ways (lock using `TryLock`, never unlocked).
Under the hood, mutexes use a compare and swap operation with an atomic int to perform a `TryLock`.
Atomic compare and swap is closer to the operation we want to perform so we replace the mutex with an atomic bool.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bootstrapper: use atomics in nodelock

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
