### PR TITLE
bazel: mount host's Docker config into builder container

### DIFF
--- a/bazel/container/container.sh
+++ b/bazel/container/container.sh
@@ -32,6 +32,7 @@ function startBazelServer {
     -v "${HOME}/.cache/bazel":"/home/builder/.cache/bazel" \
     -v "${HOME}/.cache/shared_bazel_repository_cache":"/home/builder/.cache/shared_bazel_repository_cache" \
     -v "${HOME}/.cache/shared_bazel_action_cache":"/home/builder/.cache/shared_bazel_action_cache" \
+    -v "${HOME}/.docker/config.json":"/home/builder/.docker/config.json" \
     --entrypoint=/bin/sleep \
     "${containerImage}" \
     infinity || return $?


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
When executing from the builder container without any changes, the container push (as used in `//:devbuild`, for example) failed since it didn't have the Docker / ghcr credentials. 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Mount the Docker config of the host machine into the builder container so it uses the same authentication.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
