### PR TITLE
cli: add "--skip-helm-wait" flag

### DIFF
--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -65,6 +65,7 @@ go_library(
         "//internal/config/migration",
         "//internal/constants",
         "//internal/crypto",
+        "//internal/deploy/helm",
         "//internal/file",
         "//internal/grpc/dialer",
         "//internal/grpc/grpclog",

--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -101,7 +101,7 @@ func NewLoader(csp cloudprovider.Provider, k8sVersion versions.ValidK8sVersion) 
 }
 
 // Load the embedded helm charts.
-func (i *ChartLoader) Load(config *config.Config, conformanceMode bool, masterSecret, salt []byte) ([]byte, error) {
+func (i *ChartLoader) Load(config *config.Config, conformanceMode bool, helmWaitMode helm.WaitMode, masterSecret, salt []byte) ([]byte, error) {
 	ciliumRelease, err := i.loadRelease(ciliumInfo)
 	if err != nil {
 		return nil, fmt.Errorf("loading cilium: %w", err)

--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -102,23 +102,23 @@ func NewLoader(csp cloudprovider.Provider, k8sVersion versions.ValidK8sVersion) 
 
 // Load the embedded helm charts.
 func (i *ChartLoader) Load(config *config.Config, conformanceMode bool, helmWaitMode helm.WaitMode, masterSecret, salt []byte) ([]byte, error) {
-	ciliumRelease, err := i.loadRelease(ciliumInfo)
+	ciliumRelease, err := i.loadRelease(ciliumInfo, helmWaitMode)
 	if err != nil {
 		return nil, fmt.Errorf("loading cilium: %w", err)
 	}
 	extendCiliumValues(ciliumRelease.Values, conformanceMode)
 
-	certManagerRelease, err := i.loadRelease(certManagerInfo)
+	certManagerRelease, err := i.loadRelease(certManagerInfo, helmWaitMode)
 	if err != nil {
 		return nil, fmt.Errorf("loading cert-manager: %w", err)
 	}
 
-	operatorRelease, err := i.loadRelease(constellationOperatorsInfo)
+	operatorRelease, err := i.loadRelease(constellationOperatorsInfo, helmWaitMode)
 	if err != nil {
 		return nil, fmt.Errorf("loading operators: %w", err)
 	}
 
-	conServicesRelease, err := i.loadRelease(constellationServicesInfo)
+	conServicesRelease, err := i.loadRelease(constellationServicesInfo, helmWaitMode)
 	if err != nil {
 		return nil, fmt.Errorf("loading constellation-services: %w", err)
 	}
@@ -136,7 +136,7 @@ func (i *ChartLoader) Load(config *config.Config, conformanceMode bool, helmWait
 }
 
 // loadRelease loads the embedded chart and values depending on the given info argument.
-func (i *ChartLoader) loadRelease(info chartInfo) (helm.Release, error) {
+func (i *ChartLoader) loadRelease(info chartInfo, helmWaitMode helm.WaitMode) (helm.Release, error) {
 	chart, err := loadChartsDir(helmFS, info.path)
 	if err != nil {
 		return helm.Release{}, fmt.Errorf("loading %s chart: %w", info.releaseName, err)
@@ -168,7 +168,7 @@ func (i *ChartLoader) loadRelease(info chartInfo) (helm.Release, error) {
 		return helm.Release{}, fmt.Errorf("packaging %s chart: %w", info.releaseName, err)
 	}
 
-	return helm.Release{Chart: chartRaw, Values: values, ReleaseName: info.releaseName}, nil
+	return helm.Release{Chart: chartRaw, Values: values, ReleaseName: info.releaseName, WaitMode: helmWaitMode}, nil
 }
 
 // loadCiliumValues is used to separate the marshalling step from the loading step.

--- a/cli/internal/helm/loader_test.go
+++ b/cli/internal/helm/loader_test.go
@@ -39,7 +39,7 @@ func TestLoad(t *testing.T) {
 
 	config := &config.Config{Provider: config.ProviderConfig{GCP: &config.GCPConfig{}}}
 	chartLoader := ChartLoader{csp: config.GetProvider()}
-	release, err := chartLoader.Load(config, true, []byte("secret"), []byte("salt"))
+	release, err := chartLoader.Load(config, true, helm.WaitModeAtomic, []byte("secret"), []byte("salt"))
 	require.NoError(err)
 
 	var helmReleases helm.Releases

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -253,6 +253,7 @@ constellation init [flags]
   -h, --help                   help for init
       --master-secret string   path to base64-encoded master secret
       --merge-kubeconfig       merge Constellation kubeconfig file with default kubeconfig file in $HOME/.kube/config
+      --skip-helm-wait         install helm charts without waiting for deployments to be ready
 ```
 
 ### Options inherited from parent commands

--- a/internal/deploy/helm/helm.go
+++ b/internal/deploy/helm/helm.go
@@ -12,6 +12,7 @@ type Release struct {
 	Chart       []byte
 	Values      map[string]any
 	ReleaseName string
+	WaitMode    WaitMode
 }
 
 // Releases bundles all helm releases to be deployed to Constellation.
@@ -43,3 +44,16 @@ func MergeMaps(a, b map[string]any) map[string]any {
 	}
 	return out
 }
+
+// WaitMode specifies the wait mode for a helm release.
+type WaitMode string
+
+const (
+	// WaitModeNone specifies that the helm release should not wait for the resources to be ready.
+	WaitModeNone WaitMode = ""
+	// WaitModeWait specifies that the helm release should wait for the resources to be ready.
+	WaitModeWait WaitMode = "wait"
+	// WaitModeAtomic specifies that the helm release should
+	// wait for the resources to be ready and roll back atomically on failure.
+	WaitModeAtomic WaitMode = "atomic"
+)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context

This flag can be used to disable the atomic and wait flags during helm install. This is useful when debugging a failing `constellation init`, since the user gains access to the cluster even if one of the deployments is never in a ready state.


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: add "--skip-helm-wait" flag
- bootstrapper: fix deadlock during helm install

<!-- (uncomment if applicable)
### Related issue
- [AB#3263](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3263)
-->

### Additional info
I tested this manually.
You can see the difference by either creating  a broken deployment on purpose or by measuring the time difference between skipping and waiting.
The skip flags makes `constellation init` a lot faster.



### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
