### PR TITLE
deps: ignore updates to CSI containers in renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,10 @@
   "prConcurrentLimit": 4,
   "ignorePaths": [
     "cli/internal/helm/charts/cilium/**",
+    "cli/internal/helm/charts/edgeless/constellation-services/charts/aws-csi-driver/**",
+    "cli/internal/helm/charts/edgeless/constellation-services/charts/azuredisk-csi-driver/**",
+    "cli/internal/helm/charts/edgeless/constellation-services/charts/gcp-compute-persistent-disk-csi-driver/**",
+    "cli/internal/helm/charts/edgeless/constellation-services/charts/cinder-csi-plugin/**",
     "operators/constellation-node-operator/config/manager/kustomization.yaml"
   ],
   "ignoreDeps": [


### PR DESCRIPTION
### Context
Renovate tries to update containers of the CSI charts.
CSI charts should only be updated upstream, since we automatically pull in the charts.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Let renovate ignore CSI charts 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->
