### PR TITLE
cli: remove old migrations

### DIFF
--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -337,7 +337,7 @@ func (c *Client) applyMigrations(ctx context.Context, releaseName string, values
 // migrateFrom2_8 applies the necessary migrations for upgrading from v2.8.x to v2.9.x.
 // migrateFrom2_8 should be applied for v2.8.x --> v2.9.x.
 // migrateFrom2_8 should NOT be applied for v2.8.0 --> v2.9.x.
-func migrateFrom2_8(ctx context.Context, values map[string]any, conf *config.Config, kubeclient crdClient) error {
+func migrateFrom2_8(_ context.Context, _ map[string]any, _ *config.Config, _ crdClient) error {
 	return nil
 }
 

--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -324,20 +324,20 @@ func (c *Client) applyMigrations(ctx context.Context, releaseName string, values
 		return fmt.Errorf("parsing current version: %w", err)
 	}
 
-	if currentV.Major == 2 && currentV.Minor == 7 {
+	if currentV.Major == 2 && currentV.Minor == 8 {
 		// Rename/change the following function to implement any necessary migrations.
-		return migrateFrom2_9(ctx, values, conf, c.kubectl)
+		return migrateFrom2_8(ctx, values, conf, c.kubectl)
 	}
 
 	return nil
 }
 
-// migrateFrom2_9 is currently a no-op that is kept for documentation purposes.
+// migrateFrom2_8 is currently a no-op that is kept for documentation purposes.
 // If you have to implement the function please make sure to update the below comment to your situation.
-// migrateFrom2_9 applies the necessary migrations for upgrading from v2.9.x to v2.10.x.
-// migrateFrom2_9 should be applied for v2.9.x --> v2.10.x.
-// migrateFrom2_9 should NOT be applied for v2.9.0 --> v2.9.x.
-func migrateFrom2_9(ctx context.Context, values map[string]any, conf *config.Config, kubeclient crdClient) error {
+// migrateFrom2_8 applies the necessary migrations for upgrading from v2.8.x to v2.9.x.
+// migrateFrom2_8 should be applied for v2.8.x --> v2.9.x.
+// migrateFrom2_8 should NOT be applied for v2.8.0 --> v2.9.x.
+func migrateFrom2_8(ctx context.Context, values map[string]any, conf *config.Config, kubeclient crdClient) error {
 	return nil
 }
 

--- a/cli/internal/kubernetes/BUILD.bazel
+++ b/cli/internal/kubernetes/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//cli/internal/terraform",
         "//cli/internal/upgrade",
         "//internal/api/versionsapi",
-        "//internal/attestation/measurements",
         "//internal/attestation/variant",
         "//internal/cloud/cloudprovider",
         "//internal/compatibility",

--- a/internal/kubernetes/kubectl/kubectl.go
+++ b/internal/kubernetes/kubectl/kubectl.go
@@ -241,12 +241,6 @@ func (k *Kubectl) AddNodeSelectorsToDeployment(ctx context.Context, selectors ma
 	return nil
 }
 
-// DeleteStorageClass deletes the storage class with the given name.
-// TODO(daniel-weisse): Remove with v2.9.
-func (k *Kubectl) DeleteStorageClass(ctx context.Context, name string) error {
-	return k.StorageV1().StorageClasses().Delete(ctx, name, metav1.DeleteOptions{})
-}
-
 // parseCRD takes a byte slice of data and tries to create a CustomResourceDefinition object from it.
 func parseCRD(crdString []byte) (*v1.CustomResourceDefinition, error) {
 	sch := runtime.NewScheme()


### PR DESCRIPTION
### Context
Depending on the changes in a release we need migration code during upgrades to change existing cluster resources, etc. Since we force users to upgrade one minor version at a time we can remove old migration code. This PR does that.

### Proposed change(s)
- Remove migrations that are not required for upgrading from 2.8.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
