### PR TITLE
disk-mapper: set LUKS2 token to allow reusing unintialized state disks

### DIFF
--- a/bazel/toolchains/go_module_deps.bzl
+++ b/bazel/toolchains/go_module_deps.bzl
@@ -2199,8 +2199,8 @@ def go_dependencies():
         build_file_generation = "on",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/goccy/go-json",
-        sum = "h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=",
-        version = "v0.10.2",
+        sum = "h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=",
+        version = "v0.9.11",
     )
 
     go_repository(

--- a/bazel/toolchains/go_module_deps.bzl
+++ b/bazel/toolchains/go_module_deps.bzl
@@ -2199,8 +2199,8 @@ def go_dependencies():
         build_file_generation = "on",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/goccy/go-json",
-        sum = "h1:/pAaQDLHEoCq/5FFmSKBswWmK6H0e8g4159Kc/X/nqk=",
-        version = "v0.9.11",
+        sum = "h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=",
+        version = "v0.10.2",
     )
 
     go_repository(
@@ -3569,8 +3569,9 @@ def go_dependencies():
         patches = [
             "//3rdparty/bazel/com_github_martinjungblut_go_cryptsetup:com_github_martinjungblut_go_cryptsetup.patch",  # keep
         ],
-        sum = "h1:YDjLk3wsL5ZLhLC4TIwIvT2NkSCAdAV6pzzZaRfj4jk=",
-        version = "v0.0.0-20220520180014-fd0874fd07a6",
+        replace = "github.com/daniel-weisse/go-cryptsetup",
+        sum = "h1:ToajP6trZoiqlZ3Z4uoG1P02/wtqSw1AcowOXOYjATk=",
+        version = "v0.0.0-20230705150314-d8c07bd1723c",
     )
     go_repository(
         name = "com_github_masterminds_goutils",

--- a/bootstrapper/internal/diskencryption/diskencryption.go
+++ b/bootstrapper/internal/diskencryption/diskencryption.go
@@ -52,7 +52,12 @@ func (c *DiskEncryption) UpdatePassphrase(passphrase string) error {
 	if err != nil {
 		return err
 	}
-	return c.device.KeyslotChangeByPassphrase(keyslot, keyslot, initialPassphrase, passphrase)
+	if err := c.device.KeyslotChangeByPassphrase(keyslot, keyslot, initialPassphrase, passphrase); err != nil {
+		return err
+	}
+
+	// Set token as initialized.
+	return c.device.SetConstellationStateDiskToken(cryptsetup.SetDiskInitialized)
 }
 
 // getInitialPassphrase retrieves the initial passphrase used on first boot.
@@ -68,4 +73,5 @@ type cryptdevice interface {
 	InitByName(name string) (func(), error)
 	GetUUID() (string, error)
 	KeyslotChangeByPassphrase(currentKeyslot int, newKeyslot int, currentPassphrase string, newPassphrase string) error
+	SetConstellationStateDiskToken(bool) error
 }

--- a/bootstrapper/internal/diskencryption/diskencryption_test.go
+++ b/bootstrapper/internal/diskencryption/diskencryption_test.go
@@ -90,6 +90,6 @@ func (s *stubCryptdevice) KeyslotChangeByPassphrase(_, _ int, _, _ string) error
 	return s.keyslotChangeErr
 }
 
-func (s *stubCryptdevice) Close() error {
+func (s *stubCryptdevice) SetConstellationStateDiskToken(bool) error {
 	return nil
 }

--- a/disk-mapper/cmd/main.go
+++ b/disk-mapper/cmd/main.go
@@ -147,7 +147,7 @@ func main() {
 	}
 
 	// prepare the state disk
-	if mapper.IsLUKSDevice() {
+	if mapper.IsInitialized() {
 		// set up rejoin client
 		var self metadata.InstanceMetadata
 		self, err = metadataClient.Self(context.Background())

--- a/disk-mapper/internal/setup/setup_test.go
+++ b/disk-mapper/internal/setup/setup_test.go
@@ -413,6 +413,10 @@ func (s *stubMapper) UnmapDisk(string) error {
 	return s.unmapDiskErr
 }
 
+func (s *stubMapper) SetDiskToInitialized() error {
+	return nil
+}
+
 type stubMounter struct {
 	mountCalled   bool
 	mountErr      error

--- a/disk-mapper/internal/test/integration_test.go
+++ b/disk-mapper/internal/test/integration_test.go
@@ -9,6 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 package integration
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
@@ -18,7 +19,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/disk-mapper/internal/diskencryption"
 	ccryptsetup "github.com/edgelesssys/constellation/v2/internal/cryptsetup"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
-	"github.com/goccy/go-json"
 	cryptsetup "github.com/martinjungblut/go-cryptsetup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/disk-mapper/internal/test/integration_test.go
+++ b/disk-mapper/internal/test/integration_test.go
@@ -16,8 +16,10 @@ import (
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/disk-mapper/internal/diskencryption"
+	ccryptsetup "github.com/edgelesssys/constellation/v2/internal/cryptsetup"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
-	"github.com/martinjungblut/go-cryptsetup"
+	"github.com/goccy/go-json"
+	cryptsetup "github.com/martinjungblut/go-cryptsetup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -68,7 +70,7 @@ func TestMapper(t *testing.T) {
 	require.NoError(err, "failed to initialize crypt device")
 	defer free()
 
-	assert.False(mapper.IsLUKSDevice())
+	assert.False(mapper.IsInitialized())
 
 	// Format and map disk
 	passphrase := "unit-test"
@@ -76,23 +78,33 @@ func TestMapper(t *testing.T) {
 	require.NoError(mapper.MapDisk(mappedDevice, passphrase), "failed to map disk")
 	require.NoError(mapper.UnmapDisk(mappedDevice), "failed to remove disk mapping")
 
-	assert.True(mapper.IsLUKSDevice())
+	// Make sure token was set
+	ccrypt := ccryptsetup.New()
+	freeDevice, err := ccrypt.Init(devicePath)
+	require.NoError(err, "failed to initialize crypt device")
+	defer freeDevice()
+	require.NoError(ccrypt.LoadLUKS2(), "failed to load LUKS2")
+
+	tokenJSON, err := ccrypt.TokenJSONGet(ccryptsetup.ConstellationStateDiskTokenID)
+	require.NoError(err, "token should have been set")
+	var token struct {
+		Type              string   `json:"type"`
+		Keyslots          []string `json:"keyslots"`
+		DiskIsInitialized bool     `json:"diskIsInitialized"`
+	}
+	require.NoError(json.Unmarshal([]byte(tokenJSON), &token))
+	assert.False(token.DiskIsInitialized, "disk should be marked as not initialized")
+	assert.False(ccrypt.ConstellationStateDiskTokenIsInitialized(), "disk should be marked as not initialized")
+
+	// Disk should still be marked as not initialized because token is set to false.
+	assert.False(mapper.IsInitialized())
 
 	// Try to map disk with incorrect passphrase
 	assert.Error(mapper.MapDisk(mappedDevice, "invalid-passphrase"), "was able to map disk with incorrect passphrase")
-}
 
-/*
-type fakeMetadataAPI struct{}
-
-func (f *fakeMetadataAPI) List(ctx context.Context) ([]metadata.InstanceMetadata, error) {
-	return []metadata.InstanceMetadata{
-		{
-			Name:       "instanceName",
-			ProviderID: "fake://instance-id",
-			Role:       role.Unknown,
-			VPCIP:      "192.0.2.1",
-		},
-	}, nil
+	// Disk can be reformatted without manually re-initializing a mapper
+	passphrase2 := passphrase + "2"
+	require.NoError(mapper.FormatDisk(passphrase2), "failed to format disk")
+	require.NoError(mapper.MapDisk(mappedDevice, passphrase2), "failed to map disk")
+	require.NoError(mapper.UnmapDisk(mappedDevice), "failed to remove disk mapping")
 }
-*/

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ replace (
 replace (
 	github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/api => ./operators/constellation-node-operator/api
 	github.com/google/go-tpm => github.com/thomasten/go-tpm v0.0.0-20230629092004-f43f8e2a59eb
+	github.com/martinjungblut/go-cryptsetup => github.com/daniel-weisse/go-cryptsetup v0.0.0-20230705150314-d8c07bd1723c
 )
 
 require (
@@ -74,6 +75,7 @@ require (
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.14.1
+	github.com/goccy/go-json v0.10.2
 	github.com/google/go-tpm v0.9.0
 	github.com/google/go-tpm-tools v0.4.0
 	github.com/googleapis/gax-go/v2 v2.12.0

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,6 @@ require (
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.14.1
-	github.com/goccy/go-json v0.10.2
 	github.com/google/go-tpm v0.9.0
 	github.com/google/go-tpm-tools v0.4.0
 	github.com/googleapis/gax-go/v2 v2.12.0

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,6 @@ github.com/gobuffalo/packr/v2 v2.8.3/go.mod h1:0SahksCVcx4IMnigTjiFuyldmTrdTctXs
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
-github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
-github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=

--- a/go.sum
+++ b/go.sum
@@ -279,6 +279,8 @@ github.com/cyberphone/json-canonicalization v0.0.0-20220623050100-57a0ce2678a7 h
 github.com/cyberphone/json-canonicalization v0.0.0-20220623050100-57a0ce2678a7/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/cyphar/filepath-securejoin v0.2.3 h1:YX6ebbZCZP7VkM3scTTokDgBL2TY741X51MTk3ycuNI=
 github.com/cyphar/filepath-securejoin v0.2.3/go.mod h1:aPGpWjXOXUn2NCNjFvBE6aRxGGx79pTxQpKOJNYHHl4=
+github.com/daniel-weisse/go-cryptsetup v0.0.0-20230705150314-d8c07bd1723c h1:ToajP6trZoiqlZ3Z4uoG1P02/wtqSw1AcowOXOYjATk=
+github.com/daniel-weisse/go-cryptsetup v0.0.0-20230705150314-d8c07bd1723c/go.mod h1:gZoZ0+POlM1ge/VUxWpMmZVNPzzMJ7l436CgkQ5+qzU=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -454,6 +456,8 @@ github.com/gobuffalo/packr/v2 v2.8.3/go.mod h1:0SahksCVcx4IMnigTjiFuyldmTrdTctXs
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
 github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
 github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
@@ -756,8 +760,6 @@ github.com/markbates/oncer v1.0.0 h1:E83IaVAHygyndzPimgUYJjbshhDTALZyXxvk9FOlQRY
 github.com/markbates/oncer v1.0.0/go.mod h1:Z59JA581E9GP6w96jai+TGqafHPW+cPfRxz2aSZ0mcI=
 github.com/markbates/safe v1.0.1 h1:yjZkbvRM6IzKj9tlu/zMJLS0n/V351OZWRnF3QfaUxI=
 github.com/markbates/safe v1.0.1/go.mod h1:nAqgmRi7cY2nqMc92/bSEeQA+R4OheNU2T1kNSCBdG0=
-github.com/martinjungblut/go-cryptsetup v0.0.0-20220520180014-fd0874fd07a6 h1:YDjLk3wsL5ZLhLC4TIwIvT2NkSCAdAV6pzzZaRfj4jk=
-github.com/martinjungblut/go-cryptsetup v0.0.0-20220520180014-fd0874fd07a6/go.mod h1:gZoZ0+POlM1ge/VUxWpMmZVNPzzMJ7l436CgkQ5+qzU=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=


### PR DESCRIPTION
### Context
Constellation encrypts its statefull disks using cryptsetup.
For this, a node will first generate a completely random password during the initramfs stage, and then update the password for the disk once it joins a cluster using a password derived from the master secret.

If during boot a node detects its state disk to already be an encrypted LUKS2 disk, it will request a decryption key from a running cluster, instead of formatting the disk.
This allows a node to easily rejoin a cluster upon reboot.
However, this also means that a node which restarted after having first formatted its disk, but before joining a cluster for the first time, will be stuck in initramfs trying to decrypt the disk.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
Use the cryptsetup [`token_json`](https://mbroz.fedorapeople.org/libcryptsetup_API/group__crypt-tokens.html#gadcc2116c40c3bb5a01a7f51d2998423e) functions to add additional context to our encrypted state disks:

* On boot, check if the state disk has a token set
  * If not, format the disk and set a token with custom field `diskIsInitialized=false`
  * If token is set, check the `diskIsInitialized` field
    * If `diskIsInitialized=false`, reformat the disk
    * If `diskIsInitialized=true`, request a decryption key from a running cluster
* On cluster join, update the passphrase of the disk, and update the token's `diskIsInitialized` to `true`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
How to test:

* Start a Constellation using the following image:
  ```
  ref/feat-disk-mapper-reusable-disks/stream/debug/v2.10.0-pre.0.20230717121326-51159d780840
  ```
* Reboot a node after initramfs, but before `constellation init`/it joined the cluster and make sure it can successfully boot back into userland
* Reboot a node after it joined the cluster and make sure it successfully rejoins the cluster


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
