### PR TITLE
ci: do not build additional streams

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,25 +194,6 @@ jobs:
       stream: "stable"
       ref: ${{ needs.verify-inputs.outputs.WORKING_BRANCH }}
 
-  os-image-additional-streams:
-    name: Build OS image (additional streams)
-    needs: [verify-inputs, update-versions]
-    strategy:
-      fail-fast: false
-      matrix:
-        stream: [debug, console]
-    uses: ./.github/workflows/build-os-image.yml
-    permissions:
-      id-token: write
-      contents: read
-      packages: read
-    secrets: inherit
-    with:
-      imageVersion: ${{ inputs.version }}
-      isRelease: true
-      stream: ${{ matrix.stream }}
-      ref: ${{ needs.verify-inputs.outputs.WORKING_BRANCH }}
-
   update-hardcoded-measurements:
     name: Update hardcoded measurements (in the CLI)
     needs: [verify-inputs, os-image]


### PR DESCRIPTION
### Context
<!-- Please add background information on why this PR is opened. -->
During the release pipeline we build a large amount of artifacts that are cached using the [upload-artifact](https://github.com/actions/upload-artifact) action. That action has a [history](https://github.com/actions/upload-artifact/issues?q=is%3Aissue+503) of producing 503 errors when handling large files. It seems like we are also running into some file size/amount limitations.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove `os-image-additional-streams` job from release pipeline. We can build these images on demand. 

<!-- (uncomment if applicable)
### Additional info
- The 503 errors seen e.g. [here](https://github.com/edgelesssys/constellation/actions/runs/5509031983/jobs/10043164951) may be unrelated, but it seems like a good try to skip the job.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Link to Milestone
