### PR TITLE
ci: use 2.8 as fromVersion in release upgrade test

### DIFF
--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -231,7 +231,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        fromVersion: ["v2.7.1"]
+        fromVersion: ["v2.8.0"]
         cloudProvider: ["gcp", "azure", "aws"]
     name: Run upgrade tests
     secrets: inherit


### PR DESCRIPTION
### Context
The current fromVersion value is outdated since the release of 2.8.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Update the value to 2.8 so we correctly test upgrade from 2.8 to 2.9 during release tests.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
