### PR TITLE
config: make deployCSIDriver backwards compatible

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,7 +130,7 @@ type AWSConfig struct {
 	IAMProfileWorkerNodes string `yaml:"iamProfileWorkerNodes" validate:"required"`
 	// description: |
 	//   Deploy Persistent Disk CSI driver with on-node encryption. For details see: https://docs.edgeless.systems/constellation/architecture/encrypted-storage
-	DeployCSIDriver *bool `yaml:"deployCSIDriver" validate:"required"`
+	DeployCSIDriver *bool `yaml:"deployCSIDriver"`
 }
 
 // AzureConfig are Azure specific configuration values used by the CLI.
@@ -452,10 +452,14 @@ func New(fileHandler file.Handler, name string, fetcher attestationconfigapi.Fet
 		c.Provider.OpenStack.Password = openstackPassword
 	}
 
-	// Backwards compatibility: configs without the field `microserviceVersion` are valid in version 2.6.
-	// In case the field is not set in an old config we prefill it with the default value.
-	if c.MicroserviceVersion == "" {
-		c.MicroserviceVersion = Default().MicroserviceVersion
+	// Backwards compatibility: configs without the field `deployCSIDriver` are valid in version 2.8.
+	// TODO (msanft): v2.9. Remove after v2.9 release.
+	if c.Provider.AWS != nil && c.Provider.AWS.DeployCSIDriver == nil {
+		fmt.Fprintln(
+			os.Stderr,
+			"WARNING: 'provider.aws.deployCSIDriver' will be required in an upcoming version. Setting to 'false'.",
+		)
+		c.Provider.AWS.DeployCSIDriver = toPtr(false)
 	}
 
 	return c, c.Validate(force)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,7 +130,7 @@ type AWSConfig struct {
 	IAMProfileWorkerNodes string `yaml:"iamProfileWorkerNodes" validate:"required"`
 	// description: |
 	//   Deploy Persistent Disk CSI driver with on-node encryption. For details see: https://docs.edgeless.systems/constellation/architecture/encrypted-storage
-	DeployCSIDriver *bool `yaml:"deployCSIDriver"`
+	DeployCSIDriver *bool `yaml:"deployCSIDriver"` // TODO (msanft): after v2.9 release re-enable "required" validation
 }
 
 // AzureConfig are Azure specific configuration values used by the CLI.
@@ -457,7 +457,7 @@ func New(fileHandler file.Handler, name string, fetcher attestationconfigapi.Fet
 	if c.Provider.AWS != nil && c.Provider.AWS.DeployCSIDriver == nil {
 		fmt.Fprintln(
 			os.Stderr,
-			"WARNING: 'provider.aws.deployCSIDriver' will be required in an upcoming version. Setting to 'false'.",
+			"WARNING: 'provider.aws.deployCSIDriver' not set. The key will be required in v2.10. Defaulting to 'false'.",
 		)
 		c.Provider.AWS.DeployCSIDriver = toPtr(false)
 	}

--- a/internal/config/config_doc.go
+++ b/internal/config/config_doc.go
@@ -159,7 +159,7 @@ func init() {
 	AWSConfigDoc.Fields[5].Comments[encoder.LineComment] = "Name of the IAM profile to use for the worker nodes."
 	AWSConfigDoc.Fields[6].Name = "deployCSIDriver"
 	AWSConfigDoc.Fields[6].Type = "bool"
-	AWSConfigDoc.Fields[6].Note = ""
+	AWSConfigDoc.Fields[6].Note = "TODO (msanft): after v2.9 release re-enable \"required\" validation\n"
 	AWSConfigDoc.Fields[6].Description = "Deploy Persistent Disk CSI driver with on-node encryption. For details see: https://docs.edgeless.systems/constellation/architecture/encrypted-storage"
 	AWSConfigDoc.Fields[6].Comments[encoder.LineComment] = "Deploy Persistent Disk CSI driver with on-node encryption. For details see: https://docs.edgeless.systems/constellation/architecture/encrypted-storage"
 


### PR DESCRIPTION
### Context
We added the field in 2.9 but can only require it in 2.10.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fallback to false and warn the user if the field is not specified.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
