### PR TITLE
ci: use us-east-2 for e2e tests

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -105,8 +105,8 @@ runs:
           constellation-conf.yaml
 
         yq eval -i \
-          "(.provider | select(. | has(\"aws\")).aws.region) = \"eu-west-1\" |
-            (.provider | select(. | has(\"aws\")).aws.zone) = \"eu-west-1c\" |
+          "(.provider | select(. | has(\"aws\")).aws.region) = \"us-east-2\" |
+            (.provider | select(. | has(\"aws\")).aws.zone) = \"us-east-2c\" |
             (.provider | select(. | has(\"aws\")).aws.iamProfileControlPlane) = \"e2e_test_control_plane_instance_profile\" |
             (.provider | select(. | has(\"aws\")).aws.iamProfileWorkerNodes) = \"e2e_test_worker_node_instance_profile\"" \
           constellation-conf.yaml
@@ -291,7 +291,7 @@ runs:
             ./.github/actions/constellation_create/gcp-logs.sh
             ;;
           aws)
-            ./.github/actions/constellation_create/aws-logs.sh eu-west-1
+            ./.github/actions/constellation_create/aws-logs.sh us-east-2
             ;;
         esac
         echo "::endgroup::"

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -199,7 +199,7 @@ runs:
       with:
         cloudProvider: ${{ inputs.cloudProvider }}
         namePrefix: ${{ steps.create-prefix.outputs.prefix }}
-        awsZone: eu-west-1c
+        awsZone: us-east-2c
         azureRegion: northeurope
         gcpProjectID: ${{ inputs.gcpProject }}
         gcpZone: europe-west3-b


### PR DESCRIPTION
### Context
<!-- Please add background information on why this PR is opened. -->
We are hitting our vCPU limit of 64 in eu-west-1 during release testing (needs 180 vCPUs).
Support needs manual approval and requested more details. Supplied details, but approval will probably take 1-2 more days.
We have much higher quotas in us-east-2.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- On AWS: use region us-east-2 for e2e tests

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
