### PR TITLE
cli: allow upgrade if desired attestation config == actual config

### DIFF
--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -345,8 +345,12 @@ func (u *upgradeApplyCmd) upgradeAttestConfigIfDiff(cmd *cobra.Command, newConfi
 		return fmt.Errorf("getting cluster attestation config: %w", err)
 	}
 	// If the current config is equal, or there is an error when comparing the configs, we skip the upgrade.
-	if equal, err := newConfig.EqualTo(clusterAttestationConfig); err != nil || equal {
+	equal, err := newConfig.EqualTo(clusterAttestationConfig)
+	if err != nil {
 		return fmt.Errorf("comparing attestation configs: %w", err)
+	}
+	if equal {
+		return nil
 	}
 
 	if !flags.yes {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context

Every step of `constellation upgrade apply` needs to be idempotent. Currently, if there is no diff between the desired attestation config and the actual attestation config in the cluster, the upgrade will abort with the message:

```
Error: upgrading measurements: comparing attestation configs: %!w(<nil>)
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: allow upgrade to succeed if desired attestation config == actual config

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
