### PR TITLE
cli: allow helm upgrades with old k8s patch version

### DIFF
--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -255,7 +255,7 @@ func (c *Client) upgradeRelease(
 ) error {
 	// We need to load all values that can be statically loaded before merging them with the cluster
 	// values. Otherwise the templates are not rendered correctly.
-	k8sVersion, err := versions.NewValidK8sVersion(conf.KubernetesVersion, true)
+	k8sVersion, err := versions.NewValidK8sVersion(conf.KubernetesVersion, false)
 	if err != nil {
 		return fmt.Errorf("validating k8s version: %s", conf.KubernetesVersion)
 	}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context

When upgrading, it is common that users have an older k8s patch version in their constellation-conf.yaml.
We don't want to force users to upgrade immediately.
This is why we ask the user if they want to skip the k8s version upgrade in cases where an unsupported k8s version is in the config.
However, helm upgrades should still be supported by Constellation in that case, since the deployed services only depend on the k8s minor version.
I propose a change to `ValidK8sVersion`: If the constructor returns without error, the type always contains a full, supported, known k8s version. 
If strict is set to false, the version returned may differ in the patch part of the version put in.
This ensures that `ValidK8sVersion` is actually a valid k8s version and it can be used for map lookups.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: allow helm upgrades with old k8s patch version

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
