### PR TITLE
operators: correctly update launch template default version on AWS image upgrade

### DIFF
--- a/operators/constellation-node-operator/internal/cloud/aws/client/scalinggroup.go
+++ b/operators/constellation-node-operator/internal/cloud/aws/client/scalinggroup.go
@@ -9,6 +9,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
@@ -55,7 +56,7 @@ func (c *Client) SetScalingGroupImage(ctx context.Context, scalingGroupID, image
 				ImageId: &imageURI,
 			},
 			LaunchTemplateId: launchTemplate.LaunchTemplateId,
-			SourceVersion:    toPtr(fmt.Sprintf("%d", *launchTemplate.VersionNumber)),
+			SourceVersion:    toPtr(strconv.FormatInt(*launchTemplate.VersionNumber, 10)),
 		},
 	)
 	if err != nil {
@@ -77,7 +78,7 @@ func (c *Client) SetScalingGroupImage(ctx context.Context, scalingGroupID, image
 		ctx,
 		&ec2.ModifyLaunchTemplateInput{
 			LaunchTemplateId: launchTemplate.LaunchTemplateId,
-			DefaultVersion:   toPtr(fmt.Sprintf("%d", createLaunchTemplateOut.LaunchTemplateVersion.VersionNumber)),
+			DefaultVersion:   toPtr(strconv.FormatInt(*createLaunchTemplateOut.LaunchTemplateVersion.VersionNumber, 10)),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

When upgrading the default launch template version in the operator, we would pass a `*int64` to `Sprintf("%d", VAR)`.
This results in the address of the variable being used as a launch template version when setting the default version.
This prevents the operator from reconciling correctly.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- operators: correctly update launch template default version on AWS image upgrade

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Special thanks

Kudos to @elchead for finding the root cause.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
