### PR TITLE
ci: separate PCR0 value for aws-sev-snp variant

### DIFF
--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -695,7 +695,7 @@ jobs:
           if [[ ${{ matrix.attestation_variant }} -eq "aws-sev-snp" ]]
           then
             yq e '.csp = "AWS" |
-                  .measurements.0.expected = "7b068c0c3ac29afe264134536b9be26f1d4ccd575b88d3c3ceabf36ac99c0278" \
+                  .measurements.0.expected = "7b068c0c3ac29afe264134536b9be26f1d4ccd575b88d3c3ceabf36ac99c0278"' \
                   -I 0 -o json -i "${{ github.workspace }}/pcrs-${{ matrix.csp }}-${{ matrix.attestation_variant }}.json"
           fi
 

--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -692,7 +692,7 @@ jobs:
 
           # TODO (malt3): Calculate PCR from firmware blob.
           # AWS SNP machines have a different expected value for PCR 0.
-          if [[ ${{ matrix.attestation_variant }} -eq "aws-sev-snp" ]]
+          if [[ ${{ matrix.attestation_variant }} = "aws-sev-snp" ]]
           then
             yq e '.csp = "AWS" |
                   .measurements.0.expected = "7b068c0c3ac29afe264134536b9be26f1d4ccd575b88d3c3ceabf36ac99c0278"' \

--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -608,8 +608,6 @@ jobs:
                 .measurements.4.warnOnly = false |
                 .measurements.6.warnOnly = true |
                 .measurements.6.expected = "3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969" |
-                .measurements.7.warnOnly = true |
-                .measurements.7.expected = "fb71e5e55cefba9e2b396d17604de0fe6e1841a76758856a120833e3ad1c40a3" |
                 .measurements.8.warnOnly = false |
                 .measurements.9.warnOnly = false |
                 .measurements.11.warnOnly = false |
@@ -630,8 +628,6 @@ jobs:
                 .measurements.3.warnOnly = true |
                 .measurements.3.expected = "3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969" |
                 .measurements.4.warnOnly = false |
-                .measurements.7.warnOnly = true |
-                .measurements.7.expected = "346547a8ce5957af27e552427d6b9e6d9cb502f0156e9155380451eea1b3f0ed" |
                 .measurements.8.warnOnly = false |
                 .measurements.9.warnOnly = false |
                 .measurements.11.warnOnly = false |
@@ -654,8 +650,6 @@ jobs:
                 .measurements.4.warnOnly = false |
                 .measurements.6.warnOnly = true |
                 .measurements.6.expected = "3d458cfe55cc03ea1f443f1562beec8df51c75e14a9fcf9a7234a13f198e7969" |
-                .measurements.7.warnOnly = true |
-                .measurements.7.expected = "a1d193dbfc3da1a5e93fe7b1384427fb78feeffcb06675a0cf840ec99406f237" |
                 .measurements.8.warnOnly = false |
                 .measurements.9.warnOnly = false |
                 .measurements.11.warnOnly = false |
@@ -695,6 +689,15 @@ jobs:
               exit 1
             ;;
           esac
+
+          # TODO (malt3): Calculate PCR from firmware blob.
+          # AWS SNP machines have a different expected value for PCR 0.
+          if [[ ${{ matrix.attestation_variant }} -eq "aws-sev-snp" ]]
+          then
+            yq e '.csp = "AWS" |
+                  .measurements.0.expected = "7b068c0c3ac29afe264134536b9be26f1d4ccd575b88d3c3ceabf36ac99c0278" \
+                  -I 0 -o json -i "${{ github.workspace }}/pcrs-${{ matrix.csp }}-${{ matrix.attestation_variant }}.json"
+          fi
 
       - name: Envelope measurements
         shell: bash


### PR DESCRIPTION
### Context
AWS SNP has a different value in PCR0. Since it involves more extensive changes to properly handle the image-independent data in PCR0 we opted for this ad-hoc fix. Those changes should be tested for a longer time than 1 day.

### Proposed change(s)
- Set different PCR0 value for variant `aws-sev-snp`
- Changes from https://github.com/edgelesssys/constellation/pull/2098

### Additional Information
- [Testrun](https://github.com/edgelesssys/constellation/actions/runs/5539806876) :green_circle: 
- Manual test with the image from above run fixes the warnings. With measurements in the config (via `config fetch-measurements --insecure`).

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
