### PR TITLE
ci: fix resource selection for serial log downloading

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -304,4 +304,6 @@ runs:
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
       with:
         name: serial-logs-${{ inputs.artifactNameSuffix }}
-        path: "*.log"
+        path: |
+          *.log
+          !terraform.log

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -282,16 +282,18 @@ runs:
         CSP: ${{ inputs.cloudProvider }}
       run: |
         echo "::group::Download boot logs"
+        CONSTELL_UID=$(yq '.uid' constellation-id.json)
         case $CSP in
           azure)
             AZURE_RESOURCE_GROUP=$(yq eval ".provider.azure.resourceGroup" constellation-conf.yaml)
             ./.github/actions/constellation_create/az-logs.sh ${AZURE_RESOURCE_GROUP}
             ;;
           gcp)
-            ./.github/actions/constellation_create/gcp-logs.sh
+            GCP_ZONE=$(yq eval ".provider.gcp.zone" constellation-conf.yaml)
+            ./.github/actions/constellation_create/gcp-logs.sh ${GCP_ZONE} ${CONSTELL_UID}
             ;;
           aws)
-            ./.github/actions/constellation_create/aws-logs.sh us-east-2
+            ./.github/actions/constellation_create/aws-logs.sh us-east-2 ${CONSTELL_UID}
             ;;
         esac
         echo "::endgroup::"

--- a/.github/actions/constellation_create/aws-logs.sh
+++ b/.github/actions/constellation_create/aws-logs.sh
@@ -14,7 +14,7 @@ controlInstances=$(
     --region "${1}" \
     --no-paginate \
     --output json |
-    yq '.Reservations[].Instances[].InstanceId'
+    yq eval '.Reservations[].Instances[].InstanceId' -
 )
 workerInstances=$(
   aws ec2 describe-instances \
@@ -22,7 +22,7 @@ workerInstances=$(
     --region "${1}" \
     --no-paginate \
     --output json |
-    yq '.Reservations[].Instances[].InstanceId'
+    yq eval '.Reservations[].Instances[].InstanceId' -
 )
 
 echo "Fetching logs from control planes"

--- a/.github/actions/constellation_create/aws-logs.sh
+++ b/.github/actions/constellation_create/aws-logs.sh
@@ -14,7 +14,7 @@ controlInstances=$(
     --region "${1}" \
     --no-paginate \
     --output json |
-    jq -r '.Reservations[].Instances[].InstanceId'
+    yq '.Reservations[].Instances[].InstanceId'
 )
 workerInstances=$(
   aws ec2 describe-instances \

--- a/.github/actions/constellation_create/aws-logs.sh
+++ b/.github/actions/constellation_create/aws-logs.sh
@@ -22,7 +22,7 @@ workerInstances=$(
     --region "${1}" \
     --no-paginate \
     --output json |
-    jq -r '.Reservations[].Instances[].InstanceId'
+    yq '.Reservations[].Instances[].InstanceId'
 )
 
 echo "Fetching logs from control planes"

--- a/.github/actions/constellation_create/az-logs.sh
+++ b/.github/actions/constellation_create/az-logs.sh
@@ -7,8 +7,8 @@ printf "Fetching logs of instances in resource group %s\n" "${1}"
 
 # get list of all scale sets
 scalesetsjson=$(az vmss list --resource-group "${1}" -o json)
-scalesetslist=$(echo "${scalesetsjson}" | jq -r '.[] | .name')
-subscription=$(az account show | jq -r .id)
+scalesetslist=$(echo "${scalesetsjson}" | yq eval '.[] | .name' -)
+subscription=$(az account show | yq eval .id -)
 
 printf "Checking scalesets %s\n" "${scalesetslist}"
 
@@ -18,7 +18,7 @@ for scaleset in ${scalesetslist}; do
       --resource-group "${1}" \
       --name "${scaleset}" \
       -o json |
-      jq -r '.[] | .instanceId'
+      yq eval '.[] | .instanceId' -
   )
   printf "Checking instance IDs %s\n" "${instanceids}"
   for instanceid in ${instanceids}; do
@@ -26,7 +26,7 @@ for scaleset in ${scalesetslist}; do
       az rest \
         --method post \
         --url https://management.azure.com/subscriptions/"${subscription}"/resourceGroups/"${1}"/providers/Microsoft.Compute/virtualMachineScaleSets/"${scaleset}"/virtualmachines/"${instanceid}"/retrieveBootDiagnosticsData?api-version=2022-03-01 |
-        jq '.serialConsoleLogBlobUri' -r
+        yq eval '.serialConsoleLogBlobUri' -
     )
     sleep 4
     curl -fsSL -o "./${scaleset}-${instanceid}.log" "${bloburi}"

--- a/.github/actions/constellation_create/gcp-logs.sh
+++ b/.github/actions/constellation_create/gcp-logs.sh
@@ -9,7 +9,7 @@ echo "Using Constellation UID: ${2}"
 allInstances=$(
   gcloud compute instances list \
     --filter="labels.constellation-uid=${2}" \
-    --format=json | yq '.[] | .name'
+    --format=json | yq eval '.[] | .name' -
 )
 
 for instance in ${allInstances}; do

--- a/.github/actions/constellation_create/gcp-logs.sh
+++ b/.github/actions/constellation_create/gcp-logs.sh
@@ -9,7 +9,7 @@ echo "Using Constellation UID: ${2}"
 allInstances=$(
   gcloud compute instances list \
     --filter="labels.constellation-uid=${2}" \
-    --format=json | jq -r '.[] | .id'
+    --format=json | yq '.[] | .id'
 )
 
 for instance in ${allInstances}; do

--- a/.github/actions/constellation_create/gcp-logs.sh
+++ b/.github/actions/constellation_create/gcp-logs.sh
@@ -9,11 +9,10 @@ echo "Using Constellation UID: ${2}"
 allInstances=$(
   gcloud compute instances list \
     --filter="labels.constellation-uid=${2}" \
-    --format=json | yq '.[] | .id'
+    --format=json | yq '.[] | .name'
 )
 
 for instance in ${allInstances}; do
-  shortName=${instance##*/}
   printf "Fetching for %s\n" "${shortName}"
   gcloud compute instances get-serial-port-output "${instance}" \
     --port 1 \

--- a/.github/actions/constellation_create/gcp-logs.sh
+++ b/.github/actions/constellation_create/gcp-logs.sh
@@ -3,43 +3,14 @@
 set -euo pipefail
 shopt -s inherit_errexit
 
-pushd constellation-terraform
-controlInstanceGroup=$(
-  terraform show -json |
-    jq -r .'values.root_module.child_modules[] |
-    select(.address == "module.instance_group_control_plane") |
-    .resources[0].values.base_instance_name'
-)
-workerInstanceGroup=$(
-  terraform show -json |
-    jq -r .'values.root_module.child_modules[] |
-    select(.address == "module.instance_group_worker") |
-     .resources[0].values.base_instance_name'
-)
-zone=$(
-  terraform show -json |
-    jq -r .'values.root_module.child_modules[] |
-    select(.address == "module.instance_group_control_plane") |
-     .resources[0].values.zone'
-)
-popd
+echo "Using Zone: ${1}"
+echo "Using Constellation UID: ${2}"
 
-controlInstances=$(
-  gcloud compute instance-groups managed list-instances "${controlInstanceGroup##*/}" \
-    --zone "${zone}" \
-    --format=json |
-    jq -r '.[] | .instance'
+allInstances=$(
+  gcloud compute instances list \
+    --filter="labels.constellation-uid=${2}" \
+    --format=json | jq -r '.[] | .id'
 )
-workerInstances=$(
-  gcloud compute instance-groups managed list-instances "${workerInstanceGroup##*/}" \
-    --zone "${zone}" \
-    --format=json |
-    jq -r '.[] | .instance'
-)
-
-allInstances="${controlInstances} ${workerInstances}"
-
-printf "Fetching logs for %s and %s\n" "${controlInstances}" "${workerInstances}"
 
 for instance in ${allInstances}; do
   shortName=${instance##*/}
@@ -47,5 +18,5 @@ for instance in ${allInstances}; do
   gcloud compute instances get-serial-port-output "${instance}" \
     --port 1 \
     --start 0 \
-    --zone "${zone}" > "${shortName}".log
+    --zone "${1}" > "${shortName}".log
 done

--- a/.github/actions/constellation_create/gcp-logs.sh
+++ b/.github/actions/constellation_create/gcp-logs.sh
@@ -13,9 +13,9 @@ allInstances=$(
 )
 
 for instance in ${allInstances}; do
-  printf "Fetching for %s\n" "${shortName}"
+  printf "Fetching for %s\n" "${instance}"
   gcloud compute instances get-serial-port-output "${instance}" \
     --port 1 \
     --start 0 \
-    --zone "${1}" > "${shortName}".log
+    --zone "${1}" > "${instance}".log
 done


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
To download serial logs in the CI, we have to parse the cloud resources used in the run (e.g. VM instance ID) to be able to retrieve logs for the specific instances. Previously, this relied on specific Terraform resource names, which, as the recent bugs showed, are not a stable interface to rely on.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- To have a more stable interface, use `constellation-id.json` and the `UID` contained there to target the resources. 
- Furthermore, fix a bug where the serial log artifact-upload would also select Terraform logs due to a glob.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
