### PR TITLE
ci: increase autoscaling timeout to 25m

### DIFF
--- a/.github/actions/e2e_autoscaling/action.yml
+++ b/.github/actions/e2e_autoscaling/action.yml
@@ -89,7 +89,7 @@ runs:
       env:
         KUBECONFIG: ${{ inputs.kubeconfig }}
       run: |
-        kubectl wait deployment nginx --for condition=available --timeout=15m
+        kubectl wait deployment nginx --for condition=available --timeout=25m
         worker_count=$(kubectl get nodes -o json --selector='!node-role.kubernetes.io/control-plane' | jq '.items | length')
         if [[ $(( "${{ steps.scaling_limit.outputs.worker_target }}" )) -ne $(( "${worker_count}" )) ]]; then
           echo "::error::Expected worker count ${{ steps.scaling_limit.outputs.worker_target }}, but was ${worker_count}"


### PR DESCRIPTION
### Context
During testing on AWS SNP we can sometimes observe the scaling take longer than 15 mins due to slow setup times of SNP machines. Eventually the scaling works as expected.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Increase timeout for `kubectl wait` command to 25 mins

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
