### PR TITLE
cli: write Terraform migration output directly to `constellation-id.json`

### DIFF
--- a/cli/internal/clusterid/BUILD.bazel
+++ b/cli/internal/clusterid/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//bazel/go:go_test.bzl", "go_test")
 
 go_library(
     name = "clusterid",
@@ -6,4 +7,11 @@ go_library(
     importpath = "github.com/edgelesssys/constellation/v2/cli/internal/clusterid",
     visibility = ["//cli:__subpackages__"],
     deps = ["//internal/cloud/cloudprovider"],
+)
+
+go_test(
+    name = "clusterid_test",
+    srcs = ["id_test.go"],
+    embed = [":clusterid"],
+    deps = ["@com_github_stretchr_testify//require"],
 )

--- a/cli/internal/clusterid/id.go
+++ b/cli/internal/clusterid/id.go
@@ -28,3 +28,38 @@ type File struct {
 	// It is only set if the cluster is created on Azure.
 	AttestationURL string `json:"attestationURL,omitempty"`
 }
+
+// Merge merges the other file into the current file and returns the result.
+// If a field is set in both files, the value of the other file is used.
+// This does in-place changes on the current file.
+func (f *File) Merge(other File) *File {
+	if other.ClusterID != "" {
+		f.ClusterID = other.ClusterID
+	}
+
+	if other.OwnerID != "" {
+		f.OwnerID = other.OwnerID
+	}
+
+	if other.UID != "" {
+		f.UID = other.UID
+	}
+
+	if other.CloudProvider != cloudprovider.Unknown {
+		f.CloudProvider = other.CloudProvider
+	}
+
+	if other.IP != "" {
+		f.IP = other.IP
+	}
+
+	if other.InitSecret != nil {
+		f.InitSecret = other.InitSecret
+	}
+
+	if other.AttestationURL != "" {
+		f.AttestationURL = other.AttestationURL
+	}
+
+	return f
+}

--- a/cli/internal/clusterid/id_test.go
+++ b/cli/internal/clusterid/id_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package clusterid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMerge(t *testing.T) {
+	testCases := map[string]struct {
+		current File
+		other   File
+		want    File
+	}{
+		"empty": {
+			current: File{},
+			other:   File{},
+			want:    File{},
+		},
+		"current empty": {
+			current: File{},
+			other: File{
+				ClusterID: "clusterID",
+			},
+			want: File{
+				ClusterID: "clusterID",
+			},
+		},
+		"other empty": {
+			current: File{
+				ClusterID: "clusterID",
+			},
+			other: File{},
+			want: File{
+				ClusterID: "clusterID",
+			},
+		},
+		"both set": {
+			current: File{
+				ClusterID: "clusterID",
+			},
+			other: File{
+				ClusterID: "otherClusterID",
+			},
+			want: File{
+				ClusterID: "otherClusterID",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		require := require.New(t)
+
+		ret := tc.current.Merge(tc.other)
+		require.Equal(tc.want, *ret)
+	}
+}

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -168,10 +168,9 @@ func (u *upgradeApplyCmd) migrateTerraform(cmd *cobra.Command, file file.Handler
 	u.log.Debugf("Using Terraform variables:\n%v", vars)
 
 	opts := upgrade.TerraformUpgradeOptions{
-		LogLevel:   flags.terraformLogLevel,
-		CSP:        conf.GetProvider(),
-		Vars:       vars,
-		OutputFile: constants.TerraformMigrationOutputFile,
+		LogLevel: flags.terraformLogLevel,
+		CSP:      conf.GetProvider(),
+		Vars:     vars,
 	}
 
 	// Check if there are any Terraform migrations to apply
@@ -202,8 +201,8 @@ func (u *upgradeApplyCmd) migrateTerraform(cmd *cobra.Command, file file.Handler
 			return fmt.Errorf("applying terraform migrations: %w", err)
 		}
 		cmd.Printf("Terraform migrations applied successfully and output written to: %s\n"+
-			"A backup of the pre-upgrade Terraform state has been written to: %s\n",
-			opts.OutputFile, filepath.Join(constants.UpgradeDir, constants.TerraformUpgradeBackupDir))
+			"A backup of the pre-upgrade state has been written to: %s\n",
+			constants.ClusterIDsFileName, filepath.Join(constants.UpgradeDir, constants.TerraformUpgradeBackupDir))
 	} else {
 		u.log.Debugf("No Terraform diff detected")
 	}

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -181,11 +181,11 @@ func (u stubUpgrader) GetClusterAttestationConfig(_ context.Context, _ variant.V
 	return u.currentConfig, &corev1.ConfigMap{}, nil
 }
 
-func (u stubUpgrader) CheckTerraformMigrations(file.Handler) error {
+func (u stubUpgrader) CheckTerraformMigrations() error {
 	return u.checkTerraformErr
 }
 
-func (u stubUpgrader) CleanUpTerraformMigrations(file.Handler) error {
+func (u stubUpgrader) CleanUpTerraformMigrations() error {
 	return u.cleanTerraformErr
 }
 
@@ -193,7 +193,7 @@ func (u stubUpgrader) PlanTerraformMigrations(context.Context, upgrade.Terraform
 	return u.terraformDiff, u.planTerraformErr
 }
 
-func (u stubUpgrader) ApplyTerraformMigrations(context.Context, file.Handler, upgrade.TerraformUpgradeOptions) error {
+func (u stubUpgrader) ApplyTerraformMigrations(context.Context, upgrade.TerraformUpgradeOptions) error {
 	return u.applyTerraformErr
 }
 

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -68,7 +68,7 @@ func runUpgradeCheck(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	checker, err := kubernetes.NewUpgrader(cmd.Context(), cmd.OutOrStdout(), log, kubernetes.UpgradeCmdKindCheck)
+	checker, err := kubernetes.NewUpgrader(cmd.Context(), cmd.OutOrStdout(), fileHandler, log, kubernetes.UpgradeCmdKindCheck)
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,7 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 		u.checker.AddManualStateMigration(migration)
 	}
 
-	if err := u.checker.CheckTerraformMigrations(fileHandler); err != nil {
+	if err := u.checker.CheckTerraformMigrations(); err != nil {
 		return fmt.Errorf("checking workspace: %w", err)
 	}
 
@@ -240,7 +240,7 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 		return fmt.Errorf("planning terraform migrations: %w", err)
 	}
 	defer func() {
-		if err := u.checker.CleanUpTerraformMigrations(fileHandler); err != nil {
+		if err := u.checker.CleanUpTerraformMigrations(); err != nil {
 			u.log.Debugf("Failed to clean up Terraform migrations: %v", err)
 		}
 	}()
@@ -738,8 +738,8 @@ type upgradeChecker interface {
 	CurrentImage(ctx context.Context) (string, error)
 	CurrentKubernetesVersion(ctx context.Context) (string, error)
 	PlanTerraformMigrations(ctx context.Context, opts upgrade.TerraformUpgradeOptions) (bool, error)
-	CheckTerraformMigrations(fileHandler file.Handler) error
-	CleanUpTerraformMigrations(fileHandler file.Handler) error
+	CheckTerraformMigrations() error
+	CleanUpTerraformMigrations() error
 	AddManualStateMigration(migration terraform.StateMigration)
 }
 

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -226,10 +226,9 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 	u.log.Debugf("Using Terraform variables:\n%v", vars)
 
 	opts := upgrade.TerraformUpgradeOptions{
-		LogLevel:   flags.terraformLogLevel,
-		CSP:        conf.GetProvider(),
-		Vars:       vars,
-		OutputFile: constants.TerraformMigrationOutputFile,
+		LogLevel: flags.terraformLogLevel,
+		CSP:      conf.GetProvider(),
+		Vars:     vars,
 	}
 
 	cmd.Println("The following Teraform migrations are available with this CLI:")

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -231,7 +231,7 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 		Vars:     vars,
 	}
 
-	cmd.Println("The following Teraform migrations are available with this CLI:")
+	cmd.Println("The following Terraform migrations are available with this CLI:")
 
 	// Check if there are any Terraform migrations
 	hasDiff, err := u.checker.PlanTerraformMigrations(cmd.Context(), opts)

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -377,11 +377,11 @@ func (u stubUpgradeChecker) PlanTerraformMigrations(context.Context, upgrade.Ter
 	return u.tfDiff, u.err
 }
 
-func (u stubUpgradeChecker) CheckTerraformMigrations(file.Handler) error {
+func (u stubUpgradeChecker) CheckTerraformMigrations() error {
 	return u.err
 }
 
-func (u stubUpgradeChecker) CleanUpTerraformMigrations(file.Handler) error {
+func (u stubUpgradeChecker) CleanUpTerraformMigrations() error {
 	return u.err
 }
 

--- a/cli/internal/upgrade/terraform.go
+++ b/cli/internal/upgrade/terraform.go
@@ -23,11 +23,12 @@ import (
 )
 
 // NewTerraformUpgrader returns a new TerraformUpgrader.
-func NewTerraformUpgrader(tfClient tfClient, outWriter io.Writer) (*TerraformUpgrader, error) {
+func NewTerraformUpgrader(tfClient tfClient, outWriter io.Writer, fileHandler file.Handler) (*TerraformUpgrader, error) {
 	return &TerraformUpgrader{
 		tf:            tfClient,
 		policyPatcher: cloudcmd.NewAzurePolicyPatcher(),
 		outWriter:     outWriter,
+		fileHandler:   fileHandler,
 	}, nil
 }
 
@@ -36,6 +37,7 @@ type TerraformUpgrader struct {
 	tf            tfClient
 	policyPatcher policyPatcher
 	outWriter     io.Writer
+	fileHandler   file.Handler
 }
 
 // TerraformUpgradeOptions are the options used for the Terraform upgrade.
@@ -52,7 +54,7 @@ type TerraformUpgradeOptions struct {
 
 // CheckTerraformMigrations checks whether Terraform migrations are possible in the current workspace.
 // If the files that will be written during the upgrade already exist, it returns an error.
-func (u *TerraformUpgrader) CheckTerraformMigrations(fileHandler file.Handler, upgradeID string) error {
+func (u *TerraformUpgrader) CheckTerraformMigrations(upgradeID string) error {
 	var existingFiles []string
 	filesToCheck := []string{
 		constants.TerraformMigrationOutputFile,
@@ -60,7 +62,7 @@ func (u *TerraformUpgrader) CheckTerraformMigrations(fileHandler file.Handler, u
 	}
 
 	for _, f := range filesToCheck {
-		if err := checkFileExists(fileHandler, &existingFiles, f); err != nil {
+		if err := checkFileExists(u.fileHandler, &existingFiles, f); err != nil {
 			return fmt.Errorf("checking terraform migrations: %w", err)
 		}
 	}
@@ -89,6 +91,7 @@ func checkFileExists(fileHandler file.Handler, existingFiles *[]string, filename
 // If a diff exists, it's being written to the upgrader's output writer. It also returns
 // a bool indicating whether a diff exists.
 func (u *TerraformUpgrader) PlanTerraformMigrations(ctx context.Context, opts TerraformUpgradeOptions, upgradeID string) (bool, error) {
+	// Prepare the new Terraform workspace and backup the old one
 	err := u.tf.PrepareUpgradeWorkspace(
 		filepath.Join("terraform", strings.ToLower(opts.CSP.String())),
 		constants.TerraformWorkingDir,
@@ -98,6 +101,14 @@ func (u *TerraformUpgrader) PlanTerraformMigrations(ctx context.Context, opts Te
 	)
 	if err != nil {
 		return false, fmt.Errorf("preparing terraform workspace: %w", err)
+	}
+
+	// Backup the old constellation-id.json file
+	if err := u.fileHandler.CopyFile(
+		constants.ClusterIDsFileName,
+		filepath.Join(constants.UpgradeDir, upgradeID, constants.ClusterIDsFileName+".old"),
+	); err != nil {
+		return false, fmt.Errorf("backing up %s: %w", constants.ClusterIDsFileName, err)
 	}
 
 	hasDiff, err := u.tf.Plan(ctx, opts.LogLevel, constants.TerraformUpgradePlanFile)
@@ -116,13 +127,13 @@ func (u *TerraformUpgrader) PlanTerraformMigrations(ctx context.Context, opts Te
 
 // CleanUpTerraformMigrations cleans up the Terraform migration workspace, for example when an upgrade is
 // aborted by the user.
-func (u *TerraformUpgrader) CleanUpTerraformMigrations(fileHandler file.Handler, upgradeID string) error {
+func (u *TerraformUpgrader) CleanUpTerraformMigrations(upgradeID string) error {
 	cleanupFiles := []string{
 		filepath.Join(constants.UpgradeDir, upgradeID),
 	}
 
 	for _, f := range cleanupFiles {
-		if err := fileHandler.RemoveAll(f); err != nil {
+		if err := u.fileHandler.RemoveAll(f); err != nil {
 			return fmt.Errorf("cleaning up file %s: %w", f, err)
 		}
 	}
@@ -134,7 +145,7 @@ func (u *TerraformUpgrader) CleanUpTerraformMigrations(fileHandler file.Handler,
 // If PlanTerraformMigrations has not been executed before, it will return an error.
 // In case of a successful upgrade, the output will be written to the specified file and the old Terraform directory is replaced
 // By the new one.
-func (u *TerraformUpgrader) ApplyTerraformMigrations(ctx context.Context, fileHandler file.Handler, opts TerraformUpgradeOptions, upgradeID string) error {
+func (u *TerraformUpgrader) ApplyTerraformMigrations(ctx context.Context, opts TerraformUpgradeOptions, upgradeID string) error {
 	tfOutput, err := u.tf.CreateCluster(ctx, opts.LogLevel)
 	if err != nil {
 		return fmt.Errorf("terraform apply: %w", err)
@@ -155,19 +166,19 @@ func (u *TerraformUpgrader) ApplyTerraformMigrations(ctx context.Context, fileHa
 		AttestationURL: tfOutput.AttestationURL,
 	}
 
-	if err := fileHandler.RemoveAll(constants.TerraformWorkingDir); err != nil {
+	if err := u.fileHandler.RemoveAll(constants.TerraformWorkingDir); err != nil {
 		return fmt.Errorf("removing old terraform directory: %w", err)
 	}
 
-	if err := fileHandler.CopyDir(filepath.Join(constants.UpgradeDir, upgradeID, constants.TerraformUpgradeWorkingDir), constants.TerraformWorkingDir); err != nil {
+	if err := u.fileHandler.CopyDir(filepath.Join(constants.UpgradeDir, upgradeID, constants.TerraformUpgradeWorkingDir), constants.TerraformWorkingDir); err != nil {
 		return fmt.Errorf("replacing old terraform directory with new one: %w", err)
 	}
 
-	if err := fileHandler.RemoveAll(filepath.Join(constants.UpgradeDir, upgradeID, constants.TerraformUpgradeWorkingDir)); err != nil {
+	if err := u.fileHandler.RemoveAll(filepath.Join(constants.UpgradeDir, upgradeID, constants.TerraformUpgradeWorkingDir)); err != nil {
 		return fmt.Errorf("removing terraform upgrade directory: %w", err)
 	}
 
-	if err := fileHandler.WriteJSON(opts.OutputFile, outputFileContents); err != nil {
+	if err := u.fileHandler.WriteJSON(opts.OutputFile, outputFileContents); err != nil {
 		return fmt.Errorf("writing terraform output to file: %w", err)
 	}
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -156,8 +156,6 @@ const (
 	TerraformUpgradeWorkingDir = "terraform"
 	// TerraformUpgradeBackupDir is the directory name being used to backup the pre-upgrade state in an upgrade.
 	TerraformUpgradeBackupDir = "terraform-backup"
-	// TerraformMigrationOutputFile is the file name of the output file created by a successful Terraform migration.
-	TerraformMigrationOutputFile = "terraform-migration-output.json"
 	// UpgradeDir is the name of the directory being used for cluster upgrades.
 	UpgradeDir = "constellation-upgrade"
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Previously, `constellation upgrade` commands that performed Terraform migrations would write their output to a `terraform-migration-output.json` file, which had to be manually merged with `constellation-id.json` to pertain state in one place between multiple updates. If the user failed to do so, upgrading a cluster twice would try to overwrite the existing `terraform-migration-output.json` file and hence fail.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Create a backup of the old `constellation-id.json` before an upgrade.
- Write Terraform migration output directly into `constellation-id.json` by merging Terraform migration output into the old existing file.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- Manual testing on AWS and Azure migrations done, works as expected.
- [e2e test](https://github.com/edgelesssys/constellation/actions/runs/5573453159)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
