### PR TITLE
ci: keep embedded measurements if stable image is used

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -119,7 +119,7 @@ runs:
       if: inputs.fetchMeasurements
       shell: bash
       run: |
-        config fetch-measurements --debug --insecure
+        constellation config fetch-measurements --debug --insecure
 
     - name: Set image
       id: setImage

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -115,13 +115,6 @@ runs:
           yq eval -i "(.kubernetesVersion) = \"${{ inputs.kubernetesVersion }}\"" constellation-conf.yaml
         fi
 
-    - name: Update measurements for non-stable images
-      if: inputs.fetchMeasurements
-      shell: bash
-      run: |
-        constellation config fetch-measurements --debug --insecure
-        cat constellation-conf.yaml
-
     - name: Set image
       id: setImage
       shell: bash
@@ -137,6 +130,12 @@ runs:
 
         yq eval -i "(.image) = \"${imageInput}\"" constellation-conf.yaml
         echo "image=${imageInput}" | tee -a "$GITHUB_OUTPUT"
+
+    - name: Update measurements for non-stable images
+      if: inputs.fetchMeasurements
+      shell: bash
+      run: |
+        constellation config fetch-measurements --debug --insecure
 
     - name: Set instanceType
       if: inputs.machineType && inputs.machineType != 'default'

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -120,6 +120,7 @@ runs:
       shell: bash
       run: |
         constellation config fetch-measurements --debug --insecure
+        cat constellation-conf.yaml
 
     - name: Set image
       id: setImage

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -116,7 +116,7 @@ runs:
         fi
 
     - name: Update measurements for non-stable images
-      if:  inputs.fetchMeasurements
+      if: inputs.fetchMeasurements
       shell: bash
       run: |
         constellation config fetch-measurements

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -119,7 +119,7 @@ runs:
       if: inputs.fetchMeasurements
       shell: bash
       run: |
-        constellation config fetch-measurements
+        config fetch-measurements --debug --insecure
 
     - name: Set image
       id: setImage

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -29,6 +29,9 @@ inputs:
   existingConfig:
     default: "false"
     description: "Use existing config file."
+  fetchMeasurements:
+    default: "false"
+    description: "Update measurements via the 'constellation config fetch-measurements' command."
   #
   # GCP specific inputs
   #
@@ -113,7 +116,7 @@ runs:
         fi
 
     - name: Update measurements for non-stable images
-      if: inputs.isDebugImage == 'true'
+      if:  inputs.fetchMeasurements
       shell: bash
       run: |
         constellation config fetch-measurements

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -26,9 +26,6 @@ inputs:
   artifactNameSuffix:
     description: "Suffix for artifact naming."
     required: true
-  keepMeasurements:
-    default: "false"
-    description: "Keep measurements embedded in the CLI."
   existingConfig:
     default: "false"
     description: "Use existing config file."
@@ -115,52 +112,11 @@ runs:
           yq eval -i "(.kubernetesVersion) = \"${{ inputs.kubernetesVersion }}\"" constellation-conf.yaml
         fi
 
-    - name: Remove embedded measurements
-      if: inputs.keepMeasurements == 'false'
+    - name: Update measurements for non-stable images
+      if: inputs.isDebugImage == 'true'
       shell: bash
       run: |
-        if [[ $(yq '.version' constellation-conf.yaml) == "v2" ]]
-        then
-          yq eval -i \
-            "(.provider | select(. | has(\"aws\")).aws.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
-            constellation-conf.yaml
-
-          yq eval -i \
-            "(.provider | select(. | has(\"azure\")).azure.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
-            constellation-conf.yaml
-
-          yq eval -i \
-            "(.provider | select(. | has(\"gcp\")).gcp.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}"\
-            constellation-conf.yaml
-
-          yq eval -i \
-            "(.provider | select(. | has(\"qemu\")).qemu.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
-            constellation-conf.yaml
-        else
-          yq eval -i \
-            "(.attestation | select(. | has(\"awsNitroTPM\")).awsNitroTPM.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
-            constellation-conf.yaml
-
-          yq eval -i \
-            "(.attestation | select(. | has(\"awsSEVSNP\")).awsSEVSNP.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
-            constellation-conf.yaml
-
-          yq eval -i \
-            "(.attestation | select(. | has(\"azureSEVSNP\")).azureSEVSNP.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
-            constellation-conf.yaml
-
-          yq eval -i \
-            "(.attestation | select(. | has(\"azureTrustedLaunch\")).azureTrustedLaunch.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
-            constellation-conf.yaml
-
-          yq eval -i \
-            "(.attestation | select(. | has(\"gcpSEVES\")).gcpSEVES.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}"\
-            constellation-conf.yaml
-
-          yq eval -i \
-            "(.attestation | select(. | has(\"qemuVTPM\")).qemuVTPM.measurements) = {15:{\"expected\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"warnOnly\":false}}" \
-            constellation-conf.yaml
-        fi
+        constellation config fetch-measurements
 
     - name: Set image
       id: setImage

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -71,7 +71,10 @@ inputs:
   githubToken:
     description: "GitHub authorization token"
     required: true
-
+  fetchMeasurements:
+    default: "false"
+    description: "Update measurements via the 'constellation config fetch-measurements' command."
+    
 outputs:
   kubeconfig:
     description: "The kubeconfig for the cluster."
@@ -236,6 +239,7 @@ runs:
         kubernetesVersion: ${{ inputs.kubernetesVersion }}
         existingConfig: ${{ steps.constellation-iam-create.outputs.existingConfig }}
         artifactNameSuffix: ${{ steps.create-prefix.outputs.prefix }}
+        fetchMeasurements: ${{ inputs.fetchMeasurements }}
 
     #
     # Test payloads

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -29,9 +29,6 @@ inputs:
   kubernetesVersion:
     description: "Kubernetes version to create the cluster from."
     required: false
-  keepMeasurements:
-    default: "false"
-    description: "Keep measurements embedded in the CLI."
   gcpProject:
     description: "The GCP project to deploy Constellation in."
     required: false
@@ -237,7 +234,6 @@ runs:
         osImage: ${{ inputs.osImage }}
         isDebugImage: ${{ inputs.isDebugImage }}
         kubernetesVersion: ${{ inputs.kubernetesVersion }}
-        keepMeasurements: ${{ inputs.keepMeasurements }}
         existingConfig: ${{ steps.constellation-iam-create.outputs.existingConfig }}
         artifactNameSuffix: ${{ steps.create-prefix.outputs.prefix }}
 

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -84,6 +84,7 @@ jobs:
           azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          fetchMeasurements: ${{ matrix.refStream != 'ref/release/stream/stable/?' }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -72,7 +72,6 @@ jobs:
           cloudProvider: ${{ matrix.provider }}
           osImage: ${{ matrix.refStream == 'ref/release/stream/stable/?' && needs.find-latest-image.outputs.image-release-stable || needs.find-latest-image.outputs.image-main-debug }}
           isDebugImage: ${{ matrix.refStream == 'ref/main/stream/debug/?' }}
-          keepMeasurements: ${{ matrix.refStream == 'ref/release/stream/stable/?' }}
           cliVersion: ${{ matrix.refStream == 'ref/release/stream/stable/?' && needs.find-latest-image.outputs.image-release-stable || '' }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcpClusterCreateServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -72,6 +72,7 @@ jobs:
           cloudProvider: ${{ matrix.provider }}
           osImage: ${{ matrix.refStream == 'ref/release/stream/stable/?' && needs.find-latest-image.outputs.image-release-stable || needs.find-latest-image.outputs.image-main-debug }}
           isDebugImage: ${{ matrix.refStream == 'ref/main/stream/debug/?' }}
+          keepMeasurements: ${{ matrix.refStream == 'ref/release/stream/stable/?' }}
           cliVersion: ${{ matrix.refStream == 'ref/release/stream/stable/?' && needs.find-latest-image.outputs.image-release-stable || '' }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcpClusterCreateServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -249,6 +249,7 @@ jobs:
           azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          fetchMeasurements: ${{ matrix.refStream != 'ref/release/stream/stable/?' }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -249,6 +249,7 @@ jobs:
           azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          fetchMeasurements: ${{ contains(needs.find-latest-image.outputs.image, '/stream/stable/') }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -249,7 +249,6 @@ jobs:
           azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          fetchMeasurements: ${{ matrix.refStream != 'ref/release/stream/stable/?' }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -40,11 +40,6 @@ on:
         description: "Kubernetes version to create the cluster from."
         default: "1.26"
         required: true
-      keepMeasurements:
-        description: "Keep measurements embedded in the CLI."
-        type: boolean
-        default: false
-        required: false
       cliVersion:
         description: "Version of a released CLI to download. Leave empty to build the CLI from the checked out ref."
         type: string
@@ -86,10 +81,6 @@ on:
       kubernetesVersion:
         description: "Kubernetes version to create the cluster from."
         type: string
-        required: true
-      keepMeasurements:
-        description: "Keep measurements embedded in the CLI."
-        type: boolean
         required: true
       cliVersion:
         description: "Version of a released CLI to download. Leave empty to build the CLI from the checked out ref."
@@ -247,7 +238,6 @@ jobs:
           gcpInClusterServiceAccountKey: ${{ secrets.GCP_CLUSTER_SERVICE_ACCOUNT }}
           test: ${{ inputs.test }}
           kubernetesVersion: ${{ inputs.kubernetesVersion }}
-          keepMeasurements: ${{ inputs.keepMeasurements }}
           awsOpenSearchDomain: ${{ secrets.AWS_OPENSEARCH_DOMAIN }}
           awsOpenSearchUsers: ${{ secrets.AWS_OPENSEARCH_USER }}
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -204,6 +204,7 @@ jobs:
           azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          fetchMeasurements: ${{ matrix.refStream != 'ref/release/stream/stable/?' }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -204,8 +204,7 @@ jobs:
           azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          fetchMeasurements: ${{ matrix.refStream != 'ref/release/stream/stable/?' }}
-
+          
       - name: Always terminate cluster
         if: always()
         uses: ./.github/actions/constellation_destroy

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -189,7 +189,6 @@ jobs:
           cloudProvider: ${{ matrix.provider }}
           cliVersion: ""
           kubernetesVersion: ${{ matrix.kubernetes-version }}
-          keepMeasurements: "true"
           osImage: ""
           isDebugImage: "false"
           awsOpenSearchDomain: ${{ secrets.AWS_OPENSEARCH_DOMAIN }}

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -204,7 +204,6 @@ jobs:
           azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          
       - name: Always terminate cluster
         if: always()
         uses: ./.github/actions/constellation_destroy

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -207,6 +207,7 @@ jobs:
           azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          fetchMeasurements: ${{ matrix.refStream != 'ref/release/stream/stable/?' }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -155,6 +155,7 @@ jobs:
           azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+          fetchMeasurements: ${{ matrix.refStream != 'ref/release/stream/stable/?' }}
 
       - name: Build CLI
         uses: ./.github/actions/build_cli

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -155,7 +155,6 @@ jobs:
           azureIAMCreateCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          fetchMeasurements: ${{ matrix.refStream != 'ref/release/stream/stable/?' }}
 
       - name: Build CLI
         uses: ./.github/actions/build_cli

--- a/cli/internal/cmd/configfetchmeasurements.go
+++ b/cli/internal/cmd/configfetchmeasurements.go
@@ -153,6 +153,7 @@ func (cfm *configFetchMeasurementsCmd) configFetchMeasurements(
 			conf.GetProvider(),
 			conf.GetAttestationConfig().GetVariant(),
 		)
+		cfm.log.Debugf("Measurements:\n", fetchedMeasurements)
 		if err != nil {
 			return fmt.Errorf("fetching and verifying measurements: %w", err)
 		}

--- a/cli/internal/cmd/configfetchmeasurements.go
+++ b/cli/internal/cmd/configfetchmeasurements.go
@@ -153,7 +153,6 @@ func (cfm *configFetchMeasurementsCmd) configFetchMeasurements(
 			conf.GetProvider(),
 			conf.GetAttestationConfig().GetVariant(),
 		)
-		cfm.log.Debugf("Measurements:\n", fetchedMeasurements)
 		if err != nil {
 			return fmt.Errorf("fetching and verifying measurements: %w", err)
 		}
@@ -165,7 +164,8 @@ func (cfm *configFetchMeasurementsCmd) configFetchMeasurements(
 
 		cfm.log.Debugf("Verified measurements with Rekor")
 	}
-
+	cfm.log.Debugf("Measurements:\n", fetchedMeasurements)
+	
 	cfm.log.Debugf("Updating measurements in configuration")
 	conf.UpdateMeasurements(fetchedMeasurements)
 	if err := fileHandler.WriteYAML(flags.configPath, conf, file.OptOverwrite); err != nil {

--- a/cli/internal/cmd/configfetchmeasurements.go
+++ b/cli/internal/cmd/configfetchmeasurements.go
@@ -165,7 +165,7 @@ func (cfm *configFetchMeasurementsCmd) configFetchMeasurements(
 		cfm.log.Debugf("Verified measurements with Rekor")
 	}
 	cfm.log.Debugf("Measurements:\n", fetchedMeasurements)
-	
+
 	cfm.log.Debugf("Updating measurements in configuration")
 	conf.UpdateMeasurements(fetchedMeasurements)
 	if err := fileHandler.WriteYAML(flags.configPath, conf, file.OptOverwrite); err != nil {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Previously, the daily e2e test would overwrite the CLI's expected PCR values in the `constellation-conf.yml` independent of the image used (i.e. on both debug- and release images). This caused us to notice changes in PCR values of CSPs with a delay.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Keep the CLI's default measurements in the daily e2e test if a stable image is used.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [e2e run prior to this fix](https://github.com/edgelesssys/constellation/actions/runs/5550089676), notice PCR[15] = `000...` even though a stable image is used.
- [e2e run with the fix](https://github.com/edgelesssys/constellation/pull/2109#issue-1807536801) TODO see unpatched PCR values
- [e2e after @malt3 applied his proposed fix](https://github.com/edgelesssys/constellation/actions/runs/5751553291)


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
