### PR TITLE
terraform: allows cluster name length of 10 characters on AWS

### DIFF
--- a/cli/internal/terraform/terraform/aws/variables.tf
+++ b/cli/internal/terraform/terraform/aws/variables.tf
@@ -2,8 +2,8 @@ variable "name" {
   type        = string
   description = "Name of your Constellation"
   validation {
-    condition     = length(var.name) < 10
-    error_message = "The name of the Constellation must be shorter than 10 characters"
+    condition     = length(var.name) <= 10
+    error_message = "The length of the name of the Constellation must be <= 10 characters"
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- terraform: allows cluster name length of 10 characters on AWS

<!-- (uncomment if applicable)
### Related issue
- AB#3281
-->

### Additional info
- I tested this by creating a cluster with a name length of 10 and this works.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
