### PR TITLE
image: always copy amazon ena driver into initrd

### DIFF
--- a/image/mkosi.skeleton/etc/dracut.conf.d/aws.conf
+++ b/image/mkosi.skeleton/etc/dracut.conf.d/aws.conf
@@ -1,0 +1,2 @@
+# add Amazon ena driver to the list of drivers to be loaded
+force_drivers+=" ena "


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

This allows different Kernels to be used for Constellation on EC2. For networking on AWS, the "elastic networking adapter" (ena) driver is required. Fedora's kernel builds with `CONFIG_ENA_ETHERNET=y`, while others have `CONFIG_ENA_ETHERNET=m`. With this setting, support for ena will always be available in the initrd.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- image: always copy amazon ena driver into initrd

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
- [x] [build pipeline](https://github.com/edgelesssys/constellation/actions/runs/5584467277)
