### PR TITLE
cli: set Azure ConfidentialVM option in terraform vars when migrating

### DIFF
--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -257,10 +257,7 @@ func parseTerraformUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher 
 		imageRef = strings.Replace(imageRef, "Versions", "versions", 1)
 
 		vars := &terraform.AzureClusterVariables{
-			Name:                 conf.Name,
-			ResourceGroup:        conf.Provider.Azure.ResourceGroup,
-			UserAssignedIdentity: conf.Provider.Azure.UserAssignedIdentity,
-			ImageID:              imageRef,
+			Name: conf.Name,
 			NodeGroups: map[string]terraform.AzureNodeGroup{
 				"control_plane_default": {
 					Role:         "control-plane",
@@ -275,10 +272,14 @@ func parseTerraformUpgradeVars(cmd *cobra.Command, conf *config.Config, fetcher 
 					DiskType:     conf.Provider.Azure.StateDiskType,
 				},
 			},
-			Location:   conf.Provider.Azure.Location,
-			SecureBoot: conf.Provider.Azure.SecureBoot,
-			CreateMAA:  toPtr(conf.GetAttestationConfig().GetVariant().Equal(variant.AzureSEVSNP{})),
-			Debug:      toPtr(conf.IsDebugCluster()),
+			Location:             conf.Provider.Azure.Location,
+			ImageID:              imageRef,
+			CreateMAA:            toPtr(conf.GetAttestationConfig().GetVariant().Equal(variant.AzureSEVSNP{})),
+			Debug:                toPtr(conf.IsDebugCluster()),
+			ConfidentialVM:       toPtr(conf.GetAttestationConfig().GetVariant().Equal(variant.AzureSEVSNP{})),
+			SecureBoot:           conf.Provider.Azure.SecureBoot,
+			UserAssignedIdentity: conf.Provider.Azure.UserAssignedIdentity,
+			ResourceGroup:        conf.Provider.Azure.ResourceGroup,
 		}
 		return vars, nil
 	case cloudprovider.GCP:


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

The `ConfidentialVM` option was never set when applying terraform migrations, leading to it being default initialized as `false`.
This in turn leads to the upgrade trying to change the settings for node groups on Azure from confidential VMs to non-confidential VMs.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: set Azure ConfidentialVM option in terraform vars when migrating

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [x] Link to Milestone
