### PR TITLE
image: use AWS linux kernel for AWS images to fix deadlock

### DIFF
--- a/image/Makefile
+++ b/image/Makefile
@@ -23,10 +23,12 @@ variants := aws_aws-sev-snp aws_aws-nitro-tpm azure_azure-sev-snp gcp_gcp-sev-es
 certs := $(PKI)/PK.cer $(PKI)/KEK.cer $(PKI)/db.cer
 
 SYSTEMD_FIXED_RPMS := systemd-251.11-2.fc37.x86_64.rpm systemd-libs-251.11-2.fc37.x86_64.rpm systemd-networkd-251.11-2.fc37.x86_64.rpm systemd-pam-251.11-2.fc37.x86_64.rpm systemd-resolved-251.11-2.fc37.x86_64.rpm systemd-udev-251.11-2.fc37.x86_64.rpm
+AWS_FIXED_RPMS := kernel-6.1.34-59.116.amzn2023.x86_64.rpm
 AZURE_FIXED_KERNEL_RPMS := kernel-6.1.18-200.fc37.x86_64.rpm kernel-core-6.1.18-200.fc37.x86_64.rpm kernel-modules-6.1.18-200.fc37.x86_64.rpm
 GCP_FIXED_KERNEL_RPMS := kernel-6.1.18-200.fc37.x86_64.rpm kernel-core-6.1.18-200.fc37.x86_64.rpm kernel-modules-6.1.18-200.fc37.x86_64.rpm
 PREBUILD_RPMS_SYSTEMD := $(addprefix prebuilt/rpms/systemd/,$(SYSTEMD_FIXED_RPMS))
 PREBUILT_RPMS_AZURE := $(addprefix prebuilt/rpms/azure/,$(AZURE_FIXED_KERNEL_RPMS))
+PREBUILT_RPMS_AWS := $(addprefix prebuilt/rpms/aws/,$(AWS_FIXED_RPMS))
 
 .PHONY: all clean inject-bins $(csps) $(variants)
 
@@ -34,7 +36,7 @@ PREBUILT_RPMS_AZURE := $(addprefix prebuilt/rpms/azure/,$(AZURE_FIXED_KERNEL_RPM
 
 all: $(csps)
 
-aws: aws_aws-nitro-tpm
+aws: aws_aws-sev-snp aws_aws-nitro-tpm
 azure: azure_azure-sev-snp
 gcp: gcp_gcp-sev-es gcp_gcp-sev-snp
 openstack: openstack_qemu-vtpm
@@ -46,6 +48,11 @@ prebuilt/rpms/systemd/%.rpm:
 	@echo "Downloading $*"
 	@mkdir -p $(@D)
 	@curl -fsSL -o $@ https://kojipkgs.fedoraproject.org/packages/systemd/251.11/2.fc37/x86_64/$*.rpm
+
+prebuilt/rpms/aws/kernel-6.1.34-59.116.amzn2023.x86_64.rpm:
+	@echo "Downloading $*"
+	@mkdir -p $(@D)
+	@curl -fsSL -o $@ https://cdn.confidential.cloud/constellation/kernel/6.1.34-59.116.amzn2023/kernel-6.1.34-59.116.amzn2023.x86_64.rpm
 
 prebuilt/rpms/azure/%.rpm:
 	@echo "Downloading $*"
@@ -76,7 +83,7 @@ mkosi.output.%/fedora~38/image.raw: inject-bins inject-certs
 	rm -rf .csp/
 	@echo "Image is ready: $@"
 
-inject-bins: $(PREBUILD_RPMS_SYSTEMD) $(PREBUILT_RPMS_AZURE)
+inject-bins: $(PREBUILD_RPMS_SYSTEMD) $(PREBUILT_RPMS_AZURE) $(PREBUILT_RPMS_AWS)
 	mkdir -p $(MKOSI_EXTRA)/usr/bin
 	mkdir -p $(MKOSI_EXTRA)/usr/sbin
 	cp $(UPGRADE_AGENT_BINARY) $(MKOSI_EXTRA)/usr/bin/upgrade-agent

--- a/image/README.md
+++ b/image/README.md
@@ -184,9 +184,9 @@ Warning! Never set `--version` to a value that is already used for a release ima
 - Install `aws` cli (see [here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html))
 - Login to AWS (see [here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-quickstart.html))
 - Choose secure boot PKI public keys (one of `pki_dev`, `pki_test`, `pki_prod`)
-    - `pki_dev` can be used for local image builds
-    - `pki_test` is used by the CI for non-release images
-    - `pki_prod` is used for release images
+  - `pki_dev` can be used for local image builds
+  - `pki_test` is used by the CI for non-release images
+  - `pki_prod` is used for release images
 
 ```sh
 # Warning! Never set `--version` to a value that is already used for a release image.
@@ -202,9 +202,9 @@ bazel run //image/upload -- aws --verbose --raw-image mkosi.output.aws/fedora~38
 - Install `gcloud` and `gsutil` (see [here](https://cloud.google.com/sdk/docs/install))
 - Login to GCP (see [here](https://cloud.google.com/sdk/docs/authorizing))
 - Choose secure boot PKI public keys (one of `pki_dev`, `pki_test`, `pki_prod`)
-    - `pki_dev` can be used for local image builds
-    - `pki_test` is used by the CI for non-release images
-    - `pki_prod` is used for release images
+  - `pki_dev` can be used for local image builds
+  - `pki_test` is used by the CI for non-release images
+  - `pki_prod` is used for release images
 
 ```sh
 export GCP_RAW_IMAGE_PATH=${PWD}/mkosi.output.gcp/fedora~38/image.raw

--- a/image/mkosi.conf.d/mkosi.aws.conf
+++ b/image/mkosi.conf.d/mkosi.aws.conf
@@ -2,6 +2,4 @@
 PathExists=../.csp/aws
 
 [Content]
-Packages=kernel
-         kernel-core
-         kernel-modules
+Packages=prebuilt/rpms/aws/kernel-6.1.34-59.116.amzn2023.x86_64.rpm


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context

Constellation nodes on AWS SEV-SNP frequently get stuck during boot.
They are usually automatically cleaned up and replaced by AWS after a period of 5-10 minutes.
After a lot of testing, our Kernel was deemed to be the problem.

### Proposed change(s)
- Build images using a repackaged AWS Linux Kernel, replacing the upstream Fedora Kernel

### Related issue
- Fixes [AB#3259](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/3259)


### Additional info
This does not seem to fix all problems related to booting SEV-SNP VMs, but it seems to make things a lot more stable.

We'll need a build process for the Kernel.
The standard AWS Linux Kernel (currently `6.1.34-59.116`) does not support dm-verity and has dependencies on packages which aren't actually required.
We have a prebuilt Kernel with the required modules, but in the future we should automate the process of building this Kernel.


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
