### PR TITLE
cli: do not recreate LB IP during 2.9 upgrade on Azure

### DIFF
--- a/cli/internal/terraform/terraform/azure/main.tf
+++ b/cli/internal/terraform/terraform/azure/main.tf
@@ -77,6 +77,10 @@ resource "azurerm_public_ip" "loadbalancer_ip" {
   allocation_method   = "Static"
   sku                 = "Standard"
   tags                = local.tags
+
+  lifecycle {
+    ignore_changes = [name]
+  }
 }
 
 resource "azurerm_public_ip" "nat_gateway_ip" {


### PR DESCRIPTION
### Context
<!-- Please add background information on why this PR is opened. -->
**Azure only:**
When upgrading a cluster from v2.8 to v2.9, that has been created on v2.7 and was upgraded to v2.8, you may be faced with a terraform diff that includes recreating the public IP of the cluster. This would break the cluster. 

This is due to name change of a public IP resource. The name change forces a recreate.
The bug was introduced in v2.8. The migration from v2.7 to v2.8 worked fine because of a bug in our migration code, which was fixed in v2.9. 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add `lifecycle.ignore_changes` to `azurerm_public_ip` resource

### Additional information
- Tested manually on the dogfooding cluster and a fresh Azure cluster.


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
