### PR TITLE
image: synchronize time via ntp

### DIFF
--- a/image/mkosi.skeleton/usr/lib/systemd/system-preset/30-constellation.preset
+++ b/image/mkosi.skeleton/usr/lib/systemd/system-preset/30-constellation.preset
@@ -8,3 +8,4 @@ enable systemd-networkd.socket
 enable systemd-resolved.service
 enable measurements.service
 enable export_constellation_debug.service
+enable systemd-timesyncd

--- a/image/mkosi.skeleton/usr/lib/systemd/timesyncd.conf.d/constellation.conf
+++ b/image/mkosi.skeleton/usr/lib/systemd/timesyncd.conf.d/constellation.conf
@@ -1,0 +1,1 @@
+FallbackNTP=time.google.com time.cloudflare.com time.windows.com time.apple.com time.nist.gov europe.pool.ntp.org 0.rhel.pool.ntp.org 1.rhel.pool.ntp.org 2.rhel.pool.ntp.org 3.rhel.pool.ntp.org


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context

On some hypervisors, the default clock source is not available or not reliable.
To ensure synchronized clocks between all nodes of a Constellation, we enable time synchronization via ntp.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- image: synchronize time via ntp

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [x] Link to Milestone
- [x] [build pipeline](https://github.com/edgelesssys/constellation/actions/runs/5596542586): ref/fix-image-ntp-timesync/stream/debug/v2.10.0-pre.0.20230719074512-226f7b76ee92
