### PR TITLE
cli: unify terraform variable creation

### DIFF
--- a/cli/internal/cloudcmd/BUILD.bazel
+++ b/cli/internal/cloudcmd/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "patch.go",
         "rollback.go",
         "terminate.go",
+        "terraform.go",
         "validators.go",
     ],
     importpath = "github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd",

--- a/cli/internal/cloudcmd/create.go
+++ b/cli/internal/cloudcmd/create.go
@@ -117,7 +117,7 @@ func (c *Creator) Create(ctx context.Context, opts CreateOptions) (clusterid.Fil
 	}
 
 	return clusterid.File{
-		CloudProvider:  cloudprovider.Azure,
+		CloudProvider:  opts.Provider,
 		IP:             tfOutput.IP,
 		InitSecret:     []byte(tfOutput.Secret),
 		UID:            tfOutput.UID,

--- a/cli/internal/cloudcmd/create_test.go
+++ b/cli/internal/cloudcmd/create_test.go
@@ -188,6 +188,7 @@ func TestCreator(t *testing.T) {
 			wantErr:               true,
 		},
 		"unknown provider": {
+			tfClient: &stubTerraformClient{},
 			provider: cloudprovider.Unknown,
 			config:   config.Default(),
 			wantErr:  true,

--- a/cli/internal/cloudcmd/create_test.go
+++ b/cli/internal/cloudcmd/create_test.go
@@ -257,43 +257,43 @@ func (s stubPolicyPatcher) Patch(_ context.Context, _ string) error {
 
 func TestNormalizeAzureURIs(t *testing.T) {
 	testCases := map[string]struct {
-		in   terraform.AzureClusterVariables
-		want terraform.AzureClusterVariables
+		in   *terraform.AzureClusterVariables
+		want *terraform.AzureClusterVariables
 	}{
 		"empty": {
-			in:   terraform.AzureClusterVariables{},
-			want: terraform.AzureClusterVariables{},
+			in:   &terraform.AzureClusterVariables{},
+			want: &terraform.AzureClusterVariables{},
 		},
 		"no change": {
-			in: terraform.AzureClusterVariables{
+			in: &terraform.AzureClusterVariables{
 				ImageID: "/communityGalleries/foo/images/constellation/versions/2.1.0",
 			},
-			want: terraform.AzureClusterVariables{
+			want: &terraform.AzureClusterVariables{
 				ImageID: "/communityGalleries/foo/images/constellation/versions/2.1.0",
 			},
 		},
 		"fix image id": {
-			in: terraform.AzureClusterVariables{
+			in: &terraform.AzureClusterVariables{
 				ImageID: "/CommunityGalleries/foo/Images/constellation/Versions/2.1.0",
 			},
-			want: terraform.AzureClusterVariables{
+			want: &terraform.AzureClusterVariables{
 				ImageID: "/communityGalleries/foo/images/constellation/versions/2.1.0",
 			},
 		},
 		"fix resource group": {
-			in: terraform.AzureClusterVariables{
+			in: &terraform.AzureClusterVariables{
 				UserAssignedIdentity: "/subscriptions/foo/resourcegroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uai",
 			},
-			want: terraform.AzureClusterVariables{
+			want: &terraform.AzureClusterVariables{
 				UserAssignedIdentity: "/subscriptions/foo/resourceGroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uai",
 			},
 		},
 		"fix arbitrary casing": {
-			in: terraform.AzureClusterVariables{
+			in: &terraform.AzureClusterVariables{
 				ImageID:              "/CoMMUnitygaLLeries/foo/iMAges/constellation/vERsions/2.1.0",
 				UserAssignedIdentity: "/subsCRiptions/foo/resoURCegroups/test/proViDers/MICROsoft.mANAgedIdentity/USerASsignediDENtities/uai",
 			},
-			want: terraform.AzureClusterVariables{
+			want: &terraform.AzureClusterVariables{
 				ImageID:              "/communityGalleries/foo/images/constellation/versions/2.1.0",
 				UserAssignedIdentity: "/subscriptions/foo/resourceGroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uai",
 			},

--- a/cli/internal/cloudcmd/terraform.go
+++ b/cli/internal/cloudcmd/terraform.go
@@ -1,0 +1,210 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package cloudcmd
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
+	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
+	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
+	"github.com/edgelesssys/constellation/v2/internal/config"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
+	"github.com/edgelesssys/constellation/v2/internal/role"
+)
+
+// TerraformUpgradeVars returns variables required to execute the Terraform scripts.
+func TerraformUpgradeVars(ctx context.Context, conf *config.Config, imageRef string) (terraform.Variables, error) {
+	switch conf.GetProvider() {
+	case cloudprovider.AWS:
+		vars := awsTerraformVars(conf, imageRef, nil, nil)
+		return vars, nil
+	case cloudprovider.Azure:
+		vars := azureTerraformVars(conf, imageRef, nil, nil)
+		return vars, nil
+	case cloudprovider.GCP:
+		vars := gcpTerraformVars(conf, imageRef, nil, nil)
+		return vars, nil
+	default:
+		return nil, fmt.Errorf("unsupported provider: %s", conf.GetProvider())
+	}
+}
+
+// awsTerraformVars provides variables required to execute the Terraform scripts.
+// It should be the only place to declare the AWS variables.
+func awsTerraformVars(conf *config.Config, imageRef string, controlPlaneCount, workerCount *int) *terraform.AWSClusterVariables {
+	return &terraform.AWSClusterVariables{
+		Name: conf.Name,
+		NodeGroups: map[string]terraform.AWSNodeGroup{
+			constants.ControlPlaneDefault: {
+				Role:            role.ControlPlane.TFString(),
+				StateDiskSizeGB: conf.StateDiskSizeGB,
+				InitialCount:    controlPlaneCount,
+				Zone:            conf.Provider.AWS.Zone,
+				InstanceType:    conf.Provider.AWS.InstanceType,
+				DiskType:        conf.Provider.AWS.StateDiskType,
+			},
+			constants.WorkerDefault: {
+				Role:            role.Worker.TFString(),
+				StateDiskSizeGB: conf.StateDiskSizeGB,
+				InitialCount:    workerCount,
+				Zone:            conf.Provider.AWS.Zone,
+				InstanceType:    conf.Provider.AWS.InstanceType,
+				DiskType:        conf.Provider.AWS.StateDiskType,
+			},
+		},
+		Region:                 conf.Provider.AWS.Region,
+		Zone:                   conf.Provider.AWS.Zone,
+		AMIImageID:             imageRef,
+		IAMProfileControlPlane: conf.Provider.AWS.IAMProfileControlPlane,
+		IAMProfileWorkerNodes:  conf.Provider.AWS.IAMProfileWorkerNodes,
+		Debug:                  conf.IsDebugCluster(),
+		EnableSNP:              conf.GetAttestationConfig().GetVariant().Equal(variant.AWSSEVSNP{}),
+	}
+}
+
+// azureTerraformVars provides variables required to execute the Terraform scripts.
+// It should be the only place to declare the Azure variables.
+func azureTerraformVars(conf *config.Config, imageRef string, controlPlaneCount, workerCount *int) *terraform.AzureClusterVariables {
+	vars := &terraform.AzureClusterVariables{
+		Name: conf.Name,
+		NodeGroups: map[string]terraform.AzureNodeGroup{
+			constants.ControlPlaneDefault: {
+				Role:         "control-plane",
+				InitialCount: controlPlaneCount,
+				InstanceType: conf.Provider.Azure.InstanceType,
+				DiskSizeGB:   conf.StateDiskSizeGB,
+				DiskType:     conf.Provider.Azure.StateDiskType,
+				Zones:        nil, // TODO(elchead): support zones AB#3225. check if lifecycle arg is required.
+			},
+			constants.WorkerDefault: {
+				Role:         "worker",
+				InitialCount: workerCount,
+				InstanceType: conf.Provider.Azure.InstanceType,
+				DiskSizeGB:   conf.StateDiskSizeGB,
+				DiskType:     conf.Provider.Azure.StateDiskType,
+				Zones:        nil,
+			},
+		},
+		Location:             conf.Provider.Azure.Location,
+		ImageID:              imageRef,
+		CreateMAA:            toPtr(conf.GetAttestationConfig().GetVariant().Equal(variant.AzureSEVSNP{})),
+		Debug:                toPtr(conf.IsDebugCluster()),
+		ConfidentialVM:       toPtr(conf.GetAttestationConfig().GetVariant().Equal(variant.AzureSEVSNP{})),
+		SecureBoot:           conf.Provider.Azure.SecureBoot,
+		UserAssignedIdentity: conf.Provider.Azure.UserAssignedIdentity,
+		ResourceGroup:        conf.Provider.Azure.ResourceGroup,
+	}
+
+	vars = normalizeAzureURIs(vars)
+	return vars
+}
+
+// gcpTerraformVars provides variables required to execute the Terraform scripts.
+// It should be the only place to declare the GCP variables.
+func gcpTerraformVars(conf *config.Config, imageRef string, controlPlaneCount, workerCount *int) *terraform.GCPClusterVariables {
+	return &terraform.GCPClusterVariables{
+		Name: conf.Name,
+		NodeGroups: map[string]terraform.GCPNodeGroup{
+			constants.ControlPlaneDefault: {
+				Role:            role.ControlPlane.TFString(),
+				StateDiskSizeGB: conf.StateDiskSizeGB,
+				InitialCount:    controlPlaneCount,
+				Zone:            conf.Provider.GCP.Zone,
+				InstanceType:    conf.Provider.GCP.InstanceType,
+				DiskType:        conf.Provider.GCP.StateDiskType,
+			},
+			constants.WorkerDefault: {
+				Role:            role.Worker.TFString(),
+				StateDiskSizeGB: conf.StateDiskSizeGB,
+				InitialCount:    workerCount,
+				Zone:            conf.Provider.GCP.Zone,
+				InstanceType:    conf.Provider.GCP.InstanceType,
+				DiskType:        conf.Provider.GCP.StateDiskType,
+			},
+		},
+		Project: conf.Provider.GCP.Project,
+		Region:  conf.Provider.GCP.Region,
+		Zone:    conf.Provider.GCP.Zone,
+		ImageID: imageRef,
+		Debug:   conf.IsDebugCluster(),
+	}
+}
+
+// openStackTerraformVars provides variables required to execute the Terraform scripts.
+// It should be the only place to declare the OpenStack variables.
+func openStackTerraformVars(conf *config.Config, imageRef string, controlPlaneCount, workerCount *int) *terraform.OpenStackClusterVariables {
+	return &terraform.OpenStackClusterVariables{
+		Name:                    conf.Name,
+		Cloud:                   toPtr(conf.Provider.OpenStack.Cloud),
+		FlavorID:                conf.Provider.OpenStack.FlavorID,
+		FloatingIPPoolID:        conf.Provider.OpenStack.FloatingIPPoolID,
+		ImageURL:                imageRef,
+		DirectDownload:          *conf.Provider.OpenStack.DirectDownload,
+		OpenstackUserDomainName: conf.Provider.OpenStack.UserDomainName,
+		OpenstackUsername:       conf.Provider.OpenStack.Username,
+		OpenstackPassword:       conf.Provider.OpenStack.Password,
+		Debug:                   conf.IsDebugCluster(),
+		NodeGroups: map[string]terraform.OpenStackNodeGroup{
+			constants.ControlPlaneDefault: {
+				Role:            role.ControlPlane.TFString(),
+				InitialCount:    controlPlaneCount,
+				Zone:            conf.Provider.OpenStack.AvailabilityZone, // TODO(elchead): make configurable AB#3225
+				StateDiskType:   conf.Provider.OpenStack.StateDiskType,
+				StateDiskSizeGB: conf.StateDiskSizeGB,
+			},
+			constants.WorkerDefault: {
+				Role:            role.Worker.TFString(),
+				InitialCount:    workerCount,
+				Zone:            conf.Provider.OpenStack.AvailabilityZone, // TODO(elchead): make configurable AB#3225
+				StateDiskType:   conf.Provider.OpenStack.StateDiskType,
+				StateDiskSizeGB: conf.StateDiskSizeGB,
+			},
+		},
+	}
+}
+
+// qemuTerraformVars provides variables required to execute the Terraform scripts.
+// It should be the only place to declare the QEMU variables.
+func qemuTerraformVars(conf *config.Config, imageRef string, controlPlaneCount, workerCount *int, libvirtURI, libvirtSocketPath, metadataLibvirtURI string) *terraform.QEMUVariables {
+	return &terraform.QEMUVariables{
+		Name:              conf.Name,
+		LibvirtURI:        libvirtURI,
+		LibvirtSocketPath: libvirtSocketPath,
+		// TODO(malt3): auto select boot mode based on attestation variant.
+		// requires image info v2.
+		BootMode:    "uefi",
+		ImagePath:   imageRef,
+		ImageFormat: conf.Provider.QEMU.ImageFormat,
+		NodeGroups: map[string]terraform.QEMUNodeGroup{
+			constants.ControlPlaneDefault: {
+				Role:         role.ControlPlane.TFString(),
+				InitialCount: controlPlaneCount,
+				DiskSize:     conf.StateDiskSizeGB,
+				CPUCount:     conf.Provider.QEMU.VCPUs,
+				MemorySize:   conf.Provider.QEMU.Memory,
+			},
+			constants.WorkerDefault: {
+				Role:         role.Worker.TFString(),
+				InitialCount: workerCount,
+				DiskSize:     conf.StateDiskSizeGB,
+				CPUCount:     conf.Provider.QEMU.VCPUs,
+				MemorySize:   conf.Provider.QEMU.Memory,
+			},
+		},
+		Machine:            "q35", // TODO(elchead): make configurable AB#3225
+		MetadataAPIImage:   conf.Provider.QEMU.MetadataAPIImage,
+		MetadataLibvirtURI: metadataLibvirtURI,
+		NVRAM:              conf.Provider.QEMU.NVRAM,
+		// TODO(malt3) enable once we have a way to auto-select values for these
+		// requires image info v2.
+		// BzImagePath:        placeholder,
+		// InitrdPath:         placeholder,
+		// KernelCmdline:      placeholder,
+	}
+}

--- a/cli/internal/cloudcmd/terraform.go
+++ b/cli/internal/cloudcmd/terraform.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package cloudcmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
@@ -19,7 +18,7 @@ import (
 )
 
 // TerraformUpgradeVars returns variables required to execute the Terraform scripts.
-func TerraformUpgradeVars(ctx context.Context, conf *config.Config, imageRef string) (terraform.Variables, error) {
+func TerraformUpgradeVars(conf *config.Config, imageRef string) (terraform.Variables, error) {
 	switch conf.GetProvider() {
 	case cloudprovider.AWS:
 		vars := awsTerraformVars(conf, imageRef, nil, nil)

--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -76,7 +76,6 @@ go_library(
         "//internal/license",
         "//internal/logger",
         "//internal/retry",
-        "//internal/role",
         "//internal/semver",
         "//internal/sigstore",
         "//internal/versions",

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -173,7 +173,7 @@ func (u *upgradeApplyCmd) migrateTerraform(cmd *cobra.Command, fetcher imageFetc
 		return fmt.Errorf("fetching image reference: %w", err)
 	}
 
-	vars, err := cloudcmd.TerraformUpgradeVars(cmd.Context(), conf, imageRef)
+	vars, err := cloudcmd.TerraformUpgradeVars(conf, imageRef)
 	if err != nil {
 		return fmt.Errorf("parsing upgrade variables: %w", err)
 	}
@@ -356,8 +356,4 @@ type cloudUpgrader interface {
 	CheckTerraformMigrations() error
 	CleanUpTerraformMigrations() error
 	AddManualStateMigration(migration terraform.StateMigration)
-}
-
-func toPtr[T any](v T) *T {
-	return &v
 }

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
 	"github.com/edgelesssys/constellation/v2/cli/internal/featureset"
 	"github.com/edgelesssys/constellation/v2/cli/internal/helm"
 	"github.com/edgelesssys/constellation/v2/cli/internal/kubernetes"
@@ -219,7 +220,12 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 		return fmt.Errorf("checking workspace: %w", err)
 	}
 
-	vars, err := parseTerraformUpgradeVars(cmd, conf, u.imagefetcher)
+	imageRef, err := getImage(cmd.Context(), conf, u.imagefetcher)
+	if err != nil {
+		return fmt.Errorf("fetching image reference: %w", err)
+	}
+
+	vars, err := cloudcmd.TerraformUpgradeVars(cmd.Context(), conf, imageRef)
 	if err != nil {
 		return fmt.Errorf("parsing upgrade variables: %w", err)
 	}

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -225,7 +225,7 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 		return fmt.Errorf("fetching image reference: %w", err)
 	}
 
-	vars, err := cloudcmd.TerraformUpgradeVars(cmd.Context(), conf, imageRef)
+	vars, err := cloudcmd.TerraformUpgradeVars(conf, imageRef)
 	if err != nil {
 		return fmt.Errorf("parsing upgrade variables: %w", err)
 	}

--- a/cli/internal/terraform/variables.go
+++ b/cli/internal/terraform/variables.go
@@ -75,8 +75,17 @@ type AWSClusterVariables struct {
 	NodeGroups map[string]AWSNodeGroup `hcl:"node_groups" cty:"node_groups"`
 }
 
+// GetCreateMAA gets the CreateMAA variable.
+// TODO (derpsteb): Rename this function once we have introduced an interface for config.Config.
 func (a *AWSClusterVariables) GetCreateMAA() *bool {
 	return nil
+}
+
+// String returns a string representation of the variables, formatted as Terraform variables.
+func (a *AWSClusterVariables) String() string {
+	f := hclwrite.NewEmptyFile()
+	gohcl.EncodeIntoBody(a, f.Body())
+	return string(f.Bytes())
 }
 
 // AWSNodeGroup is a node group to create on AWS.
@@ -94,12 +103,6 @@ type AWSNodeGroup struct {
 	InstanceType string `hcl:"instance_type" cty:"instance_type"`
 	// DiskType is the EBS disk type to use for the state disk.
 	DiskType string `hcl:"disk_type" cty:"disk_type"`
-}
-
-func (v *AWSClusterVariables) String() string {
-	f := hclwrite.NewEmptyFile()
-	gohcl.EncodeIntoBody(v, f.Body())
-	return string(f.Bytes())
 }
 
 // AWSIAMVariables is user configuration for creating the IAM configuration with Terraform on Microsoft Azure.
@@ -137,8 +140,17 @@ type GCPClusterVariables struct {
 	NodeGroups map[string]GCPNodeGroup `hcl:"node_groups" cty:"node_groups"`
 }
 
+// GetCreateMAA gets the CreateMAA variable.
+// TODO (derpsteb): Rename this function once we have introduced an interface for config.Config.
 func (g *GCPClusterVariables) GetCreateMAA() *bool {
 	return nil
+}
+
+// String returns a string representation of the variables, formatted as Terraform variables.
+func (g *GCPClusterVariables) String() string {
+	f := hclwrite.NewEmptyFile()
+	gohcl.EncodeIntoBody(g, f.Body())
+	return string(f.Bytes())
 }
 
 // GCPNodeGroup is a node group to create on GCP.
@@ -153,13 +165,6 @@ type GCPNodeGroup struct {
 	Zone         string `hcl:"zone" cty:"zone"`
 	InstanceType string `hcl:"instance_type" cty:"instance_type"`
 	DiskType     string `hcl:"disk_type" cty:"disk_type"`
-}
-
-// String returns a string representation of the variables, formatted as Terraform variables.
-func (v *GCPClusterVariables) String() string {
-	f := hclwrite.NewEmptyFile()
-	gohcl.EncodeIntoBody(v, f.Body())
-	return string(f.Bytes())
 }
 
 // GCPIAMVariables is user configuration for creating the IAM confioguration with Terraform on GCP.
@@ -209,14 +214,16 @@ type AzureClusterVariables struct {
 	NodeGroups map[string]AzureNodeGroup `hcl:"node_groups" cty:"node_groups"`
 }
 
+// GetCreateMAA gets the CreateMAA variable.
+// TODO (derpsteb): Rename this function once we have introduced an interface for config.Config.
 func (a *AzureClusterVariables) GetCreateMAA() *bool {
 	return a.CreateMAA
 }
 
 // String returns a string representation of the variables, formatted as Terraform variables.
-func (v *AzureClusterVariables) String() string {
+func (a *AzureClusterVariables) String() string {
 	f := hclwrite.NewEmptyFile()
-	gohcl.EncodeIntoBody(v, f.Body())
+	gohcl.EncodeIntoBody(a, f.Body())
 	return string(f.Bytes())
 }
 
@@ -278,8 +285,17 @@ type OpenStackClusterVariables struct {
 	Debug bool `hcl:"debug" cty:"debug"`
 }
 
+// GetCreateMAA gets the CreateMAA variable.
+// TODO (derpsteb): Rename this function once we have introduced an interface for config.Config.
 func (o *OpenStackClusterVariables) GetCreateMAA() *bool {
 	return nil
+}
+
+// String returns a string representation of the variables, formatted as Terraform variables.
+func (o *OpenStackClusterVariables) String() string {
+	f := hclwrite.NewEmptyFile()
+	gohcl.EncodeIntoBody(o, f.Body())
+	return string(f.Bytes())
 }
 
 // OpenStackNodeGroup is a node group to create on OpenStack.
@@ -295,13 +311,6 @@ type OpenStackNodeGroup struct {
 	StateDiskType string `hcl:"state_disk_type" cty:"state_disk_type"`
 	// StateDiskSizeGB is the size of the state disk to allocate to each node, in GB.
 	StateDiskSizeGB int `hcl:"state_disk_size" cty:"state_disk_size"`
-}
-
-// String returns a string representation of the variables, formatted as Terraform variables.
-func (v *OpenStackClusterVariables) String() string {
-	f := hclwrite.NewEmptyFile()
-	gohcl.EncodeIntoBody(v, f.Body())
-	return string(f.Bytes())
 }
 
 // TODO(malt3): Add support for OpenStack IAM variables.
@@ -343,14 +352,16 @@ type QEMUVariables struct {
 	KernelCmdline *string `hcl:"constellation_cmdline" cty:"constellation_cmdline"`
 }
 
+// GetCreateMAA gets the CreateMAA variable.
+// TODO (derpsteb): Rename this function once we have introduced an interface for config.Config.
 func (q *QEMUVariables) GetCreateMAA() *bool {
 	return nil
 }
 
 // String returns a string representation of the variables, formatted as Terraform variables.
-func (v *QEMUVariables) String() string {
+func (q *QEMUVariables) String() string {
 	// copy v object
-	vCopy := *v
+	vCopy := *q
 	switch vCopy.NVRAM {
 	case "production":
 		vCopy.NVRAM = "/usr/share/OVMF/constellation_vars.production.fd"

--- a/cli/internal/terraform/variables.go
+++ b/cli/internal/terraform/variables.go
@@ -27,7 +27,7 @@ type ClusterVariables interface {
 	// There are functions creating Variables objects outside of this package.
 	// These functions can only be moved into this package once we have introduced an interface for config.Config,
 	// since we do not want to introduce a dependency on config.Config in this package.
-	GetCreateMAA() *bool
+	GetCreateMAA() bool
 }
 
 // CommonVariables is user configuration for creating a cluster with Terraform.
@@ -77,8 +77,8 @@ type AWSClusterVariables struct {
 
 // GetCreateMAA gets the CreateMAA variable.
 // TODO (derpsteb): Rename this function once we have introduced an interface for config.Config.
-func (a *AWSClusterVariables) GetCreateMAA() *bool {
-	return nil
+func (a *AWSClusterVariables) GetCreateMAA() bool {
+	return false
 }
 
 // String returns a string representation of the variables, formatted as Terraform variables.
@@ -142,8 +142,8 @@ type GCPClusterVariables struct {
 
 // GetCreateMAA gets the CreateMAA variable.
 // TODO (derpsteb): Rename this function once we have introduced an interface for config.Config.
-func (g *GCPClusterVariables) GetCreateMAA() *bool {
-	return nil
+func (g *GCPClusterVariables) GetCreateMAA() bool {
+	return false
 }
 
 // String returns a string representation of the variables, formatted as Terraform variables.
@@ -216,8 +216,12 @@ type AzureClusterVariables struct {
 
 // GetCreateMAA gets the CreateMAA variable.
 // TODO (derpsteb): Rename this function once we have introduced an interface for config.Config.
-func (a *AzureClusterVariables) GetCreateMAA() *bool {
-	return a.CreateMAA
+func (a *AzureClusterVariables) GetCreateMAA() bool {
+	if a.CreateMAA == nil {
+		return false
+	}
+
+	return *a.CreateMAA
 }
 
 // String returns a string representation of the variables, formatted as Terraform variables.
@@ -287,8 +291,8 @@ type OpenStackClusterVariables struct {
 
 // GetCreateMAA gets the CreateMAA variable.
 // TODO (derpsteb): Rename this function once we have introduced an interface for config.Config.
-func (o *OpenStackClusterVariables) GetCreateMAA() *bool {
-	return nil
+func (o *OpenStackClusterVariables) GetCreateMAA() bool {
+	return false
 }
 
 // String returns a string representation of the variables, formatted as Terraform variables.
@@ -354,8 +358,8 @@ type QEMUVariables struct {
 
 // GetCreateMAA gets the CreateMAA variable.
 // TODO (derpsteb): Rename this function once we have introduced an interface for config.Config.
-func (q *QEMUVariables) GetCreateMAA() *bool {
-	return nil
+func (q *QEMUVariables) GetCreateMAA() bool {
+	return false
 }
 
 // String returns a string representation of the variables, formatted as Terraform variables.

--- a/cli/internal/terraform/variables_test.go
+++ b/cli/internal/terraform/variables_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/role"
 	"github.com/stretchr/testify/assert"
 )
@@ -18,18 +19,18 @@ func TestAWSClusterVariables(t *testing.T) {
 	vars := AWSClusterVariables{
 		Name: "cluster-name",
 		NodeGroups: map[string]AWSNodeGroup{
-			"control_plane_default": {
+			constants.ControlPlaneDefault: {
 				Role:            role.ControlPlane.TFString(),
 				StateDiskSizeGB: 30,
-				InitialCount:    1,
+				InitialCount:    toPtr(1),
 				Zone:            "eu-central-1b",
 				InstanceType:    "x1.foo",
 				DiskType:        "foodisk",
 			},
-			"worker_default": {
+			constants.WorkerDefault: {
 				Role:            role.Worker.TFString(),
 				StateDiskSizeGB: 30,
-				InitialCount:    2,
+				InitialCount:    toPtr(2),
 				Zone:            "eu-central-1c",
 				InstanceType:    "x1.bar",
 				DiskType:        "bardisk",
@@ -99,18 +100,18 @@ func TestGCPClusterVariables(t *testing.T) {
 		ImageID: "image-0123456789abcdef",
 		Debug:   true,
 		NodeGroups: map[string]GCPNodeGroup{
-			"control_plane_default": {
+			constants.ControlPlaneDefault: {
 				Role:            "control-plane",
 				StateDiskSizeGB: 30,
-				InitialCount:    1,
+				InitialCount:    toPtr(1),
 				Zone:            "eu-central-1a",
 				InstanceType:    "n2d-standard-4",
 				DiskType:        "pd-ssd",
 			},
-			"worker_default": {
+			constants.WorkerDefault: {
 				Role:            "worker",
 				StateDiskSizeGB: 10,
-				InitialCount:    1,
+				InitialCount:    toPtr(1),
 				Zone:            "eu-central-1b",
 				InstanceType:    "n2d-standard-8",
 				DiskType:        "pd-ssd",
@@ -170,7 +171,7 @@ func TestAzureClusterVariables(t *testing.T) {
 	vars := AzureClusterVariables{
 		Name: "cluster-name",
 		NodeGroups: map[string]AzureNodeGroup{
-			"control_plane_default": {
+			constants.ControlPlaneDefault: {
 				Role:         "ControlPlane",
 				InitialCount: to.Ptr(1),
 				InstanceType: "Standard_D2s_v3",
@@ -240,9 +241,9 @@ func TestOpenStackClusterVariables(t *testing.T) {
 		OpenstackPassword:       "my-password",
 		Debug:                   true,
 		NodeGroups: map[string]OpenStackNodeGroup{
-			"control_plane_default": {
+			constants.ControlPlaneDefault: {
 				Role:            "control-plane",
-				InitialCount:    1,
+				InitialCount:    toPtr(1),
 				Zone:            "az-01",
 				StateDiskType:   "performance-8",
 				StateDiskSizeGB: 30,
@@ -281,7 +282,7 @@ func TestQEMUClusterVariables(t *testing.T) {
 		NodeGroups: map[string]QEMUNodeGroup{
 			"control-plane": {
 				Role:         role.ControlPlane.TFString(),
-				InitialCount: 1,
+				InitialCount: toPtr(1),
 				DiskSize:     30,
 				CPUCount:     4,
 				MemorySize:   8192,
@@ -325,8 +326,4 @@ constellation_cmdline   = "console=ttyS0,115200n8"
 `
 	got := vars.String()
 	assert.Equal(t, want, got)
-}
-
-func toPtr[T any](v T) *T {
-	return &v
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -158,6 +158,10 @@ const (
 	TerraformUpgradeBackupDir = "terraform-backup"
 	// UpgradeDir is the name of the directory being used for cluster upgrades.
 	UpgradeDir = "constellation-upgrade"
+	// ControlPlaneDefault is the name of the default control plane worker group.
+	ControlPlaneDefault = "control_plane_default"
+	// WorkerDefault is the name of the default worker group.
+	WorkerDefault = "worker_default"
 
 	//
 	// Kubernetes.

--- a/operators/constellation-node-operator/internal/cloud/aws/client/BUILD.bazel
+++ b/operators/constellation-node-operator/internal/cloud/aws/client/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/internal/cloud/aws/client",
     visibility = ["//operators/constellation-node-operator:__subpackages__"],
     deps = [
+        "//internal/constants",
         "//operators/constellation-node-operator/api/v1alpha1",
         "//operators/constellation-node-operator/internal/cloud/api",
         "@com_github_aws_aws_sdk_go_v2_config//:config",
@@ -36,6 +37,7 @@ go_test(
     ],
     embed = [":client"],
     deps = [
+        "//internal/constants",
         "//operators/constellation-node-operator/api/v1alpha1",
         "//operators/constellation-node-operator/internal/cloud/api",
         "@com_github_aws_aws_sdk_go_v2_service_autoscaling//:autoscaling",

--- a/operators/constellation-node-operator/internal/cloud/aws/client/scalinggroup.go
+++ b/operators/constellation-node-operator/internal/cloud/aws/client/scalinggroup.go
@@ -16,6 +16,7 @@ import (
 	scalingtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 	updatev1alpha1 "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/api/v1alpha1"
 	cspapi "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/internal/cloud/api"
 )
@@ -185,9 +186,9 @@ func (c *Client) ListScalingGroups(ctx context.Context, uid string) ([]cspapi.Sc
 		if nodeGroupName == "" {
 			switch role {
 			case updatev1alpha1.ControlPlaneRole:
-				nodeGroupName = "control_plane_default"
+				nodeGroupName = constants.ControlPlaneDefault
 			case updatev1alpha1.WorkerRole:
-				nodeGroupName = "worker_default"
+				nodeGroupName = constants.WorkerDefault
 			}
 		}
 

--- a/operators/constellation-node-operator/internal/cloud/aws/client/scalinggroup_test.go
+++ b/operators/constellation-node-operator/internal/cloud/aws/client/scalinggroup_test.go
@@ -14,6 +14,7 @@ import (
 	scalingtypes "github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 	cspapi "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/internal/cloud/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -279,14 +280,14 @@ func TestListScalingGroups(t *testing.T) {
 			wantGroups: []cspapi.ScalingGroup{
 				{
 					Name:                 "control-plane-asg",
-					NodeGroupName:        "control_plane_default",
+					NodeGroupName:        constants.ControlPlaneDefault,
 					GroupID:              "control-plane-asg",
 					AutoscalingGroupName: "control-plane-asg",
 					Role:                 "ControlPlane",
 				},
 				{
 					Name:                 "worker-asg",
-					NodeGroupName:        "worker_default",
+					NodeGroupName:        constants.WorkerDefault,
 					GroupID:              "worker-asg",
 					AutoscalingGroupName: "worker-asg",
 					Role:                 "Worker",

--- a/operators/constellation-node-operator/internal/cloud/azure/client/BUILD.bazel
+++ b/operators/constellation-node-operator/internal/cloud/azure/client/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
     importpath = "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/internal/cloud/azure/client",
     visibility = ["//operators/constellation-node-operator:__subpackages__"],
     deps = [
+        "//internal/constants",
         "//operators/constellation-node-operator/api/v1alpha1",
         "//operators/constellation-node-operator/internal/cloud/api",
         "//operators/constellation-node-operator/internal/poller",
@@ -44,6 +45,7 @@ go_test(
     ],
     embed = [":client"],
     deps = [
+        "//internal/constants",
         "//operators/constellation-node-operator/api/v1alpha1",
         "//operators/constellation-node-operator/internal/cloud/api",
         "//operators/constellation-node-operator/internal/poller",

--- a/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup.go
+++ b/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 	updatev1alpha1 "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/api/v1alpha1"
 	cspapi "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/internal/cloud/api"
 )
@@ -117,9 +118,9 @@ func (c *Client) ListScalingGroups(ctx context.Context, uid string) ([]cspapi.Sc
 			if nodeGroupName == "" {
 				switch role {
 				case updatev1alpha1.ControlPlaneRole:
-					nodeGroupName = "control_plane_default"
+					nodeGroupName = constants.ControlPlaneDefault
 				case updatev1alpha1.WorkerRole:
-					nodeGroupName = "worker_default"
+					nodeGroupName = constants.WorkerDefault
 				}
 			}
 

--- a/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup_test.go
+++ b/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v4"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 	cspapi "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/internal/cloud/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -202,7 +203,7 @@ func TestListScalingGroups(t *testing.T) {
 			wantGroups: []cspapi.ScalingGroup{
 				{
 					Name:                 "constellation-scale-set-control-planes-uid",
-					NodeGroupName:        "control_plane_default",
+					NodeGroupName:        constants.ControlPlaneDefault,
 					GroupID:              "/subscriptions/subscription-id/resourceGroups/resource-group/providers/Microsoft.Compute/virtualMachineScaleSets/constellation-scale-set-control-planes-uid",
 					AutoscalingGroupName: "constellation-scale-set-control-planes-uid",
 					Role:                 "ControlPlane",
@@ -221,7 +222,7 @@ func TestListScalingGroups(t *testing.T) {
 			wantGroups: []cspapi.ScalingGroup{
 				{
 					Name:                 "constellation-scale-set-workers-uid",
-					NodeGroupName:        "worker_default",
+					NodeGroupName:        constants.WorkerDefault,
 					GroupID:              "/subscriptions/subscription-id/resourceGroups/resource-group/providers/Microsoft.Compute/virtualMachineScaleSets/constellation-scale-set-workers-uid",
 					AutoscalingGroupName: "constellation-scale-set-workers-uid",
 					Role:                 "Worker",
@@ -240,7 +241,7 @@ func TestListScalingGroups(t *testing.T) {
 			wantGroups: []cspapi.ScalingGroup{
 				{
 					Name:                 "some-scale-set",
-					NodeGroupName:        "control_plane_default",
+					NodeGroupName:        constants.ControlPlaneDefault,
 					GroupID:              "/subscriptions/subscription-id/resourceGroups/resource-group/providers/Microsoft.Compute/virtualMachineScaleSets/some-scale-set",
 					AutoscalingGroupName: "some-scale-set",
 					Role:                 "ControlPlane",

--- a/operators/constellation-node-operator/internal/cloud/gcp/client/BUILD.bazel
+++ b/operators/constellation-node-operator/internal/cloud/gcp/client/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     importpath = "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/internal/cloud/gcp/client",
     visibility = ["//operators/constellation-node-operator:__subpackages__"],
     deps = [
+        "//internal/constants",
         "//operators/constellation-node-operator/api/v1alpha1",
         "//operators/constellation-node-operator/internal/cloud/api",
         "@com_github_googleapis_gax_go_v2//:gax-go",
@@ -51,6 +52,7 @@ go_test(
     ],
     embed = [":client"],
     deps = [
+        "//internal/constants",
         "//operators/constellation-node-operator/api/v1alpha1",
         "//operators/constellation-node-operator/internal/cloud/api",
         "@com_github_googleapis_gax_go_v2//:gax-go",

--- a/operators/constellation-node-operator/internal/cloud/gcp/client/scalinggroup.go
+++ b/operators/constellation-node-operator/internal/cloud/gcp/client/scalinggroup.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 	updatev1alpha1 "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/api/v1alpha1"
 	cspapi "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/internal/cloud/api"
 	"google.golang.org/api/iterator"
@@ -164,9 +165,9 @@ func (c *Client) ListScalingGroups(ctx context.Context, uid string) ([]cspapi.Sc
 			if nodeGroupName == "" {
 				switch role {
 				case updatev1alpha1.ControlPlaneRole:
-					nodeGroupName = "control_plane_default"
+					nodeGroupName = constants.ControlPlaneDefault
 				case updatev1alpha1.WorkerRole:
-					nodeGroupName = "worker_default"
+					nodeGroupName = constants.WorkerDefault
 				}
 			}
 

--- a/operators/constellation-node-operator/internal/cloud/gcp/client/scalinggroup_test.go
+++ b/operators/constellation-node-operator/internal/cloud/gcp/client/scalinggroup_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"cloud.google.com/go/compute/apiv1/computepb"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 	cspapi "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/internal/cloud/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -356,7 +357,7 @@ func TestListScalingGroups(t *testing.T) {
 			wantGroups: []cspapi.ScalingGroup{
 				{
 					Name:                 "test-control-plane-uid",
-					NodeGroupName:        "control_plane_default",
+					NodeGroupName:        constants.ControlPlaneDefault,
 					GroupID:              "projects/project/zones/zone/instanceGroupManagers/test-control-plane-uid",
 					AutoscalingGroupName: "https://www.googleapis.com/compute/v1/projects/project/zones/zone/instanceGroups/test-control-plane-uid",
 					Role:                 "ControlPlane",
@@ -374,7 +375,7 @@ func TestListScalingGroups(t *testing.T) {
 			wantGroups: []cspapi.ScalingGroup{
 				{
 					Name:                 "test-worker-uid",
-					NodeGroupName:        "worker_default",
+					NodeGroupName:        constants.WorkerDefault,
 					GroupID:              "projects/project/zones/zone/instanceGroupManagers/test-worker-uid",
 					AutoscalingGroupName: "https://www.googleapis.com/compute/v1/projects/project/zones/zone/instanceGroups/test-worker-uid",
 					Role:                 "Worker",
@@ -411,7 +412,7 @@ func TestListScalingGroups(t *testing.T) {
 			wantGroups: []cspapi.ScalingGroup{
 				{
 					Name:                 "some-instance-group-manager",
-					NodeGroupName:        "control_plane_default",
+					NodeGroupName:        constants.ControlPlaneDefault,
 					GroupID:              "projects/project/zones/zone/instanceGroupManagers/some-instance-group-manager",
 					AutoscalingGroupName: "https://www.googleapis.com/compute/v1/projects/project/zones/zone/instanceGroups/some-instance-group-manager",
 					Role:                 "ControlPlane",


### PR DESCRIPTION

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
There was a bug in a previous release where upgrade used different terraform variables than create ([AB#3283](https://dev.azure.com/Edgeless/Edgeless/_backlogs/backlog/Edgeless%20Team/Features?showParents=false&workitem=3283)). That bug was [fixed](https://github.com/edgelesssys/constellation/pull/2113/files) by adding the missing variables to create.

To prevent the same thing from happening again this PR refactors the relevant code to use the same variables in both places.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- use constant as name for control plane and worker default node group
- get terraform variables from new functions `azure/gcp/aws/openStack/qemuTerraformVars` during create and upgrade.

### Additional info
- azure nop: https://github.com/edgelesssys/constellation/actions/runs/5596357804
- gcp nop: https://github.com/edgelesssys/constellation/actions/runs/5596363251
- aws nop: https://github.com/edgelesssys/constellation/actions/runs/5596366914
- azure upgrade: https://github.com/edgelesssys/constellation/actions/runs/5597586569
- gcp upgrade: https://github.com/edgelesssys/constellation/actions/runs/5597583291
- aws upgrade: https://github.com/edgelesssys/constellation/actions/runs/5597590389

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
