### PR TITLE
ci: fix ahead-check for working branch

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -35,14 +35,14 @@ jobs:
           PART_MINOR=${WITHOUT_V#*.}
           MAJOR_MINOR=${PART_MAJOR}.${PART_MINOR}
           RELEASE_BRANCH="release/v${MAJOR_MINOR}"
-          WORKING_BRANCH_PREFIX="tmp/${FULL_VERSION}"
+          WORKING_BRANCH_PREFIX="origin/tmp/${FULL_VERSION}"
           echo "RELEASE_BRANCH=${RELEASE_BRANCH}" | tee -a "$GITHUB_ENV"
           echo "WORKING_BRANCH_PREFIX=${WORKING_BRANCH_PREFIX}" | tee -a "$GITHUB_ENV"
 
       - name: Find temporary branch
         id: find-temporary-branch
         run: |
-          working_branch_count=$(git branch --list "${WORKING_BRANCH_PREFIX}*" | wc -l)
+          working_branch_count=$(git branch --list -r "${WORKING_BRANCH_PREFIX}*" | wc -l)
           if [[ "${working_branch_count}" -ne 1 ]]; then
             echo "More than one (or zero) temporary branches found. Cannot finish transaction."
             git branch --list "${WORKING_BRANCH_PREFIX}*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,7 +131,7 @@ jobs:
           git checkout "${RELEASE_BRANCH}" || exit 0
           git checkout "${WORKING_BRANCH}"
           ahead=$(git rev-list HEAD --not "${RELEASE_BRANCH}"  | wc -l)
-          if [[ "${ahead}" -gt 0 ]]; then
+          if [[ "${ahead}" -eq 0 ]]; then
             echo "The current branch is not strictly ahead of the release branch. Please rebase."
             exit 1
           fi


### PR DESCRIPTION

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Minor bugs that showed up while preparing a patch release.
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Adjust ahead test between working branch and release branch from `-gt 0` to `-eq 0` 
- list remote branches during on-release with `-r` and adjust working branch prefix to start with `origin/`
