### PR TITLE
cli: print supported k8s versions on error

### DIFF
--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -142,7 +142,7 @@ func (i *initCmd) initialize(cmd *cobra.Command, newDialer func(validator atls.V
 	// init only supported up-to-date versions.
 	k8sVersion, err := versions.NewValidK8sVersion(compatibility.EnsurePrefixV(conf.KubernetesVersion), true)
 	if err != nil {
-		return fmt.Errorf("invalid Kubernetes version: %s", conf.KubernetesVersion)
+		return err
 	}
 	i.log.Debugf("Validated k8s version as %s", k8sVersion)
 	if versions.IsPreviewK8sVersion(k8sVersion) {

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -52,7 +52,7 @@ func NewValidK8sVersion(k8sVersion string, strict bool) (ValidK8sVersion, error)
 		supported = isSupportedK8sVersion(k8sVersion)
 	}
 	if !supported {
-		return "", fmt.Errorf("invalid Kubernetes version: %s", k8sVersion)
+		return "", fmt.Errorf("invalid Kubernetes version: %s; supported versions are %v", k8sVersion, SupportedK8sVersions())
 	}
 	if !strict {
 		k8sVersion, _ = supportedVersionForMajorMinor(k8sVersion)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add the supported K8s versions to the error output when e.g. the user tries to create a Constellation with an outdated version.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
