### PR TITLE
bazel: check for docker config and fix cli usage in container

### DIFF
--- a/bazel/container/container.sh
+++ b/bazel/container/container.sh
@@ -5,6 +5,13 @@ function setup {
   mkdir -p "${HOME}/.cache/bazel"
   mkdir -p "${HOME}/.cache/shared_bazel_repository_cache"
   mkdir -p "${HOME}/.cache/shared_bazel_action_cache"
+
+  if [[ ! -f "${HOME}/.docker/config.json" ]]; then
+    echo "ERROR: ${HOME}/.docker/config.json does not exist."
+    echo "Please login into your container registry to create it."
+    echo "echo <TOKEN> | docker login ghcr.io -u <USERNAME> --password-stdin"
+    exit 1
+  fi
 }
 
 function startBazelServer {

--- a/bazel/devbuild/prepare_developer_workspace.sh.in
+++ b/bazel/devbuild/prepare_developer_workspace.sh.in
@@ -63,11 +63,11 @@ ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${cdbg}")" "${workd
 ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${container_sums}")" "${workdir}/container_sums.sha256"
 ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${cli}")" "${workdir}/constellation"
 
-build_version=$("${workdir}"/constellation version | grep ^Version: | awk '{print $2}')
+build_version=$("${cli}" version | grep ^Version: | awk '{print $2}')
 if [[ ! -f "${workdir}/constellation-conf.yaml" ]]; then
   echo "constellation-conf.yaml not present in workspace"
   echo "Build version: ${build_version}"
 else
-  $yq -i eval ".microserviceVersion=\"${build_version}\"" ./constellation-conf.yaml
+  ${yq} -i eval ".microserviceVersion=\"${build_version}\"" ./constellation-conf.yaml
   echo "Microservice version updated to ${build_version} in constellation-conf.yaml"
 fi


### PR DESCRIPTION

### Context
<!-- Please add background information on why this PR is opened. -->
The bazel container enables running bazel in situations where bazel cannot executed directly on the host.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Check for container config file when starting container. Without the file container images can't be pushed.
- Use the injected paths to the bazel cache when executing binaries that were previously build (cli). The created symlinks within the container are pointing to host fs paths and won't work.



### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
