### PR TITLE
aws: fix get version error

### DIFF
--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -210,13 +210,16 @@ func (c *Client) Versions() (ServiceVersions, error) {
 		return ServiceVersions{}, fmt.Errorf("getting %s version: %w", awsLBControllerInfo.releaseName, err)
 	}
 
-	return ServiceVersions{
+	res := ServiceVersions{
 		cilium:                 compatibility.EnsurePrefixV(ciliumVersion),
 		certManager:            compatibility.EnsurePrefixV(certManagerVersion),
 		constellationOperators: compatibility.EnsurePrefixV(operatorsVersion),
 		constellationServices:  compatibility.EnsurePrefixV(servicesVersion),
-		awsLBController:        compatibility.EnsurePrefixV(awsLBVersion),
-	}, nil
+	}
+	if awsLBVersion != "" {
+		res.awsLBController = compatibility.EnsurePrefixV(awsLBVersion)
+	}
+	return res, nil
 }
 
 // currentVersion returns the version of the currently installed helm release.

--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -206,7 +206,7 @@ func (c *Client) Versions() (ServiceVersions, error) {
 		return ServiceVersions{}, fmt.Errorf("getting %s version: %w", constellationServicesInfo.releaseName, err)
 	}
 	awsLBVersion, err := c.currentVersion(awsLBControllerInfo.releaseName)
-	if !errors.Is(err, errReleaseNotFound) {
+	if err != nil && !errors.Is(err, errReleaseNotFound) {
 		return ServiceVersions{}, fmt.Errorf("getting %s version: %w", awsLBControllerInfo.releaseName, err)
 	}
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Fixes bug from #2090, that throws an error even if there is no error at all:
```
2023-07-24T09:12:00.7870989Z Stderr: Error: getting status: getting service versions: getting aws-load-balancer-controller version: %!w(<nil>)
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
-

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
