### PR TITLE
cli: output CSI driver versions on `status`

### DIFF
--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -136,7 +136,6 @@ go_test(
         "//bootstrapper/initproto",
         "//cli/internal/cloudcmd",
         "//cli/internal/clusterid",
-        "//cli/internal/helm",
         "//cli/internal/iamid",
         "//cli/internal/kubernetes",
         "//cli/internal/terraform",

--- a/cli/internal/cmd/status_test.go
+++ b/cli/internal/cmd/status_test.go
@@ -24,7 +24,7 @@ import (
 const successOutput = `Target versions:
 	Image: v1.1.0
 	Kubernetes: v1.2.3
-Installed service versions:
+Service versions:
 	Cilium: v1.0.0
 	cert-manager: v1.0.0
 	constellation-operators: v1.1.0

--- a/cli/internal/cmd/status_test.go
+++ b/cli/internal/cmd/status_test.go
@@ -35,7 +35,7 @@ Cluster status: Node version of every node is up to date
 const inProgressOutput = `Target versions:
 	Image: v1.1.0
 	Kubernetes: v1.2.3
-Installed service versions:
+Service versions:
 	Cilium: v1.0.0
 	cert-manager: v1.0.0
 	constellation-operators: v1.1.0
@@ -193,7 +193,7 @@ func TestStatus(t *testing.T) {
 				context.Background(),
 				tc.kubeClient,
 				configMapper,
-				stubGetVersions,
+				stubGetVersions(successOutput),
 				&stubDynamicInterface{data: unstructured.Unstructured{Object: raw}, err: tc.dynamicErr},
 				variant,
 			)
@@ -239,17 +239,16 @@ func (s *stubDynamicInterface) Update(_ context.Context, _ *unstructured.Unstruc
 	return &s.data, s.err
 }
 
-func stubGetVersions() (fmt.Stringer, error) {
-	return stubServiceVersions{}, nil
+func stubGetVersions(output string) func() (fmt.Stringer, error) {
+	return func() (fmt.Stringer, error) {
+		return stubServiceVersions{output}, nil
+	}
 }
 
-type stubServiceVersions struct{}
+type stubServiceVersions struct {
+	output string
+}
 
-func (stubServiceVersions) String() string {
-	return `Installed service versions:
-	Cilium: v1.0.0
-	cert-manager: v1.0.0
-	constellation-operators: v1.1.0
-	constellation-services: v1.1.0
-`
+func (s stubServiceVersions) String() string {
+	return s.output
 }

--- a/cli/internal/cmd/status_test.go
+++ b/cli/internal/cmd/status_test.go
@@ -21,29 +21,29 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-const successOutput = `Target versions:
-	Image: v1.1.0
-	Kubernetes: v1.2.3
-Service versions:
-	Cilium: v1.0.0
-	cert-manager: v1.0.0
-	constellation-operators: v1.1.0
-	constellation-services: v1.1.0
-Cluster status: Node version of every node is up to date
-` + attestationConfigOutput
+const successOutput = targetVersions + versionsOutput + nodesUpToDateOutput + attestationConfigOutput
 
-const inProgressOutput = `Target versions:
+const inProgressOutput = targetVersions + versionsOutput + nodesInProgressOutput + attestationConfigOutput
+
+const targetVersions = `Target versions:
 	Image: v1.1.0
 	Kubernetes: v1.2.3
-Service versions:
-	Cilium: v1.0.0
-	cert-manager: v1.0.0
-	constellation-operators: v1.1.0
-	constellation-services: v1.1.0
-Cluster status: Some node versions are out of date
+`
+
+const nodesUpToDateOutput = `Cluster status: Node version of every node is up to date
+`
+
+const nodesInProgressOutput = `Cluster status: Some node versions are out of date
 	Image: 1/2
 	Kubernetes: 1/2
-` + attestationConfigOutput
+`
+
+const versionsOutput = `Service versions:
+	Cilium: v1.0.0
+	cert-manager: v1.0.0
+	constellation-operators: v1.1.0
+	constellation-services: v1.1.0
+`
 
 const attestationConfigOutput = `Attestation config:
 	measurements:
@@ -193,7 +193,7 @@ func TestStatus(t *testing.T) {
 				context.Background(),
 				tc.kubeClient,
 				configMapper,
-				stubGetVersions(successOutput),
+				stubGetVersions(versionsOutput),
 				&stubDynamicInterface{data: unstructured.Unstructured{Object: raw}, err: tc.dynamicErr},
 				variant,
 			)

--- a/cli/internal/cmd/status_test.go
+++ b/cli/internal/cmd/status_test.go
@@ -8,11 +8,10 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
-	"github.com/edgelesssys/constellation/v2/cli/internal/helm"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
-	consemver "github.com/edgelesssys/constellation/v2/internal/semver"
 	updatev1alpha1 "github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/api/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -93,7 +92,6 @@ const attestationConfigOutput = `Attestation config:
 func TestStatus(t *testing.T) {
 	testCases := map[string]struct {
 		kubeClient     stubKubeClient
-		helmClient     stubHelmClient
 		nodeVersion    updatev1alpha1.NodeVersion
 		dynamicErr     error
 		expectedOutput string
@@ -116,9 +114,6 @@ func TestStatus(t *testing.T) {
 						},
 					},
 				},
-			},
-			helmClient: stubHelmClient{
-				serviceVersions: helm.NewServiceVersions(consemver.NewFromInt(1, 0, 0, ""), consemver.NewFromInt(1, 0, 0, ""), consemver.NewFromInt(1, 1, 0, ""), consemver.NewFromInt(1, 1, 0, "")),
 			},
 			nodeVersion: updatev1alpha1.NodeVersion{
 				Spec: updatev1alpha1.NodeVersionSpec{
@@ -167,9 +162,6 @@ func TestStatus(t *testing.T) {
 					},
 				},
 			},
-			helmClient: stubHelmClient{
-				serviceVersions: helm.NewServiceVersions(consemver.NewFromInt(1, 0, 0, ""), consemver.NewFromInt(1, 0, 0, ""), consemver.NewFromInt(1, 1, 0, ""), consemver.NewFromInt(1, 1, 0, "")),
-			},
 			nodeVersion: updatev1alpha1.NodeVersion{
 				Spec: updatev1alpha1.NodeVersionSpec{
 					ImageVersion:             "v1.1.0",
@@ -197,7 +189,14 @@ func TestStatus(t *testing.T) {
 			require.NoError(err)
 			configMapper := stubConfigMapperAWSNitro{}
 			variant := variant.AWSNitroTPM{}
-			output, err := status(context.Background(), tc.kubeClient, configMapper, tc.helmClient, &stubDynamicInterface{data: unstructured.Unstructured{Object: raw}, err: tc.dynamicErr}, variant)
+			output, err := status(
+				context.Background(),
+				tc.kubeClient,
+				configMapper,
+				stubGetVersions,
+				&stubDynamicInterface{data: unstructured.Unstructured{Object: raw}, err: tc.dynamicErr},
+				variant,
+			)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -227,15 +226,6 @@ func (s stubKubeClient) GetNodes(_ context.Context) ([]corev1.Node, error) {
 	return s.nodes, s.err
 }
 
-type stubHelmClient struct {
-	serviceVersions helm.ServiceVersions
-	err             error
-}
-
-func (s stubHelmClient) Versions() (helm.ServiceVersions, error) {
-	return s.serviceVersions, s.err
-}
-
 type stubDynamicInterface struct {
 	data unstructured.Unstructured
 	err  error
@@ -247,4 +237,19 @@ func (s *stubDynamicInterface) GetCurrent(_ context.Context, _ string) (*unstruc
 
 func (s *stubDynamicInterface) Update(_ context.Context, _ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
 	return &s.data, s.err
+}
+
+func stubGetVersions() (fmt.Stringer, error) {
+	return stubServiceVersions{}, nil
+}
+
+type stubServiceVersions struct{}
+
+func (stubServiceVersions) String() string {
+	return `Installed service versions:
+	Cilium: v1.0.0
+	cert-manager: v1.0.0
+	constellation-operators: v1.1.0
+	constellation-services: v1.1.0
+`
 }

--- a/cli/internal/helm/BUILD.bazel
+++ b/cli/internal/helm/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "client.go",
         "helm.go",
         "loader.go",
+        "serviceversion.go",
         "values.go",
     ],
     embedsrcs = [

--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -221,23 +221,27 @@ func (c *Client) Versions() (ServiceVersions, error) {
 	if err != nil {
 		return ServiceVersions{}, fmt.Errorf("getting %s version: %w", constellationServicesInfo.releaseName, err)
 	}
-	awsLBVersion, err := c.currentVersion(awsLBControllerInfo.releaseName)
-	if err != nil && !errors.Is(err, errReleaseNotFound) {
-		return ServiceVersions{}, fmt.Errorf("getting %s version: %w", awsLBControllerInfo.releaseName, err)
+	csiVersions, err := c.csiVersions()
+	if err != nil {
+		return ServiceVersions{}, fmt.Errorf("getting CSI versions: %w", err)
 	}
 
-	res := ServiceVersions{
+	serviceVersions := ServiceVersions{
 		cilium:                 ciliumVersion,
 		certManager:            certManagerVersion,
 		constellationOperators: operatorsVersion,
 		constellationServices:  servicesVersion,
-		awsLBController:        awsLBVersion,
-	}
-	if awsLBVersion != (semver.Semver{}) {
-		res.awsLBController = awsLBVersion
+		csiVersions:            csiVersions,
 	}
 
-	return res, nil
+	if awsLBVersion, err := c.currentVersion(awsLBControllerInfo.releaseName); err != nil {
+		if !errors.Is(err, errReleaseNotFound) {
+			return ServiceVersions{}, fmt.Errorf("getting %s version: %w", awsLBControllerInfo.releaseName, err)
+		}
+		serviceVersions.awsLBController = awsLBVersion
+	}
+
+	return serviceVersions, nil
 }
 
 // currentVersion returns the version of the currently installed helm release.
@@ -261,43 +265,35 @@ func (c *Client) currentVersion(release string) (semver.Semver, error) {
 	return semver.New(rel[0].Chart.Metadata.Version)
 }
 
-// ServiceVersions bundles the versions of all services that are part of Constellation.
-type ServiceVersions struct {
-	cilium                 semver.Semver
-	certManager            semver.Semver
-	constellationOperators semver.Semver
-	constellationServices  semver.Semver
-	awsLBController        semver.Semver
-}
-
-// NewServiceVersions returns a new ServiceVersions struct.
-func NewServiceVersions(cilium, certManager, constellationOperators, constellationServices semver.Semver) ServiceVersions {
-	return ServiceVersions{
-		cilium:                 cilium,
-		certManager:            certManager,
-		constellationOperators: constellationOperators,
-		constellationServices:  constellationServices,
+func (c *Client) csiVersions() (map[string]semver.Semver, error) {
+	packedChartRelease, err := c.actions.listAction(csiInfo.releaseName)
+	if err != nil {
+		return nil, fmt.Errorf("listing %s: %w", csiInfo.releaseName, err)
 	}
-}
 
-// Cilium returns the version of the Cilium release.
-func (s ServiceVersions) Cilium() semver.Semver {
-	return s.cilium
-}
+	// No CSI driver installed
+	if len(packedChartRelease) == 0 {
+		return nil, nil
+	}
 
-// CertManager returns the version of the cert-manager release.
-func (s ServiceVersions) CertManager() semver.Semver {
-	return s.certManager
-}
+	if len(packedChartRelease) > 1 {
+		return nil, fmt.Errorf("multiple releases found for %s", csiInfo.releaseName)
+	}
 
-// ConstellationOperators returns the version of the constellation-operators release.
-func (s ServiceVersions) ConstellationOperators() semver.Semver {
-	return s.constellationOperators
-}
+	if packedChartRelease[0] == nil || packedChartRelease[0].Chart == nil {
+		return nil, fmt.Errorf("received invalid release %s", csiInfo.releaseName)
+	}
 
-// ConstellationServices returns the version of the constellation-services release.
-func (s ServiceVersions) ConstellationServices() semver.Semver {
-	return s.constellationServices
+	csiVersions := map[string]semver.Semver{}
+	dependencies := packedChartRelease[0].Chart.Metadata.Dependencies
+	for _, dep := range dependencies {
+		var err error
+		csiVersions[dep.Name], err = semver.New(dep.Version)
+		if err != nil {
+			return nil, fmt.Errorf("parsing CSI version %q: %w", dep.Name, err)
+		}
+	}
+	return csiVersions, nil
 }
 
 // installNewRelease installs a previously not installed release on the cluster.

--- a/cli/internal/helm/client.go
+++ b/cli/internal/helm/client.go
@@ -118,10 +118,12 @@ func (c *Client) Upgrade(ctx context.Context, config *config.Config, idFile clus
 			return fmt.Errorf("loading chart: %w", err)
 		}
 
-		// define target version the chart is upgraded to
+		// Get version of the chart embedded in the CLI
+		// This is the version we are upgrading to
+		// Since our bundled charts are embedded with version 0.0.0,
+		// we need to update them to the same version as the CLI
 		var upgradeVersion semver.Semver
-		if info == constellationOperatorsInfo || info == constellationServicesInfo {
-			// ensure that the services chart has the same version as the CLI
+		if info == constellationOperatorsInfo || info == constellationServicesInfo || info == csiInfo {
 			updateVersions(chart, constants.BinaryVersion())
 			upgradeVersion = config.MicroserviceVersion
 		} else {

--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -48,11 +48,14 @@ type chartInfo struct {
 }
 
 var (
-	ciliumInfo                 = chartInfo{releaseName: "cilium", chartName: "cilium", path: "charts/cilium"}
-	certManagerInfo            = chartInfo{releaseName: "cert-manager", chartName: "cert-manager", path: "charts/cert-manager"}
+	// Charts we fetch from an upstream with real versions.
+	ciliumInfo          = chartInfo{releaseName: "cilium", chartName: "cilium", path: "charts/cilium"}
+	certManagerInfo     = chartInfo{releaseName: "cert-manager", chartName: "cert-manager", path: "charts/cert-manager"}
+	awsLBControllerInfo = chartInfo{releaseName: "aws-load-balancer-controller", chartName: "aws-load-balancer-controller", path: "charts/aws-load-balancer-controller"}
+
+	// Bundled charts with embedded with version 0.0.0.
 	constellationOperatorsInfo = chartInfo{releaseName: "constellation-operators", chartName: "constellation-operators", path: "charts/edgeless/operators"}
 	constellationServicesInfo  = chartInfo{releaseName: "constellation-services", chartName: "constellation-services", path: "charts/edgeless/constellation-services"}
-	awsLBControllerInfo        = chartInfo{releaseName: "aws-load-balancer-controller", chartName: "aws-load-balancer-controller", path: "charts/aws-load-balancer-controller"}
 	csiInfo                    = chartInfo{releaseName: "constellation-csi", chartName: "constellation-csi", path: "charts/edgeless/csi"}
 )
 

--- a/cli/internal/helm/serviceversion.go
+++ b/cli/internal/helm/serviceversion.go
@@ -26,7 +26,7 @@ type ServiceVersions struct {
 // String returns a string representation of the ServiceVersions struct.
 func (s ServiceVersions) String() string {
 	builder := strings.Builder{}
-	builder.WriteString("Installed service versions:\n")
+	builder.WriteString("Service versions:\n")
 	builder.WriteString(fmt.Sprintf("\tCilium: %s\n", s.cilium))
 	builder.WriteString(fmt.Sprintf("\tcert-manager: %s\n", s.certManager))
 	builder.WriteString(fmt.Sprintf("\tconstellation-operators: %s\n", s.constellationOperators))
@@ -36,11 +36,14 @@ func (s ServiceVersions) String() string {
 		builder.WriteString(fmt.Sprintf("\taws-load-balancer-controller: %s\n", s.awsLBController))
 	}
 
-	if s.csiVersions != nil {
-		builder.WriteString("\tCSI:\n")
+	builder.WriteString("\tCSI:")
+	if len(s.csiVersions) != 0 {
+		builder.WriteString("\n")
 		for name, csiVersion := range s.csiVersions {
 			builder.WriteString(fmt.Sprintf("\t\t%s: %s\n", name, csiVersion))
 		}
+	} else {
+		builder.WriteString(" not installed\n")
 	}
 
 	return builder.String()

--- a/cli/internal/helm/serviceversion.go
+++ b/cli/internal/helm/serviceversion.go
@@ -1,0 +1,52 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package helm
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/edgelesssys/constellation/v2/internal/semver"
+)
+
+// ServiceVersions bundles the versions of all services that are part of Constellation.
+type ServiceVersions struct {
+	cilium                 semver.Semver
+	certManager            semver.Semver
+	constellationOperators semver.Semver
+	constellationServices  semver.Semver
+	awsLBController        semver.Semver
+	csiVersions            map[string]semver.Semver
+}
+
+// String returns a string representation of the ServiceVersions struct.
+func (s ServiceVersions) String() string {
+	builder := strings.Builder{}
+	builder.WriteString("Installed service versions:\n")
+	builder.WriteString(fmt.Sprintf("\tCilium: %s\n", s.cilium))
+	builder.WriteString(fmt.Sprintf("\tcert-manager: %s\n", s.certManager))
+	builder.WriteString(fmt.Sprintf("\tconstellation-operators: %s\n", s.constellationOperators))
+	builder.WriteString(fmt.Sprintf("\tconstellation-services: %s\n", s.constellationServices))
+
+	if s.awsLBController != (semver.Semver{}) {
+		builder.WriteString(fmt.Sprintf("\taws-load-balancer-controller: %s\n", s.awsLBController))
+	}
+
+	if s.csiVersions != nil {
+		builder.WriteString("\tCSI:\n")
+		for name, csiVersion := range s.csiVersions {
+			builder.WriteString(fmt.Sprintf("\t\t%s: %s\n", name, csiVersion))
+		}
+	}
+
+	return builder.String()
+}
+
+// ConstellationServices returns the version of the constellation-services release.
+func (s ServiceVersions) ConstellationServices() semver.Semver {
+	return s.constellationServices
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Individual versions of the CSI chart were not printed when running `constellation status`

### Proposed change(s)
- Print the installed versions of the CSI chart
- Only print aws-load-balancer-controller version if it is installed

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->