### PR TITLE
cli: add role to aws instance name

### DIFF
--- a/cli/internal/terraform/terraform/aws/main.tf
+++ b/cli/internal/terraform/terraform/aws/main.tf
@@ -275,7 +275,7 @@ module "instance_group" {
   enable_snp           = var.enable_snp
   tags = merge(
     local.tags,
-    { Name = local.name },
+    { Name = "${local.name}-${each.value.role}" },
     { constellation-role = each.value.role },
     { constellation-node-group = each.key },
     { constellation-uid = local.uid },


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add role (worker/control-plane) to the EC2 instance as we also do on the other CSPs.

Upgrade tests: https://github.com/edgelesssys/constellation/actions/runs/5653649494
https://github.com/edgelesssys/constellation/actions/runs/5833130850/job/15819883482

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->

- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
