### PR TITLE
api: add functions to transparently handle signatures upon API interaction

### DIFF
--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -162,6 +162,7 @@ go_test(
         "//internal/license",
         "//internal/logger",
         "//internal/semver",
+        "//internal/sigstore",
         "//internal/versions",
         "//operators/constellation-node-operator/api/v1alpha1",
         "//verify/verifyproto",

--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -80,6 +80,7 @@ go_library(
         "//internal/retry",
         "//internal/semver",
         "//internal/sigstore",
+        "//internal/sigstore/keyselect",
         "//internal/versions",
         "//operators/constellation-node-operator/api/v1alpha1",
         "//verify/verifyproto",

--- a/cli/internal/cmd/configfetchmeasurements.go
+++ b/cli/internal/cmd/configfetchmeasurements.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/sigstore"
+	"github.com/edgelesssys/constellation/v2/internal/sigstore/keyselect"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
@@ -117,7 +118,7 @@ func (cfm *configFetchMeasurementsCmd) configFetchMeasurements(
 		return err
 	}
 
-	publicKey, err := sigstore.CosignPublicKeyForVersion(imageVersion)
+	publicKey, err := keyselect.CosignPublicKeyForVersion(imageVersion)
 	if err != nil {
 		return fmt.Errorf("getting public key: %w", err)
 	}
@@ -156,7 +157,7 @@ func (cfm *configFetchMeasurementsCmd) configFetchMeasurements(
 			return fmt.Errorf("fetching and verifying measurements: %w", err)
 		}
 		cfm.log.Debugf("Fetched and verified measurements, hash is %s", hash)
-		if err := sigstore.VerifyWithRekor(cmd.Context(), imageVersion, rekor, hash); err != nil {
+		if err := sigstore.VerifyWithRekor(cmd.Context(), publicKey, rekor, hash); err != nil {
 			cmd.PrintErrf("Ignoring Rekor related error: %v\n", err)
 			cmd.PrintErrln("Make sure the downloaded measurements are trustworthy!")
 		}

--- a/cli/internal/cmd/configfetchmeasurements_test.go
+++ b/cli/internal/cmd/configfetchmeasurements_test.go
@@ -102,12 +102,11 @@ func TestParseFetchMeasurementsFlags(t *testing.T) {
 }
 
 func TestUpdateURLs(t *testing.T) {
-	ver := versionsapi.Version{
-		Ref:     "foo",
-		Stream:  "nightly",
-		Version: "v7.7.7",
-		Kind:    versionsapi.VersionKindImage,
-	}
+	require := require.New(t)
+
+	ver, err := versionsapi.NewVersion("foo", "nightly", "v7.7.7", versionsapi.VersionKindImage)
+	require.NoError(err)
+
 	testCases := map[string]struct {
 		conf                   *config.Config
 		flags                  *fetchMeasurementsFlags

--- a/cli/internal/cmd/configfetchmeasurements_test.go
+++ b/cli/internal/cmd/configfetchmeasurements_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
+	"github.com/edgelesssys/constellation/v2/internal/sigstore"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -233,39 +234,43 @@ func TestConfigFetchMeasurements(t *testing.T) {
 	})
 
 	testCases := map[string]struct {
-		cosign       cosignVerifier
+		cosign       cosignVerifierConstructor
 		rekor        rekorVerifier
 		insecureFlag bool
 		wantErr      bool
 	}{
 		"success": {
-			cosign: &stubCosignVerifier{},
+			cosign: newStubCosignVerifier,
 			rekor:  singleUUIDVerifier(),
 		},
 		"success without cosign": {
 			insecureFlag: true,
-			cosign: &stubCosignVerifier{
-				verifyError: assert.AnError,
+			cosign: func(_ []byte) (sigstore.Verifier, error) {
+				return &stubCosignVerifier{
+					verifyError: assert.AnError,
+				}, nil
 			},
 			rekor: singleUUIDVerifier(),
 		},
 		"failing search should not result in error": {
-			cosign: &stubCosignVerifier{},
+			cosign: newStubCosignVerifier,
 			rekor: &stubRekorVerifier{
 				SearchByHashUUIDs: []string{},
 				SearchByHashError: assert.AnError,
 			},
 		},
 		"failing verify should not result in error": {
-			cosign: &stubCosignVerifier{},
+			cosign: newStubCosignVerifier,
 			rekor: &stubRekorVerifier{
 				SearchByHashUUIDs: []string{"11111111111111111111111111111111111111111111111111111111111111111111111111111111"},
 				VerifyEntryError:  assert.AnError,
 			},
 		},
 		"signature verification failure": {
-			cosign: &stubCosignVerifier{
-				verifyError: assert.AnError,
+			cosign: func(_ []byte) (sigstore.Verifier, error) {
+				return &stubCosignVerifier{
+					verifyError: assert.AnError,
+				}, nil
 			},
 			rekor:   singleUUIDVerifier(),
 			wantErr: true,

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -307,7 +307,7 @@ func validateCLIandConstellationVersionAreEqual(cliVersion semver.Semver, imageV
 		return fmt.Errorf("parsing image version: %w", err)
 	}
 
-	semImage, err := semver.New(parsedImageVersion.Version)
+	semImage, err := semver.New(parsedImageVersion.Version())
 	if err != nil {
 		return fmt.Errorf("parsing image semantical version: %w", err)
 	}

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -52,7 +52,7 @@ func newUpgradeCheckCmd() *cobra.Command {
 	}
 
 	cmd.Flags().BoolP("update-config", "u", false, "update the specified config file with the suggested versions")
-	cmd.Flags().String("ref", versionsapi.ReleaseRef, "the reference to use for querying new versions")
+	cmd.Flags().String("ref", constants.ReleaseRef, "the reference to use for querying new versions")
 	cmd.Flags().String("stream", "stable", "the stream to use for querying new versions")
 
 	return cmd
@@ -301,7 +301,7 @@ func sortedMapKeys[T any](a map[string]T) []string {
 func filterImageUpgrades(currentVersion string, newVersions []versionsapi.Version) []versionsapi.Version {
 	newImages := []versionsapi.Version{}
 	for i := range newVersions {
-		if err := compatibility.IsValidUpgrade(currentVersion, newVersions[i].Version); err != nil {
+		if err := compatibility.IsValidUpgrade(currentVersion, newVersions[i].Version()); err != nil {
 			continue
 		}
 		newImages = append(newImages, newVersions[i])

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -151,21 +151,17 @@ func TestGetCurrentImageVersion(t *testing.T) {
 
 func TestGetCompatibleImageMeasurements(t *testing.T) {
 	assert := assert.New(t)
+	require := require.New(t)
 
 	csp := cloudprovider.Azure
 	attestationVariant := variant.AzureSEVSNP{}
-	zero := versionsapi.Version{
-		Ref:     "-",
-		Stream:  "stable",
-		Version: "v0.0.0",
-		Kind:    versionsapi.VersionKindImage,
-	}
-	one := versionsapi.Version{
-		Ref:     "-",
-		Stream:  "stable",
-		Version: "v1.0.0",
-		Kind:    versionsapi.VersionKindImage,
-	}
+
+	zero, err := versionsapi.NewVersion("-", "stable", "v0.0.0", versionsapi.VersionKindImage)
+	require.NoError(err)
+
+	one, err := versionsapi.NewVersion("-", "stable", "v1.0.0", versionsapi.VersionKindImage)
+	require.NoError(err)
+
 	images := []versionsapi.Version{zero, one}
 
 	client := newTestClient(func(req *http.Request) *http.Response {
@@ -215,18 +211,13 @@ func TestGetCompatibleImageMeasurements(t *testing.T) {
 }
 
 func TestUpgradeCheck(t *testing.T) {
-	v2_3 := versionsapi.Version{
-		Ref:     "-",
-		Stream:  "stable",
-		Version: "v2.3.0",
-		Kind:    versionsapi.VersionKindImage,
-	}
-	v2_5 := versionsapi.Version{
-		Ref:     "-",
-		Stream:  "stable",
-		Version: "v2.5.0",
-		Kind:    versionsapi.VersionKindImage,
-	}
+	require := require.New(t)
+	v2_3, err := versionsapi.NewVersion("-", "stable", "v2.3.0", versionsapi.VersionKindImage)
+	require.NoError(err)
+
+	v2_5, err := versionsapi.NewVersion("-", "stable", "v2.5.0", versionsapi.VersionKindImage)
+	require.NoError(err)
+
 	collector := stubVersionCollector{
 		supportedServicesVersions: consemver.NewFromInt(2, 5, 0, ""),
 		supportedImages:           []versionsapi.Version{v2_3},
@@ -279,7 +270,6 @@ func TestUpgradeCheck(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
-			require := require.New(t)
 
 			fileHandler := file.NewHandler(afero.NewMemMapFs())
 			cfg := defaultConfigWithExpectedMeasurements(t, config.Default(), tc.csp)

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -156,41 +156,21 @@ func TestGetCompatibleImageMeasurements(t *testing.T) {
 	csp := cloudprovider.Azure
 	attestationVariant := variant.AzureSEVSNP{}
 
-	zero, err := versionsapi.NewVersion("-", "stable", "v0.0.0", versionsapi.VersionKindImage)
+	versionZero, err := versionsapi.NewVersion("-", "stable", "v0.0.0", versionsapi.VersionKindImage)
 	require.NoError(err)
-
-	one, err := versionsapi.NewVersion("-", "stable", "v1.0.0", versionsapi.VersionKindImage)
-	require.NoError(err)
-
-	images := []versionsapi.Version{zero, one}
 
 	client := newTestClient(func(req *http.Request) *http.Response {
-		if strings.HasSuffix(req.URL.String(), "v0.0.0/azure/measurements.json") {
+		if strings.HasSuffix(req.URL.String(), "v0.0.0/image/measurements.json") {
 			return &http.Response{
 				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(`{"csp":"azure","image":"v0.0.0","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}`)),
+				Body:       io.NopCloser(strings.NewReader(`{"version": "v0.0.0","ref": "-","stream": "stable","list": [{"csp": "Azure","attestationVariant": "azure-sev-snp","measurements": {"0": {"expected": "0000000000000000000000000000000000000000000000000000000000000000","warnOnly": false}}}]}`)),
 				Header:     make(http.Header),
 			}
 		}
-		if strings.HasSuffix(req.URL.String(), "v0.0.0/azure/measurements.json.sig") {
+		if strings.HasSuffix(req.URL.String(), "v0.0.0/image/measurements.json.sig") {
 			return &http.Response{
 				StatusCode: http.StatusOK,
 				Body:       io.NopCloser(strings.NewReader("MEQCIGRR7RaSMs892Ta06/Tz7LqPUxI05X4wQcP+nFFmZtmaAiBNl9X8mUKmUBfxg13LQBfmmpw6JwYQor5hOwM3NFVPAg==")),
-				Header:     make(http.Header),
-			}
-		}
-
-		if strings.HasSuffix(req.URL.String(), "v1.0.0/azure/measurements.json") {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader(`{"csp":"azure","image":"v1.0.0","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}`)),
-				Header:     make(http.Header),
-			}
-		}
-		if strings.HasSuffix(req.URL.String(), "v1.0.0/azure/measurements.json.sig") {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader("MEQCIFh8CVELp/Da2U2Jt404OXsUeDfqtrf3pqGRuvxnxhI8AiBTHF9tHEPwFedYG3Jgn2ELOxss+Ybc6135vEtClBrbpg==")),
 				Header:     make(http.Header),
 			}
 		}
@@ -202,7 +182,7 @@ func TestGetCompatibleImageMeasurements(t *testing.T) {
 		}
 	})
 
-	upgrades, err := getCompatibleImageMeasurements(context.Background(), &bytes.Buffer{}, client, &stubCosignVerifier{}, singleUUIDVerifier(), csp, attestationVariant, images, logger.NewTest(t))
+	upgrades, err := getCompatibleImageMeasurements(context.Background(), &bytes.Buffer{}, client, &stubCosignVerifier{}, singleUUIDVerifier(), csp, attestationVariant, versionZero, logger.NewTest(t))
 	assert.NoError(err)
 
 	for _, measurement := range upgrades {

--- a/cli/internal/cmd/verifier_test.go
+++ b/cli/internal/cmd/verifier_test.go
@@ -39,6 +39,10 @@ type stubCosignVerifier struct {
 	verifyError error
 }
 
-func (v *stubCosignVerifier) VerifySignature(_, _, _ []byte) error {
+func (v *stubCosignVerifier) SetPublicKey(_ []byte) error {
+	return nil
+}
+
+func (v *stubCosignVerifier) VerifySignature(_, _ []byte) error {
 	return v.verifyError
 }

--- a/cli/internal/cmd/verifier_test.go
+++ b/cli/internal/cmd/verifier_test.go
@@ -6,7 +6,11 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 package cmd
 
-import "context"
+import (
+	"context"
+
+	"github.com/edgelesssys/constellation/v2/internal/sigstore"
+)
 
 // singleUUIDVerifier constructs a RekorVerifier that returns a single UUID and no errors,
 // and should work for most tests on the happy path.
@@ -39,8 +43,8 @@ type stubCosignVerifier struct {
 	verifyError error
 }
 
-func (v *stubCosignVerifier) SetPublicKey(_ []byte) error {
-	return nil
+func newStubCosignVerifier(_ []byte) (sigstore.Verifier, error) {
+	return &stubCosignVerifier{}, nil
 }
 
 func (v *stubCosignVerifier) VerifySignature(_, _ []byte) error {

--- a/cli/internal/kubernetes/upgrade.go
+++ b/cli/internal/kubernetes/upgrade.go
@@ -224,7 +224,7 @@ func (u *Upgrader) UpgradeNodeVersion(ctx context.Context, conf *config.Config, 
 	upgradeErrs := []error{}
 	var upgradeErr *compatibility.InvalidUpgradeError
 
-	err = u.updateImage(&nodeVersion, imageReference, imageVersion.Version, force)
+	err = u.updateImage(&nodeVersion, imageReference, imageVersion.Version(), force)
 	switch {
 	case errors.As(err, &upgradeErr):
 		upgradeErrs = append(upgradeErrs, fmt.Errorf("skipping image upgrades: %w", err))

--- a/image/upload/internal/cmd/measurementsenvelope.go
+++ b/image/upload/internal/cmd/measurementsenvelope.go
@@ -67,9 +67,9 @@ func runEnvelopeMeasurements(cmd *cobra.Command, _ []string) error {
 	}
 
 	enveloped := measurements.ImageMeasurementsV2{
-		Ref:     flags.version.Ref,
-		Stream:  flags.version.Stream,
-		Version: flags.version.Version,
+		Ref:     flags.version.Ref(),
+		Stream:  flags.version.Stream(),
+		Version: flags.version.Version(),
 		List: []measurements.ImageMeasurementsV2Entry{
 			{
 				CSP:                flags.csp,

--- a/image/upload/internal/cmd/upload.go
+++ b/image/upload/internal/cmd/upload.go
@@ -43,9 +43,9 @@ func uploadImage(ctx context.Context, archiveC archivist, uploadC uploader, req 
 	}
 
 	imageInfo := versionsapi.ImageInfo{
-		Ref:     req.Version.Ref,
-		Stream:  req.Version.Stream,
-		Version: req.Version.Version,
+		Ref:     req.Version.Ref(),
+		Stream:  req.Version.Stream(),
+		Version: req.Version.Version(),
 		List:    imageReferences,
 	}
 

--- a/internal/api/attestationconfigapi/fetcher.go
+++ b/internal/api/attestationconfigapi/fetcher.go
@@ -43,8 +43,7 @@ func NewFetcher() Fetcher {
 
 // NewFetcherWithClient returns a new fetcher with custom http client.
 func NewFetcherWithClient(client apifetcher.HTTPClient) Fetcher {
-	verifier := sigstore.CosignVerifier{}
-	err := verifier.SetPublicKey([]byte(cosignPublicKey))
+	verifier, err := sigstore.NewCosignVerifier([]byte(cosignPublicKey))
 	if err != nil {
 		// This relies on an embedded public key. If this key can not be validated, there is no way to recover from this.
 		panic(fmt.Errorf("creating cosign verifier: %w", err))

--- a/internal/api/attestationconfigapi/fetcher_test.go
+++ b/internal/api/attestationconfigapi/fetcher_test.go
@@ -161,6 +161,6 @@ func (f *fakeConfigAPIHandler) RoundTrip(req *http.Request) (*http.Response, err
 
 type dummyVerifier struct{}
 
-func (s dummyVerifier) VerifySignature(_, _, _ []byte) error {
+func (s dummyVerifier) VerifySignature(_, _ []byte) error {
 	return nil
 }

--- a/internal/api/client/BUILD.bazel
+++ b/internal/api/client/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//:__subpackages__"],
     deps = [
         "//internal/logger",
+        "//internal/sigstore",
         "//internal/staticupload",
         "@com_github_aws_aws_sdk_go_v2_feature_s3_manager//:manager",
         "@com_github_aws_aws_sdk_go_v2_service_s3//:s3",

--- a/internal/api/fetcher/BUILD.bazel
+++ b/internal/api/fetcher/BUILD.bazel
@@ -5,4 +5,5 @@ go_library(
     srcs = ["fetcher.go"],
     importpath = "github.com/edgelesssys/constellation/v2/internal/api/fetcher",
     visibility = ["//:__subpackages__"],
+    deps = ["//internal/sigstore"],
 )

--- a/internal/api/versionsapi/cli/add.go
+++ b/internal/api/versionsapi/cli/add.go
@@ -13,7 +13,6 @@ import (
 
 	apiclient "github.com/edgelesssys/constellation/v2/internal/api/client"
 	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
-	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap/zapcore"
@@ -204,8 +203,8 @@ func (f *addFlags) validate(log *logger.Logger) error {
 	}
 
 	if f.release {
-		log.Debugf("Setting ref to %q, as release flag is set", constants.ReleaseRef)
-		f.ref = constants.ReleaseRef
+		log.Debugf("Setting ref to %q, as release flag is set", versionsapi.ReleaseRef)
+		f.ref = versionsapi.ReleaseRef
 	} else {
 		log.Debugf("Setting latest to true, as release flag is not set")
 		f.latest = true // always set latest for non-release versions

--- a/internal/api/versionsapi/cli/list.go
+++ b/internal/api/versionsapi/cli/list.go
@@ -91,7 +91,7 @@ func runList(cmd *cobra.Command, _ []string) error {
 		log.Debugf("Printing versions as JSON")
 		var vers []string
 		for _, v := range patchVersions {
-			vers = append(vers, v.Version)
+			vers = append(vers, v.Version())
 		}
 		raw, err := json.Marshal(vers)
 		if err != nil {

--- a/internal/api/versionsapi/cli/rm.go
+++ b/internal/api/versionsapi/cli/rm.go
@@ -26,7 +26,6 @@ import (
 	"github.com/aws/smithy-go"
 	apiclient "github.com/edgelesssys/constellation/v2/internal/api/client"
 	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
-	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	gaxv2 "github.com/googleapis/gax-go/v2"
 	"github.com/spf13/cobra"
@@ -266,7 +265,7 @@ type rmFlags struct {
 }
 
 func (f *rmFlags) validate() error {
-	if f.ref == constants.ReleaseRef {
+	if f.ref == versionsapi.ReleaseRef {
 		return fmt.Errorf("cannot delete from release ref")
 	}
 

--- a/internal/api/versionsapi/cliinfo_test.go
+++ b/internal/api/versionsapi/cliinfo_test.go
@@ -28,7 +28,7 @@ func TestCLIInfoJSONPath(t *testing.T) {
 		},
 		"cli info release": {
 			info: CLIInfo{
-				Ref:     constants.ReleaseRef,
+				Ref:     ReleaseRef,
 				Stream:  "stable",
 				Version: "v1.0.0",
 			},
@@ -59,7 +59,7 @@ func TestCLIInfoURL(t *testing.T) {
 		},
 		"cli info release": {
 			info: CLIInfo{
-				Ref:     constants.ReleaseRef,
+				Ref:     ReleaseRef,
 				Stream:  "stable",
 				Version: "v1.0.0",
 			},

--- a/internal/api/versionsapi/cliinfo_test.go
+++ b/internal/api/versionsapi/cliinfo_test.go
@@ -28,7 +28,7 @@ func TestCLIInfoJSONPath(t *testing.T) {
 		},
 		"cli info release": {
 			info: CLIInfo{
-				Ref:     ReleaseRef,
+				Ref:     constants.ReleaseRef,
 				Stream:  "stable",
 				Version: "v1.0.0",
 			},
@@ -59,7 +59,7 @@ func TestCLIInfoURL(t *testing.T) {
 		},
 		"cli info release": {
 			info: CLIInfo{
-				Ref:     ReleaseRef,
+				Ref:     constants.ReleaseRef,
 				Stream:  "stable",
 				Version: "v1.0.0",
 			},

--- a/internal/api/versionsapi/imageinfo_test.go
+++ b/internal/api/versionsapi/imageinfo_test.go
@@ -28,7 +28,7 @@ func TestImageInfoJSONPath(t *testing.T) {
 		},
 		"image info release": {
 			info: ImageInfo{
-				Ref:     constants.ReleaseRef,
+				Ref:     ReleaseRef,
 				Stream:  "stable",
 				Version: "v1.0.0",
 			},
@@ -59,7 +59,7 @@ func TestImageInfoURL(t *testing.T) {
 		},
 		"image info release": {
 			info: ImageInfo{
-				Ref:     constants.ReleaseRef,
+				Ref:     ReleaseRef,
 				Stream:  "stable",
 				Version: "v1.0.0",
 			},

--- a/internal/api/versionsapi/imageinfo_test.go
+++ b/internal/api/versionsapi/imageinfo_test.go
@@ -28,7 +28,7 @@ func TestImageInfoJSONPath(t *testing.T) {
 		},
 		"image info release": {
 			info: ImageInfo{
-				Ref:     ReleaseRef,
+				Ref:     constants.ReleaseRef,
 				Stream:  "stable",
 				Version: "v1.0.0",
 			},
@@ -59,7 +59,7 @@ func TestImageInfoURL(t *testing.T) {
 		},
 		"image info release": {
 			info: ImageInfo{
-				Ref:     ReleaseRef,
+				Ref:     constants.ReleaseRef,
 				Stream:  "stable",
 				Version: "v1.0.0",
 			},

--- a/internal/api/versionsapi/latest_test.go
+++ b/internal/api/versionsapi/latest_test.go
@@ -28,7 +28,7 @@ func TestLatestJSONPath(t *testing.T) {
 		},
 		"latest list release": {
 			list: Latest{
-				Ref:    ReleaseRef,
+				Ref:    constants.ReleaseRef,
 				Stream: "stable",
 				Kind:   VersionKindImage,
 			},
@@ -59,7 +59,7 @@ func TestLatestURL(t *testing.T) {
 		},
 		"latest list release": {
 			list: Latest{
-				Ref:    ReleaseRef,
+				Ref:    constants.ReleaseRef,
 				Stream: "stable",
 				Kind:   VersionKindImage,
 			},

--- a/internal/api/versionsapi/latest_test.go
+++ b/internal/api/versionsapi/latest_test.go
@@ -28,7 +28,7 @@ func TestLatestJSONPath(t *testing.T) {
 		},
 		"latest list release": {
 			list: Latest{
-				Ref:    constants.ReleaseRef,
+				Ref:    ReleaseRef,
 				Stream: "stable",
 				Kind:   VersionKindImage,
 			},
@@ -59,7 +59,7 @@ func TestLatestURL(t *testing.T) {
 		},
 		"latest list release": {
 			list: Latest{
-				Ref:    constants.ReleaseRef,
+				Ref:    ReleaseRef,
 				Stream: "stable",
 				Kind:   VersionKindImage,
 			},

--- a/internal/api/versionsapi/list.go
+++ b/internal/api/versionsapi/list.go
@@ -163,10 +163,10 @@ func (l List) StructuredVersions() []Version {
 	versions := make([]Version, len(l.Versions))
 	for i, v := range l.Versions {
 		versions[i] = Version{
-			Ref:     l.Ref,
-			Stream:  l.Stream,
-			Version: v,
-			Kind:    l.Kind,
+			ref:     l.Ref,
+			stream:  l.Stream,
+			version: v,
+			kind:    l.Kind,
 		}
 	}
 	return versions

--- a/internal/api/versionsapi/list_test.go
+++ b/internal/api/versionsapi/list_test.go
@@ -344,10 +344,10 @@ func TestListStructuredVersions(t *testing.T) {
 
 	verStrs := make([]string, len(versions))
 	for i, v := range versions {
-		assert.Equal(list.Ref, v.Ref)
-		assert.Equal(list.Stream, v.Stream)
-		assert.Equal(list.Kind, v.Kind)
-		verStrs[i] = v.Version
+		assert.Equal(list.Ref, v.Ref())
+		assert.Equal(list.Stream, v.Stream())
+		assert.Equal(list.Kind, v.Kind())
+		verStrs[i] = v.version
 	}
 
 	assert.ElementsMatch(list.Versions, verStrs)

--- a/internal/api/versionsapi/version.go
+++ b/internal/api/versionsapi/version.go
@@ -20,19 +20,35 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 )
 
-// ReleaseRef is the ref used for release versions.
-const ReleaseRef = "-"
-
 // Version represents a version. A version has a ref, stream, version string and kind.
 //
 // Notice that version is a meta object to the versions API and there isn't an
 // actual corresponding object in the S3 bucket.
 // Therefore, the version object doesn't have a URL or JSON path.
+//
+// Versions fields are private so the type can be used in other packages by
+// defining private interfaces.
 type Version struct {
-	Ref     string
-	Stream  string
-	Version string
-	Kind    VersionKind
+	ref     string
+	stream  string
+	version string
+	kind    VersionKind
+}
+
+// NewVersion creates a new Version object and validates it.
+func NewVersion(ref, stream, version string, kind VersionKind) (Version, error) {
+	ver := Version{
+		ref:     ref,
+		stream:  stream,
+		version: version,
+		kind:    kind,
+	}
+
+	if err := ver.Validate(); err != nil {
+		return Version{}, err
+	}
+
+	return ver, nil
 }
 
 // NewVersionFromShortPath creates a new Version from a version short path.
@@ -43,10 +59,10 @@ func NewVersionFromShortPath(shortPath string, kind VersionKind) (Version, error
 	}
 
 	ver := Version{
-		Ref:     ref,
-		Stream:  stream,
-		Version: version,
-		Kind:    kind,
+		ref:     ref,
+		stream:  stream,
+		version: version,
+		kind:    kind,
 	}
 
 	if err := ver.Validate(); err != nil {
@@ -56,27 +72,47 @@ func NewVersionFromShortPath(shortPath string, kind VersionKind) (Version, error
 	return ver, nil
 }
 
+// Ref returns the ref of the version.
+func (v Version) Ref() string {
+	return v.ref
+}
+
+// Stream returns the stream of the version.
+func (v Version) Stream() string {
+	return v.stream
+}
+
+// Version returns the version string of the version.
+func (v Version) Version() string {
+	return v.version
+}
+
+// Kind returns the kind of the version.
+func (v Version) Kind() VersionKind {
+	return v.kind
+}
+
 // ShortPath returns the short path of the version.
 func (v Version) ShortPath() string {
-	return shortPath(v.Ref, v.Stream, v.Version)
+	return shortPath(v.ref, v.stream, v.version)
 }
 
 // Validate validates the version.
 func (v Version) Validate() error {
 	var retErr error
-	if err := ValidateRef(v.Ref); err != nil {
+	if err := ValidateRef(v.ref); err != nil {
 		retErr = errors.Join(retErr, err)
 	}
-	if err := ValidateStream(v.Ref, v.Stream); err != nil {
+	if err := ValidateStream(v.ref, v.stream); err != nil {
 		retErr = errors.Join(retErr, err)
 	}
-	if !semver.IsValid(v.Version) {
-		retErr = errors.Join(retErr, fmt.Errorf("version %q is not a valid semantic version", v.Version))
+	if !semver.IsValid(v.version) {
+		retErr = errors.Join(retErr, fmt.Errorf("version %q is not a valid semantic version", v.version))
 	}
-	if semver.Canonical(v.Version) != v.Version {
-		retErr = errors.Join(retErr, fmt.Errorf("version %q is not a canonical semantic version", v.Version))
+	if semver.Canonical(v.version) != v.version {
+		retErr = errors.Join(retErr, fmt.Errorf("version %q is not a canonical semantic version", v.version))
 	}
-	if v.Kind == VersionKindUnknown {
+	if v.kind == VersionKindUnknown {
 		retErr = errors.Join(retErr, errors.New("version kind is unknown"))
 	}
 	return retErr
@@ -84,29 +120,29 @@ func (v Version) Validate() error {
 
 // Equal returns true if the versions are equal.
 func (v Version) Equal(other Version) bool {
-	return v.Ref == other.Ref &&
-		v.Stream == other.Stream &&
-		v.Version == other.Version &&
-		v.Kind == other.Kind
+	return v.ref == other.ref &&
+		v.stream == other.stream &&
+		v.version == other.version &&
+		v.kind == other.kind
 }
 
 // Major returns the major version corresponding to the version.
 // For example, if the version is "v1.2.3", the major version is "v1".
 func (v Version) Major() string {
-	return semver.Major(v.Version)
+	return semver.Major(v.version)
 }
 
 // MajorMinor returns the major and minor version corresponding to the version.
 // For example, if the version is "v1.2.3", the major and minor version is "v1.2".
 func (v Version) MajorMinor() string {
-	return semver.MajorMinor(v.Version)
+	return semver.MajorMinor(v.version)
 }
 
 // WithGranularity returns the version with the given granularity.
 //
 // For example, if the version is "v1.2.3" and the granularity is GranularityMajor,
 // the returned version is "v1".
-// This is a helper function for Major() and MajorMinor() and v.Version.
+// This is a helper function for Major() and MajorMinor() and v.version.
 // In case of an unknown granularity, an empty string is returned.
 func (v Version) WithGranularity(gran Granularity) string {
 	switch gran {
@@ -115,7 +151,7 @@ func (v Version) WithGranularity(gran Granularity) string {
 	case GranularityMinor:
 		return v.MajorMinor()
 	case GranularityPatch:
-		return v.Version
+		return v.version
 	default:
 		return ""
 	}
@@ -144,11 +180,11 @@ func (v Version) ListPath(gran Granularity) string {
 	}
 	return path.Join(
 		constants.CDNAPIPrefix,
-		"ref", v.Ref,
-		"stream", v.Stream,
+		"ref", v.ref,
+		"stream", v.stream,
 		"versions",
 		gran.String(), v.WithGranularity(gran),
-		v.Kind.String()+".json",
+		v.kind.String()+".json",
 	)
 }
 
@@ -164,9 +200,9 @@ func (v Version) ArtifactPath(apiVer apiVersion) string {
 	return path.Join(
 		constants.CDNAPIBase,
 		apiVer.String(),
-		"ref", v.Ref,
-		"stream", v.Stream,
-		v.Version,
+		"ref", v.ref,
+		"stream", v.stream,
+		v.version,
 	)
 }
 
@@ -285,13 +321,13 @@ var notAZ09Regexp = regexp.MustCompile("[^a-zA-Z0-9-]")
 
 // CanonicalizeRef returns the canonicalized ref for the given ref.
 func CanonicalizeRef(ref string) string {
-	if ref == ReleaseRef {
+	if ref == constants.ReleaseRef {
 		return ref
 	}
 
 	canRef := notAZ09Regexp.ReplaceAllString(ref, "-")
 
-	if canRef == ReleaseRef {
+	if canRef == constants.ReleaseRef {
 		return "" // No ref should be cannonicalized to the release ref.
 	}
 
@@ -321,7 +357,7 @@ func ValidateStream(ref, stream string) error {
 	validReleaseStreams := []string{"stable", "console", "debug"}
 	validStreams := []string{"nightly", "console", "debug"}
 
-	if ref == ReleaseRef {
+	if ref == constants.ReleaseRef {
 		validStreams = validReleaseStreams
 	}
 
@@ -336,8 +372,8 @@ func ValidateStream(ref, stream string) error {
 
 // MeasurementURL builds the measurement and signature URLs for the given version.
 func MeasurementURL(version Version) (measurementURL, signatureURL *url.URL, err error) {
-	if version.Kind != VersionKindImage {
-		return &url.URL{}, &url.URL{}, fmt.Errorf("kind %q is not supported", version.Kind)
+	if version.kind != VersionKindImage {
+		return &url.URL{}, &url.URL{}, fmt.Errorf("kind %q is not supported", version.kind)
 	}
 
 	measurementPath, err := url.JoinPath(version.ArtifactsURL(APIV2), "image", constants.CDNMeasurementsFile)
@@ -368,7 +404,7 @@ var (
 
 func shortPath(ref, stream, version string) string {
 	var sp string
-	if ref != ReleaseRef {
+	if ref != constants.ReleaseRef {
 		return path.Join("ref", ref, "stream", stream, version)
 	}
 
@@ -408,11 +444,11 @@ func parseShortPath(shortPath string) (ref, stream, version string, err error) {
 		if !semver.IsValid(version) {
 			return "", "", "", fmt.Errorf("invalid version %q", version)
 		}
-		return ReleaseRef, stream, version, nil
+		return constants.ReleaseRef, stream, version, nil
 	}
 
 	if semver.IsValid(shortPath) {
-		return ReleaseRef, "stable", shortPath, nil
+		return constants.ReleaseRef, "stable", shortPath, nil
 	}
 
 	return "", "", "", fmt.Errorf("invalid short path %q", shortPath)

--- a/internal/api/versionsapi/version.go
+++ b/internal/api/versionsapi/version.go
@@ -20,6 +20,9 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 )
 
+// ReleaseRef is the ref used for release versions.
+const ReleaseRef = "-"
+
 // Version represents a version. A version has a ref, stream, version string and kind.
 //
 // Notice that version is a meta object to the versions API and there isn't an
@@ -321,13 +324,13 @@ var notAZ09Regexp = regexp.MustCompile("[^a-zA-Z0-9-]")
 
 // CanonicalizeRef returns the canonicalized ref for the given ref.
 func CanonicalizeRef(ref string) string {
-	if ref == constants.ReleaseRef {
+	if ref == ReleaseRef {
 		return ref
 	}
 
 	canRef := notAZ09Regexp.ReplaceAllString(ref, "-")
 
-	if canRef == constants.ReleaseRef {
+	if canRef == ReleaseRef {
 		return "" // No ref should be cannonicalized to the release ref.
 	}
 
@@ -357,7 +360,7 @@ func ValidateStream(ref, stream string) error {
 	validReleaseStreams := []string{"stable", "console", "debug"}
 	validStreams := []string{"nightly", "console", "debug"}
 
-	if ref == constants.ReleaseRef {
+	if ref == ReleaseRef {
 		validStreams = validReleaseStreams
 	}
 
@@ -404,7 +407,7 @@ var (
 
 func shortPath(ref, stream, version string) string {
 	var sp string
-	if ref != constants.ReleaseRef {
+	if ref != ReleaseRef {
 		return path.Join("ref", ref, "stream", stream, version)
 	}
 
@@ -444,11 +447,11 @@ func parseShortPath(shortPath string) (ref, stream, version string, err error) {
 		if !semver.IsValid(version) {
 			return "", "", "", fmt.Errorf("invalid version %q", version)
 		}
-		return constants.ReleaseRef, stream, version, nil
+		return ReleaseRef, stream, version, nil
 	}
 
 	if semver.IsValid(shortPath) {
-		return constants.ReleaseRef, "stable", shortPath, nil
+		return ReleaseRef, "stable", shortPath, nil
 	}
 
 	return "", "", "", fmt.Errorf("invalid short path %q", shortPath)

--- a/internal/api/versionsapi/version_test.go
+++ b/internal/api/versionsapi/version_test.go
@@ -27,7 +27,7 @@ func TestNewVersionFromShortPath(t *testing.T) {
 			path: "v9.9.9",
 			kind: VersionKindImage,
 			wantVer: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
@@ -37,7 +37,7 @@ func TestNewVersionFromShortPath(t *testing.T) {
 			path: "stream/debug/v9.9.9",
 			kind: VersionKindImage,
 			wantVer: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "debug",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
@@ -47,7 +47,7 @@ func TestNewVersionFromShortPath(t *testing.T) {
 			path: "v9.9.9",
 			kind: VersionKindCLI,
 			wantVer: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9",
 				kind:    VersionKindCLI,
@@ -57,7 +57,7 @@ func TestNewVersionFromShortPath(t *testing.T) {
 			path: "stream/debug/v9.9.9",
 			kind: VersionKindCLI,
 			wantVer: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "debug",
 				version: "v9.9.9",
 				kind:    VersionKindCLI,
@@ -102,7 +102,7 @@ func TestVersionShortPath(t *testing.T) {
 	}{
 		"stable release image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
@@ -111,7 +111,7 @@ func TestVersionShortPath(t *testing.T) {
 		},
 		"release debug image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "debug",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
@@ -129,7 +129,7 @@ func TestVersionShortPath(t *testing.T) {
 		},
 		"stable release cli": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9",
 				kind:    VersionKindCLI,
@@ -138,7 +138,7 @@ func TestVersionShortPath(t *testing.T) {
 		},
 		"release debug cli": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "debug",
 				version: "v9.9.9",
 				kind:    VersionKindCLI,
@@ -173,7 +173,7 @@ func TestVersionValidate(t *testing.T) {
 	}{
 		"valid image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
@@ -190,7 +190,7 @@ func TestVersionValidate(t *testing.T) {
 		},
 		"invalid stream image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "foo/bar",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
@@ -199,7 +199,7 @@ func TestVersionValidate(t *testing.T) {
 		},
 		"invalid version image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9/foo",
 				kind:    VersionKindImage,
@@ -208,7 +208,7 @@ func TestVersionValidate(t *testing.T) {
 		},
 		"valid cli": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9",
 				kind:    VersionKindCLI,
@@ -225,7 +225,7 @@ func TestVersionValidate(t *testing.T) {
 		},
 		"invalid stream cli": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "foo/bar",
 				version: "v9.9.9",
 				kind:    VersionKindCLI,
@@ -234,7 +234,7 @@ func TestVersionValidate(t *testing.T) {
 		},
 		"invalid version cli": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9/foo",
 				kind:    VersionKindCLI,
@@ -348,29 +348,29 @@ func TestVersionListPathURL(t *testing.T) {
 	}{
 		"release image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
 			},
 			gran:     GranularityMajor,
-			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/stable/versions/major/v9/image.json",
-			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/stable/versions/major/v9/image.json",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/stable/versions/major/v9/image.json",
+			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/stable/versions/major/v9/image.json",
 		},
 		"release with minor image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
 			},
 			gran:     GranularityMinor,
-			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/stable/versions/minor/v9.9/image.json",
-			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/stable/versions/minor/v9.9/image.json",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/stable/versions/minor/v9.9/image.json",
+			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/stable/versions/minor/v9.9/image.json",
 		},
 		"release with patch image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
@@ -381,7 +381,7 @@ func TestVersionListPathURL(t *testing.T) {
 		},
 		"release with unknown image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
@@ -392,25 +392,25 @@ func TestVersionListPathURL(t *testing.T) {
 		},
 		"release debug stream image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "debug",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
 			},
 			gran:     GranularityMajor,
-			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/debug/versions/major/v9/image.json",
-			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/debug/versions/major/v9/image.json",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/debug/versions/major/v9/image.json",
+			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/debug/versions/major/v9/image.json",
 		},
 		"release debug stream with minor image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "debug",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
 			},
 			gran:     GranularityMinor,
-			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/debug/versions/minor/v9.9/image.json",
-			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/debug/versions/minor/v9.9/image.json",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/debug/versions/minor/v9.9/image.json",
+			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/debug/versions/minor/v9.9/image.json",
 		},
 		"branch ref image": {
 			ver: Version{
@@ -503,21 +503,21 @@ func TestVersionArtifactPathURL(t *testing.T) {
 	}{
 		"release image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
 			},
-			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/stable/v9.9.9",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/stable/v9.9.9",
 		},
 		"release debug stream image": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "debug",
 				version: "v9.9.9",
 				kind:    VersionKindImage,
 			},
-			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/debug/v9.9.9",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/debug/v9.9.9",
 		},
 		"branch ref image": {
 			ver: Version{
@@ -530,21 +530,21 @@ func TestVersionArtifactPathURL(t *testing.T) {
 		},
 		"release cli": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "stable",
 				version: "v9.9.9",
 				kind:    VersionKindCLI,
 			},
-			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/stable/v9.9.9",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/stable/v9.9.9",
 		},
 		"release debug stream cli": {
 			ver: Version{
-				ref:     constants.ReleaseRef,
+				ref:     ReleaseRef,
 				stream:  "debug",
 				version: "v9.9.9",
 				kind:    VersionKindCLI,
 			},
-			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/debug/v9.9.9",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/debug/v9.9.9",
 		},
 		"branch ref cli": {
 			ver: Version{
@@ -659,14 +659,14 @@ func TestGranularityFromString(t *testing.T) {
 
 func TestCanonicalRef(t *testing.T) {
 	testCases := map[string]string{
-		"feat/foo":           "feat-foo",
-		"feat-foo":           "feat-foo",
-		"feat$foo":           "feat-foo",
-		"3234":               "3234",
-		"feat foo":           "feat-foo",
-		"/../":               "----",
-		constants.ReleaseRef: constants.ReleaseRef,
-		".":                  "",
+		"feat/foo": "feat-foo",
+		"feat-foo": "feat-foo",
+		"feat$foo": "feat-foo",
+		"3234":     "3234",
+		"feat foo": "feat-foo",
+		"/../":     "----",
+		ReleaseRef: ReleaseRef,
+		".":        "",
 	}
 
 	for ref, want := range testCases {
@@ -742,17 +742,17 @@ func TestShortPath(t *testing.T) {
 		version string
 	}{
 		"v9.9.9": {
-			ref:     constants.ReleaseRef,
+			ref:     ReleaseRef,
 			stream:  "stable",
 			version: "v9.9.9",
 		},
 		"v9.9.9-foo": {
-			ref:     constants.ReleaseRef,
+			ref:     ReleaseRef,
 			stream:  "stable",
 			version: "v9.9.9-foo",
 		},
 		"stream/debug/v9.9.9": {
-			ref:     constants.ReleaseRef,
+			ref:     ReleaseRef,
 			stream:  "debug",
 			version: "v9.9.9",
 		},
@@ -786,17 +786,17 @@ func TestParseShortPath(t *testing.T) {
 		wantErr     bool
 	}{
 		"v9.9.9": {
-			wantRef:     constants.ReleaseRef,
+			wantRef:     ReleaseRef,
 			wantStream:  "stable",
 			wantVersion: "v9.9.9",
 		},
 		"v9.9.9-foo": {
-			wantRef:     constants.ReleaseRef,
+			wantRef:     ReleaseRef,
 			wantStream:  "stable",
 			wantVersion: "v9.9.9-foo",
 		},
 		"stream/debug/v9.9.9": {
-			wantRef:     constants.ReleaseRef,
+			wantRef:     ReleaseRef,
 			wantStream:  "debug",
 			wantVersion: "v9.9.9",
 		},

--- a/internal/api/versionsapi/version_test.go
+++ b/internal/api/versionsapi/version_test.go
@@ -27,40 +27,40 @@ func TestNewVersionFromShortPath(t *testing.T) {
 			path: "v9.9.9",
 			kind: VersionKindImage,
 			wantVer: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 		},
 		"release debug image": {
 			path: "stream/debug/v9.9.9",
 			kind: VersionKindImage,
 			wantVer: Version{
-				Ref:     ReleaseRef,
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 		},
 		"stable release cli": {
 			path: "v9.9.9",
 			kind: VersionKindCLI,
 			wantVer: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindCLI,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindCLI,
 			},
 		},
 		"release debug cli": {
 			path: "stream/debug/v9.9.9",
 			kind: VersionKindCLI,
 			wantVer: Version{
-				Ref:     ReleaseRef,
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindCLI,
+				ref:     constants.ReleaseRef,
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindCLI,
 			},
 		},
 		"unknown kind": {
@@ -102,55 +102,55 @@ func TestVersionShortPath(t *testing.T) {
 	}{
 		"stable release image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			want: "v9.9.9",
 		},
 		"release debug image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			want: "stream/debug/v9.9.9",
 		},
 		"branch image": {
 			ver: Version{
-				Ref:     "foo",
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     "foo",
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			want: "ref/foo/stream/debug/v9.9.9",
 		},
 		"stable release cli": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindCLI,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindCLI,
 			},
 			want: "v9.9.9",
 		},
 		"release debug cli": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindCLI,
+				ref:     constants.ReleaseRef,
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindCLI,
 			},
 			want: "stream/debug/v9.9.9",
 		},
 		"branch cli": {
 			ver: Version{
-				Ref:     "foo",
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindCLI,
+				ref:     "foo",
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindCLI,
 			},
 			want: "ref/foo/stream/debug/v9.9.9",
 		},
@@ -173,71 +173,71 @@ func TestVersionValidate(t *testing.T) {
 	}{
 		"valid image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 		},
 		"invalid ref image": {
 			ver: Version{
-				Ref:     "foo/bar",
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     "foo/bar",
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			wantErr: true,
 		},
 		"invalid stream image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "foo/bar",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "foo/bar",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			wantErr: true,
 		},
 		"invalid version image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9/foo",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9/foo",
+				kind:    VersionKindImage,
 			},
 			wantErr: true,
 		},
 		"valid cli": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindCLI,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindCLI,
 			},
 		},
 		"invalid ref cli": {
 			ver: Version{
-				Ref:     "foo/bar",
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindCLI,
+				ref:     "foo/bar",
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindCLI,
 			},
 			wantErr: true,
 		},
 		"invalid stream cli": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "foo/bar",
-				Version: "v9.9.9",
-				Kind:    VersionKindCLI,
+				ref:     constants.ReleaseRef,
+				stream:  "foo/bar",
+				version: "v9.9.9",
+				kind:    VersionKindCLI,
 			},
 			wantErr: true,
 		},
 		"invalid version cli": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9/foo",
-				Kind:    VersionKindCLI,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9/foo",
+				kind:    VersionKindCLI,
 			},
 			wantErr: true,
 		},
@@ -268,7 +268,7 @@ func TestVersionMajor(t *testing.T) {
 		t.Run(version, func(t *testing.T) {
 			assert := assert.New(t)
 
-			ver := Version{Version: version}
+			ver := Version{version: version}
 			assert.Equal(major, ver.Major())
 		})
 	}
@@ -285,7 +285,7 @@ func TestVersionMajorMinor(t *testing.T) {
 		t.Run(version, func(t *testing.T) {
 			assert := assert.New(t)
 
-			ver := Version{Version: version}
+			ver := Version{version: version}
 			assert.Equal(major, ver.MajorMinor())
 		})
 	}
@@ -333,7 +333,7 @@ func TestVersionWithGranularity(t *testing.T) {
 		t.Run(tc.ver, func(t *testing.T) {
 			assert := assert.New(t)
 
-			ver := Version{Version: tc.ver}
+			ver := Version{version: tc.ver}
 			assert.Equal(tc.want, ver.WithGranularity(tc.gran))
 		})
 	}
@@ -348,32 +348,32 @@ func TestVersionListPathURL(t *testing.T) {
 	}{
 		"release image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			gran:     GranularityMajor,
-			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/stable/versions/major/v9/image.json",
-			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/stable/versions/major/v9/image.json",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/stable/versions/major/v9/image.json",
+			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/stable/versions/major/v9/image.json",
 		},
 		"release with minor image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			gran:     GranularityMinor,
-			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/stable/versions/minor/v9.9/image.json",
-			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/stable/versions/minor/v9.9/image.json",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/stable/versions/minor/v9.9/image.json",
+			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/stable/versions/minor/v9.9/image.json",
 		},
 		"release with patch image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			gran:     GranularityPatch,
 			wantPath: "",
@@ -381,10 +381,10 @@ func TestVersionListPathURL(t *testing.T) {
 		},
 		"release with unknown image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			gran:     GranularityUnknown,
 			wantPath: "",
@@ -392,32 +392,32 @@ func TestVersionListPathURL(t *testing.T) {
 		},
 		"release debug stream image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			gran:     GranularityMajor,
-			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/debug/versions/major/v9/image.json",
-			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/debug/versions/major/v9/image.json",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/debug/versions/major/v9/image.json",
+			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/debug/versions/major/v9/image.json",
 		},
 		"release debug stream with minor image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			gran:     GranularityMinor,
-			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/debug/versions/minor/v9.9/image.json",
-			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/debug/versions/minor/v9.9/image.json",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/debug/versions/minor/v9.9/image.json",
+			wantURL:  constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/debug/versions/minor/v9.9/image.json",
 		},
 		"branch ref image": {
 			ver: Version{
-				Ref:     "foo",
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     "foo",
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			gran:     GranularityMajor,
 			wantPath: constants.CDNAPIPrefix + "/ref/foo/stream/debug/versions/major/v9/image.json",
@@ -425,10 +425,10 @@ func TestVersionListPathURL(t *testing.T) {
 		},
 		"branch ref with minor image": {
 			ver: Version{
-				Ref:     "foo",
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     "foo",
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			gran:     GranularityMinor,
 			wantPath: constants.CDNAPIPrefix + "/ref/foo/stream/debug/versions/minor/v9.9/image.json",
@@ -463,10 +463,10 @@ func TestVersionArtifactURL(t *testing.T) {
 	}{
 		"nightly-feature": {
 			ver: Version{
-				Ref:     "feat-some-feature",
-				Stream:  "nightly",
-				Version: "v2.6.0-pre.0.20230217095603-193dd48ca19f",
-				Kind:    VersionKindImage,
+				ref:     "feat-some-feature",
+				stream:  "nightly",
+				version: "v2.6.0-pre.0.20230217095603-193dd48ca19f",
+				kind:    VersionKindImage,
 			},
 			csp:                cloudprovider.GCP,
 			wantMeasurementURL: constants.CDNRepositoryURL + "/" + constants.CDNAPIPrefixV2 + "/ref/feat-some-feature/stream/nightly/v2.6.0-pre.0.20230217095603-193dd48ca19f/image/measurements.json",
@@ -474,7 +474,7 @@ func TestVersionArtifactURL(t *testing.T) {
 		},
 		"fail for wrong kind": {
 			ver: Version{
-				Kind: VersionKindCLI,
+				kind: VersionKindCLI,
 			},
 			wantErr: true,
 		},
@@ -503,55 +503,55 @@ func TestVersionArtifactPathURL(t *testing.T) {
 	}{
 		"release image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
-			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/stable/v9.9.9",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/stable/v9.9.9",
 		},
 		"release debug stream image": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     constants.ReleaseRef,
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
-			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/debug/v9.9.9",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/debug/v9.9.9",
 		},
 		"branch ref image": {
 			ver: Version{
-				Ref:     "foo",
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindImage,
+				ref:     "foo",
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindImage,
 			},
 			wantPath: constants.CDNAPIPrefix + "/ref/foo/stream/debug/v9.9.9",
 		},
 		"release cli": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "stable",
-				Version: "v9.9.9",
-				Kind:    VersionKindCLI,
+				ref:     constants.ReleaseRef,
+				stream:  "stable",
+				version: "v9.9.9",
+				kind:    VersionKindCLI,
 			},
-			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/stable/v9.9.9",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/stable/v9.9.9",
 		},
 		"release debug stream cli": {
 			ver: Version{
-				Ref:     ReleaseRef,
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindCLI,
+				ref:     constants.ReleaseRef,
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindCLI,
 			},
-			wantPath: constants.CDNAPIPrefix + "/ref/" + ReleaseRef + "/stream/debug/v9.9.9",
+			wantPath: constants.CDNAPIPrefix + "/ref/" + constants.ReleaseRef + "/stream/debug/v9.9.9",
 		},
 		"branch ref cli": {
 			ver: Version{
-				Ref:     "foo",
-				Stream:  "debug",
-				Version: "v9.9.9",
-				Kind:    VersionKindCLI,
+				ref:     "foo",
+				stream:  "debug",
+				version: "v9.9.9",
+				kind:    VersionKindCLI,
 			},
 			wantPath: constants.CDNAPIPrefix + "/ref/foo/stream/debug/v9.9.9",
 		},
@@ -659,14 +659,14 @@ func TestGranularityFromString(t *testing.T) {
 
 func TestCanonicalRef(t *testing.T) {
 	testCases := map[string]string{
-		"feat/foo": "feat-foo",
-		"feat-foo": "feat-foo",
-		"feat$foo": "feat-foo",
-		"3234":     "3234",
-		"feat foo": "feat-foo",
-		"/../":     "----",
-		ReleaseRef: ReleaseRef,
-		".":        "",
+		"feat/foo":           "feat-foo",
+		"feat-foo":           "feat-foo",
+		"feat$foo":           "feat-foo",
+		"3234":               "3234",
+		"feat foo":           "feat-foo",
+		"/../":               "----",
+		constants.ReleaseRef: constants.ReleaseRef,
+		".":                  "",
 	}
 
 	for ref, want := range testCases {
@@ -742,17 +742,17 @@ func TestShortPath(t *testing.T) {
 		version string
 	}{
 		"v9.9.9": {
-			ref:     ReleaseRef,
+			ref:     constants.ReleaseRef,
 			stream:  "stable",
 			version: "v9.9.9",
 		},
 		"v9.9.9-foo": {
-			ref:     ReleaseRef,
+			ref:     constants.ReleaseRef,
 			stream:  "stable",
 			version: "v9.9.9-foo",
 		},
 		"stream/debug/v9.9.9": {
-			ref:     ReleaseRef,
+			ref:     constants.ReleaseRef,
 			stream:  "debug",
 			version: "v9.9.9",
 		},
@@ -786,17 +786,17 @@ func TestParseShortPath(t *testing.T) {
 		wantErr     bool
 	}{
 		"v9.9.9": {
-			wantRef:     ReleaseRef,
+			wantRef:     constants.ReleaseRef,
 			wantStream:  "stable",
 			wantVersion: "v9.9.9",
 		},
 		"v9.9.9-foo": {
-			wantRef:     ReleaseRef,
+			wantRef:     constants.ReleaseRef,
 			wantStream:  "stable",
 			wantVersion: "v9.9.9-foo",
 		},
 		"stream/debug/v9.9.9": {
-			wantRef:     ReleaseRef,
+			wantRef:     constants.ReleaseRef,
 			wantStream:  "debug",
 			wantVersion: "v9.9.9",
 		},

--- a/internal/attestation/measurements/BUILD.bazel
+++ b/internal/attestation/measurements/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
         "//internal/api/versionsapi",
         "//internal/attestation/variant",
         "//internal/cloud/cloudprovider",
-        "//internal/sigstore",
         "@com_github_google_go_tpm//tpmutil",
         "@com_github_siderolabs_talos_pkg_machinery//config/encoder",
         "@in_gopkg_yaml_v3//:yaml_v3",

--- a/internal/attestation/measurements/measurement-generator/BUILD.bazel
+++ b/internal/attestation/measurements/measurement-generator/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//internal/attestation/variant",
         "//internal/cloud/cloudprovider",
         "//internal/sigstore",
+        "//internal/sigstore/keyselect",
         "@org_golang_x_tools//go/ast/astutil",
     ],
 )

--- a/internal/attestation/measurements/measurement-generator/generate.go
+++ b/internal/attestation/measurements/measurement-generator/generate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/sigstore"
+	"github.com/edgelesssys/constellation/v2/internal/sigstore/keyselect"
 	"golang.org/x/tools/go/ast/astutil"
 )
 
@@ -122,7 +123,7 @@ func mustGetMeasurements(ctx context.Context, verifier rekorVerifier, provider c
 		panic(err)
 	}
 
-	publicKey, err := sigstore.CosignPublicKeyForVersion(imageVersion)
+	publicKey, err := keyselect.CosignPublicKeyForVersion(imageVersion)
 	if err != nil {
 		panic(fmt.Errorf("getting public key: %w", err))
 	}
@@ -145,7 +146,7 @@ func mustGetMeasurements(ctx context.Context, verifier rekorVerifier, provider c
 	if err != nil {
 		panic(err)
 	}
-	if err := sigstore.VerifyWithRekor(ctx, imageVersion, verifier, hash); err != nil {
+	if err := sigstore.VerifyWithRekor(ctx, publicKey, verifier, hash); err != nil {
 		panic(err)
 	}
 	return fetchedMeasurements

--- a/internal/attestation/measurements/measurement-generator/generate.go
+++ b/internal/attestation/measurements/measurement-generator/generate.go
@@ -127,8 +127,7 @@ func mustGetMeasurements(ctx context.Context, verifier rekorVerifier, provider c
 		panic(fmt.Errorf("getting public key: %w", err))
 	}
 
-	cosignVerifier := sigstore.CosignVerifier{}
-	err = cosignVerifier.SetPublicKey(publicKey)
+	cosignVerifier, err := sigstore.NewCosignVerifier(publicKey)
 	if err != nil {
 		panic(fmt.Errorf("creating cosign verifier: %w", err))
 	}
@@ -136,7 +135,7 @@ func mustGetMeasurements(ctx context.Context, verifier rekorVerifier, provider c
 	log.Println("Fetching measurements from", measurementsURL, "and signature from", signatureURL)
 	var fetchedMeasurements measurements.M
 	hash, err := fetchedMeasurements.FetchAndVerify(
-		ctx, http.DefaultClient, &cosignVerifier,
+		ctx, http.DefaultClient, cosignVerifier,
 		measurementsURL,
 		signatureURL,
 		imageVersion,

--- a/internal/attestation/measurements/measurement-generator/generate.go
+++ b/internal/attestation/measurements/measurement-generator/generate.go
@@ -122,10 +122,21 @@ func mustGetMeasurements(ctx context.Context, verifier rekorVerifier, provider c
 		panic(err)
 	}
 
+	publicKey, err := sigstore.CosignPublicKeyForVersion(imageVersion)
+	if err != nil {
+		panic(fmt.Errorf("getting public key: %w", err))
+	}
+
+	cosignVerifier := sigstore.CosignVerifier{}
+	err = cosignVerifier.SetPublicKey(publicKey)
+	if err != nil {
+		panic(fmt.Errorf("creating cosign verifier: %w", err))
+	}
+
 	log.Println("Fetching measurements from", measurementsURL, "and signature from", signatureURL)
 	var fetchedMeasurements measurements.M
 	hash, err := fetchedMeasurements.FetchAndVerify(
-		ctx, http.DefaultClient, sigstore.CosignVerifier{},
+		ctx, http.DefaultClient, &cosignVerifier,
 		measurementsURL,
 		signatureURL,
 		imageVersion,

--- a/internal/attestation/measurements/measurements.go
+++ b/internal/attestation/measurements/measurements.go
@@ -546,6 +546,5 @@ func getFromURL(ctx context.Context, client *http.Client, sourceURL *url.URL) ([
 }
 
 type cosignVerifier interface {
-	SetPublicKey(pem []byte) error
 	VerifySignature(content, signature []byte) error
 }

--- a/internal/attestation/measurements/measurements.go
+++ b/internal/attestation/measurements/measurements.go
@@ -308,11 +308,9 @@ func (m *M) fromImageMeasurementsV2(
 	measurements ImageMeasurementsV2, wantVersion versionsapi.Version,
 	csp cloudprovider.Provider, attestationVariant variant.Variant,
 ) error {
-	gotVersion := versionsapi.Version{
-		Ref:     measurements.Ref,
-		Stream:  measurements.Stream,
-		Version: measurements.Version,
-		Kind:    versionsapi.VersionKindImage,
+	gotVersion, err := versionsapi.NewVersion(measurements.Ref, measurements.Stream, measurements.Version, versionsapi.VersionKindImage)
+	if err != nil {
+		return fmt.Errorf("invalid metadata version: %w", err)
 	}
 	if !wantVersion.Equal(gotVersion) {
 		return fmt.Errorf("invalid measurement metadata: version mismatch: expected %s, got %s", wantVersion.ShortPath(), gotVersion.ShortPath())

--- a/internal/attestation/measurements/measurements_test.go
+++ b/internal/attestation/measurements/measurements_test.go
@@ -332,6 +332,11 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 	// -----END ENCRYPTED COSIGN PRIVATE KEY-----
 	cosignPublicKey := []byte("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEu78QgxOOcao6U91CSzEXxrKhvFTt\nJHNy+eX6EMePtDm8CnDF9HSwnTlD0itGJ/XHPQA5YX10fJAqI1y+ehlFMw==\n-----END PUBLIC KEY-----")
 
+	v1Test, err := versionsapi.NewVersion("-", "stable", "v1.0.0-test", versionsapi.VersionKindImage)
+	require.NoError(t, err)
+	v1AnotherImage, err := versionsapi.NewVersion("-", "stable", "v1.0.0-another-image", versionsapi.VersionKindImage)
+	require.NoError(t, err)
+
 	testCases := map[string]struct {
 		measurements       string
 		csp                cloudprovider.Provider
@@ -347,7 +352,7 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 		"json measurements": {
 			measurements:       `{"version":"v1.0.0-test","ref":"-","stream":"stable","list":[{"csp":"Unknown","attestationVariant":"dummy","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}]}`,
 			csp:                cloudprovider.Unknown,
-			imageVersion:       versionsapi.Version{Ref: "-", Stream: "stable", Version: "v1.0.0-test", Kind: versionsapi.VersionKindImage},
+			imageVersion:       v1Test,
 			measurementsStatus: http.StatusOK,
 			signature:          "MEUCIHuW2420EqN4Kj6OEaVMmufH7d01vyR1J+SWg8H4elyBAiEA1Ki5Hfq0iI70qpViYbrTFrd8e840NjtdAxGqJKiJgbA=",
 			signatureStatus:    http.StatusOK,
@@ -359,7 +364,7 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 		"404 measurements": {
 			measurements:       `{"version":"v1.0.0-test","ref":"-","stream":"stable","list":[{"csp":"Unknown","attestationVariant":"dummy","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}]}`,
 			csp:                cloudprovider.Unknown,
-			imageVersion:       versionsapi.Version{Ref: "-", Stream: "stable", Version: "v1.0.0-test", Kind: versionsapi.VersionKindImage},
+			imageVersion:       v1Test,
 			measurementsStatus: http.StatusNotFound,
 			signature:          "MEUCIHuW2420EqN4Kj6OEaVMmufH7d01vyR1J+SWg8H4elyBAiEA1Ki5Hfq0iI70qpViYbrTFrd8e840NjtdAxGqJKiJgbA=",
 			signatureStatus:    http.StatusOK,
@@ -368,7 +373,7 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 		"404 signature": {
 			measurements:       `{"version":"v1.0.0-test","ref":"-","stream":"stable","list":[{"csp":"Unknown","attestationVariant":"dummy","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}]}`,
 			csp:                cloudprovider.Unknown,
-			imageVersion:       versionsapi.Version{Ref: "-", Stream: "stable", Version: "v1.0.0-test", Kind: versionsapi.VersionKindImage},
+			imageVersion:       v1Test,
 			measurementsStatus: http.StatusOK,
 			signature:          "MEUCIHuW2420EqN4Kj6OEaVMmufH7d01vyR1J+SWg8H4elyBAiEA1Ki5Hfq0iI70qpViYbrTFrd8e840NjtdAxGqJKiJgbA=",
 			signatureStatus:    http.StatusNotFound,
@@ -377,7 +382,7 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 		"broken signature": {
 			measurements:       `{"version":"v1.0.0-test","ref":"-","stream":"stable","list":[{"csp":"Unknown","attestationVariant":"dummy","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}]}`,
 			csp:                cloudprovider.Unknown,
-			imageVersion:       versionsapi.Version{Ref: "-", Stream: "stable", Version: "v1.0.0-test", Kind: versionsapi.VersionKindImage},
+			imageVersion:       v1Test,
 			measurementsStatus: http.StatusOK,
 			signature:          "AAAAAAA1RR91pWPw1BMWXTSmTBHg/JtfKerbZNQ9PJTWDdW0sgIhANQbETJGb67qzQmMVmcq007VUFbHRMtYWKZeeyRf0gVa",
 			signatureStatus:    http.StatusOK,
@@ -386,7 +391,7 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 		"metadata CSP mismatch": {
 			measurements:       `{"version":"v1.0.0-test","ref":"-","stream":"stable","list":[{"csp":"Unknown","attestationVariant":"dummy","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}]}`,
 			csp:                cloudprovider.GCP,
-			imageVersion:       versionsapi.Version{Ref: "-", Stream: "stable", Version: "v1.0.0-test", Kind: versionsapi.VersionKindImage},
+			imageVersion:       v1Test,
 			measurementsStatus: http.StatusOK,
 			signature:          "MEUCIHuW2420EqN4Kj6OEaVMmufH7d01vyR1J+SWg8H4elyBAiEA1Ki5Hfq0iI70qpViYbrTFrd8e840NjtdAxGqJKiJgbA=",
 			signatureStatus:    http.StatusOK,
@@ -395,7 +400,7 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 		"metadata image mismatch": {
 			measurements:       `{"version":"v1.0.0-test","ref":"-","stream":"stable","list":[{"csp":"Unknown","attestationVariant":"dummy","measurements":{"0":{"expected":"0000000000000000000000000000000000000000000000000000000000000000","warnOnly":false}}}]}`,
 			csp:                cloudprovider.Unknown,
-			imageVersion:       versionsapi.Version{Ref: "-", Stream: "stable", Version: "v1.0.0-another-image", Kind: versionsapi.VersionKindImage},
+			imageVersion:       v1AnotherImage,
 			measurementsStatus: http.StatusOK,
 			signature:          "MEUCIHuW2420EqN4Kj6OEaVMmufH7d01vyR1J+SWg8H4elyBAiEA1Ki5Hfq0iI70qpViYbrTFrd8e840NjtdAxGqJKiJgbA=",
 			signatureStatus:    http.StatusOK,
@@ -404,7 +409,7 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 		"not json": {
 			measurements:       "This is some content to be signed!\n",
 			csp:                cloudprovider.Unknown,
-			imageVersion:       versionsapi.Version{Ref: "-", Stream: "stable", Version: "v1.0.0-test", Kind: versionsapi.VersionKindImage},
+			imageVersion:       v1Test,
 			measurementsStatus: http.StatusOK,
 			signature:          "MEUCIQCGA/lSu5qCJgNNvgMaTKJ9rj6vQMecUDaQo3ukaiAfUgIgWoxXRoDKLY9naN7YgxokM7r2fwnyYk3M2WKJJO1g6yo=",
 			signatureStatus:    http.StatusOK,

--- a/internal/attestation/measurements/measurements_test.go
+++ b/internal/attestation/measurements/measurements_test.go
@@ -423,6 +423,7 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
+			require := require.New(t)
 
 			if tc.attestationVariant == nil {
 				tc.attestationVariant = variant.Dummy{}
@@ -452,10 +453,13 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 
 			m := M{}
 
+			verifier := sigstore.CosignVerifier{}
+			err := verifier.SetPublicKey(cosignPublicKey)
+			require.NoError(err)
+
 			hash, err := m.fetchAndVerify(
-				context.Background(), client, sigstore.CosignVerifier{},
+				context.Background(), client, &verifier,
 				measurementsURL, signatureURL,
-				cosignPublicKey,
 				tc.imageVersion,
 				tc.csp,
 				tc.attestationVariant,

--- a/internal/attestation/measurements/measurements_test.go
+++ b/internal/attestation/measurements/measurements_test.go
@@ -453,12 +453,11 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 
 			m := M{}
 
-			verifier := sigstore.CosignVerifier{}
-			err := verifier.SetPublicKey(cosignPublicKey)
+			verifier, err := sigstore.NewCosignVerifier(cosignPublicKey)
 			require.NoError(err)
 
 			hash, err := m.fetchAndVerify(
-				context.Background(), client, &verifier,
+				context.Background(), client, verifier,
 				measurementsURL, signatureURL,
 				tc.imageVersion,
 				tc.csp,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -578,7 +578,7 @@ func (c *Config) IsNamedLikeDebugImage() bool {
 	if err != nil {
 		return false
 	}
-	return v.Stream == "debug"
+	return v.Stream() == "debug"
 }
 
 // GetProvider returns the configured cloud provider.

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -513,7 +513,7 @@ func validateImageCompatibilityHelper(binaryVersion consemver.Semver, fieldName,
 		if err != nil {
 			return err
 		}
-		configuredVersion = imageVersion.Version
+		configuredVersion = imageVersion.Version()
 	}
 
 	return compatibility.BinaryWith(binaryVersion.String(), configuredVersion)

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -232,6 +232,14 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELcPl4Ik+qZuH4K049wksoXK/Os3Z
 b92PDCpM7FZAINQF88s1TZS/HmRXYk62UJ4eqPduvUnJmXhNikhLbMi6fw==
 -----END PUBLIC KEY-----
 `
+
+	// ReleaseRef is the ref used for release versions.
+	// TODO (derpsteb): move this back into versionsapi all Fetch calls that validate signatures are replaced with FetchAndVerify.
+	// Located in this global pkg at the moment because versionsapi and sigstore should not import each other.
+	// Previously sigstore imported versionsapi to access the ReleaseRef constant.
+	// internal/api needs to import sigstore to create and verify signatures.
+	// Currently, we creating signature in different places. This could move into internal/api.
+	ReleaseRef = "-"
 )
 
 // BinaryVersion returns the version of this Binary.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -232,14 +232,6 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELcPl4Ik+qZuH4K049wksoXK/Os3Z
 b92PDCpM7FZAINQF88s1TZS/HmRXYk62UJ4eqPduvUnJmXhNikhLbMi6fw==
 -----END PUBLIC KEY-----
 `
-
-	// ReleaseRef is the ref used for release versions.
-	// TODO (derpsteb): move this back into versionsapi all Fetch calls that validate signatures are replaced with FetchAndVerify.
-	// Located in this global pkg at the moment because versionsapi and sigstore should not import each other.
-	// Previously sigstore imported versionsapi to access the ReleaseRef constant.
-	// internal/api needs to import sigstore to create and verify signatures.
-	// Currently, we creating signature in different places. This could move into internal/api.
-	ReleaseRef = "-"
 )
 
 // BinaryVersion returns the version of this Binary.

--- a/internal/imagefetcher/imagefetcher.go
+++ b/internal/imagefetcher/imagefetcher.go
@@ -51,9 +51,9 @@ func (f *Fetcher) FetchReference(ctx context.Context,
 	}
 
 	imgInfoReq := versionsapi.ImageInfo{
-		Ref:     ver.Ref,
-		Stream:  ver.Stream,
-		Version: ver.Version,
+		Ref:     ver.Ref(),
+		Stream:  ver.Stream(),
+		Version: ver.Version(),
 	}
 
 	url, err := imgInfoReq.URL()

--- a/internal/osimage/archive/archive.go
+++ b/internal/osimage/archive/archive.go
@@ -67,7 +67,7 @@ func (a *Archivist) Close(ctx context.Context) error {
 
 // Archive reads the OS image in img and uploads it as key.
 func (a *Archivist) Archive(ctx context.Context, version versionsapi.Version, csp, attestationVariant string, img io.Reader) (string, error) {
-	key, err := url.JoinPath(version.ArtifactPath(versionsapi.APIV1), version.Kind.String(), "csp", csp, attestationVariant, "image.raw")
+	key, err := url.JoinPath(version.ArtifactPath(versionsapi.APIV1), version.Kind().String(), "csp", csp, attestationVariant, "image.raw")
 	if err != nil {
 		return "", err
 	}

--- a/internal/osimage/aws/awsupload.go
+++ b/internal/osimage/aws/awsupload.go
@@ -73,7 +73,7 @@ func New(region, bucketName string, log *logger.Logger) (*Uploader, error) {
 
 // Upload uploads an OS image to AWS.
 func (u *Uploader) Upload(ctx context.Context, req *osimage.UploadRequest) ([]versionsapi.ImageInfoEntry, error) {
-	blobName := fmt.Sprintf("image-%s-%s-%d.raw", req.Version.Stream, req.Version.Version, req.Timestamp.Unix())
+	blobName := fmt.Sprintf("image-%s-%s-%d.raw", req.Version.Stream(), req.Version.Version(), req.Timestamp.Unix())
 	imageName := imageName(req.Version, req.AttestationVariant, req.Timestamp)
 	allRegions := []string{u.region}
 	allRegions = append(allRegions, replicationRegions...)
@@ -479,10 +479,10 @@ func (u *Uploader) ensureImageDeleted(ctx context.Context, imageName, region str
 }
 
 func imageName(version versionsapi.Version, attestationVariant string, timestamp time.Time) string {
-	if version.Stream == "stable" {
-		return fmt.Sprintf("constellation-%s-%s", version.Version, attestationVariant)
+	if version.Stream() == "stable" {
+		return fmt.Sprintf("constellation-%s-%s", version.Version(), attestationVariant)
 	}
-	return fmt.Sprintf("constellation-%s-%s-%s-%s", version.Stream, version.Version, attestationVariant, timestamp.Format(timestampFormat))
+	return fmt.Sprintf("constellation-%s-%s-%s-%s", version.Stream(), version.Version(), attestationVariant, timestamp.Format(timestampFormat))
 }
 
 func waitForSnapshotImport(ctx context.Context, ec2C ec2API, importTaskID string) (string, error) {

--- a/internal/osimage/azure/azureupload.go
+++ b/internal/osimage/azure/azureupload.go
@@ -95,9 +95,9 @@ func New(subscription, location, resourceGroup string, log *logger.Logger) (*Upl
 // Upload uploads an OS image to Azure.
 func (u *Uploader) Upload(ctx context.Context, req *osimage.UploadRequest) ([]versionsapi.ImageInfoEntry, error) {
 	formattedTime := req.Timestamp.Format(timestampFormat)
-	diskName := fmt.Sprintf("constellation-%s-%s-%s", req.Version.Stream, formattedTime, req.AttestationVariant)
+	diskName := fmt.Sprintf("constellation-%s-%s-%s", req.Version.Stream(), formattedTime, req.AttestationVariant)
 	var sigName string
-	switch req.Version.Stream {
+	switch req.Version.Stream() {
 	case "stable":
 		sigName = sigNameStable
 	case "debug":
@@ -517,12 +517,12 @@ func uploadChunk(ctx context.Context, uploader azurePageblobAPI, chunk io.ReadSe
 
 func imageOffer(version versionsapi.Version) string {
 	switch {
-	case version.Stream == "stable":
+	case version.Stream() == "stable":
 		return "constellation"
-	case version.Stream == "debug" && version.Ref == "-":
-		return version.Version
+	case version.Stream() == "debug" && version.Ref() == "-":
+		return version.Version()
 	}
-	return version.Ref + "-" + version.Stream
+	return version.Ref() + "-" + version.Stream()
 }
 
 // imageVersion determines the semantic version string used inside a sig image.
@@ -530,10 +530,10 @@ func imageOffer(version versionsapi.Version) string {
 // Otherwise, the version is derived from the commit timestamp.
 func imageVersion(version versionsapi.Version, timestamp time.Time) (string, error) {
 	switch {
-	case version.Stream == "stable":
+	case version.Stream() == "stable":
 		fallthrough
-	case version.Stream == "debug" && version.Ref == "-":
-		return strings.TrimLeft(version.Version, "v"), nil
+	case version.Stream() == "debug" && version.Ref() == "-":
+		return strings.TrimLeft(version.Version(), "v"), nil
 	}
 
 	formattedTime := timestamp.Format(timestampFormat)

--- a/internal/osimage/gcp/gcpupload.go
+++ b/internal/osimage/gcp/gcpupload.go
@@ -225,16 +225,16 @@ func (u *Uploader) blobURL(blobName string) string {
 }
 
 func (u *Uploader) imageName(version versionsapi.Version, attestationVariant string) string {
-	return strings.ReplaceAll(version.Version, ".", "-") + "-" + attestationVariant + "-" + version.Stream
+	return strings.ReplaceAll(version.Version(), ".", "-") + "-" + attestationVariant + "-" + version.Stream()
 }
 
 func (u *Uploader) imageFamily(version versionsapi.Version) string {
-	if version.Stream == "stable" {
+	if version.Stream() == "stable" {
 		return "constellation"
 	}
-	truncatedRef := version.Ref
-	if len(version.Ref) > 45 {
-		truncatedRef = version.Ref[:45]
+	truncatedRef := version.Ref()
+	if len(version.Ref()) > 45 {
+		truncatedRef = version.Ref()[:45]
 	}
 	return "constellation-" + truncatedRef
 }

--- a/internal/osimage/imageinfo/imageinfo.go
+++ b/internal/osimage/imageinfo/imageinfo.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/url"
 
 	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -67,13 +68,11 @@ func (a *Uploader) Close(ctx context.Context) error {
 
 // Upload marshals the image info to JSON and uploads it to S3.
 func (a *Uploader) Upload(ctx context.Context, imageInfo versionsapi.ImageInfo) (string, error) {
-	ver := versionsapi.Version{
-		Ref:     imageInfo.Ref,
-		Stream:  imageInfo.Stream,
-		Version: imageInfo.Version,
-		Kind:    versionsapi.VersionKindImage,
+	ver, err := versionsapi.NewVersion(imageInfo.Ref, imageInfo.Stream, imageInfo.Version, versionsapi.VersionKindImage)
+	if err != nil {
+		return "", fmt.Errorf("creating version: %w", err)
 	}
-	key, err := url.JoinPath(ver.ArtifactPath(versionsapi.APIV2), ver.Kind.String(), "info.json")
+	key, err := url.JoinPath(ver.ArtifactPath(versionsapi.APIV2), ver.Kind().String(), "info.json")
 	if err != nil {
 		return "", err
 	}

--- a/internal/osimage/measurementsuploader/measurementsuploader.go
+++ b/internal/osimage/measurementsuploader/measurementsuploader.go
@@ -78,17 +78,15 @@ func (a *Uploader) Upload(ctx context.Context, rawMeasurement, signature io.Read
 		return "", "", err
 	}
 
-	ver := versionsapi.Version{
-		Ref:     measurements.Ref,
-		Stream:  measurements.Stream,
-		Version: measurements.Version,
-		Kind:    versionsapi.VersionKindImage,
+	ver, err := versionsapi.NewVersion(measurements.Ref, measurements.Stream, measurements.Version, versionsapi.VersionKindImage)
+	if err != nil {
+		return "", "", fmt.Errorf("creating version: %w", err)
 	}
-	key, err := url.JoinPath(ver.ArtifactPath(versionsapi.APIV2), ver.Kind.String(), "measurements.json")
+	key, err := url.JoinPath(ver.ArtifactPath(versionsapi.APIV2), ver.Kind().String(), "measurements.json")
 	if err != nil {
 		return "", "", err
 	}
-	sigKey, err := url.JoinPath(ver.ArtifactPath(versionsapi.APIV2), ver.Kind.String(), "measurements.json.sig")
+	sigKey, err := url.JoinPath(ver.ArtifactPath(versionsapi.APIV2), ver.Kind().String(), "measurements.json.sig")
 	if err != nil {
 		return "", "", err
 	}

--- a/internal/sigstore/BUILD.bazel
+++ b/internal/sigstore/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     importpath = "github.com/edgelesssys/constellation/v2/internal/sigstore",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/api/versionsapi",
         "//internal/constants",
         "@com_github_sigstore_rekor//pkg/client",
         "@com_github_sigstore_rekor//pkg/generated/client",

--- a/internal/sigstore/BUILD.bazel
+++ b/internal/sigstore/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     importpath = "github.com/edgelesssys/constellation/v2/internal/sigstore",
     visibility = ["//:__subpackages__"],
     deps = [
-        "//internal/constants",
         "@com_github_sigstore_rekor//pkg/client",
         "@com_github_sigstore_rekor//pkg/generated/client",
         "@com_github_sigstore_rekor//pkg/generated/client/entries",

--- a/internal/sigstore/keyselect/BUILD.bazel
+++ b/internal/sigstore/keyselect/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "foo",
+    srcs = ["foo.go"],
+    importpath = "github.com/edgelesssys/constellation/v2/internal/sigstore/foo",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/api/versionsapi",
+        "//internal/constants",
+    ],
+)
+
+go_library(
+    name = "keyselect",
+    srcs = ["keyselect.go"],
+    importpath = "github.com/edgelesssys/constellation/v2/internal/sigstore/keyselect",
+    visibility = ["//:__subpackages__"],
+    deps = [
+        "//internal/api/versionsapi",
+        "//internal/constants",
+    ],
+)

--- a/internal/sigstore/keyselect/keyselect.go
+++ b/internal/sigstore/keyselect/keyselect.go
@@ -1,0 +1,28 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+// Package keyselect is used to select the correct public key for signature verification.
+// The content of keyselect was moved from internal/sigstore to this subpackage because keyselect relies on internal/api/versionsapi.
+// Since internal/api relies on internal/sigstore, we need to separate the functions that rely on versionsapi.
+package keyselect
+
+import (
+	"fmt"
+
+	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
+)
+
+// CosignPublicKeyForVersion returns the public key for the given version.
+func CosignPublicKeyForVersion(ver versionsapi.Version) ([]byte, error) {
+	if err := ver.Validate(); err != nil {
+		return nil, fmt.Errorf("selecting public key: invalid version %s: %w", ver.ShortPath(), err)
+	}
+	if ver.Ref() == versionsapi.ReleaseRef && ver.Stream() == "stable" {
+		return []byte(constants.CosignPublicKeyReleases), nil
+	}
+	return []byte(constants.CosignPublicKeyDev), nil
+}

--- a/internal/sigstore/keyselect/keyselect.go
+++ b/internal/sigstore/keyselect/keyselect.go
@@ -5,8 +5,8 @@ SPDX-License-Identifier: AGPL-3.0-only
 */
 
 // Package keyselect is used to select the correct public key for signature verification.
-// The content of keyselect was moved from internal/sigstore to this subpackage because keyselect relies on internal/api/versionsapi.
-// Since internal/api relies on internal/sigstore, we need to separate the functions that rely on versionsapi.
+// The content of keyselect must be kept separate from internal/sigstore because keyselect relies on internal/api/versionsapi.
+// Since internal/api relies on internal/sigstore, we need to separate the functions to avoid import cycles.
 package keyselect
 
 import (

--- a/internal/sigstore/rekor.go
+++ b/internal/sigstore/rekor.go
@@ -28,12 +28,7 @@ import (
 )
 
 // VerifyWithRekor checks if the hash of a signature is present in Rekor.
-func VerifyWithRekor(ctx context.Context, version version, verifier rekorVerifier, hash string) error {
-	publicKey, err := CosignPublicKeyForVersion(version)
-	if err != nil {
-		return fmt.Errorf("getting public key: %w", err)
-	}
-
+func VerifyWithRekor(ctx context.Context, publicKey []byte, verifier rekorVerifier, hash string) error {
 	uuids, err := verifier.SearchByHash(ctx, hash)
 	if err != nil {
 		return fmt.Errorf("searching Rekor for hash: %w", err)
@@ -226,9 +221,4 @@ func isEntrySignedBy(rekord *hashedrekord.V001Entry, publicKey string) bool {
 type rekorVerifier interface {
 	SearchByHash(context.Context, string) ([]string, error)
 	VerifyEntry(context.Context, string, string) error
-}
-
-type version interface {
-	Ref() string
-	Stream() string
 }

--- a/internal/sigstore/rekor.go
+++ b/internal/sigstore/rekor.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
 	"github.com/sigstore/rekor/pkg/client"
 	genclient "github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/client/entries"
@@ -29,7 +28,7 @@ import (
 )
 
 // VerifyWithRekor checks if the hash of a signature is present in Rekor.
-func VerifyWithRekor(ctx context.Context, version versionsapi.Version, verifier rekorVerifier, hash string) error {
+func VerifyWithRekor(ctx context.Context, version version, verifier rekorVerifier, hash string) error {
 	publicKey, err := CosignPublicKeyForVersion(version)
 	if err != nil {
 		return fmt.Errorf("getting public key: %w", err)
@@ -227,4 +226,9 @@ func isEntrySignedBy(rekord *hashedrekord.V001Entry, publicKey string) bool {
 type rekorVerifier interface {
 	SearchByHash(context.Context, string) ([]string, error)
 	VerifyEntry(context.Context, string, string) error
+}
+
+type version interface {
+	Ref() string
+	Stream() string
 }

--- a/internal/sigstore/sign_test.go
+++ b/internal/sigstore/sign_test.go
@@ -51,8 +51,8 @@ func TestSignSignature(t *testing.T) {
 				assert.Error(err)
 			} else {
 				assert.NoError(err)
-				verifier := CosignVerifier{}
-				err := verifier.SetPublicKey(publicKey)
+
+				verifier, err := NewCosignVerifier(publicKey)
 				require.NoError(t, err)
 				assert.NoError(verifier.VerifySignature(tc.content, signature))
 

--- a/internal/sigstore/sign_test.go
+++ b/internal/sigstore/sign_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSignSignature(t *testing.T) {
@@ -51,7 +52,9 @@ func TestSignSignature(t *testing.T) {
 			} else {
 				assert.NoError(err)
 				verifier := CosignVerifier{}
-				assert.NoError(verifier.VerifySignature(tc.content, signature, publicKey))
+				err := verifier.SetPublicKey(publicKey)
+				require.NoError(t, err)
+				assert.NoError(verifier.VerifySignature(tc.content, signature))
 
 			}
 		})

--- a/internal/sigstore/verify.go
+++ b/internal/sigstore/verify.go
@@ -12,7 +12,6 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	sigsig "github.com/sigstore/sigstore/pkg/signature"
@@ -55,11 +54,8 @@ func (CosignVerifier) VerifySignature(content, signature, publicKey []byte) erro
 }
 
 // CosignPublicKeyForVersion returns the public key for the given version.
-func CosignPublicKeyForVersion(ver versionsapi.Version) ([]byte, error) {
-	if err := ver.Validate(); err != nil {
-		return nil, fmt.Errorf("selecting public key: invalid version %s: %w", ver.ShortPath(), err)
-	}
-	if ver.Ref == versionsapi.ReleaseRef && ver.Stream == "stable" {
+func CosignPublicKeyForVersion(v version) ([]byte, error) {
+	if v.Ref() == constants.ReleaseRef && v.Stream() == "stable" {
 		return []byte(constants.CosignPublicKeyReleases), nil
 	}
 	return []byte(constants.CosignPublicKeyDev), nil

--- a/internal/sigstore/verify.go
+++ b/internal/sigstore/verify.go
@@ -12,7 +12,6 @@ import (
 	"encoding/base64"
 	"fmt"
 
-	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	sigsig "github.com/sigstore/sigstore/pkg/signature"
 )
@@ -63,12 +62,4 @@ func (c CosignVerifier) VerifySignature(content, signature []byte) error {
 	}
 
 	return nil
-}
-
-// CosignPublicKeyForVersion returns the public key for the given version.
-func CosignPublicKeyForVersion(v version) ([]byte, error) {
-	if v.Ref() == constants.ReleaseRef && v.Stream() == "stable" {
-		return []byte(constants.CosignPublicKeyReleases), nil
-	}
-	return []byte(constants.CosignPublicKeyDev), nil
 }

--- a/internal/sigstore/verify.go
+++ b/internal/sigstore/verify.go
@@ -27,19 +27,17 @@ type CosignVerifier struct {
 	publicKey crypto.PublicKey
 }
 
-// SetPublicKey parses the pem encoded public key, validates it's parameters and updates the object if necessary.
-func (c *CosignVerifier) SetPublicKey(pem []byte) error {
+// NewCosignVerifier unmarshalls and validates the given pem encoded public key and returns a new CosignVerifier.
+func NewCosignVerifier(pem []byte) (Verifier, error) {
 	pubkey, err := cryptoutils.UnmarshalPEMToPublicKey(pem)
 	if err != nil {
-		return fmt.Errorf("unable to parse public key: %w", err)
+		return CosignVerifier{}, fmt.Errorf("unable to parse public key: %w", err)
 	}
 	if err := cryptoutils.ValidatePubKey(pubkey); err != nil {
-		return fmt.Errorf("unable to validate public key: %w", err)
+		return CosignVerifier{}, fmt.Errorf("unable to validate public key: %w", err)
 	}
 
-	c.publicKey = pubkey
-
-	return nil
+	return CosignVerifier{pubkey}, nil
 }
 
 // VerifySignature checks if the signature of content can be verified

--- a/internal/sigstore/verify_test.go
+++ b/internal/sigstore/verify_test.go
@@ -37,8 +37,7 @@ gCDlEzkuOCybCHf+q766bve799L7Y5y5oRsHY1MrUCUwYF/tL7Sg7EYMsA==
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			verifier := CosignVerifier{}
-			err := verifier.SetPublicKey(tc.publicKey)
+			verifier, err := NewCosignVerifier(tc.publicKey)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -79,8 +78,7 @@ gCDlEzkuOCybCHf+q766bve799L7Y5y5oRsHY1MrUCUwYF/tL7Sg7EYMsA==
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			cosign := CosignVerifier{}
-			err := cosign.SetPublicKey(tc.publicKey)
+			cosign, err := NewCosignVerifier(tc.publicKey)
 			require.NoError(t, err)
 			err = cosign.VerifySignature(tc.content, tc.signature)
 			if tc.wantErr {


### PR DESCRIPTION
### Context
<!-- Please add background information on why this PR is opened. -->
We currently need to add more objects to the attestationcfg api (AWS SNP). These objects need to be signed. For Azure SNP we are already creating signed objects. Same for image measurements. However, both of these implementation work differently. For AWS SNP we would have to copy the code from Azure SNP 1:1. We will have to add more objects in the future (TDX, GCP SNP, ...). Which will again require copying the code. To prevent this code duplication and potentially harmonize image measurement signing, I want to add functions to the API client/fetcher that transparently handle signatures. 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- make properties of `internal/api/versionsapi/version.go:Version` private. This allows us to remove the dependency on `internal/api` from `internal/sigstore`.
- move public key from `internal/sigstore/verify.go:VerifySignature` into property of CosignVerifier. Until now we had to pass a CosignVerifier object _and_ the public key. By combining them we only need to pass one. It also separate public key parsing and signature verification. Main point being that the number of arguments for `FetchAndVerify` is increased by 1 instead of 2. 
- Add `FetchAndVerify`, `SignAndUpload` and `DeleteWithSignature` functions to fetcher/client. If we can migrate all API interactions to these methods we will also remove the need for passing public keys directly and can only rely on CosignVerifier.


### Additional info
- An upcoming PR will use the new functions in the Azure SNP implementation
- An upcoming PR will use the new functions to add AWS SNP objects


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
