### PR TITLE
azure: fix ccm config with correct uami client_id

### DIFF
--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -254,13 +254,13 @@ func (c *Client) ShowCluster(ctx context.Context, provider cloudprovider.Provide
 			}
 		}
 
-		azureUAMIOutput, ok := tfState.Values.Outputs["user_assigned_identity"]
+		azureUAMIOutput, ok := tfState.Values.Outputs["user_assigned_identity_client_id"]
 		if !ok {
-			return ApplyOutput{}, errors.New("no user_assigned_identity output found")
+			return ApplyOutput{}, errors.New("no user_assigned_identity_client_id output found")
 		}
 		azureUAMI, ok := azureUAMIOutput.Value.(string)
 		if !ok {
-			return ApplyOutput{}, errors.New("invalid type in user_assigned_identity output: not a string")
+			return ApplyOutput{}, errors.New("invalid type in user_assigned_identity_client_id output: not a string")
 		}
 
 		rgOutput, ok := tfState.Values.Outputs["resource_group"]

--- a/cli/internal/terraform/terraform/azure/main.tf
+++ b/cli/internal/terraform/terraform/azure/main.tf
@@ -38,6 +38,8 @@ locals {
   // wildcard_lb_dns_name is the DNS name of the load balancer with a wildcard for the name.
   // example: given "name-1234567890.location.cloudapp.azure.com" it will return "*.location.cloudapp.azure.com"
   wildcard_lb_dns_name = replace(data.azurerm_public_ip.loadbalancer_ip.fqdn, "/^[^.]*\\./", "*.")
+  uai_resource_group   = element(split("/", var.user_assigned_identity), 4)                                                  // deduce from format /$ID/resourceGroups/$RG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$NAME"
+  uai_name             = element(split("/", var.user_assigned_identity), length(split("/", var.user_assigned_identity)) - 1) // deduce as above
 }
 
 resource "random_id" "uid" {
@@ -278,6 +280,11 @@ module "scale_set_group" {
 }
 
 data "azurerm_subscription" "current" {
+}
+
+data "azurerm_user_assigned_identity" "uaid" {
+  name                = local.uai_name
+  resource_group_name = local.uai_resource_group
 }
 
 moved {

--- a/cli/internal/terraform/terraform/azure/outputs.tf
+++ b/cli/internal/terraform/terraform/azure/outputs.tf
@@ -28,7 +28,7 @@ output "loadbalancer_name" {
 }
 
 
-output "user_assigned_identity" {
+output "user_assigned_identity_client_id" {
   value = data.azurerm_user_assigned_identity.uaid.client_id
 }
 

--- a/cli/internal/terraform/terraform/azure/outputs.tf
+++ b/cli/internal/terraform/terraform/azure/outputs.tf
@@ -29,7 +29,7 @@ output "loadbalancer_name" {
 
 
 output "user_assigned_identity" {
-  value = var.user_assigned_identity
+  value = data.azurerm_user_assigned_identity.uaid.client_id
 }
 
 output "resource_group" {

--- a/cli/internal/terraform/terraform/azure/variables.tf
+++ b/cli/internal/terraform/terraform/azure/variables.tf
@@ -59,7 +59,7 @@ variable "resource_group" {
 }
 variable "user_assigned_identity" {
   type        = string
-  description = "The name of the user assigned identity to attache to the nodes of the cluster."
+  description = "The name of the user assigned identity to attach to the nodes of the cluster. Should be of format: /subscriptions/$ID/resourceGroups/$RG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$NAME"
 }
 
 variable "custom_endpoint" {

--- a/cli/internal/terraform/terraform/iam/azure/outputs.tf
+++ b/cli/internal/terraform/terraform/iam/azure/outputs.tf
@@ -7,5 +7,6 @@ output "tenant_id" {
 }
 
 output "uami_id" {
-  value = azurerm_user_assigned_identity.identity_uami.id
+  description = "Outputs the id in the format: /$ID/resourceGroups/$RG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$NAME. Not to be confused with the client_id"
+  value       = azurerm_user_assigned_identity.identity_uami.id
 }

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -248,7 +248,7 @@ func TestCreateCluster(t *testing.T) {
 					"api_server_cert_sans": {
 						Value: []any{"192.0.2.100"},
 					},
-					"user_assigned_identity": {
+					"user_assigned_identity_client_id": {
 						Value: "test_uami_id",
 					},
 					"resource_group": {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
#2136 introduced a bug by providing the name of the UAMI  in the `azureConfig` secret, instead of the expected client_id.
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- inject the client_id correctly

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
