### PR TITLE
ci: upgrade fromVersion for upgrade tests

### DIFF
--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -231,7 +231,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        fromVersion: ["v2.9.0"]
+        fromVersion: ["v2.9.1"]
         cloudProvider: ["gcp", "azure", "aws"]
     name: Run upgrade tests
     secrets: inherit

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -248,7 +248,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        fromVersion: ["v2.9.0"]
+        fromVersion: ["v2.9.1"]
         cloudProvider: ["gcp", "azure", "aws"]
     name: Run upgrade tests
     secrets: inherit

--- a/dev-docs/workflows/release.md
+++ b/dev-docs/workflows/release.md
@@ -66,7 +66,7 @@ Releases should be performed using [the automated release pipeline](https://gith
    3. Close the milestone for the release
    4. Move open issues and PRs from closed milestone to next milestone
 3.  If the release is a minor version release, bump the pre-release version in the `version.txt` file.
-
+4. Update the `fromVersion` in `e2e-test-release.yml` and `e2e-test-weekly.yaml` to the newly released version (`grep "fromVersion: \[.*\]" -R .github`).
 
 ## Pipeline cleanup
 


### PR DESCRIPTION
### Context
<!-- Please add background information on why this PR is opened. -->
Whenever we release a new version the fromVersion for our automated e2e-upgrade tests need to be upgraded. I forgot to do so. Updated the manual and the values.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
