### PR TITLE
ci: remove old incompatible test option

### DIFF
--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -35,7 +35,6 @@ on:
           - "verify"
           - "recover"
           - "nop"
-          - "iamcreate"
         required: true
       kubernetesVersion:
         description: "Kubernetes version to create the cluster from."


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove `iamcreate` as an option to run for e2e tests. It is [not supported by the CI anymore](https://github.com/edgelesssys/constellation/blob/002c3a9a3289de79c92ad757970301d274e74e00/.github/actions/e2e_test/action.yml#L90).

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
