### PR TITLE
terraform: fix uami parsing

### DIFF
--- a/cli/internal/terraform/terraform/azure/main.tf
+++ b/cli/internal/terraform/terraform/azure/main.tf
@@ -38,8 +38,11 @@ locals {
   // wildcard_lb_dns_name is the DNS name of the load balancer with a wildcard for the name.
   // example: given "name-1234567890.location.cloudapp.azure.com" it will return "*.location.cloudapp.azure.com"
   wildcard_lb_dns_name = replace(data.azurerm_public_ip.loadbalancer_ip.fqdn, "/^[^.]*\\./", "*.")
-  uai_resource_group   = element(split("/", var.user_assigned_identity), 4)                                                  // deduce from format /$ID/resourceGroups/$RG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$NAME"
-  uai_name             = element(split("/", var.user_assigned_identity), length(split("/", var.user_assigned_identity)) - 1) // deduce as above
+  // deduce from format (subscriptions)/$ID/resourceGroups/$RG/providers/Microsoft.ManagedIdentity/userAssignedIdentities/$NAME"
+  // move from the right as to ignore the optional prefixes
+  uai_resource_group = element(split("/", var.user_assigned_identity), length(split("/", var.user_assigned_identity)) - 5)
+  // deduce as above
+  uai_name = element(split("/", var.user_assigned_identity), length(split("/", var.user_assigned_identity)) - 1)
 }
 
 resource "random_id" "uid" {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Count from the right side of the string to ignore optional prefix values that are still part of the users config

My config contains: 
`userAssignedIdentity: subscriptions/<id>/resourceGroups/<name>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<name>`

I think that the "correct way would be to use that e.g. the resource Group name is "prefixed" with `/resourceGroup/`. The regex would be a bit complex though. Therefore I went with the simpler solution.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
