### PR TITLE
ci: fix recover test

### DIFF
--- a/.github/actions/e2e_recover/action.yml
+++ b/.github/actions/e2e_recover/action.yml
@@ -17,22 +17,24 @@ runs:
   steps:
     - name: Restart worker node
       shell: bash
+      env:
+        KUBECONFIG: ${{ inputs.kubeconfig }}
       run: |
         WORKER_NODE=$(kubectl get nodes --selector='!node-role.kubernetes.io/control-plane' -o json | jq '.items[0].metadata.name' -r)
         kubectl debug node/$WORKER_NODE --image=ubuntu -- bash -c "echo reboot > reboot.sh && chroot /host < reboot.sh"
         kubectl wait --for=condition=Ready=false --timeout=10m node/$WORKER_NODE
         kubectl wait --for=condition=Ready=true --timeout=10m --all nodes
-      env:
-        KUBECONFIG: ${{ inputs.kubeconfig }}
+      
     - name: Restart all control plane nodes
       shell: bash
+      env:
+        KUBECONFIG: ${{ inputs.kubeconfig }}
       run: |
         CONTROL_PLANE_NODES=$(kubectl get nodes --selector='node-role.kubernetes.io/control-plane' -o json | jq '.items[].metadata.name' -r)
         for CONTROL_PLANE_NODE in ${CONTROL_PLANE_NODES}; do
           kubectl debug node/$CONTROL_PLANE_NODE --image=ubuntu -- bash -c "echo reboot > reboot.sh && chroot /host < reboot.sh"
         done
-      env:
-        KUBECONFIG: ${{ inputs.kubeconfig }}
+      
     - name: Constellation recover
       shell: bash
       run: |
@@ -59,8 +61,11 @@ runs:
             echo "Did not recover a quorum (>${{inputs.controlNodesCount}}/2) of control-plane nodes yet, retrying in 5 seconds [$recovered/${{ inputs.controlNodesCount }}]"
             sleep 5
         done
+
     - name: Wait for control plane to get back up
       shell: bash
+      env:
+        KUBECONFIG: ${{ inputs.kubeconfig }}
       run: |
         timeout=600
         start_time=$(date +%s)
@@ -80,5 +85,3 @@ runs:
           echo "Cannot reach control plane, retrying in 10 seconds"
           sleep 10
         done
-      env:
-        KUBECONFIG: ${{ inputs.kubeconfig }}

--- a/.github/actions/e2e_recover/action.yml
+++ b/.github/actions/e2e_recover/action.yml
@@ -45,7 +45,7 @@ runs:
                 echo "$output"
                 i=$(echo "$output" | grep -o "Pushed recovery key." | wc -l | sed 's/ //g')
                 recovered=$((recovered+i))
-                if [[ $recovered -eq ${{ inputs.controlNodesCount }} ]]; then
+                if [[ $recovered -gt ${{ inputs.controlNodesCount }}/2 ]]; then
                     break
                 fi
             fi
@@ -56,7 +56,7 @@ runs:
                 exit 1
             fi
 
-            echo "Did not recover all nodes yet, retrying in 5 seconds [$recovered/${{ inputs.controlNodesCount }}]"
+            echo "Did not recover a quorum (>${{inputs.controlNodesCount}}/2) of control-plane nodes yet, retrying in 5 seconds [$recovered/${{ inputs.controlNodesCount }}]"
             sleep 5
         done
     - name: Wait for control plane to get back up


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Skip to the waiting on all nodes step after at least 1 control-plane node has been recovered. 

This is probably the normal user flow anyway since all other (control-plane) nodes are recovered automatically.
This should fix flaky test, where some nodes recovered themselves. Then we didn't push a key to them and didn't count it in the `Constellation recover` step failing the test.

AWS, recover test: https://github.com/edgelesssys/constellation/actions/runs/5753138424 and https://github.com/edgelesssys/constellation/actions/runs/5753706243/job/15597486830

Since this is intended to fix a flake, I'll additionally monitor the test over the following days. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
