### PR TITLE
kubernetes: document total log size

### DIFF
--- a/bootstrapper/internal/kubernetes/k8sapi/kubeadm_config.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/kubeadm_config.go
@@ -67,12 +67,13 @@ func (c *KubdeadmConfiguration) InitConfiguration(externalCloudProvider bool, cl
 			APIServer: kubeadm.APIServer{
 				ControlPlaneComponent: kubeadm.ControlPlaneComponent{
 					ExtraArgs: map[string]string{
-						"audit-policy-file":           auditPolicyPath,
-						"audit-log-path":              filepath.Join(auditLogDir, auditLogFile), // CIS benchmark
-						"audit-log-maxage":            "30",                                     // CIS benchmark - Default value of Rancher
-						"audit-log-maxbackup":         "10",                                     // CIS benchmark - Default value of Rancher
-						"audit-log-maxsize":           "100",                                    // CIS benchmark - Default value of Rancher
-						"profiling":                   "false",                                  // CIS benchmark
+						"audit-policy-file": auditPolicyPath,
+						"audit-log-path":    filepath.Join(auditLogDir, auditLogFile), // CIS benchmark
+						"audit-log-maxage":  "30",                                     // CIS benchmark - Default value of Rancher
+						// log size = 10 files * 100MB + 100 MB (which is currently being written) = 1.1GB
+						"audit-log-maxbackup":         "10",    // CIS benchmark - Default value of Rancher
+						"audit-log-maxsize":           "100",   // CIS benchmark - Default value of Rancher
+						"profiling":                   "false", // CIS benchmark
 						"egress-selector-config-file": "/etc/kubernetes/egress-selector-configuration.yaml",
 						"kubelet-certificate-authority": filepath.Join(
 							kubeconstants.KubernetesDir,


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add documentation to spell out how much disk space is used by the logs. 

This should avoid confusion about the `audit-log-maxsize` parameter, which is the max size of _one_ file and not the total size.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
