### PR TITLE
cli: declare mastersecret as immutable and print attestationCfg diff in warning

### DIFF
--- a/bazel/toolchains/go_module_deps.bzl
+++ b/bazel/toolchains/go_module_deps.bzl
@@ -4472,8 +4472,8 @@ def go_dependencies():
         build_file_generation = "on",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/rogpeppe/go-internal",
-        sum = "h1:3RPlVWzZ/PDqmVuf/FKHARG5EMid/tl7cv54Sw/QRVY=",
-        version = "v1.10.1-0.20230524175051-ec119421bb97",
+        sum = "h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=",
+        version = "v1.11.0",
     )
     go_repository(
         name = "com_github_rs_cors",

--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -88,6 +88,7 @@ go_library(
         "@com_github_google_go_sev_guest//kds",
         "@com_github_google_uuid//:uuid",
         "@com_github_mattn_go_isatty//:go-isatty",
+        "@com_github_rogpeppe_go_internal//diff",
         "@com_github_siderolabs_talos_pkg_machinery//config/encoder",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",

--- a/cli/internal/cmd/status.go
+++ b/cli/internal/cmd/status.go
@@ -97,7 +97,7 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	}
 	variant := conf.GetAttestationConfig().GetVariant()
 
-	stableClient := kubernetes.NewStableClientWithK8sClient(kubeClient)
+	stableClient := kubernetes.NewStableClient(kubeClient)
 	output, err := status(cmd.Context(), kubeClient, stableClient, helmVersionGetter, kubernetes.NewNodeVersionClient(unstructuredClient), variant)
 	if err != nil {
 		return fmt.Errorf("getting status: %w", err)

--- a/cli/internal/cmd/status.go
+++ b/cli/internal/cmd/status.go
@@ -89,8 +89,6 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 		return helmClient.Versions()
 	}
 
-	stableClient := kubernetes.NewStableClient(kubeClient)
-
 	fetcher := attestationconfigapi.NewFetcher()
 	conf, err := config.New(fileHandler, constants.ConfigFilename, fetcher, flags.force)
 	var configValidationErr *config.ValidationError
@@ -99,6 +97,7 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	}
 	variant := conf.GetAttestationConfig().GetVariant()
 
+	stableClient := kubernetes.NewStableClientWithK8sClient(kubeClient)
 	output, err := status(cmd.Context(), kubeClient, stableClient, helmVersionGetter, kubernetes.NewNodeVersionClient(unstructuredClient), variant)
 	if err != nil {
 		return fmt.Errorf("getting status: %w", err)
@@ -121,18 +120,9 @@ func status(
 		return "", fmt.Errorf("expected exactly one condition, got %d", len(nodeVersion.Status.Conditions))
 	}
 
-	// attestation version
-	joinConfig, err := cmClient.GetCurrentConfigMap(ctx, constants.JoinConfigMap)
+	attestationConfig, err := getAttestationConfig(ctx, cmClient, attestVariant)
 	if err != nil {
-		return "", fmt.Errorf("getting current config map: %w", err)
-	}
-	rawAttestationConfig, ok := joinConfig.Data[constants.AttestationConfigFilename]
-	if !ok {
-		return "", fmt.Errorf("attestationConfig not found in %s", constants.JoinConfigMap)
-	}
-	attestationConfig, err := config.UnmarshalAttestationConfig([]byte(rawAttestationConfig), attestVariant)
-	if err != nil {
-		return "", fmt.Errorf("unmarshalling attestation config: %w", err)
+		return "", fmt.Errorf("getting attestation config: %w", err)
 	}
 	prettyYAML, err := yaml.Marshal(attestationConfig)
 	if err != nil {
@@ -155,6 +145,22 @@ func status(
 	}
 
 	return statusOutput(targetVersions, serviceVersions, status, nodeVersion, string(prettyYAML)), nil
+}
+
+func getAttestationConfig(ctx context.Context, cmClient configMapClient, attestVariant variant.Variant) (config.AttestationCfg, error) {
+	joinConfig, err := cmClient.GetCurrentConfigMap(ctx, constants.JoinConfigMap)
+	if err != nil {
+		return nil, fmt.Errorf("getting current config map: %w", err)
+	}
+	rawAttestationConfig, ok := joinConfig.Data[constants.AttestationConfigFilename]
+	if !ok {
+		return nil, fmt.Errorf("attestationConfig not found in %s", constants.JoinConfigMap)
+	}
+	attestationConfig, err := config.UnmarshalAttestationConfig([]byte(rawAttestationConfig), attestVariant)
+	if err != nil {
+		return nil, fmt.Errorf("unmarshalling attestation config: %w", err)
+	}
+	return attestationConfig, nil
 }
 
 // statusOutput creates the status cmd output string by formatting the received information.

--- a/cli/internal/cmd/status.go
+++ b/cli/internal/cmd/status.go
@@ -97,7 +97,10 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	}
 	variant := conf.GetAttestationConfig().GetVariant()
 
-	stableClient := kubernetes.NewStableClient(kubeClient)
+	stableClient, err := kubernetes.NewStableClient(constants.AdminConfFilename)
+	if err != nil {
+		return fmt.Errorf("setting up stable client: %w", err)
+	}
 	output, err := status(cmd.Context(), kubeClient, stableClient, helmVersionGetter, kubernetes.NewNodeVersionClient(unstructuredClient), variant)
 	if err != nil {
 		return fmt.Errorf("getting status: %w", err)

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -81,7 +81,7 @@ func runUpgradeApply(cmd *cobra.Command, _ []string) error {
 
 type stableClientFactory func(kubeconfigPath string) (getConfigMapper, error)
 
-// needed because StableClient returns the bigger kubernetes.StableInterface
+// needed because StableClient returns the bigger kubernetes.StableInterface.
 func stableClientFactoryImpl(kubeconfigPath string) (getConfigMapper, error) {
 	return kubernetes.NewStableClient(kubeconfigPath)
 }
@@ -135,7 +135,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, fileHandler file.Hand
 	conf.UpdateMAAURL(idFile.AttestationURL)
 
 	// If an image upgrade was just executed there won't be a diff. The function will return nil in that case.
-	stableClient, err := stableClientFactory(adminConfPath(flags.workspace))
+	stableClient, err := stableClientFactory(constants.AdminConfFilename)
 	if err != nil {
 		return fmt.Errorf("creating stable client: %w", err)
 	}

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -81,12 +81,9 @@ func runUpgradeApply(cmd *cobra.Command, _ []string) error {
 
 type stableClientFactory func(kubeconfigPath string) (getConfigMapper, error)
 
+// needed because StableClient returns the bigger kubernetes.StableInterface
 func stableClientFactoryImpl(kubeconfigPath string) (getConfigMapper, error) {
-	client, err := kubernetes.NewClient(kubeconfigPath)
-	if err != nil {
-		return nil, err
-	}
-	return kubernetes.NewStableClient(client), nil
+	return kubernetes.NewStableClient(kubeconfigPath)
 }
 
 type getConfigMapper interface {

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -9,6 +9,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -32,11 +33,12 @@ import (
 func TestUpgradeApply(t *testing.T) {
 	someErr := errors.New("some error")
 	testCases := map[string]struct {
-		upgrader stubUpgrader
-		fetcher  stubImageFetcher
-		wantErr  bool
-		yesFlag  bool
-		stdin    string
+		upgrader             stubUpgrader
+		fetcher              stubImageFetcher
+		wantErr              bool
+		yesFlag              bool
+		stdin                string
+		remoteAttestationCfg config.AttestationCfg // attestation config returned by the stub Kubernetes client
 	}{
 		"success": {
 			upgrader: stubUpgrader{currentConfig: config.DefaultForAzureSEVSNP()},
@@ -140,10 +142,14 @@ func TestUpgradeApply(t *testing.T) {
 
 			handler := file.NewHandler(afero.NewMemMapFs())
 			cfg := defaultConfigWithExpectedMeasurements(t, config.Default(), cloudprovider.Azure)
+
+			if tc.remoteAttestationCfg == nil {
+				tc.remoteAttestationCfg = fakeAttestationConfigFromCluster(cmd.Context(), t, cloudprovider.Azure)
+			}
 			require.NoError(handler.WriteYAML(constants.ConfigFilename, cfg))
 			require.NoError(handler.WriteJSON(constants.ClusterIDsFilename, clusterid.File{}))
 
-			upgrader := upgradeApplyCmd{upgrader: tc.upgrader, log: logger.NewTest(t), imageFetcher: tc.fetcher, configFetcher: stubAttestationFetcher{}}
+			upgrader := upgradeApplyCmd{upgrader: tc.upgrader, log: logger.NewTest(t), imageFetcher: tc.fetcher, configFetcher: stubAttestationFetcher{}, stableClient: stubGetConfigMap{tc.remoteAttestationCfg}}
 
 			err := upgrader.upgradeApply(cmd, handler)
 			if tc.wantErr {
@@ -153,6 +159,21 @@ func TestUpgradeApply(t *testing.T) {
 			}
 		})
 	}
+}
+
+type stubGetConfigMap struct {
+	attestationCfg config.AttestationCfg
+}
+
+func (s stubGetConfigMap) GetCurrentConfigMap(_ context.Context, _ string) (*corev1.ConfigMap, error) {
+	data, err := json.Marshal(s.attestationCfg)
+	if err != nil {
+		return nil, err
+	}
+	dataMap := map[string]string{
+		constants.AttestationConfigFilename: string(data),
+	}
+	return &corev1.ConfigMap{Data: dataMap}, nil
 }
 
 type stubUpgrader struct {
@@ -221,4 +242,12 @@ func (f stubImageFetcher) FetchReference(_ context.Context,
 	_, _ string,
 ) (string, error) {
 	return "", f.fetchReferenceErr
+}
+
+func fakeAttestationConfigFromCluster(ctx context.Context, t *testing.T, provider cloudprovider.Provider) config.AttestationCfg {
+	cpCfg := defaultConfigWithExpectedMeasurements(t, config.Default(), provider)
+	// the cluster attestation config needs to have real version numbers that are translated from "latest" as defined in config.Default()
+	err := cpCfg.Attestation.AzureSEVSNP.FetchAndSetLatestVersionNumbers(ctx, stubAttestationFetcher{}, time.Date(2022, time.January, 1, 0, 0, 0, 0, time.UTC))
+	require.NoError(t, err)
+	return cpCfg.GetAttestationConfig()
 }

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -149,9 +149,12 @@ func TestUpgradeApply(t *testing.T) {
 			require.NoError(handler.WriteYAML(constants.ConfigFilename, cfg))
 			require.NoError(handler.WriteJSON(constants.ClusterIDsFilename, clusterid.File{}))
 
-			upgrader := upgradeApplyCmd{upgrader: tc.upgrader, log: logger.NewTest(t), imageFetcher: tc.fetcher, configFetcher: stubAttestationFetcher{}, stableClient: stubGetConfigMap{tc.remoteAttestationCfg}}
+			upgrader := upgradeApplyCmd{upgrader: tc.upgrader, log: logger.NewTest(t), imageFetcher: tc.fetcher, configFetcher: stubAttestationFetcher{}}
 
-			err := upgrader.upgradeApply(cmd, handler)
+			stubStableClientFactory := func(_ string) (getConfigMapper, error) {
+				return stubGetConfigMap{tc.remoteAttestationCfg}, nil
+			}
+			err := upgrader.upgradeApply(cmd, handler, stubStableClientFactory)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/join-service/templates/configmap.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/join-service/templates/configmap.yaml
@@ -1,5 +1,6 @@
 apiVersion: v1
 kind: ConfigMap
+immutable: true
 metadata:
   name: join-config
   namespace: {{ .Release.Namespace }}

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/join-service/templates/configmap.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/join-service/templates/configmap.yaml
@@ -1,6 +1,5 @@
 apiVersion: v1
 kind: ConfigMap
-immutable: true
 metadata:
   name: join-config
   namespace: {{ .Release.Namespace }}

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/key-service/templates/mastersecret.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/key-service/templates/mastersecret.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Secret
 type: Opaque
+immutable: true
 metadata:
   name: {{ .Values.masterSecretName | quote }}
   namespace: {{ .Release.Namespace }}

--- a/cli/internal/helm/testdata/AWS/constellation-services/charts/key-service/templates/mastersecret.yaml
+++ b/cli/internal/helm/testdata/AWS/constellation-services/charts/key-service/templates/mastersecret.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Secret
 type: Opaque
+immutable: true
 metadata:
   name: constellation-mastersecret
   namespace: testNamespace

--- a/cli/internal/helm/testdata/Azure/constellation-services/charts/key-service/templates/mastersecret.yaml
+++ b/cli/internal/helm/testdata/Azure/constellation-services/charts/key-service/templates/mastersecret.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Secret
 type: Opaque
+immutable: true
 metadata:
   name: constellation-mastersecret
   namespace: testNamespace

--- a/cli/internal/helm/testdata/GCP/constellation-services/charts/key-service/templates/mastersecret.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-services/charts/key-service/templates/mastersecret.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Secret
 type: Opaque
+immutable: true
 metadata:
   name: constellation-mastersecret
   namespace: testNamespace

--- a/cli/internal/helm/testdata/OpenStack/constellation-services/charts/key-service/templates/mastersecret.yaml
+++ b/cli/internal/helm/testdata/OpenStack/constellation-services/charts/key-service/templates/mastersecret.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Secret
 type: Opaque
+immutable: true
 metadata:
   name: constellation-mastersecret
   namespace: testNamespace

--- a/cli/internal/helm/testdata/QEMU/constellation-services/charts/key-service/templates/mastersecret.yaml
+++ b/cli/internal/helm/testdata/QEMU/constellation-services/charts/key-service/templates/mastersecret.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Secret
 type: Opaque
+immutable: true
 metadata:
   name: constellation-mastersecret
   namespace: testNamespace

--- a/cli/internal/kubernetes/kubernetes.go
+++ b/cli/internal/kubernetes/kubernetes.go
@@ -10,3 +10,82 @@ Package kubernetes provides functions to interact with a live cluster to the CLI
 Currently it is used to implement the status and upgrade commands.
 */
 package kubernetes
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/edgelesssys/constellation/v2/internal/constants"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func newClient() (kubernetes.Interface, error) {
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", constants.AdminConfFilename)
+	if err != nil {
+		return nil, fmt.Errorf("building kubernetes config: %w", err)
+	}
+
+	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	if err != nil {
+		return nil, fmt.Errorf("setting up kubernetes client: %w", err)
+	}
+	return kubeClient, nil
+}
+
+// StableInterface is an interface to interact with stable resources.
+type StableInterface interface {
+	GetCurrentConfigMap(ctx context.Context, name string) (*corev1.ConfigMap, error)
+	UpdateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
+	CreateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
+	DeleteConfigMap(ctx context.Context, name string) error
+	KubernetesVersion() (string, error)
+}
+
+// NewStableClient returns a new StableClient.
+func NewStableClient() (StableInterface, error) {
+	client, err := newClient()
+	if err != nil {
+		return nil, err
+	}
+	return NewStableClientWithK8sClient(client), nil
+}
+
+// NewStableClientWithK8sClient returns a new StableInterface.
+func NewStableClientWithK8sClient(client kubernetes.Interface) StableInterface {
+	return &stableClient{client: client}
+}
+
+type stableClient struct {
+	client kubernetes.Interface
+}
+
+// GetCurrentConfigMap returns a ConfigMap given it's name.
+func (u *stableClient) GetCurrentConfigMap(ctx context.Context, name string) (*corev1.ConfigMap, error) {
+	return u.client.CoreV1().ConfigMaps(constants.ConstellationNamespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+// UpdateConfigMap updates the given ConfigMap.
+func (u *stableClient) UpdateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return u.client.CoreV1().ConfigMaps(constants.ConstellationNamespace).Update(ctx, configMap, metav1.UpdateOptions{})
+}
+
+func (u *stableClient) DeleteConfigMap(ctx context.Context, name string) error {
+	return u.client.CoreV1().ConfigMaps(constants.ConstellationNamespace).Delete(ctx, name, metav1.DeleteOptions{})
+}
+
+// CreateConfigMap creates the given ConfigMap.
+func (u *stableClient) CreateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	return u.client.CoreV1().ConfigMaps(constants.ConstellationNamespace).Create(ctx, configMap, metav1.CreateOptions{})
+}
+
+// KubernetesVersion returns the Kubernetes version of the cluster.
+func (u *stableClient) KubernetesVersion() (string, error) {
+	serverVersion, err := u.client.Discovery().ServerVersion()
+	if err != nil {
+		return "", err
+	}
+	return serverVersion.GitVersion, nil
+}

--- a/cli/internal/kubernetes/kubernetes.go
+++ b/cli/internal/kubernetes/kubernetes.go
@@ -40,7 +40,6 @@ type StableInterface interface {
 	GetCurrentConfigMap(ctx context.Context, name string) (*corev1.ConfigMap, error)
 	UpdateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
 	CreateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
-	DeleteConfigMap(ctx context.Context, name string) error
 	KubernetesVersion() (string, error)
 }
 
@@ -70,10 +69,6 @@ func (u *stableClient) GetCurrentConfigMap(ctx context.Context, name string) (*c
 // UpdateConfigMap updates the given ConfigMap.
 func (u *stableClient) UpdateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 	return u.client.CoreV1().ConfigMaps(constants.ConstellationNamespace).Update(ctx, configMap, metav1.UpdateOptions{})
-}
-
-func (u *stableClient) DeleteConfigMap(ctx context.Context, name string) error {
-	return u.client.CoreV1().ConfigMaps(constants.ConstellationNamespace).Delete(ctx, name, metav1.DeleteOptions{})
 }
 
 // CreateConfigMap creates the given ConfigMap.

--- a/cli/internal/kubernetes/kubernetes.go
+++ b/cli/internal/kubernetes/kubernetes.go
@@ -22,8 +22,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// NewClient returns a new Kubernetes client.
-func NewClient(kubeconfigPath string) (kubernetes.Interface, error) {
+func newClient(kubeconfigPath string) (kubernetes.Interface, error) {
 	kubeConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("building kubernetes config: %w", err)
@@ -44,9 +43,13 @@ type StableInterface interface {
 	KubernetesVersion() (string, error)
 }
 
-// NewStableClient returns a new StableInterface.
-func NewStableClient(client kubernetes.Interface) StableInterface {
-	return &stableClient{client: client}
+// NewStableClient returns a new StableClient.
+func NewStableClient(kubeconfigPath string) (StableInterface, error) {
+	client, err := newClient(kubeconfigPath)
+	if err != nil {
+		return nil, err
+	}
+	return &stableClient{client}, nil
 }
 
 type stableClient struct {

--- a/cli/internal/kubernetes/kubernetes.go
+++ b/cli/internal/kubernetes/kubernetes.go
@@ -22,8 +22,9 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-func newClient() (kubernetes.Interface, error) {
-	kubeConfig, err := clientcmd.BuildConfigFromFlags("", constants.AdminConfFilename)
+// NewClient returns a new Kubernetes client.
+func NewClient(kubeconfigPath string) (kubernetes.Interface, error) {
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("building kubernetes config: %w", err)
 	}
@@ -43,17 +44,8 @@ type StableInterface interface {
 	KubernetesVersion() (string, error)
 }
 
-// NewStableClient returns a new StableClient.
-func NewStableClient() (StableInterface, error) {
-	client, err := newClient()
-	if err != nil {
-		return nil, err
-	}
-	return NewStableClientWithK8sClient(client), nil
-}
-
-// NewStableClientWithK8sClient returns a new StableInterface.
-func NewStableClientWithK8sClient(client kubernetes.Interface) StableInterface {
+// NewStableClient returns a new StableInterface.
+func NewStableClient(client kubernetes.Interface) StableInterface {
 	return &stableClient{client: client}
 }
 

--- a/cli/internal/kubernetes/upgrade.go
+++ b/cli/internal/kubernetes/upgrade.go
@@ -120,18 +120,17 @@ func NewUpgrader(
 		upgradeID:    upgradeID,
 	}
 
-	kubeConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
-	if err != nil {
-		return nil, fmt.Errorf("building kubernetes config: %w", err)
-	}
-
-	kubeClient, err := newClient()
+	kubeClient, err := NewClient(kubeConfigPath)
 	if err != nil {
 		return nil, err
 	}
 	u.stableInterface = &stableClient{client: kubeClient}
 
 	// use unstructured client to avoid importing the operator packages
+	kubeConfig, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("building kubernetes config: %w", err)
+	}
 	unstructuredClient, err := dynamic.NewForConfig(kubeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("setting up custom resource client: %w", err)

--- a/cli/internal/kubernetes/upgrade.go
+++ b/cli/internal/kubernetes/upgrade.go
@@ -120,7 +120,7 @@ func NewUpgrader(
 		upgradeID:    upgradeID,
 	}
 
-	kubeClient, err := NewClient(kubeConfigPath)
+	kubeClient, err := newClient(kubeConfigPath)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/kubernetes/upgrade.go
+++ b/cli/internal/kubernetes/upgrade.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/retry"
 	kubeadmv1beta3 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta3"
@@ -126,9 +125,9 @@ func NewUpgrader(
 		return nil, fmt.Errorf("building kubernetes config: %w", err)
 	}
 
-	kubeClient, err := kubernetes.NewForConfig(kubeConfig)
+	kubeClient, err := newClient()
 	if err != nil {
-		return nil, fmt.Errorf("setting up kubernetes client: %w", err)
+		return nil, err
 	}
 	u.stableInterface = &stableClient{client: kubeClient}
 
@@ -552,47 +551,6 @@ func upgradeInProgress(nodeVersion updatev1alpha1.NodeVersion) bool {
 		}
 	}
 	return false
-}
-
-// StableInterface is an interface to interact with stable resources.
-type StableInterface interface {
-	GetCurrentConfigMap(ctx context.Context, name string) (*corev1.ConfigMap, error)
-	UpdateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
-	CreateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error)
-	KubernetesVersion() (string, error)
-}
-
-// NewStableClient returns a new StableInterface.
-func NewStableClient(client kubernetes.Interface) StableInterface {
-	return &stableClient{client: client}
-}
-
-type stableClient struct {
-	client kubernetes.Interface
-}
-
-// GetCurrentConfigMap returns a ConfigMap given it's name.
-func (u *stableClient) GetCurrentConfigMap(ctx context.Context, name string) (*corev1.ConfigMap, error) {
-	return u.client.CoreV1().ConfigMaps(constants.ConstellationNamespace).Get(ctx, name, metav1.GetOptions{})
-}
-
-// UpdateConfigMap updates the given ConfigMap.
-func (u *stableClient) UpdateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	return u.client.CoreV1().ConfigMaps(constants.ConstellationNamespace).Update(ctx, configMap, metav1.UpdateOptions{})
-}
-
-// CreateConfigMap creates the given ConfigMap.
-func (u *stableClient) CreateConfigMap(ctx context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
-	return u.client.CoreV1().ConfigMaps(constants.ConstellationNamespace).Create(ctx, configMap, metav1.CreateOptions{})
-}
-
-// KubernetesVersion returns the Kubernetes version of the cluster.
-func (u *stableClient) KubernetesVersion() (string, error) {
-	serverVersion, err := u.client.Discovery().ServerVersion()
-	if err != nil {
-		return "", err
-	}
-	return serverVersion.GitVersion, nil
 }
 
 type helmInterface interface {

--- a/cli/internal/kubernetes/upgrade_test.go
+++ b/cli/internal/kubernetes/upgrade_test.go
@@ -38,7 +38,7 @@ import (
 func TestUpgradeNodeVersion(t *testing.T) {
 	someErr := errors.New("some error")
 	testCases := map[string]struct {
-		stable                *stubStableClient
+		stable                *fakeStableClient
 		conditions            []metav1.Condition
 		currentImageVersion   string
 		newImageReference     string
@@ -61,7 +61,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			}(),
 			currentImageVersion:   "v1.2.2",
 			currentClusterVersion: versions.SupportedK8sVersions()[0],
-			stable: &stubStableClient{
+			stable: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
 				},
@@ -77,7 +77,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			}(),
 			currentImageVersion:   "v1.2.2",
 			currentClusterVersion: versions.SupportedK8sVersions()[0],
-			stable: &stubStableClient{
+			stable: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
 				},
@@ -98,7 +98,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			}(),
 			currentImageVersion:   "v1.2.2",
 			currentClusterVersion: versions.SupportedK8sVersions()[0],
-			stable: &stubStableClient{
+			stable: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
 				},
@@ -119,7 +119,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			}(),
 			currentImageVersion:   "v1.2.2",
 			currentClusterVersion: versions.SupportedK8sVersions()[0],
-			stable:                &stubStableClient{},
+			stable:                &fakeStableClient{},
 			wantErr:               true,
 			assertCorrectError: func(t *testing.T, err error) bool {
 				var upgradeErr *compatibility.InvalidUpgradeError
@@ -139,7 +139,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			}},
 			currentImageVersion:   "v1.2.2",
 			currentClusterVersion: versions.SupportedK8sVersions()[0],
-			stable:                &stubStableClient{},
+			stable:                &fakeStableClient{},
 			wantErr:               true,
 			assertCorrectError: func(t *testing.T, err error) bool {
 				return assert.ErrorIs(t, err, ErrInProgress)
@@ -158,7 +158,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			}},
 			currentImageVersion:   "v1.2.2",
 			currentClusterVersion: versions.SupportedK8sVersions()[0],
-			stable:                &stubStableClient{},
+			stable:                &fakeStableClient{},
 			force:                 true,
 			wantUpdate:            true,
 		},
@@ -184,7 +184,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			newImageReference:     "path/to/image:v1.4.2",
 			currentImageVersion:   "v1.2.2",
 			currentClusterVersion: versions.SupportedK8sVersions()[0],
-			stable: &stubStableClient{
+			stable: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
 				},
@@ -206,7 +206,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			newImageReference:     "path/to/image:v1.4.2",
 			currentImageVersion:   "v1.2.2",
 			currentClusterVersion: versions.SupportedK8sVersions()[0],
-			stable: &stubStableClient{
+			stable: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
 				},
@@ -224,7 +224,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			currentImageVersion:   "v1.2.2",
 			currentClusterVersion: versions.SupportedK8sVersions()[0],
 			badImageVersion:       "v3.2.1",
-			stable: &stubStableClient{
+			stable: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
 				},
@@ -245,7 +245,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			}(),
 			currentImageVersion:   "v1.2.2",
 			currentClusterVersion: versions.SupportedK8sVersions()[0],
-			stable: &stubStableClient{
+			stable: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
 				},
@@ -266,7 +266,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			}(),
 			currentImageVersion:   "v1.2.2",
 			currentClusterVersion: versions.SupportedK8sVersions()[0],
-			stable: &stubStableClient{
+			stable: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
 				},
@@ -340,13 +340,13 @@ func TestUpgradeNodeVersion(t *testing.T) {
 func TestUpdateMeasurements(t *testing.T) {
 	someErr := errors.New("error")
 	testCases := map[string]struct {
-		updater    *stubStableClient
+		updater    *fakeStableClient
 		newConfig  config.AttestationCfg
 		wantUpdate bool
 		wantErr    bool
 	}{
 		"success": {
-			updater: &stubStableClient{
+			updater: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"measurements":{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}}`),
 				},
@@ -359,7 +359,7 @@ func TestUpdateMeasurements(t *testing.T) {
 			wantUpdate: true,
 		},
 		"measurements are the same": {
-			updater: &stubStableClient{
+			updater: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"measurements":{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}}`),
 				},
@@ -371,7 +371,7 @@ func TestUpdateMeasurements(t *testing.T) {
 			},
 		},
 		"setting warnOnly to true is allowed": {
-			updater: &stubStableClient{
+			updater: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"measurements":{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}}`),
 				},
@@ -384,7 +384,7 @@ func TestUpdateMeasurements(t *testing.T) {
 			wantUpdate: true,
 		},
 		"setting warnOnly to false is allowed": {
-			updater: &stubStableClient{
+			updater: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"measurements":{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":true}}}`),
 				},
@@ -397,7 +397,7 @@ func TestUpdateMeasurements(t *testing.T) {
 			wantUpdate: true,
 		},
 		"getCurrent error": {
-			updater: &stubStableClient{getErr: someErr},
+			updater: &fakeStableClient{getErr: someErr},
 			newConfig: &config.GCPSEVES{
 				Measurements: measurements.M{
 					0: measurements.WithAllBytes(0xBB, measurements.Enforce, measurements.PCRMeasurementLength),
@@ -406,7 +406,7 @@ func TestUpdateMeasurements(t *testing.T) {
 			wantErr: true,
 		},
 		"update error": {
-			updater: &stubStableClient{
+			updater: &fakeStableClient{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"measurements":{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}}`),
 				},
@@ -616,7 +616,7 @@ func (u *stubDynamicClient) Update(_ context.Context, updatedObject *unstructure
 	return u.updatedObject, u.updateErr
 }
 
-type stubStableClient struct {
+type fakeStableClient struct {
 	configMaps        map[string]*corev1.ConfigMap
 	updatedConfigMaps map[string]*corev1.ConfigMap
 	k8sVersion        string
@@ -626,11 +626,11 @@ type stubStableClient struct {
 	k8sErr            error
 }
 
-func (s *stubStableClient) GetCurrentConfigMap(_ context.Context, name string) (*corev1.ConfigMap, error) {
+func (s *fakeStableClient) GetCurrentConfigMap(_ context.Context, name string) (*corev1.ConfigMap, error) {
 	return s.configMaps[name], s.getErr
 }
 
-func (s *stubStableClient) UpdateConfigMap(_ context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+func (s *fakeStableClient) UpdateConfigMap(_ context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 	if s.updatedConfigMaps == nil {
 		s.updatedConfigMaps = map[string]*corev1.ConfigMap{}
 	}
@@ -638,7 +638,7 @@ func (s *stubStableClient) UpdateConfigMap(_ context.Context, configMap *corev1.
 	return s.updatedConfigMaps[configMap.ObjectMeta.Name], s.updateErr
 }
 
-func (s *stubStableClient) CreateConfigMap(_ context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+func (s *fakeStableClient) CreateConfigMap(_ context.Context, configMap *corev1.ConfigMap) (*corev1.ConfigMap, error) {
 	if s.configMaps == nil {
 		s.configMaps = map[string]*corev1.ConfigMap{}
 	}
@@ -646,11 +646,7 @@ func (s *stubStableClient) CreateConfigMap(_ context.Context, configMap *corev1.
 	return s.configMaps[configMap.ObjectMeta.Name], s.createErr
 }
 
-func (s *stubStableClient) DeleteConfigMap(_ context.Context, _ string) error {
-	return nil
-}
-
-func (s *stubStableClient) KubernetesVersion() (string, error) {
+func (s *fakeStableClient) KubernetesVersion() (string, error) {
 	return s.k8sVersion, s.k8sErr
 }
 

--- a/cli/internal/kubernetes/upgrade_test.go
+++ b/cli/internal/kubernetes/upgrade_test.go
@@ -646,6 +646,10 @@ func (s *stubStableClient) CreateConfigMap(_ context.Context, configMap *corev1.
 	return s.configMaps[configMap.ObjectMeta.Name], s.createErr
 }
 
+func (s *stubStableClient) DeleteConfigMap(_ context.Context, _ string) error {
+	return nil
+}
+
 func (s *stubStableClient) KubernetesVersion() (string, error) {
 	return s.k8sVersion, s.k8sErr
 }

--- a/go.mod
+++ b/go.mod
@@ -91,6 +91,7 @@ require (
 	github.com/mattn/go-isatty v0.0.19
 	github.com/microsoft/ApplicationInsights-Go v0.4.4
 	github.com/pkg/errors v0.9.1
+	github.com/rogpeppe/go-internal v1.11.0
 	github.com/schollz/progressbar/v3 v3.13.1
 	github.com/siderolabs/talos/pkg/machinery v1.4.6
 	github.com/sigstore/rekor v1.2.2

--- a/go.sum
+++ b/go.sum
@@ -914,7 +914,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rubenv/sql-migrate v1.3.1 h1:Vx+n4Du8X8VTYuXbhNxdEUoh6wiJERA0GlWocR5FrbA=
 github.com/rubenv/sql-migrate v1.3.1/go.mod h1:YzG/Vh82CwyhTFXy+Mf5ahAiiEOpAlHurg+23VEzcsk=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -247,6 +247,7 @@ require (
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
+	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/rubenv/sql-migrate v1.3.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect

--- a/hack/go.sum
+++ b/hack/go.sum
@@ -867,7 +867,8 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rubenv/sql-migrate v1.3.1 h1:Vx+n4Du8X8VTYuXbhNxdEUoh6wiJERA0GlWocR5FrbA=
 github.com/rubenv/sql-migrate v1.3.1/go.mod h1:YzG/Vh82CwyhTFXy+Mf5ahAiiEOpAlHurg+23VEzcsk=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/operators/constellation-node-operator/go.sum
+++ b/operators/constellation-node-operator/go.sum
@@ -297,7 +297,7 @@ github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+Pymzi
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/spf13/afero v1.9.5 h1:stMpOSZFs//0Lv29HduCmli3GUfpFoF3Y1Q/aXj/wVM=
 github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
In order to make an upgrade safe that applies our entire cluster configuration, we should take precaution to not update resources that can destroy the cluster.
We found `constellation-mastersecret` and the attestation config (inside `join-config`) to be such critical resources.
We decided to not make `join-config` immutable, because we actually allow updating it. Deleting the resource during an upgrade is troublesome when the upgrade fails.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- declare `constellation-mastersecret` immutable
- attestation config can be updated, but only through explicit user confirmation (already done). We know additionally print a diff to show the user what has changed.
- the attestationConfigDiff check now fetches the resource through the shared logic from `status` cmd to start decoupling from the upgrader which should soon be removed
 

### Related issue
- [AB#3321](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3321)

### Additional info
It would be nice if we could rollback a wrong attestation config, but it's currently not done since the attestation config update is outside of helm. With the planned `apply` functionality, the attestationconfig (`join-config`) should be updated as part of a helm upgrade and rollback when deployments fail.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [x] Link to Milestone
