### PR TITLE
cdbg: implement workspace / "-C" flag and "--bindir"

### DIFF
--- a/debugd/internal/cdbg/cmd/root.go
+++ b/debugd/internal/cdbg/cmd/root.go
@@ -8,9 +8,9 @@ SPDX-License-Identifier: AGPL-3.0-only
 package cmd
 
 import (
+	"fmt"
 	"os"
 
-	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/spf13/cobra"
 )
 
@@ -20,9 +20,12 @@ func newRootCmd() *cobra.Command {
 		Short: "Constellation debugging client",
 		Long: `cdbg is the constellation debugging client.
 	It connects to Constellation instances running debugd and deploys a self-compiled version of the bootstrapper.`,
+		PersistentPreRunE: preRunRoot,
 	}
-	cmd.PersistentFlags().String("config", constants.ConfigFilename, "Constellation config file")
+	cmd.PersistentFlags().StringP("workspace", "C", "", "path to the Constellation workspace")
 	cmd.PersistentFlags().Bool("force", false, "disables version validation errors - might result in corrupted clusters")
+
+	must(cmd.MarkPersistentFlagDirname("workspace"))
 
 	cmd.AddCommand(newDeployCmd())
 	return cmd
@@ -34,4 +37,29 @@ func Execute() {
 	if err := cmd.Execute(); err != nil {
 		os.Exit(1)
 	}
+}
+
+func preRunRoot(cmd *cobra.Command, _ []string) error {
+	cmd.SilenceUsage = true
+
+	workspace, err := cmd.Flags().GetString("workspace")
+	if err != nil {
+		return fmt.Errorf("getting workspace flag: %w", err)
+	}
+
+	// Change to workspace directory if set.
+	if workspace != "" {
+		if err := os.Chdir(workspace); err != nil {
+			return fmt.Errorf("changing from current directory to workspace %q: %w", workspace, err)
+		}
+	}
+
+	return nil
+}
+
+func must(err error) {
+	if err == nil {
+		return
+	}
+	panic(err)
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Allows cdbg to be started outside the workspace.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cdbg: implement workspace / "-C" flag and "--bindir"

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

Proper usage:

```shell-session
./constellation create -C path/to/workspace
./cdbg deploy -C path/to/workspace --bindir $(pwd)
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
