### PR TITLE
e2e: fix upgrade test by adding deprecated flags

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -177,7 +177,8 @@ runs:
         if [[ $output == *"tf-log"* ]]; then
           TFFLAG="--tf-log=DEBUG"
         fi
-        constellation create -y --force --debug ${TFFLAG:-}
+        constellation create -y --force --debug ${TFFLAG:-} -c ${{ inputs.controlNodesCount }} -w ${{ inputs.workerNodesCount }}
+      # TODO(elchead): remove -c and -w once 2.10 is released, such that a fromVersion upgrade E2E no longer requires these flags
 
     - name: Cdbg deploy
       if: inputs.isDebugImage == 'true'


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The `-w` and `-c` flags for `create` are still needed to create a cluster on v2.9 in the upgrade test.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
-

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
