### PR TITLE
cli: fix upgrade test by only setting nodeGroup for >v2.9

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -2,6 +2,7 @@ name: Constellation create
 description: Create a new Constellation cluster using latest OS image.
 
 inputs:
+  # TODO(elchead): remove once 2.10 is released
   workerNodesCount:
     description: "Number of worker nodes to spawn."
     required: true
@@ -14,6 +15,9 @@ inputs:
   machineType:
     description: "Machine type of VM to spawn."
     required: false
+  cliVersion:
+    description: "Version of the CLI"
+    required: true
   osImage:
     description: "OS image to use."
     required: true
@@ -144,6 +148,7 @@ runs:
         yq eval -i "(.nodeGroups[] | .instanceType) = \"${{ inputs.machineType }}\"" constellation-conf.yaml
 
     - name: Set node count
+      if: inputs.cliVersion  != 'v2.9.0' && inputs.cliVersion  != 'v2.9.1'
       shell: bash
       run: |
         yq eval -i "(.nodeGroups[] | select(.role == \"control-plane\") | .initialCount) = ${{ inputs.controlNodesCount }}" constellation-conf.yaml

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -74,7 +74,7 @@ inputs:
   fetchMeasurements:
     default: "false"
     description: "Update measurements via the 'constellation config fetch-measurements' command."
-    
+
 outputs:
   kubeconfig:
     description: "The kubeconfig for the cluster."
@@ -240,6 +240,7 @@ runs:
         existingConfig: ${{ steps.constellation-iam-create.outputs.existingConfig }}
         artifactNameSuffix: ${{ steps.create-prefix.outputs.prefix }}
         fetchMeasurements: ${{ inputs.fetchMeasurements }}
+        cliVersion: ${{ inputs.cliVersion }}
 
     #
     # Test payloads


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
-

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
E2E is fixed: https://github.com/edgelesssys/constellation/actions/runs/5782899866/job/15670623206

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
