### PR TITLE
ci: fix e2e upgrade config migration

### DIFF
--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -183,9 +183,10 @@ jobs:
         uses: ./.github/actions/login_azure
         with:
           azure_credentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
-
-
-          ## IAM upgrade
+      - name: Migrate config
+        id: constellation-config-migrate
+        run: |
+          ./build/constellation config migrate --debug
       - name: Upgrade IAM configuration
         id: constellation-iam-upgrade
         uses: ./.github/actions/constellation_iam_upgrade

--- a/e2e/internal/upgrade/upgrade_test.go
+++ b/e2e/internal/upgrade/upgrade_test.go
@@ -78,18 +78,11 @@ func TestUpgrade(t *testing.T) {
 	cli, err := getCLIPath(*cliPath)
 	require.NoError(err)
 
-	// Migrate config if necessary.
-	log.Println("Migrating config if needed.")
-	cmd := exec.CommandContext(context.Background(), cli, "config", "migrate", "--debug")
-	stdout, stderr, err := runCommandWithSeparateOutputs(cmd)
-	require.NoError(err, "Stdout: %s\nStderr: %s", string(stdout), string(stderr))
-	log.Println(string(stdout))
-
 	targetVersions := writeUpgradeConfig(require, *targetImage, *targetKubernetes, *targetMicroservices)
 
 	log.Println("Fetching measurements for new image.")
-	cmd = exec.CommandContext(context.Background(), cli, "config", "fetch-measurements", "--insecure", "--debug")
-	stdout, stderr, err = runCommandWithSeparateOutputs(cmd)
+	cmd := exec.CommandContext(context.Background(), cli, "config", "fetch-measurements", "--insecure", "--debug")
+	stdout, stderr, err := runCommandWithSeparateOutputs(cmd)
 	require.NoError(err, "Stdout: %s\nStderr: %s", string(stdout), string(stderr))
 	log.Println(string(stdout))
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The introduction of #2152 requires a config migration. Due to the new necessity of IAM migration introduced in #2132, the config migration now needs to happen outside of `upgrade_test` and before IAM migration.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- perform config migration before IAM upgrade in upgrade test

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
[E2E Azure](https://github.com/edgelesssys/constellation/actions/runs/5787140974/job/15683397471)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [x] Link to Milestone
