### PR TITLE
cli: strict input validation on attestation version numbers

### DIFF
--- a/internal/config/attestationversion.go
+++ b/internal/config/attestationversion.go
@@ -9,6 +9,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -73,9 +74,9 @@ func (v *AttestationVersion) parseRawUnmarshal(rawUnmarshal any) error {
 			return fmt.Errorf("invalid version value: %s", s)
 		}
 	case int:
-		v.Value = uint8(s)
-	// yaml spec allows "1" as float64, so version number might come as a float:  https://github.com/go-yaml/yaml/issues/430
-	case float64:
+		if s > math.MaxUint8 || s < 0 {
+			return fmt.Errorf("invalid version value: %d", s)
+		}
 		v.Value = uint8(s)
 	default:
 		return fmt.Errorf("invalid version value type: %s", s)

--- a/internal/config/attestationversion_test.go
+++ b/internal/config/attestationversion_test.go
@@ -91,8 +91,13 @@ func TestVersionUnmarshalYAML(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "09 errors",
-			sut:     "09",
+			name:    "hex format is invalid",
+			sut:     "0x10",
+			wantErr: true,
+		},
+		{
+			name:    "octal format is invalid",
+			sut:     "010",
 			wantErr: true,
 		},
 	}

--- a/internal/config/attestationversion_test.go
+++ b/internal/config/attestationversion_test.go
@@ -44,3 +44,68 @@ func TestVersionMarshalYAML(t *testing.T) {
 		})
 	}
 }
+
+func TestVersionUnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name    string
+		sut     string
+		want    AttestationVersion
+		wantErr bool
+	}{
+		{
+			name: "latest resolves to isLatest",
+			sut:  "latest",
+			want: AttestationVersion{
+				Value:      0,
+				WantLatest: true,
+			},
+			wantErr: false,
+		},
+		{
+			name: "1 resolves to value 1",
+			sut:  "1",
+			want: AttestationVersion{
+				Value:      1,
+				WantLatest: false,
+			},
+			wantErr: false,
+		},
+		{
+			name:    "max uint8+1 errors",
+			sut:     "256",
+			wantErr: true,
+		},
+		{
+			name:    "-1 errors",
+			sut:     "-1",
+			wantErr: true,
+		},
+		{
+			name:    "2.6 errors",
+			sut:     "2.6",
+			wantErr: true,
+		},
+		{
+			name:    "2.0 errors",
+			sut:     "2.0",
+			wantErr: true,
+		},
+		{
+			name:    "09 errors",
+			sut:     "09",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var sut AttestationVersion
+			err := yaml.Unmarshal([]byte(tt.sut), &sut)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, sut)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
For Azure-SEV SNP, we currently accept attestation version values such as:
2.6
09
As a user,  such input should fail config validation.

The version logically should only allow uint values such as: 1 or "1"

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- don't allow float parsings and validate valid uint8 range

### Related issue
- [AB#3271](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3271)

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
