### PR TITLE
e2e: remove existingConfig field

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -30,42 +30,9 @@ inputs:
   artifactNameSuffix:
     description: "Suffix for artifact naming."
     required: true
-  existingConfig:
-    default: "false"
-    description: "Use existing config file."
   fetchMeasurements:
     default: "false"
     description: "Update measurements via the 'constellation config fetch-measurements' command."
-  #
-  # GCP specific inputs
-  #
-  gcpProject:
-    description: "The GCP project to deploy Constellation in."
-    required: false
-  gcpInClusterServiceAccountKey:
-    description: "The GCP Service account to use inside the created Constellation cluster."
-    required: false
-  #
-  # Azure specific inputs
-  #
-  azureSubscription:
-    description: "The Azure subscription ID to deploy Constellation in."
-    required: false
-  azureTenant:
-    description: "The Azure tenant ID to deploy Constellation in."
-    required: false
-  azureClientID:
-    description: "The Azure client ID of the application registration created for Constellation."
-    required: false
-  azureClientSecret:
-    description: "The Azure client secret value of the used secret."
-    required: false
-  azureUserAssignedIdentity:
-    description: "The Azure user assigned identity to use for Constellation."
-    required: false
-  azureResourceGroup:
-    description: "The Azure resource group to use for Constellation cluster"
-    required: false
 
 outputs:
   kubeconfig:
@@ -81,43 +48,10 @@ outputs:
 runs:
   using: "composite"
   steps:
-    - name: Constellation config generate
+    - name: Set constellation name
       shell: bash
-      if: inputs.existingConfig != 'true'
       run: |
-        if [[ -n "${{ inputs.kubernetesVersion }}" ]]; then
-          constellation config generate ${{ inputs.cloudProvider }} --kubernetes="${{ inputs.kubernetesVersion }}" --debug
-        else
-          constellation config generate ${{ inputs.cloudProvider }} --debug
-        fi
-
         yq eval -i "(.name) = \"e2e-test\"" constellation-conf.yaml
-
-        yq eval -i \
-          "(.provider | select(. | has(\"azure\")).azure.subscription) = \"${{ inputs.azureSubscription }}\" |
-            (.provider | select(. | has(\"azure\")).azure.tenant) = \"${{ inputs.azureTenant }}\" |
-            (.provider | select(. | has(\"azure\")).azure.location) = \"West US\" |
-            (.provider | select(. | has(\"azure\")).azure.userAssignedIdentity) = \"${{ inputs.azureUserAssignedIdentity }}\" |
-            (.provider | select(. | has(\"azure\")).azure.resourceGroup) = \"${{ inputs.azureResourceGroup }}\" |
-          constellation-conf.yaml
-
-        yq eval -i \
-          "(.provider | select(. | has(\"gcp\")).gcp.project) = \"${{ inputs.gcpProject }}\" |
-            (.provider | select(. | has(\"gcp\")).gcp.region) = \"europe-west3\" |
-            (.provider | select(. | has(\"gcp\")).gcp.zone) = \"europe-west3-b\" |
-            (.provider | select(. | has(\"gcp\")).gcp.serviceAccountKeyPath) = \"serviceAccountKey.json\"" \
-          constellation-conf.yaml
-
-        yq eval -i \
-          "(.provider | select(. | has(\"aws\")).aws.region) = \"us-east-2\" |
-            (.provider | select(. | has(\"aws\")).aws.zone) = \"us-east-2c\" |
-            (.provider | select(. | has(\"aws\")).aws.iamProfileControlPlane) = \"e2e_test_control_plane_instance_profile\" |
-            (.provider | select(. | has(\"aws\")).aws.iamProfileWorkerNodes) = \"e2e_test_worker_node_instance_profile\"" \
-          constellation-conf.yaml
-
-        if [[ -n "${{ inputs.kubernetesVersion }}" ]]; then
-          yq eval -i "(.kubernetesVersion) = \"${{ inputs.kubernetesVersion }}\"" constellation-conf.yaml
-        fi
 
     - name: Set image
       id: setImage
@@ -148,19 +82,11 @@ runs:
         yq eval -i "(.nodeGroups[] | .instanceType) = \"${{ inputs.machineType }}\"" constellation-conf.yaml
 
     - name: Set node count
-      if: inputs.cliVersion  != 'v2.9.0' && inputs.cliVersion  != 'v2.9.1'
+      if: inputs.cliVersion != 'v2.9.0' && inputs.cliVersion != 'v2.9.1'
       shell: bash
       run: |
         yq eval -i "(.nodeGroups[] | select(.role == \"control-plane\") | .initialCount) = ${{ inputs.controlNodesCount }}" constellation-conf.yaml
         yq eval -i "(.nodeGroups[] | select(.role == \"worker\") | .initialCount) = ${{ inputs.workerNodesCount }}" constellation-conf.yaml
-
-    - name: Create serviceAccountKey.json
-      if: inputs.cloudProvider == 'gcp' && !inputs.existingConfig # Skip if using existing config. serviceAccountKey.json is already present in that case.
-      shell: bash
-      env:
-        GCP_CLUSTER_SERVICE_ACCOUNT_KEY: ${{ inputs.gcpInClusterServiceAccountKey }}
-      run: |
-        echo "$GCP_CLUSTER_SERVICE_ACCOUNT_KEY" > serviceAccountKey.json
 
     - name: Enable debugCluster flag
       if: inputs.isDebugImage == 'true'

--- a/.github/actions/constellation_iam_create/action.yml
+++ b/.github/actions/constellation_iam_create/action.yml
@@ -5,6 +5,9 @@ inputs:
   cloudProvider:
     description: "Either 'aws', 'azure' or 'gcp'."
     required: true
+  kubernetesVersion:
+    description: "Kubernetes version to create the cluster from."
+    required: true
   namePrefix:
     description: "Name prefix to use for resources."
     required: true
@@ -30,76 +33,51 @@ inputs:
     description: "The GCP zone to deploy Constellation in."
     required: false
 
-outputs:
-  existingConfig:
-    description: "Whether a configuration file has been created to be used in the next step."
-    value: ${{ steps.setExistingConfig.outputs.existingConfig }}
-
 runs:
   using: "composite"
   steps:
+    - name: Generate config
+      id: generate-config
+      shell: bash
+      # TODO(katexochen): Remove the generate-config flag once v2.10 is released.
+      run: |
+        output=$(constellation iam create --help)
+        if [[ $output == *"generate-config"* ]]; then
+          echo "flag=--generate-config" | tee -a "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        echo "flag=--update-config" | tee -a "$GITHUB_OUTPUT"
+        constellation config generate ${{ inputs.cloudProvider }} --kubernetes=${{ inputs.kubernetesVersion }}
+
     - name: Constellation iam create aws
       shell: bash
       if: inputs.cloudProvider == 'aws'
       run: |
-        constellation config generate aws
-        iam_conf_flag="--update-config"
-
-        output=$(constellation iam create --help)
-        if [[ $output == *"generate-config"* ]]; then
-          rm constellation-conf.yaml
-          iam_conf_flag="--generate-config"
-        fi
-
         constellation iam create aws \
           --zone=${{ inputs.awsZone }} \
           --prefix=${{ inputs.namePrefix }} \
-          ${iam_conf_flag} --yes
+          ${{ steps.generate-config.outputs.flag }} \
+          --yes
 
-    - name: Constellation iam create azure
+    - name: Constellation iam create azure --kubernetes=${{ inputs.kubernetesVersion }}
       shell: bash
       if: inputs.cloudProvider == 'azure'
       run: |
-        output=$(constellation --help)
-        if [[ $output == *"tf-log"* ]]; then
-          TFFLAG="--tf-log=DEBUG"
-        fi
-        constellation config generate azure
-        iam_conf_flag="--update-config"
-
-        output=$(constellation iam create --help)
-        if [[ $output == *"generate-config"* ]]; then
-          rm constellation-conf.yaml
-          iam_conf_flag="--generate-config"
-        fi
-
         constellation iam create azure \
           --region=${{ inputs.azureRegion }} \
           --resourceGroup="${{ inputs.namePrefix }}-rg" \
           --servicePrincipal="${{ inputs.namePrefix }}-sp" \
-          ${iam_conf_flag} --yes ${TFFLAG:-}
+          ${{ steps.generate-config.outputs.flag }} \
+          --yes
 
     - name: Constellation iam create gcp
       shell: bash
       if: inputs.cloudProvider == 'gcp'
       run: |
-        constellation config generate gcp
-        iam_conf_flag="--update-config"
-
-        output=$(constellation iam create --help)
-        if [[ $output == *"generate-config"* ]]; then
-          rm constellation-conf.yaml
-          iam_conf_flag="--generate-config"
-        fi
-
         constellation iam create gcp \
           --projectID=${{ inputs.gcpProjectID }} \
           --zone=${{ inputs.gcpZone }} \
           --serviceAccountID="${{ inputs.namePrefix }}-sa" \
-          ${iam_conf_flag} --yes
-
-    - name: Set existing config
-      id: setExistingConfig
-      shell: bash
-      run: |
-        echo "existingConfig=true" | tee -a $GITHUB_OUTPUT
+          ${{ steps.generate-config.outputs.flag }} \
+          --yes

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -203,6 +203,7 @@ runs:
         azureRegion: northeurope
         gcpProjectID: ${{ inputs.gcpProject }}
         gcpZone: europe-west3-b
+        kubernetesVersion: ${{ inputs.kubernetesVersion }}
 
     - name: Login to GCP (Cluster service account)
       if: inputs.cloudProvider == 'gcp'
@@ -230,14 +231,11 @@ runs:
       uses: ./.github/actions/constellation_create
       with:
         cloudProvider: ${{ inputs.cloudProvider }}
-        gcpInClusterServiceAccountKey: ${{ inputs.gcpInClusterServiceAccountKey }}
         workerNodesCount: ${{ inputs.workerNodesCount }}
         controlNodesCount: ${{ inputs.controlNodesCount }}
         machineType: ${{ inputs.machineType }}
         osImage: ${{ inputs.osImage }}
         isDebugImage: ${{ inputs.isDebugImage }}
-        kubernetesVersion: ${{ inputs.kubernetesVersion }}
-        existingConfig: ${{ steps.constellation-iam-create.outputs.existingConfig }}
         artifactNameSuffix: ${{ steps.create-prefix.outputs.prefix }}
         fetchMeasurements: ${{ inputs.fetchMeasurements }}
         cliVersion: ${{ inputs.cliVersion }}


### PR DESCRIPTION
The existingConfig field is always set to true during create, as we use the IAM create step to generate the config in all cases. Accordingly, secret injection into config isn't needed anymore in create. This fixes a bug where other parameters like Kubernetes version and cluster name wouldn't be injected into the config due to existingConfig being true.

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
