### PR TITLE
docs: add note on how we handle deprecations

### DIFF
--- a/dev-docs/workflows/deprecations.md
+++ b/dev-docs/workflows/deprecations.md
@@ -1,0 +1,10 @@
+# Deprecations
+
+When removing a feature/flag/command we strive to mark said feature as deprecated one minor version before the removal happens.
+I.e. to remove the CLI command `foo` in version v10.6, all invocations of `foo` in v10.5 should print a deprecation warning.
+The deprecation should also be noted in the help text of the command to make it show up in the Constellation docs.
+
+The changelog for v10.5 should contain a deprecation warning for `foo`.
+The changelog for v10.6, should sort the removal of `foo` in the category `Breaking Changes`.
+
+It may happen that the effort to implement a feature in this manner is deemed to high.


### PR DESCRIPTION
### Context
We have discussed how we want to handle deprecations in the past. IIRC we are breaking with what we discussed in v2.10.0. I think we also said that our policy is not binding for the moment. 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Document how we handle deprecations.


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
