### PR TITLE
ci: replace mastersecret flag in recover

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -71,9 +71,9 @@ outputs:
   kubeconfig:
     description: "The kubeconfig for the cluster."
     value: ${{ steps.constellation-init.outputs.KUBECONFIG }}
-  masterSecret:
-    description: "The master-secret for the cluster."
-    value: ${{ steps.constellation-init.outputs.MASTERSECRET }}
+  workspace:
+    description: "The Constellation workspace directory."
+    value: ${{ steps.constellation-init.outputs.WORKSPACE }}
   osImageUsed:
     description: "The OS image used in the cluster."
     value: ${{ steps.setImage.outputs.image }}
@@ -211,8 +211,8 @@ runs:
       shell: bash
       run: |
         constellation init --force --debug
-        echo "KUBECONFIG=$(pwd)/constellation-admin.conf" >> $GITHUB_OUTPUT
-        echo "MASTERSECRET=$(pwd)/constellation-mastersecret.json" >> $GITHUB_OUTPUT
+        echo "KUBECONFIG=$(pwd)/constellation-admin.conf" | tee -a $GITHUB_OUTPUT
+        echo "WORKSPACE=$(pwd)" | tee -a $GITHUB_OUTPUT
 
     - name: Wait for nodes to join and become ready
       shell: bash

--- a/.github/actions/e2e_recover/action.yml
+++ b/.github/actions/e2e_recover/action.yml
@@ -8,8 +8,8 @@ inputs:
   kubeconfig:
     description: "The kubeconfig for the cluster."
     required: true
-  masterSecret:
-    description: "The master-secret for the cluster."
+  workspace:
+    description: "The argument to use for constellation -C."
     required: true
 
 runs:
@@ -40,7 +40,7 @@ runs:
         start_time=$(date +%s)
         recovered=0
         while true; do
-            output=$(constellation recover --master-secret=${{ inputs.masterSecret }} --force)
+            output=$(constellation recover -C ${{ inputs.workspace }} --force)
             if echo "$output" | grep -q "Pushed recovery key."; then
                 echo "$output"
                 i=$(echo "$output" | grep -o "Pushed recovery key." | wc -l | sed 's/ //g')


### PR DESCRIPTION
### Context
<!-- Please add background information on why this PR is opened. -->
Since we added the workspace flag to the CLI we no longer support the dedicated mastersecret flag. Thus we need to adapt how the recover action gets the mastersecret.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add workspace output to constellation_create action
- Use workspace output in recover action


### Additional info
- [CI run](https://github.com/edgelesssys/constellation/actions/runs/5807255670)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
