### PR TITLE
internal: fix unmarshalling attestation version numbers from JSON

### DIFF
--- a/internal/config/attestationversion.go
+++ b/internal/config/attestationversion.go
@@ -64,11 +64,11 @@ func (v *AttestationVersion) UnmarshalJSON(data []byte) (err error) {
 	// Therefore, try to unmarshal to string, and then to int, instead of using type assertions.
 	var unmarshalString string
 	if err := json.Unmarshal(data, &unmarshalString); err != nil {
-		var unmarshalInt int
+		var unmarshalInt int64
 		if err := json.Unmarshal(data, &unmarshalInt); err != nil {
 			return fmt.Errorf("unable to unmarshal to string or int: %w", err)
 		}
-		unmarshalString = strconv.FormatInt(int64(unmarshalInt), 10)
+		unmarshalString = strconv.FormatInt(unmarshalInt, 10)
 	}
 
 	return v.parseRawUnmarshal(unmarshalString)

--- a/internal/config/attestationversion.go
+++ b/internal/config/attestationversion.go
@@ -58,15 +58,24 @@ func (v AttestationVersion) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements a custom unmarshaller to resolve "latest" values.
 func (v *AttestationVersion) UnmarshalJSON(data []byte) (err error) {
-	var rawUnmarshal string
-	if err := json.Unmarshal(data, &rawUnmarshal); err != nil {
-		return fmt.Errorf("raw unmarshal: %w", err)
+	// JSON has two distinct ways to represent numbers and strings.
+	// This means we cannot simply unmarshal to string, like with YAML.
+	// Unmarshalling to `any` causes Go to unmarshal numbers to float64.
+	// Therefore, try to unmarshal to string, and then to int, instead of using type assertions.
+	var unmarshalString string
+	if err := json.Unmarshal(data, &unmarshalString); err != nil {
+		var unmarshalInt int
+		if err := json.Unmarshal(data, &unmarshalInt); err != nil {
+			return fmt.Errorf("unable to unmarshal to string or int: %w", err)
+		}
+		unmarshalString = strconv.FormatInt(int64(unmarshalInt), 10)
 	}
-	return v.parseRawUnmarshal(rawUnmarshal)
+
+	return v.parseRawUnmarshal(unmarshalString)
 }
 
 func (v *AttestationVersion) parseRawUnmarshal(str string) error {
-	if strings.HasPrefix(str, "0") {
+	if strings.HasPrefix(str, "0") && len(str) != 1 {
 		return fmt.Errorf("no format with prefixed 0 (octal, hexadecimal) allowed: %s", str)
 	}
 	if strings.ToLower(str) == "latest" {

--- a/internal/config/attestationversion_test.go
+++ b/internal/config/attestationversion_test.go
@@ -14,21 +14,18 @@ import (
 )
 
 func TestVersionMarshalYAML(t *testing.T) {
-	tests := []struct {
-		name string
+	tests := map[string]struct {
 		sut  AttestationVersion
 		want string
 	}{
-		{
-			name: "isLatest resolves to latest",
+		"isLatest resolves to latest": {
 			sut: AttestationVersion{
 				Value:      1,
 				WantLatest: true,
 			},
 			want: "latest\n",
 		},
-		{
-			name: "value 5 resolves to 5",
+		"value 5 resolves to 5": {
 			sut: AttestationVersion{
 				Value:      5,
 				WantLatest: false,
@@ -36,81 +33,81 @@ func TestVersionMarshalYAML(t *testing.T) {
 			want: "5\n",
 		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			bt, err := yaml.Marshal(tt.sut)
-			require.NoError(t, err)
-			require.Equal(t, tt.want, string(bt))
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
+			bt, err := yaml.Marshal(tc.sut)
+			require.NoError(err)
+			require.Equal(tc.want, string(bt))
 		})
 	}
 }
 
 func TestVersionUnmarshalYAML(t *testing.T) {
-	tests := []struct {
-		name    string
+	tests := map[string]struct {
 		sut     string
 		want    AttestationVersion
 		wantErr bool
 	}{
-		{
-			name: "latest resolves to isLatest",
-			sut:  "latest",
+		"latest resolves to isLatest": {
+			sut: "latest",
 			want: AttestationVersion{
 				Value:      0,
 				WantLatest: true,
 			},
 			wantErr: false,
-		},
-		{
-			name: "1 resolves to value 1",
-			sut:  "1",
+		}, "1 resolves to value 1": {
+			sut: "1",
 			want: AttestationVersion{
 				Value:      1,
 				WantLatest: false,
 			},
 			wantErr: false,
-		},
-		{
-			name:    "max uint8+1 errors",
+		}, "max uint8+1 errors": {
 			sut:     "256",
 			wantErr: true,
-		},
-		{
-			name:    "-1 errors",
+		}, "-1 errors": {
 			sut:     "-1",
 			wantErr: true,
-		},
-		{
-			name:    "2.6 errors",
+		}, "2.6 errors": {
 			sut:     "2.6",
 			wantErr: true,
 		},
-		{
-			name:    "2.0 errors",
+		"2.0 errors": {
 			sut:     "2.0",
 			wantErr: true,
-		},
-		{
-			name:    "hex format is invalid",
+		}, "hex format is invalid": {
 			sut:     "0x10",
 			wantErr: true,
-		},
-		{
-			name:    "octal format is invalid",
+		}, "octal format is invalid": {
 			sut:     "010",
 			wantErr: true,
 		},
+		"0 resolves to value 0": {
+			sut: "0",
+			want: AttestationVersion{
+				Value:      0,
+				WantLatest: false,
+			},
+		},
+		"00 errors": {
+			sut:     "00",
+			wantErr: true,
+		},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			require := require.New(t)
+
 			var sut AttestationVersion
-			err := yaml.Unmarshal([]byte(tt.sut), &sut)
-			if tt.wantErr {
-				require.Error(t, err)
+			err := yaml.Unmarshal([]byte(tc.sut), &sut)
+			if tc.wantErr {
+				require.Error(err)
 				return
 			}
-			require.NoError(t, err)
-			require.Equal(t, tt.want, sut)
+			require.NoError(err)
+			require.Equal(tc.want, sut)
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Unmarshalling a JSON representation of an AttestationConfig fails since https://github.com/edgelesssys/constellation/pull/2180.
This is because we now always try to unmarshal a given version as a Go string.

JSON has two distinct ways to represent numbers and strings: Numbers are always given without quotation marks, while strings have to use quotation marks.
This means we cannot simply unmarshal a value to string, like we do with YAML.
Additionally, unmarshalling to `any` causes Go to unmarshal numbers to float64.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Try to unmarshal attestation version numbers to string, and then to int, when converting from JSON

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
