### PR TITLE
bazel: remove stale build rules

### DIFF
--- a/cli/internal/cmd/pathprefix/BUILD.bazel
+++ b/cli/internal/cmd/pathprefix/BUILD.bazel
@@ -1,14 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "workspace",
-    srcs = ["workspace.go"],
-    importpath = "github.com/edgelesssys/constellation/v2/cli/internal/cmd/workspace",
-    visibility = ["//cli:__subpackages__"],
-    deps = ["//internal/constants"],
-)
-
-go_library(
     name = "pathprefix",
     srcs = ["pathprefix.go"],
     importpath = "github.com/edgelesssys/constellation/v2/cli/internal/cmd/pathprefix",

--- a/disk-mapper/internal/diskencryption/BUILD.bazel
+++ b/disk-mapper/internal/diskencryption/BUILD.bazel
@@ -1,69 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "mapper",
-    srcs = [
-        "cryptdevice.go",
-        "mapper.go",
-        "mapper_cgo.go",
-        "mapper_cross.go",
-    ],
-    importpath = "github.com/edgelesssys/constellation/v2/disk-mapper/internal/mapper",
-    visibility = ["//disk-mapper:__subpackages__"],
-    deps = select({
-        "@io_bazel_rules_go//go/platform:aix": [
-            "//internal/logger",
-        ],
-        "@io_bazel_rules_go//go/platform:android": [
-            "//internal/cryptsetup",
-            "//internal/logger",
-            "@com_github_martinjungblut_go_cryptsetup//:go-cryptsetup",
-            "@org_uber_go_zap//:zap",
-        ],
-        "@io_bazel_rules_go//go/platform:darwin": [
-            "//internal/logger",
-        ],
-        "@io_bazel_rules_go//go/platform:dragonfly": [
-            "//internal/logger",
-        ],
-        "@io_bazel_rules_go//go/platform:freebsd": [
-            "//internal/logger",
-        ],
-        "@io_bazel_rules_go//go/platform:illumos": [
-            "//internal/logger",
-        ],
-        "@io_bazel_rules_go//go/platform:ios": [
-            "//internal/logger",
-        ],
-        "@io_bazel_rules_go//go/platform:js": [
-            "//internal/logger",
-        ],
-        "@io_bazel_rules_go//go/platform:linux": [
-            "//internal/cryptsetup",
-            "//internal/logger",
-            "@com_github_martinjungblut_go_cryptsetup//:go-cryptsetup",
-            "@org_uber_go_zap//:zap",
-        ],
-        "@io_bazel_rules_go//go/platform:netbsd": [
-            "//internal/logger",
-        ],
-        "@io_bazel_rules_go//go/platform:openbsd": [
-            "//internal/logger",
-        ],
-        "@io_bazel_rules_go//go/platform:plan9": [
-            "//internal/logger",
-        ],
-        "@io_bazel_rules_go//go/platform:solaris": [
-            "//internal/logger",
-        ],
-        "@io_bazel_rules_go//go/platform:windows": [
-            "//internal/logger",
-        ],
-        "//conditions:default": [],
-    }),
-)
-
-go_library(
     name = "diskencryption",
     srcs = ["diskencryption.go"],
     importpath = "github.com/edgelesssys/constellation/v2/disk-mapper/internal/diskencryption",

--- a/internal/sigstore/keyselect/BUILD.bazel
+++ b/internal/sigstore/keyselect/BUILD.bazel
@@ -1,17 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
-    name = "foo",
-    srcs = ["foo.go"],
-    importpath = "github.com/edgelesssys/constellation/v2/internal/sigstore/foo",
-    visibility = ["//:__subpackages__"],
-    deps = [
-        "//internal/api/versionsapi",
-        "//internal/constants",
-    ],
-)
-
-go_library(
     name = "keyselect",
     srcs = ["keyselect.go"],
     importpath = "github.com/edgelesssys/constellation/v2/internal/sigstore/keyselect",


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Some build rules became stale after moving / deleting go packages.
This can currently not be automatically cleaned up by gazelle, since it will only update existing build rules but never remove a build rule.
I'm working on a linter test to find those cases in the CI.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bazel: remove stale build rules

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
