### PR TITLE
ci: allow setting region/zone for e2e tests

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -23,6 +23,9 @@ inputs:
     description: "Version of a released CLI to download, e.g. 'v2.3.0', leave empty to build it."
   kubernetesVersion:
     description: "Kubernetes version to create the cluster from."
+  regionZone:
+    description: "Region or zone to use for resource creation"
+    required: false
   gcpProject:
     description: "The GCP project to deploy Constellation in."
     required: true
@@ -190,10 +193,10 @@ runs:
       with:
         cloudProvider: ${{ inputs.cloudProvider }}
         namePrefix: ${{ steps.create-prefix.outputs.prefix }}
-        awsZone: us-east-2c
-        azureRegion: northeurope
+        awsZone: ${{ inputs.regionZone || 'us-east-2c' }}
+        azureRegion: ${{ inputs.regionZone || 'northeurope' }}
         gcpProjectID: ${{ inputs.gcpProject }}
-        gcpZone: europe-west3-b
+        gcpZone: ${{ inputs.regionZone || 'europe-west3-b' }}
         kubernetesVersion: ${{ inputs.kubernetesVersion }}
 
     - name: Login to GCP (Cluster service account)

--- a/.github/workflows/e2e-test-manual.yml
+++ b/.github/workflows/e2e-test-manual.yml
@@ -55,6 +55,9 @@ on:
         type: string
         default: "default"
         required: false
+      regionZone:
+        description: "Region or zone to create the cluster in. Leave empty for default region/zone."
+        type: string
       git-ref:
         description: "Git ref to checkout."
         type: string
@@ -96,6 +99,9 @@ on:
         description: "Override VM machine type. Leave as 'default' or empty to use the default VM type for the selected cloud provider."
         type: string
         required: true
+      regionZone:
+        description: "Region or zone to create the cluster in. Leave empty for default region/zone."
+        type: string
       git-ref:
         description: "Git ref to checkout."
         type: string
@@ -232,6 +238,7 @@ jobs:
           controlNodesCount: ${{ needs.split-nodeCount.outputs.controlPlaneNodes }}
           cloudProvider: ${{ inputs.cloudProvider }}
           machineType: ${{ inputs.machineType }}
+          regionZone: ${{ inputs.regionZone }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcpClusterCreateServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
           gcpIAMCreateServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -19,6 +19,9 @@ on:
         type: string
         description: "Target version to test"
         required: true
+      regionZone:
+        description: "Region or zone to run e2e tests in. Leave empty for default region/zone."
+        type: string
   workflow_call:
     inputs:
       ref:
@@ -191,6 +194,7 @@ jobs:
           kubernetesVersion: ${{ matrix.kubernetes-version }}
           osImage: ""
           isDebugImage: "false"
+          regionZone: ${{ inputs.regionZone }}
           awsOpenSearchDomain: ${{ secrets.AWS_OPENSEARCH_DOMAIN }}
           awsOpenSearchUsers: ${{ secrets.AWS_OPENSEARCH_USER }}
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
@@ -243,6 +247,5 @@ jobs:
       fromVersion: ${{ matrix.fromVersion }}
       toImage: ${{ inputs.targetVersion }}
       cloudProvider: ${{ matrix.cloudProvider }}
-      workerNodesCount: 2
-      controlNodesCount: 3
+      nodeCount: '3:2'
       gitRef: ${{ inputs.ref || github.head_ref }}

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -264,8 +264,7 @@ jobs:
     with:
       fromVersion: ${{ matrix.fromVersion }}
       cloudProvider: ${{ matrix.cloudProvider }}
-      workerNodesCount: 2
-      controlNodesCount: 3
+      nodeCount: '3:2'
       scheduled: ${{ github.event_name == 'schedule' }}
   e2e-mini:
     name: Run miniconstellation E2E test

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -11,12 +11,10 @@ on:
           - "azure"
           - "aws"
         default: "azure"
-      workerNodesCount:
-        description: "Number of worker nodes to spawn."
-        default: "2"
-      controlNodesCount:
-        description: "Number of control-plane nodes to spawn."
-        default: "3"
+      nodeCount:
+        description: "Number of nodes to use in the cluster. Given in format `<control-plane nodes>:<worker nodes>`."
+        default: "3:2"
+        type: string
       fromVersion:
         description: CLI version to create a new cluster with. This has to be a released version, e.g., 'v2.1.3'.
         type: string
@@ -42,25 +40,19 @@ on:
         description: Enter a version to build the CLI with. This can be used to simulate a patch-upgrade.
         type: string
         required: false
-      scheduled:
-        description: Don't set this when triggering manually.
-        type: boolean
-        default: false
-        required: false
+      regionZone:
+        description: "Region or zone to create the cluster in. Leave empty for default region/zone."
+        type: string
   workflow_call:
     inputs:
       cloudProvider:
         description: "Which cloud provider to use."
         type: string
         required: true
-      workerNodesCount:
-        description: "Number of worker nodes to spawn."
-        type: number
-        required: true
-      controlNodesCount:
-        description: "Number of control-plane nodes to spawn."
-        type: number
-        required: true
+      nodeCount:
+        description: "Number of nodes to use in the cluster. Given in format `<control-plane nodes>:<worker nodes>`."
+        default: "3:2"
+        type: string
       fromVersion:
         description: CLI version to create a new cluster with. This has to be a released version, e.g., 'v2.1.3'.
         type: string
@@ -93,6 +85,32 @@ on:
         required: false
 
 jobs:
+  split-nodeCount:
+    name: Split nodeCount
+    runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
+    outputs:
+      workerNodes: ${{ steps.split-nodeCount.outputs.workerNodes }}
+      controlPlaneNodes: ${{ steps.split-nodeCount.outputs.controlPlaneNodes }}
+    steps:
+      - name: Split nodeCount
+        id: split-nodeCount
+        shell: bash
+        run: |
+          nodeCount="${{ inputs.nodeCount }}"
+          workerNodes="${nodeCount##*:}"
+          controlPlaneNodes="${nodeCount%%:*}"
+
+          if [[ -z "${workerNodes}" ]] || [[ -z "{controlPlaneNodes}" ]]; then
+            echo "Invalid nodeCount input: '${nodeCount}'."
+            exit 1
+          fi
+
+          echo "workerNodes=${workerNodes}" | tee -a "$GITHUB_OUTPUT"
+          echo "controlPlaneNodes=${controlPlaneNodes}" | tee -a "$GITHUB_OUTPUT"
+
   e2e-upgrade:
     runs-on: ubuntu-22.04
     permissions:
@@ -100,6 +118,7 @@ jobs:
       checks: write
       contents: read
       packages: write
+    needs: [split-nodeCount]
     steps:
       - name: Checkout
         if: inputs.gitRef == 'head'
@@ -139,12 +158,13 @@ jobs:
         id: e2e_test
         uses: ./.github/actions/e2e_test
         with:
-          workerNodesCount: ${{ inputs.workerNodesCount }}
-          controlNodesCount: ${{ inputs.controlNodesCount }}
+          workerNodesCount: ${{ needs.split-nodeCount.outputs.workerNodes }}
+          controlNodesCount: ${{ needs.split-nodeCount.outputs.controlPlaneNodes }}
           cloudProvider: ${{ inputs.cloudProvider }}
           osImage: ${{ inputs.fromVersion }}
           isDebugImage: "false"
           cliVersion: ${{ inputs.fromVersion }}
+          regionZone: ${{ inputs.regionZone }}
           gcpProject: ${{ secrets.GCP_E2E_PROJECT }}
           gcpClusterCreateServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
           gcpIAMCreateServiceAccount: "constellation-iam-e2e@constellation-331613.iam.gserviceaccount.com"
@@ -218,8 +238,8 @@ jobs:
           IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-image.outputs.output }}
           KUBERNETES: ${{ inputs.toKubernetes }}
           MICROSERVICES: ${{ inputs.toMicroservices }}
-          WORKERNODES: ${{ inputs.workerNodesCount }}
-          CONTROLNODES: ${{ inputs.controlNodesCount }}
+          WORKERNODES:  ${{ needs.split-nodeCount.outputs.workerNodes }}
+          CONTROLNODES: ${{ needs.split-nodeCount.outputs.controlPlaneNodes }}
         run: |
           echo "Image target: $IMAGE"
           echo "K8s target: $KUBERNETES"
@@ -278,7 +298,7 @@ jobs:
           failure() &&
           github.ref == 'refs/heads/main' &&
           github.event_name == 'workflow_call' &&
-          inputs.scheduled == 'true'
+          ${{ inputs.scheduled || 'true' }} == 'true'
         continue-on-error: true
         uses: ./.github/actions/notify_failure
         with:


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
We currently hardcode the region/zone we run our e2e tests in.
CSP resources in our default regions may be exhausted, causing our tests to fail, or we might want to simply test in other regions, e.g. to avoid zonal quota limits in our subscription.

### Proposed change(s)
- Make region/zone configurable in e2e tests
  - Users can input anything right now, invalid input will result in errors during IAM create
  - For empty input, our old default region/zone is used

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
e2e test GCP using default zone (empty regionZone field): https://github.com/edgelesssys/constellation/actions/runs/5819355990
e2e test AWS using eu-west-1b as zone: https://github.com/edgelesssys/constellation/actions/runs/5819736713
