### PR TITLE
cli: correctly print absolute path for kubeconfig

### DIFF
--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -436,7 +436,7 @@ func (i *initCmd) writeOutput(
 	if !mergeConfig {
 		fmt.Fprintln(wr, "You can now connect to your cluster by executing:")
 
-		exportPath, err := filepath.Abs(i.pf.PrefixPath(constants.AdminConfFilename))
+		exportPath, err := filepath.Abs(constants.AdminConfFilename)
 		if err != nil {
 			return fmt.Errorf("getting absolute path to kubeconfig: %w", err)
 		}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
In https://github.com/edgelesssys/constellation/pull/2181 the output of `constellation init` was changed to include the path to a clusters kubeconfig file as an absolute path to avoid issues if a user provided their workspace as an absolute path, instead of relative to their current directory.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Don't prefix the path of the kubeconfig with current workspace, instead just use absolute path for admin conf

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
