### PR TITLE
cli: fix version check for CSI chart

### DIFF
--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -144,14 +144,14 @@ func (v Semver) MajorMinorEqual(other Semver) bool {
 // It checks if the version of v is greater than the version of other and allows a drift of at most one minor version.
 func (v Semver) IsUpgradeTo(other Semver) error {
 	if v.Compare(other) <= 0 {
-		return compatibility.NewInvalidUpgradeError(v.String(), other.String(), errors.New("current version newer than or equal to new version"))
+		return compatibility.NewInvalidUpgradeError(other.String(), v.String(), errors.New("current version newer than or equal to new version"))
 	}
 	if v.major != other.major {
-		return compatibility.NewInvalidUpgradeError(v.String(), other.String(), compatibility.ErrMajorMismatch)
+		return compatibility.NewInvalidUpgradeError(other.String(), v.String(), compatibility.ErrMajorMismatch)
 	}
 
 	if v.minor-other.minor > 1 {
-		return compatibility.NewInvalidUpgradeError(v.String(), other.String(), compatibility.ErrMinorDrift)
+		return compatibility.NewInvalidUpgradeError(other.String(), v.String(), compatibility.ErrMinorDrift)
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Helm upgrades never checked if the CSI chart we want to upgrade to was equal to the version of the CLI.
In practice, this should have only occurred under very rare circumstances, if ever: constellationServices and the constellationOperators charts would have to be previously successfully upgrade to the version set in a users config file. The upgrade then had to be aborted before the CSI charts could be upgrade. If a user now changes their CLI version, `constellation upgrade apply` will upgrade the CSI chart to a different version than specified in the config.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a new function `isCLIVersionedRelease`, to check if a given helm release is one of the released directly versioned by the CLI.
- Fix the ordering of versions in error messages returned by the `semver` package

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
