### PR TITLE
cloud: use instanceid as name in aws

### DIFF
--- a/internal/cloud/aws/aws.go
+++ b/internal/cloud/aws/aws.go
@@ -302,13 +302,8 @@ func (c *Cloud) convertToMetadataInstance(ec2Instances []ec2Types.Instance) ([]m
 
 		newInstance := metadata.InstanceMetadata{
 			VPCIP: *ec2Instance.PrivateIpAddress,
+			Name:  *ec2Instance.InstanceId,
 		}
-
-		name, err := findTag(ec2Instance.Tags, tagName)
-		if err != nil {
-			return nil, fmt.Errorf("retrieving tag for instance %s: %w", *ec2Instance.InstanceId, err)
-		}
-		newInstance.Name = name
 
 		instanceRole, err := findTag(ec2Instance.Tags, cloud.TagRole)
 		if err != nil {

--- a/internal/cloud/aws/aws_test.go
+++ b/internal/cloud/aws/aws_test.go
@@ -122,10 +122,6 @@ func TestSelf(t *testing.T) {
 									InstanceId: aws.String("test-instance-id"),
 									Tags: []ec2Types.Tag{
 										{
-											Key:   aws.String(tagName),
-											Value: aws.String("test-instance"),
-										},
-										{
 											Key:   aws.String(cloud.TagRole),
 											Value: aws.String("controlplane"),
 										},
@@ -170,12 +166,7 @@ func TestSelf(t *testing.T) {
 							Instances: []ec2Types.Instance{
 								{
 									InstanceId: aws.String("test-instance-id"),
-									Tags: []ec2Types.Tag{
-										{
-											Key:   aws.String(tagName),
-											Value: aws.String("test-instance"),
-										},
-									},
+									Tags:       []ec2Types.Tag{},
 								},
 							},
 						},
@@ -222,10 +213,6 @@ func TestList(t *testing.T) {
 						},
 						Tags: []ec2Types.Tag{
 							{
-								Key:   aws.String(tagName),
-								Value: aws.String("name-1"),
-							},
-							{
 								Key:   aws.String(cloud.TagRole),
 								Value: aws.String("controlplane"),
 							},
@@ -243,10 +230,6 @@ func TestList(t *testing.T) {
 							AvailabilityZone: aws.String("test-zone"),
 						},
 						Tags: []ec2Types.Tag{
-							{
-								Key:   aws.String(tagName),
-								Value: aws.String("name-2"),
-							},
 							{
 								Key:   aws.String(cloud.TagRole),
 								Value: aws.String("worker"),
@@ -285,10 +268,6 @@ func TestList(t *testing.T) {
 									InstanceId: aws.String("id-1"),
 									Tags: []ec2Types.Tag{
 										{
-											Key:   aws.String(tagName),
-											Value: aws.String("name-1"),
-										},
-										{
 											Key:   aws.String(cloud.TagRole),
 											Value: aws.String("controlplane"),
 										},
@@ -306,13 +285,13 @@ func TestList(t *testing.T) {
 			},
 			wantList: []metadata.InstanceMetadata{
 				{
-					Name:       "name-1",
+					Name:       "id-1",
 					Role:       role.ControlPlane,
 					ProviderID: "aws:///test-zone/id-1",
 					VPCIP:      "192.0.2.1",
 				},
 				{
-					Name:       "name-2",
+					Name:       "id-2",
 					Role:       role.Worker,
 					ProviderID: "aws:///test-zone/id-2",
 					VPCIP:      "192.0.2.2",
@@ -335,10 +314,6 @@ func TestList(t *testing.T) {
 								{
 									InstanceId: aws.String("id-1"),
 									Tags: []ec2Types.Tag{
-										{
-											Key:   aws.String(tagName),
-											Value: aws.String("name-1"),
-										},
 										{
 											Key:   aws.String(cloud.TagRole),
 											Value: aws.String("controlplane"),
@@ -366,10 +341,6 @@ func TestList(t *testing.T) {
 									},
 									Tags: []ec2Types.Tag{
 										{
-											Key:   aws.String(tagName),
-											Value: aws.String("name-3"),
-										},
-										{
 											Key:   aws.String(cloud.TagRole),
 											Value: aws.String("worker"),
 										},
@@ -388,19 +359,19 @@ func TestList(t *testing.T) {
 			},
 			wantList: []metadata.InstanceMetadata{
 				{
-					Name:       "name-3",
+					Name:       "id-3",
 					Role:       role.Worker,
 					ProviderID: "aws:///test-zone-2/id-3",
 					VPCIP:      "192.0.2.3",
 				},
 				{
-					Name:       "name-1",
+					Name:       "id-1",
 					Role:       role.ControlPlane,
 					ProviderID: "aws:///test-zone/id-1",
 					VPCIP:      "192.0.2.1",
 				},
 				{
-					Name:       "name-2",
+					Name:       "id-2",
 					Role:       role.Worker,
 					ProviderID: "aws:///test-zone/id-2",
 					VPCIP:      "192.0.2.2",
@@ -423,10 +394,6 @@ func TestList(t *testing.T) {
 								{
 									InstanceId: aws.String("id-1"),
 									Tags: []ec2Types.Tag{
-										{
-											Key:   aws.String(tagName),
-											Value: aws.String("name-1"),
-										},
 										{
 											Key:   aws.String(cloud.TagRole),
 											Value: aws.String("controlplane"),
@@ -847,10 +814,6 @@ func TestConvertToMetadataInstance(t *testing.T) {
 					},
 					Tags: []ec2Types.Tag{
 						{
-							Key:   aws.String(tagName),
-							Value: aws.String("name-1"),
-						},
-						{
 							Key:   aws.String(cloud.TagRole),
 							Value: aws.String("controlplane"),
 						},
@@ -859,7 +822,7 @@ func TestConvertToMetadataInstance(t *testing.T) {
 			},
 			wantInstances: []metadata.InstanceMetadata{
 				{
-					Name:       "name-1",
+					Name:       "id-1",
 					Role:       role.ControlPlane,
 					ProviderID: "aws:///test-zone/id-1",
 					VPCIP:      "192.0.2.1",
@@ -874,10 +837,6 @@ func TestConvertToMetadataInstance(t *testing.T) {
 					PrivateIpAddress: aws.String("192.0.2.1"),
 					Tags: []ec2Types.Tag{
 						{
-							Key:   aws.String(tagName),
-							Value: aws.String("name-1"),
-						},
-						{
 							Key:   aws.String(cloud.TagRole),
 							Value: aws.String("controlplane"),
 						},
@@ -887,7 +846,7 @@ func TestConvertToMetadataInstance(t *testing.T) {
 
 			wantInstances: []metadata.InstanceMetadata{
 				{
-					Name:       "name-1",
+					Name:       "id-1",
 					Role:       role.ControlPlane,
 					ProviderID: "aws:///id-1",
 					VPCIP:      "192.0.2.1",
@@ -914,10 +873,6 @@ func TestConvertToMetadataInstance(t *testing.T) {
 					},
 					Tags: []ec2Types.Tag{
 						{
-							Key:   aws.String(tagName),
-							Value: aws.String("name-1"),
-						},
-						{
 							Key:   aws.String(cloud.TagRole),
 							Value: aws.String("controlplane"),
 						},
@@ -931,29 +886,6 @@ func TestConvertToMetadataInstance(t *testing.T) {
 				{
 					State:      &ec2Types.InstanceState{Name: ec2Types.InstanceStateNameRunning},
 					InstanceId: aws.String("id-1"),
-					Placement: &ec2Types.Placement{
-						AvailabilityZone: aws.String("test-zone"),
-					},
-					Tags: []ec2Types.Tag{
-						{
-							Key:   aws.String(tagName),
-							Value: aws.String("name-1"),
-						},
-						{
-							Key:   aws.String(cloud.TagRole),
-							Value: aws.String("controlplane"),
-						},
-					},
-				},
-			},
-			wantErr: true,
-		},
-		"missing name tag": {
-			in: []ec2Types.Instance{
-				{
-					State:            &ec2Types.InstanceState{Name: ec2Types.InstanceStateNameRunning},
-					InstanceId:       aws.String("id-1"),
-					PrivateIpAddress: aws.String("192.0.2.1"),
 					Placement: &ec2Types.Placement{
 						AvailabilityZone: aws.String("test-zone"),
 					},
@@ -976,12 +908,7 @@ func TestConvertToMetadataInstance(t *testing.T) {
 					Placement: &ec2Types.Placement{
 						AvailabilityZone: aws.String("test-zone"),
 					},
-					Tags: []ec2Types.Tag{
-						{
-							Key:   aws.String(tagName),
-							Value: aws.String("name-1"),
-						},
-					},
+					Tags: []ec2Types.Tag{},
 				},
 			},
 			wantErr: true,


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- When listing AWS instances, use the InstanceId as name. 

This aligns the behavior with the `Self()` function (line 99, same file).  
Note that this change does not break anything ans is essentially a NOP, as we currently never read the Name field after we've listed instances. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
