### PR TITLE
upgrade: don't pass vm image

### DIFF
--- a/cli/internal/cloudcmd/terraform.go
+++ b/cli/internal/cloudcmd/terraform.go
@@ -18,16 +18,18 @@ import (
 )
 
 // TerraformUpgradeVars returns variables required to execute the Terraform scripts.
-func TerraformUpgradeVars(conf *config.Config, imageRef string) (terraform.Variables, error) {
+func TerraformUpgradeVars(conf *config.Config) (terraform.Variables, error) {
+	// Note that we pass "" as imageRef, as we ignore changes to the image in the terraform.
+	// The image is updates via our operator.
 	switch conf.GetProvider() {
 	case cloudprovider.AWS:
-		vars := awsTerraformVars(conf, imageRef)
+		vars := awsTerraformVars(conf, "")
 		return vars, nil
 	case cloudprovider.Azure:
-		vars := azureTerraformVars(conf, imageRef)
+		vars := azureTerraformVars(conf, "")
 		return vars, nil
 	case cloudprovider.GCP:
-		vars := gcpTerraformVars(conf, imageRef)
+		vars := gcpTerraformVars(conf, "")
 		return vars, nil
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", conf.GetProvider())

--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -68,7 +68,6 @@ go_library(
         "//internal/grpc/dialer",
         "//internal/grpc/grpclog",
         "//internal/grpc/retry",
-        "//internal/imagefetcher",
         "//internal/kms/uri",
         "//internal/kubernetes/kubectl",
         "//internal/license",

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -27,7 +27,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
-	"github.com/edgelesssys/constellation/v2/internal/imagefetcher"
 	"github.com/edgelesssys/constellation/v2/internal/kms/uri"
 	"github.com/edgelesssys/constellation/v2/internal/versions"
 	"github.com/rogpeppe/go-internal/diff"
@@ -76,20 +75,18 @@ func runUpgradeApply(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	imagefetcher := imagefetcher.New()
 	configFetcher := attestationconfigapi.NewFetcher()
 	tfClient, err := terraform.New(cmd.Context(), constants.TerraformWorkingDir)
 	if err != nil {
 		return fmt.Errorf("setting up terraform client: %w", err)
 	}
 
-	applyCmd := upgradeApplyCmd{upgrader: upgrader, log: log, imageFetcher: imagefetcher, configFetcher: configFetcher, clusterShower: tfClient, fileHandler: fileHandler}
+	applyCmd := upgradeApplyCmd{upgrader: upgrader, log: log, configFetcher: configFetcher, clusterShower: tfClient, fileHandler: fileHandler}
 	return applyCmd.upgradeApply(cmd)
 }
 
 type upgradeApplyCmd struct {
 	upgrader      cloudUpgrader
-	imageFetcher  imageFetcher
 	configFetcher attestationconfigapi.Fetcher
 	clusterShower clusterShower
 	fileHandler   file.Handler
@@ -149,7 +146,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command) error {
 		return fmt.Errorf("upgrading measurements: %w", err)
 	}
 	// not moving existing Terraform migrator because of planned apply refactor
-	tfOutput, err := u.migrateTerraform(cmd, u.imageFetcher, conf, flags)
+	tfOutput, err := u.migrateTerraform(cmd, conf, flags)
 	if err != nil {
 		return fmt.Errorf("performing Terraform migrations: %w", err)
 	}
@@ -210,18 +207,10 @@ func diffAttestationCfg(currentAttestationCfg config.AttestationCfg, newAttestat
 	return diff, nil
 }
 
-func getImage(ctx context.Context, conf *config.Config, fetcher imageFetcher) (string, error) {
-	// Fetch variables to execute Terraform script with
-	provider := conf.GetProvider()
-	attestationVariant := conf.GetAttestationConfig().GetVariant()
-	region := conf.GetRegion()
-	return fetcher.FetchReference(ctx, provider, attestationVariant, conf.Image, region)
-}
-
 // migrateTerraform checks if the Constellation version the cluster is being upgraded to requires a migration
 // of cloud resources with Terraform. If so, the migration is performed.
 func (u *upgradeApplyCmd) migrateTerraform(
-	cmd *cobra.Command, fetcher imageFetcher, conf *config.Config, flags upgradeApplyFlags,
+	cmd *cobra.Command, conf *config.Config, flags upgradeApplyFlags,
 ) (res terraform.ApplyOutput, err error) {
 	u.log.Debugf("Planning Terraform migrations")
 
@@ -229,12 +218,7 @@ func (u *upgradeApplyCmd) migrateTerraform(
 		return res, fmt.Errorf("checking workspace: %w", err)
 	}
 
-	imageRef, err := getImage(cmd.Context(), conf, fetcher)
-	if err != nil {
-		return res, fmt.Errorf("fetching image reference: %w", err)
-	}
-
-	vars, err := cloudcmd.TerraformUpgradeVars(conf, imageRef)
+	vars, err := cloudcmd.TerraformUpgradeVars(conf)
 	if err != nil {
 		return res, fmt.Errorf("parsing upgrade variables: %w", err)
 	}
@@ -338,13 +322,6 @@ func validK8sVersion(cmd *cobra.Command, version string, yes bool) (validVersion
 	}
 
 	return validVersion, nil
-}
-
-type imageFetcher interface {
-	FetchReference(ctx context.Context,
-		provider cloudprovider.Provider, attestationVariant variant.Variant,
-		image, region string,
-	) (string, error)
 }
 
 // confirmIfUpgradeAttestConfigHasDiff checks if the locally configured measurements are different from the cluster's measurements.

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -31,7 +31,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
-	"github.com/edgelesssys/constellation/v2/internal/imagefetcher"
 	"github.com/edgelesssys/constellation/v2/internal/kubernetes/kubectl"
 	consemver "github.com/edgelesssys/constellation/v2/internal/semver"
 	"github.com/edgelesssys/constellation/v2/internal/sigstore"
@@ -100,9 +99,8 @@ func runUpgradeCheck(cmd *cobra.Command, _ []string) error {
 			log:            log,
 			versionsapi:    versionfetcher,
 		},
-		checker:      checker,
-		imagefetcher: imagefetcher.New(),
-		log:          log,
+		checker: checker,
+		log:     log,
 	}
 
 	return up.upgradeCheck(cmd, fileHandler, attestationconfigapi.NewFetcher(), flags)
@@ -148,7 +146,6 @@ type upgradeCheckCmd struct {
 	canUpgradeCheck bool
 	collect         collector
 	checker         upgradeChecker
-	imagefetcher    imageFetcher
 	log             debugLog
 }
 
@@ -219,12 +216,7 @@ func (u *upgradeCheckCmd) upgradeCheck(cmd *cobra.Command, fileHandler file.Hand
 		return fmt.Errorf("checking workspace: %w", err)
 	}
 
-	imageRef, err := getImage(cmd.Context(), conf, u.imagefetcher)
-	if err != nil {
-		return fmt.Errorf("fetching image reference: %w", err)
-	}
-
-	vars, err := cloudcmd.TerraformUpgradeVars(conf, imageRef)
+	vars, err := cloudcmd.TerraformUpgradeVars(conf)
 	if err != nil {
 		return fmt.Errorf("parsing upgrade variables: %w", err)
 	}

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -213,29 +213,26 @@ func TestUpgradeCheck(t *testing.T) {
 	}
 
 	testCases := map[string]struct {
-		collector    stubVersionCollector
-		csp          cloudprovider.Provider
-		checker      stubUpgradeChecker
-		imagefetcher stubImageFetcher
-		cliVersion   string
-		wantError    bool
+		collector  stubVersionCollector
+		csp        cloudprovider.Provider
+		checker    stubUpgradeChecker
+		cliVersion string
+		wantError  bool
 	}{
 		"upgrades gcp": {
-			collector:    collector,
-			checker:      stubUpgradeChecker{},
-			imagefetcher: stubImageFetcher{},
-			csp:          cloudprovider.GCP,
-			cliVersion:   "v1.0.0",
+			collector:  collector,
+			checker:    stubUpgradeChecker{},
+			csp:        cloudprovider.GCP,
+			cliVersion: "v1.0.0",
 		},
 		"terraform err": {
 			collector: collector,
 			checker: stubUpgradeChecker{
 				err: assert.AnError,
 			},
-			imagefetcher: stubImageFetcher{},
-			csp:          cloudprovider.GCP,
-			cliVersion:   "v1.0.0",
-			wantError:    true,
+			csp:        cloudprovider.GCP,
+			cliVersion: "v1.0.0",
+			wantError:  true,
 		},
 	}
 
@@ -251,7 +248,6 @@ func TestUpgradeCheck(t *testing.T) {
 				canUpgradeCheck: true,
 				collect:         &tc.collector,
 				checker:         tc.checker,
-				imagefetcher:    tc.imagefetcher,
 				log:             logger.NewTest(t),
 			}
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- we don't need to acquire and pass the imageRef to the terraform during terraform migration. Any changes to it are ignored anyway. We upgrade the VM image of the cluster through the NodeVersion and the operator. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
