### PR TITLE
ci: fix notify trigger in e2e upgrade workflow

### DIFF
--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -297,8 +297,7 @@ jobs:
         if: |
           failure() &&
           github.ref == 'refs/heads/main' &&
-          github.event_name == 'workflow_call' &&
-          ${{ inputs.scheduled || 'false' }} == 'true'
+          inputs.scheduled
         continue-on-error: true
         uses: ./.github/actions/notify_failure
         with:


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove check for `event_name`
  - From what I can tell, it does not seem to do what we thought it does
  - What I think is happening: When `e2e-upgrade` is called by another workflow, the variable will not be set to `workflow_call`, but inherit the value from the calling workflow, e.g. `workflow_dispatch` for manually triggered runs, or `scheduled` for scheduled runs.
  - I'm not 100% sure on this, so for now I would like to keep the `inputs.scheduled` workaround

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
[e2e test with debug output](https://github.com/edgelesssys/constellation/actions/runs/5853425805/job/15867727552#step:23:1)
