### PR TITLE
ci: set bazel build event stream timeout to 600s

### DIFF
--- a/.github/actions/setup_bazel/action.yml
+++ b/.github/actions/setup_bazel/action.yml
@@ -57,6 +57,7 @@ runs:
         cat <<EOF >> "${WORKSPACE}/.bazeloverwriterc"
         build --bes_results_url=https://app.buildbuddy.io/invocation/
         build --bes_backend=grpcs://remote.buildbuddy.io
+        build --bes_timeout=600s
         build --remote_cache=grpcs://remote.buildbuddy.io
         build --remote_timeout=3600
         build --experimental_remote_build_event_upload=minimal
@@ -88,6 +89,7 @@ runs:
         cat <<EOF >> "${WORKSPACE}/.bazeloverwriterc"
         build --bes_results_url=https://app.buildbuddy.io/invocation/
         build --bes_backend=grpcs://remote.buildbuddy.io
+        build --bes_timeout=600s
         build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_ORG_API_KEY}
         build --nolegacy_important_outputs
         EOF


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: set bazel build event stream timeout to 600s

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Additional info

[This is recommended by buildbuddy](https://www.buildbuddy.io/docs/troubleshooting-slow-upload/#the-build-event-protocol-upload-timed-out)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [ ] Link to Milestone
