### PR TITLE
cli: only allow chart upgrades with greater version

### DIFF
--- a/cli/internal/helm/upgrade.go
+++ b/cli/internal/helm/upgrade.go
@@ -154,7 +154,7 @@ func (c *UpgradeClient) Upgrade(ctx context.Context, config *config.Config, idFi
 			newReleases = append(newReleases, release)
 		case errors.As(err, &invalidUpgrade):
 			c.log.Debugf("Appending to %s upgrade: %s", release.ReleaseName, err)
-			upgradeReleases = append(upgradeReleases, release)
+			upgradeErrs = append(upgradeErrs, fmt.Errorf("skipping %s upgrade: %w", release.ReleaseName, err))
 		case err != nil:
 			c.log.Debugf("Adding %s to upgrade releases...", release.ReleaseName)
 			return fmt.Errorf("should upgrade %s: %w", release.ReleaseName, err)

--- a/cli/internal/helm/upgrade.go
+++ b/cli/internal/helm/upgrade.go
@@ -156,9 +156,9 @@ func (c *UpgradeClient) Upgrade(ctx context.Context, config *config.Config, idFi
 			c.log.Debugf("Appending to %s upgrade: %s", release.ReleaseName, err)
 			upgradeErrs = append(upgradeErrs, fmt.Errorf("skipping %s upgrade: %w", release.ReleaseName, err))
 		case err != nil:
-			c.log.Debugf("Adding %s to upgrade releases...", release.ReleaseName)
 			return fmt.Errorf("should upgrade %s: %w", release.ReleaseName, err)
 		case err == nil:
+			c.log.Debugf("Adding %s to upgrade releases...", release.ReleaseName)
 			upgradeReleases = append(upgradeReleases, release)
 
 			// Check if installing/upgrading the chart could be destructive


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
A bug introduced in #2177 allowed chart upgrades with invalid upgrade errors.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
-

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
