### PR TITLE
ci: set bazlrc options for "common" instead of "build" if they are common

### DIFF
--- a/.github/actions/setup_bazel/action.yml
+++ b/.github/actions/setup_bazel/action.yml
@@ -34,15 +34,24 @@ runs:
       run: |
         echo "::group::Configure Bazel"
         cat <<EOF >> "${WORKSPACE}/.bazeloverwriterc"
-        build --color=yes
-        build --terminal_columns=143
-        build --build_metadata=ROLE=CI
-        build --show_progress_rate_limit=5
-        build --curses=yes
-        build --verbose_failures
-        build --announce_rc
+        # general
+        common --color=yes
+        common --terminal_columns=143
+        common --build_metadata=ROLE=CI
+        common --show_progress_rate_limit=5
+        common --curses=yes
+        common --verbose_failures
+        common --announce_rc
+        # test related
         test --show_timestamps
         test --keep_going
+        # remote cache / execution related
+        common --bes_timeout=600s
+        common --experimental_remote_build_event_upload=minimal
+        common --experimental_remote_cache_compression
+        common --nolegacy_important_outputs
+        common --noremote_upload_local_results
+        common --remote_timeout=3600
         EOF
         echo "::endgroup::"
 
@@ -55,16 +64,10 @@ runs:
       run: |
         echo "::group::Configure Bazel"
         cat <<EOF >> "${WORKSPACE}/.bazeloverwriterc"
-        build --bes_results_url=https://app.buildbuddy.io/invocation/
-        build --bes_backend=grpcs://remote.buildbuddy.io
-        build --bes_timeout=600s
-        build --remote_cache=grpcs://remote.buildbuddy.io
-        build --remote_timeout=3600
-        build --experimental_remote_build_event_upload=minimal
-        build --experimental_remote_cache_compression
-        build --noremote_upload_local_results
-        build --nolegacy_important_outputs
-        build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_ORG_API_KEY}
+        common --bes_results_url=https://app.buildbuddy.io/invocation/
+        common --bes_backend=grpcs://remote.buildbuddy.io
+        common --remote_cache=grpcs://remote.buildbuddy.io
+        common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_ORG_API_KEY}
         EOF
         echo "::endgroup::"
 
@@ -75,7 +78,7 @@ runs:
         WORKSPACE: ${{ github.workspace }}
       run: |
         echo "::group::Configure Bazel (readonly)"
-        echo "build --remote_upload_local_results=false" >> "${WORKSPACE}/.bazeloverwriterc"
+        echo "common --remote_upload_local_results=false" >> "${WORKSPACE}/.bazeloverwriterc"
         echo "::endgroup::"
 
     - name: Configure Bazel (logs)
@@ -87,11 +90,9 @@ runs:
       run: |
         echo "::group::Configure Bazel"
         cat <<EOF >> "${WORKSPACE}/.bazeloverwriterc"
-        build --bes_results_url=https://app.buildbuddy.io/invocation/
-        build --bes_backend=grpcs://remote.buildbuddy.io
-        build --bes_timeout=600s
-        build --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_ORG_API_KEY}
-        build --nolegacy_important_outputs
+        common --bes_results_url=https://app.buildbuddy.io/invocation/
+        common --bes_backend=grpcs://remote.buildbuddy.io
+        common --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_ORG_API_KEY}
         EOF
         echo "::endgroup::"
 
@@ -102,8 +103,8 @@ runs:
       if: startsWith(runner.name , 'GitHub Actions')
       run: |
         echo "::group::Configure Bazel (disk cache)"
-        echo "build --disk_cache=" >> "${WORKSPACE}/.bazeloverwriterc"
-        echo "build --repository_cache=" >> "${WORKSPACE}/.bazeloverwriterc"
+        echo "common --disk_cache=" >> "${WORKSPACE}/.bazeloverwriterc"
+        echo "common --repository_cache=" >> "${WORKSPACE}/.bazeloverwriterc"
         echo "::endgroup::"
 
     - name: Check bazel version


### PR DESCRIPTION
Most flags set in the bazelrc in CI are always applicable, so we set them with the common prefix.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: set bazlrc options for "common" instead of "build" if they are common

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [Building things in Baze (`bazel build`)](https://github.com/edgelesssys/constellation/actions/runs/5864790389)
- [Running tests in Bazel (`bazel test`)](https://github.com/edgelesssys/constellation/actions/runs/5864802030)
- [Executing things with Bazel (`bazel run`)](https://github.com/edgelesssys/constellation/actions/runs/5864779742)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
