### PR TITLE
cli: update join-config manually during upgrade

### DIFF
--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -360,6 +360,9 @@ func (u *upgradeApplyCmd) confirmIfUpgradeAttestConfigHasDiff(cmd *cobra.Command
 	if err := u.upgrader.BackupConfigMap(cmd.Context(), constants.JoinConfigMap); err != nil {
 		return fmt.Errorf("backing up join-config: %w", err)
 	}
+	if err := u.upgrader.UpdateAttestationConfig(cmd.Context(), newConfig); err != nil {
+		return fmt.Errorf("updating attestation config: %w", err)
+	}
 	return nil
 }
 
@@ -472,6 +475,7 @@ type cloudUpgrader interface {
 	UpgradeHelmServices(ctx context.Context, config *config.Config, idFile clusterid.File, timeout time.Duration, allowDestructive bool, force bool, conformance bool, helmWaitMode helm.WaitMode, masterSecret uri.MasterSecret, serviceAccURI string, validK8sVersion versions.ValidK8sVersion, tfOutput terraform.ApplyOutput) error
 	ExtendClusterConfigCertSANs(ctx context.Context, alternativeNames []string) error
 	GetClusterAttestationConfig(ctx context.Context, variant variant.Variant) (config.AttestationCfg, error)
+	UpdateAttestationConfig(ctx context.Context, newAttestConfig config.AttestationCfg) error
 	GetMeasurementSalt(ctx context.Context) ([]byte, error)
 	PlanTerraformMigrations(ctx context.Context, opts upgrade.TerraformUpgradeOptions) (bool, error)
 	ApplyTerraformMigrations(ctx context.Context, opts upgrade.TerraformUpgradeOptions) (terraform.ApplyOutput, error)

--- a/cli/internal/kubernetes/upgrade.go
+++ b/cli/internal/kubernetes/upgrade.go
@@ -356,7 +356,6 @@ func (u *Upgrader) UpdateAttestationConfig(ctx context.Context, newAttestConfig 
 	if err != nil {
 		return fmt.Errorf("getting join-config configmap: %w", err)
 	}
-	joinConfig.Data[constants.AttestationConfigFilename+"_backup"] = joinConfig.Data[constants.AttestationConfigFilename]
 
 	newConfigJSON, err := json.Marshal(newAttestConfig)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Fixes a bug from #2177.
After an upgrade with wrong attestation config (i.e. no updated measurments), it is not possible to update the join-config with the correct values through another upgrade. Reason: we don't allow upgrades with the same version.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- update the join-config manually when the attestation config changes

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
Verified in dogfooding cluster, that the config is properly updated during upgrade

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [x] Link to Milestone
