### PR TITLE
cli: parse image and k8s versions as semver

### DIFF
--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -131,6 +131,7 @@ func (v Semver) String() string {
 }
 
 // Compare compares two versions. It relies on the semver.Compare function internally.
+// The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
 func (v Semver) Compare(other Semver) int {
 	return semver.Compare(v.String(), other.String())
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
During `constellation upgrade check`, the Constellation image version, and Kubernetes version are validated to be valid semantic versions, yet we continue passing them around as regular strings.

### Proposed change(s)
- Enforce both versions to be semver by using the concrete data type

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->
