### PR TITLE
bazel: use -C flag in govulncheck ci

### DIFF
--- a/bazel/ci/govulncheck.sh.in
+++ b/bazel/ci/govulncheck.sh.in
@@ -31,7 +31,7 @@ check() {
   for mod in ${submodules}; do
     echo "  ${mod}"
     echo -n "  "
-    CGO_ENABLED=0 ${govulncheck} "${mod}/..." |
+    CGO_ENABLED=0 ${govulncheck} -C "${mod}" "./..." |
       tail -n 2 | # Providing some nice output...
       tr '\n' ' ' |
       sed s/" your code and"// &&


### PR DESCRIPTION


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use new -C flag from govulncheck v1.0.0 release

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

