### PR TITLE
deps: limit Terraform version to FOSS releases

### DIFF
--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	tfVersion         = ">= 1.4.6"
+	tfVersion         = ">= 1.4.6, < 1.6.0"
 	terraformVarsFile = "terraform.tfvars"
 
 	// terraformUpgradePlanFile is the file name of the zipfile created by Terraform plan for Constellation upgrades.

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -39,6 +39,7 @@ import (
 )
 
 const (
+	// Enforce "<1.6.0" to ensure that only MPL licensed Terraform versions are used.
 	tfVersion         = ">= 1.4.6, < 1.6.0"
 	terraformVarsFile = "terraform.tfvars"
 
@@ -521,10 +522,19 @@ func GetExecutable(ctx context.Context, workingDir string) (terraform *tfexec.Te
 		return nil, nil, err
 	}
 
-	downloadVersion := &releases.LatestVersion{
+	constrainedVersions := &releases.Versions{
 		Product:     product.Terraform,
 		Constraints: version,
 	}
+	installCandidates, err := constrainedVersions.List(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(installCandidates) == 0 {
+		return nil, nil, fmt.Errorf("no Terraform version found for constraint %s", version)
+	}
+	downloadVersion := installCandidates[len(installCandidates)-1]
+
 	localVersion := &fs.Version{
 		Product:     product.Terraform,
 		Constraints: version,


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Starting with v1.6, Terraform will be licensed under BUSL. v1.5 will get critical security updates until end of 2023.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Limit Terraform version to open-source releases until it's clear how we proceed.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
