### PR TITLE
ci: automatically build GCP CCM container

### DIFF
--- a/.github/actions/gcpccm_vers_to_build/action.yml
+++ b/.github/actions/gcpccm_vers_to_build/action.yml
@@ -1,0 +1,24 @@
+name: Find GCP CCM versions that need to be build
+description: Find GCP CCM versions that need to be build
+
+inputs:
+  path:
+    description: "Path to the GCP CCM repository"
+    required: true
+
+outputs:
+  versions:
+    description: "Versions that need to be build"
+    value: ${{ steps.find-versions.outputs.versions }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Find versions that need to be build
+      id: find-versions
+      shell: bash
+      run: |
+        script=$(realpath .github/actions/gcpccm_vers_to_build/findvers.sh)
+        pushd "${{ inputs.path }}"
+        versions=$(${script})
+        echo "versions=${versions}" | tee -a "$GITHUB_OUTPUT"

--- a/.github/actions/gcpccm_vers_to_build/findvers.sh
+++ b/.github/actions/gcpccm_vers_to_build/findvers.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+function info() {
+  echo "$@" 1>&2
+}
+
+function error() {
+  echo "::err::$*"
+  exit 1
+}
+
+allCCMVersions=$(git tag | grep ccm || test $? = 1)
+if [[ -z ${allCCMVersions} ]]; then
+  error "No CCM tags found in git"
+fi
+
+allMajorVersions=()
+
+for ver in ${allCCMVersions}; do
+  major=${ver#ccm/v} # remove "ccm/v" prefix
+  major=${major%%.*} # remove everything after the first dot
+
+  if [[ ${major} -eq 0 ]]; then
+    continue # skip major version 0
+  fi
+
+  # Check if this major version is already in the list.
+  for existingMajor in "${allMajorVersions[@]}"; do
+    if [[ ${existingMajor} -eq ${major} ]]; then
+      continue 2
+    fi
+  done
+
+  info "Found major version ${major}"
+  allMajorVersions+=("${major}")
+done
+
+if [[ ${#allMajorVersions[@]} -eq 0 ]]; then
+  error "No major versions found in CCM tags"
+fi
+
+existingContainerVersions=$(crane ls "ghcr.io/edgelesssys/cloud-provider-gcp")
+if [[ -z ${existingContainerVersions} ]]; then
+  info "No existing container versions found"
+fi
+
+versionsToBuild=()
+
+for major in "${allMajorVersions[@]}"; do
+  # Get the latest released version with this major version.
+  latest=$(echo "${allCCMVersions[@]}" | grep "${major}" | sort -V | tail -n 1)
+  latest=${latest#ccm/} # remove "ccm/" prefix, keep v
+  if [[ -z ${latest} ]]; then
+    error "Could not determine latest version with major ${major}"
+  fi
+  info "Latest ${major} version is ${latest}"
+
+  # Find the latest version with this major version.
+  majorVerRegexp="v${major}.[0-9]+.[0-9]+"
+  allExistingWithMajor=$(grep -E "${majorVerRegexp}" <<< "${existingContainerVersions}" || test $? = 1)
+  latestExistingWithMinor=$(echo "${allExistingWithMajor}" | sort -V | tail -n 1)
+
+  # If there is no existing version with this major version, build the latest released version.
+  if [[ -z ${latestExistingWithMinor} ]]; then
+    info "No existing version with major ${major}, adding ${latest} to versionsToBuild"
+    versionsToBuild+=("${latest}")
+    continue
+  fi
+  info "Latest existing version with major ${major} is ${latestExistingWithMinor}"
+
+  newerVer=$(echo -e "${latest}\n${latestExistingWithMinor}" | sort -V | tail -n 1)
+  if [[ ${newerVer} == "${latestExistingWithMinor}" ]]; then
+    info "Existing version ${latestExistingWithMinor} is up to date, skipping"
+    continue
+  fi
+
+  info "Newer version ${latest} is available, existing version is ${latestExistingWithMinor}."
+  info "Adding ${latest} to versionsToBuild"
+  versionsToBuild+=("${latest}")
+done
+
+printf '%s\n' "${versionsToBuild[@]}" | jq -R | jq -sc

--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -1,29 +1,75 @@
 name: Build and Upload GCP CCM container image
-env:
-  REGISTRY: ghcr.io
-on: [workflow_dispatch]
+
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '.github/workflows/build-ccm-gcp.yml'
+      - '.github/actions/gcpccm_vers_to_build/**'
+  schedule:
+    - cron: "0 4 * * 3" # Every Wednesday at 4am UTC
+  workflow_dispatch:
 
 jobs:
+  find-ccm-versions:
+    runs-on: ubuntu-22.04
+    outputs:
+      versions: ${{ steps.find-versions.outputs.versions }}
+      latest: ${{ steps.find-latest.outputs.latest }}
+    steps:
+      - name: Checkout Constellation
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
+      - name: Checkout kubernetes/cloud-provider-gcp
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        with:
+          repository: "kubernetes/cloud-provider-gcp"
+          path: "cloud-provider-gcp"
+          fetch-depth: 0
+
+      - name: Setup Go environment
+        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: "1.20.7"
+          cache: false
+
+      - name: Install Crane
+        run: |
+          go install github.com/google/go-containerregistry/cmd/crane@latest
+
+      - name: Find versions
+        id: find-versions
+        uses: ./.github/actions/gcpccm_vers_to_build
+        with:
+          path: "cloud-provider-gcp"
+
+      - name: Find latest
+        id: find-latest
+        run: |
+          rawList=$(jq -r '.[]' <<< '${{ steps.find-versions.outputs.versions }}')
+          lastest=$(echo "${rawList}" | sort -V | tail -n 1)
+          echo "latest=${lastest}" | tee -a "$GITHUB_OUTPUT"
+
   build-ccm-gcp:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
+    needs: find-ccm-versions
     strategy:
+      fail-fast: false
       matrix:
-        version: [v26.0.1]
-        # TODO(katexochen): Once issue is closed upgrade older versions, rebuild, and update versions.go
-        # https://github.com/kubernetes/cloud-provider-gcp/issues/451
-        # Alternativly, they start to publish releases themselves and we can remove this workflow (see https://github.com/kubernetes/cloud-provider-gcp/issues/289).
-        # version: [v26.0.1, v25.5.0, v24.0.0]
-        include:
-          - version: v26.0.1
-            latest: true
+        version: ${{ fromJson(needs.find-ccm-versions.outputs.versions) }}
     steps:
+      - name: Checkout Constellation
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+
       - name: Checkout kubernetes/cloud-provider-gcp
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
         with:
           repository: "kubernetes/cloud-provider-gcp"
+          path: "cloud-provider-gcp"
           ref: refs/tags/ccm/${{ matrix.version }}
 
       - name: Docker meta
@@ -31,33 +77,32 @@ jobs:
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
         with:
           images: |
-            ${{ env.REGISTRY }}/edgelesssys/cloud-provider-gcp
+            ghcr.io/edgelesssys/cloud-provider-gcp
           flavor: |
-            latest=${{ matrix.latest || false }}
+            latest=${{ matrix.version == needs.find-ccm-versions.outputs.latest }}
           tags: |
             type=semver,pattern=v{{version}},value=${{ matrix.version }}
-            type=semver,pattern=v{{major}}.{{minor}},value=${{ matrix.version }}
-            type=semver,pattern=v{{major}},value=${{ matrix.version }}
 
       - name: Log in to the Container registry
         id: docker-login
         uses: ./.github/actions/container_registry_login
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build CCM
+        working-directory: cloud-provider-gcp
         run: |
           bazel build //cmd/cloud-controller-manager:cloud-controller-manager
 
       - name: Copy CCM
+        working-directory: cloud-provider-gcp
         run: |
-          # support new and old bazel output paths
-          cp ./bazel-bin/cmd/cloud-controller-manager/cloud-controller-manager_/cloud-controller-manager ./cloud-controller-manager || \
-          cp ./bazel-bin/cmd/cloud-controller-manager/linux_amd64_pure_stripped/cloud-controller-manager ./cloud-controller-manager
+          cp ./bazel-bin/cmd/cloud-controller-manager/cloud-controller-manager_/cloud-controller-manager ./cloud-controller-manager
 
       - name: Prepare Dockerfile
+        working-directory: cloud-provider-gcp
         run: |
           cat > Dockerfile <<EOF
           FROM scratch
@@ -68,7 +113,7 @@ jobs:
         id: build
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825 # v4.1.1
         with:
-          context: .
-          push: true
+          context: ./cloud-provider-gcp
+          push: ${{ github.ref_name == 'main' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- The CCM wasn't build since a half year. Automating the workflow to build new releases on schedule.
- v25.5.0 needed some hacks to be build, and is already in the registry. I didn't commit the hacks as there won't be another v25 release 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
