### PR TITLE
cli: fix upgrade by passing placeholder values for images

### DIFF
--- a/cli/internal/cloudcmd/terraform.go
+++ b/cli/internal/cloudcmd/terraform.go
@@ -19,7 +19,7 @@ import (
 
 // TerraformUpgradeVars returns variables required to execute the Terraform scripts.
 func TerraformUpgradeVars(conf *config.Config) (terraform.Variables, error) {
-	// Note that we pass "" as imageRef, as we ignore changes to the image in the terraform.
+	// Note that we don't pass any real image as imageRef, as we ignore changes to the image in the terraform.
 	// The image is updates via our operator.
 	// Still, the terraform variable verification must accept the values.
 	// For AWS, we enforce some basic constraints on the image variable.

--- a/cli/internal/cloudcmd/terraform.go
+++ b/cli/internal/cloudcmd/terraform.go
@@ -21,15 +21,19 @@ import (
 func TerraformUpgradeVars(conf *config.Config) (terraform.Variables, error) {
 	// Note that we pass "" as imageRef, as we ignore changes to the image in the terraform.
 	// The image is updates via our operator.
+	// Still, the terraform variable verification must accept the values.
+	// For AWS, we enforce some basic constraints on the image variable.
+	// For Azure, the provider enforces the format below.
+	// For GCP, any placeholder works.
 	switch conf.GetProvider() {
 	case cloudprovider.AWS:
-		vars := awsTerraformVars(conf, "")
+		vars := awsTerraformVars(conf, "ami-placeholder")
 		return vars, nil
 	case cloudprovider.Azure:
-		vars := azureTerraformVars(conf, "")
+		vars := azureTerraformVars(conf, "/communityGalleries/myGalleryName/images/myImageName/versions/myImageVersion")
 		return vars, nil
 	case cloudprovider.GCP:
-		vars := gcpTerraformVars(conf, "")
+		vars := gcpTerraformVars(conf, "placeholder")
 		return vars, nil
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", conf.GetProvider())

--- a/cli/internal/cloudcmd/terraform.go
+++ b/cli/internal/cloudcmd/terraform.go
@@ -30,7 +30,7 @@ func TerraformUpgradeVars(conf *config.Config) (terraform.Variables, error) {
 		vars := awsTerraformVars(conf, "ami-placeholder")
 		return vars, nil
 	case cloudprovider.Azure:
-		vars := azureTerraformVars(conf, "/communityGalleries/myGalleryName/images/myImageName/versions/myImageVersion")
+		vars := azureTerraformVars(conf, "/communityGalleries/myGalleryName/images/myImageName/versions/latest")
 		return vars, nil
 	case cloudprovider.GCP:
 		vars := gcpTerraformVars(conf, "placeholder")

--- a/cli/internal/terraform/terraform/aws/variables.tf
+++ b/cli/internal/terraform/terraform/aws/variables.tf
@@ -36,6 +36,10 @@ variable "iam_instance_profile_control_plane" {
 variable "ami" {
   type        = string
   description = "AMI ID"
+  validation {
+    condition     = length(var.ami) > 4 && substr(var.ami, 0, 4) == "ami-"
+    error_message = "The image_id value must be a valid AMI id, starting with \"ami-\"."
+  }
 }
 
 variable "region" {

--- a/cli/internal/terraform/terraform/aws/variables.tf
+++ b/cli/internal/terraform/terraform/aws/variables.tf
@@ -36,10 +36,6 @@ variable "iam_instance_profile_control_plane" {
 variable "ami" {
   type        = string
   description = "AMI ID"
-  validation {
-    condition     = length(var.ami) > 4 && substr(var.ami, 0, 4) == "ami-"
-    error_message = "The image_id value must be a valid AMI id, starting with \"ami-\"."
-  }
 }
 
 variable "region" {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Fixes a bug from #2211.
The current TF validation on AWS prevents an empty value set during an upgrade. Similarly, Azure also doesn't allow empty strings.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- insert placeholder values for the imageRef during an upgrade

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
