### PR TITLE
cli: clean up terraform package

### DIFF
--- a/cli/internal/cloudcmd/clients.go
+++ b/cli/internal/cloudcmd/clients.go
@@ -32,13 +32,13 @@ type tfCommonClient interface {
 
 type tfResourceClient interface {
 	tfCommonClient
-	CreateCluster(ctx context.Context, provider cloudprovider.Provider, logLevel terraform.LogLevel) (terraform.ApplyOutput, error)
+	ApplyCluster(ctx context.Context, provider cloudprovider.Provider, logLevel terraform.LogLevel) (terraform.ApplyOutput, error)
 	ShowCluster(ctx context.Context, provider cloudprovider.Provider) (terraform.ApplyOutput, error)
 }
 
 type tfIAMClient interface {
 	tfCommonClient
-	ApplyIAMConfig(ctx context.Context, provider cloudprovider.Provider, logLevel terraform.LogLevel) (terraform.IAMOutput, error)
+	ApplyIAM(ctx context.Context, provider cloudprovider.Provider, logLevel terraform.LogLevel) (terraform.IAMOutput, error)
 	ShowIAM(ctx context.Context, provider cloudprovider.Provider) (terraform.IAMOutput, error)
 }
 

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -44,7 +44,7 @@ type stubTerraformClient struct {
 	showErr                error
 }
 
-func (c *stubTerraformClient) CreateCluster(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (terraform.ApplyOutput, error) {
+func (c *stubTerraformClient) ApplyCluster(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (terraform.ApplyOutput, error) {
 	return terraform.ApplyOutput{
 		IP:     c.ip,
 		Secret: c.initSecret,
@@ -55,7 +55,7 @@ func (c *stubTerraformClient) CreateCluster(_ context.Context, _ cloudprovider.P
 	}, c.createClusterErr
 }
 
-func (c *stubTerraformClient) ApplyIAMConfig(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (terraform.IAMOutput, error) {
+func (c *stubTerraformClient) ApplyIAM(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (terraform.IAMOutput, error) {
 	return c.iamOutput, c.iamOutputErr
 }
 

--- a/cli/internal/cloudcmd/create.go
+++ b/cli/internal/cloudcmd/create.go
@@ -229,7 +229,7 @@ func runTerraformCreate(ctx context.Context, cl tfResourceClient, provider cloud
 	}
 
 	defer rollbackOnError(outWriter, &retErr, &rollbackerTerraform{client: cl}, loglevel)
-	tfOutput, err := cl.CreateCluster(ctx, provider, loglevel)
+	tfOutput, err := cl.ApplyCluster(ctx, provider, loglevel)
 	if err != nil {
 		return terraform.ApplyOutput{}, err
 	}
@@ -302,7 +302,7 @@ func (c *Creator) createQEMU(ctx context.Context, cl tfResourceClient, lv libvir
 	// Allow rollback of QEMU Terraform workspace from this point on
 	qemuRollbacker.createdWorkspace = true
 
-	tfOutput, err = cl.CreateCluster(ctx, opts.Provider, opts.TFLogLevel)
+	tfOutput, err = cl.ApplyCluster(ctx, opts.Provider, opts.TFLogLevel)
 	if err != nil {
 		return terraform.ApplyOutput{}, fmt.Errorf("create cluster: %w", err)
 	}

--- a/cli/internal/cloudcmd/iam.go
+++ b/cli/internal/cloudcmd/iam.go
@@ -148,7 +148,7 @@ func (c *IAMCreator) createGCP(ctx context.Context, cl tfIAMClient, opts *IAMCon
 		return IAMOutput{}, err
 	}
 
-	iamOutput, err := cl.ApplyIAMConfig(ctx, cloudprovider.GCP, opts.TFLogLevel)
+	iamOutput, err := cl.ApplyIAM(ctx, cloudprovider.GCP, opts.TFLogLevel)
 	if err != nil {
 		return IAMOutput{}, err
 	}
@@ -175,7 +175,7 @@ func (c *IAMCreator) createAzure(ctx context.Context, cl tfIAMClient, opts *IAMC
 		return IAMOutput{}, err
 	}
 
-	iamOutput, err := cl.ApplyIAMConfig(ctx, cloudprovider.Azure, opts.TFLogLevel)
+	iamOutput, err := cl.ApplyIAM(ctx, cloudprovider.Azure, opts.TFLogLevel)
 	if err != nil {
 		return IAMOutput{}, err
 	}
@@ -203,7 +203,7 @@ func (c *IAMCreator) createAWS(ctx context.Context, cl tfIAMClient, opts *IAMCon
 		return IAMOutput{}, err
 	}
 
-	iamOutput, err := cl.ApplyIAMConfig(ctx, cloudprovider.AWS, opts.TFLogLevel)
+	iamOutput, err := cl.ApplyIAM(ctx, cloudprovider.AWS, opts.TFLogLevel)
 	if err != nil {
 		return IAMOutput{}, err
 	}

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -458,6 +458,7 @@ func (c *Client) apply(ctx context.Context, logLevel LogLevel) error {
 }
 
 // applyManualStateMigrations applies manual state migrations that are not handled by Terraform due to missing features.
+// This functions expects to be run on an initialized Terraform workspace.
 // Each migration is expected to be idempotent.
 // This is a temporary solution until we can remove the need for manual state migrations.
 func (c *Client) applyManualStateMigrations(ctx context.Context) error {

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -449,7 +449,7 @@ func TestCreateCluster(t *testing.T) {
 
 			path := path.Join(tc.pathBase, strings.ToLower(tc.provider.String()))
 			require.NoError(c.PrepareWorkspace(path, tc.vars))
-			tfOutput, err := c.CreateCluster(context.Background(), tc.provider, LogLevelDebug)
+			tfOutput, err := c.ApplyCluster(context.Background(), tc.provider, LogLevelDebug)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -742,7 +742,7 @@ func TestCreateIAM(t *testing.T) {
 
 			path := path.Join(tc.pathBase, strings.ToLower(tc.provider.String()))
 			require.NoError(c.PrepareWorkspace(path, tc.vars))
-			IAMoutput, err := c.ApplyIAMConfig(context.Background(), tc.provider, LogLevelDebug)
+			IAMoutput, err := c.ApplyIAM(context.Background(), tc.provider, LogLevelDebug)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/upgrade/iammigrate.go
+++ b/cli/internal/upgrade/iammigrate.go
@@ -88,7 +88,7 @@ func (c *IAMMigrateCmd) Plan(ctx context.Context, file file.Handler, outWriter i
 
 // Apply applies the Terraform IAM migrations for the Constellation upgrade.
 func (c *IAMMigrateCmd) Apply(ctx context.Context, fileHandler file.Handler) error {
-	if _, err := c.tf.ApplyIAMConfig(ctx, c.csp, c.logLevel); err != nil {
+	if _, err := c.tf.ApplyIAM(ctx, c.csp, c.logLevel); err != nil {
 		return fmt.Errorf("terraform apply: %w", err)
 	}
 

--- a/cli/internal/upgrade/iammigrate_test.go
+++ b/cli/internal/upgrade/iammigrate_test.go
@@ -97,7 +97,7 @@ func (t *tfClientStub) ShowPlan(_ context.Context, _ terraform.LogLevel, _ io.Wr
 	return nil
 }
 
-func (t *tfClientStub) ApplyIAMConfig(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (terraform.IAMOutput, error) {
+func (t *tfClientStub) ApplyIAM(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (terraform.IAMOutput, error) {
 	upgradeDir := filepath.Join(constants.UpgradeDir, t.upgradeID, constants.TerraformIAMUpgradeWorkingDir)
 	err := t.file.Remove(filepath.Join(upgradeDir, "terraform.tfvars"))
 	if err != nil {

--- a/cli/internal/upgrade/terraform.go
+++ b/cli/internal/upgrade/terraform.go
@@ -101,7 +101,7 @@ func (u *TerraformUpgrader) CleanUpTerraformMigrations(upgradeWorkspace string) 
 // In case of a successful upgrade, the output will be written to the specified file and the old Terraform directory is replaced
 // By the new one.
 func (u *TerraformUpgrader) ApplyTerraformMigrations(ctx context.Context, opts TerraformUpgradeOptions) (terraform.ApplyOutput, error) {
-	tfOutput, err := u.tf.CreateCluster(ctx, opts.CSP, opts.LogLevel)
+	tfOutput, err := u.tf.ApplyCluster(ctx, opts.CSP, opts.LogLevel)
 	if err != nil {
 		return tfOutput, fmt.Errorf("terraform apply: %w", err)
 	}
@@ -181,13 +181,13 @@ type tfClientCommon interface {
 // tfResourceClient is a Terraform client for managing cluster resources.
 type tfResourceClient interface {
 	PrepareUpgradeWorkspace(embeddedPath, oldWorkingDir, newWorkingDir, backupDir string, vars terraform.Variables) error
-	CreateCluster(ctx context.Context, provider cloudprovider.Provider, logLevel terraform.LogLevel) (terraform.ApplyOutput, error)
+	ApplyCluster(ctx context.Context, provider cloudprovider.Provider, logLevel terraform.LogLevel) (terraform.ApplyOutput, error)
 	tfClientCommon
 }
 
 // tfIAMClient is a Terraform client for managing IAM resources.
 type tfIAMClient interface {
-	ApplyIAMConfig(ctx context.Context, csp cloudprovider.Provider, logLevel terraform.LogLevel) (terraform.IAMOutput, error)
+	ApplyIAM(ctx context.Context, csp cloudprovider.Provider, logLevel terraform.LogLevel) (terraform.IAMOutput, error)
 	tfClientCommon
 }
 

--- a/cli/internal/upgrade/terraform_test.go
+++ b/cli/internal/upgrade/terraform_test.go
@@ -318,7 +318,7 @@ func (u *stubTerraformClient) Plan(_ context.Context, _ terraform.LogLevel) (boo
 	return u.hasDiff, u.planErr
 }
 
-func (u *stubTerraformClient) CreateCluster(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (terraform.ApplyOutput, error) {
+func (u *stubTerraformClient) ApplyCluster(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (terraform.ApplyOutput, error) {
 	return terraform.ApplyOutput{}, u.CreateClusterErr
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Preliminary clean up of the terraform CLI package to prepare for future reworks.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Reorder Functions in `cli/internal/terraform/terraform.go` in accordance with [our guidelines](https://github.com/edgelesssys/wiki/blob/master/company/gostyle.md#order-of-elements-in-a-source-file)
- Rename `CreateCluster` and `ApplyIAMConfig` to `ApplyCluster` and `ApplyIAM`
- reduce some code duplication

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
@malt3 I removed some commented out code in the manual state migration function. Not sure if we want to keep this in the future, or if this part was already obsolete for a while. Please review
