### PR TITLE
bazel: never run buildifier in remote execution

### DIFF
--- a/bazel/ci/BUILD.bazel
+++ b/bazel/ci/BUILD.bazel
@@ -40,6 +40,7 @@ buildifier_test(
     lint_warnings = ["all"],
     mode = "diff",
     no_sandbox = True,
+    tags = ["no-remote-exec"],
     verbose = True,
     workspace = "//:WORKSPACE.bazel",
 )
@@ -49,6 +50,7 @@ buildifier(
     lint_mode = "fix",
     lint_warnings = ["all"],
     mode = "fix",
+    tags = ["no-remote-exec"],
     verbose = True,
 )
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

While experimenting with remote execution in Bazel, I noticed that buildifier itself calls `xargs`, which is not guaranteed to be installed on the remote builder.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bazel: never run buildifier in remote execution

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
