### PR TITLE
bazel: fix ordering of injects

### DIFF
--- a/bazel/devbuild/prepare_developer_workspace.sh.in
+++ b/bazel/devbuild/prepare_developer_workspace.sh.in
@@ -8,15 +8,14 @@
 lib=$(realpath @@BASE_LIB@@) || exit 1
 stat "${lib}" >> /dev/null || exit 1
 
-yq=$(realpath @@YQ@@)
-stat "${yq}" >> /dev/null
-
 # shellcheck source=../sh/lib.bash
 if ! source "${lib}"; then
   echo "Error: could not find import"
   exit 1
 fi
 
+yq=$(realpath @@YQ@@)
+stat "${yq}" >> /dev/null
 bootstrapper=$(realpath @@BOOTSTRAPPER@@)
 stat "${bootstrapper}" >> /dev/null
 upgrade_agent=$(realpath @@UPGRADE_AGENT@@)


### PR DESCRIPTION
@msanft Includes other than baselib must always be placed under the source check.