### PR TITLE
cli: add spinner to helm chart installation

### DIFF
--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -255,17 +255,18 @@ func (i *initCmd) initialize(cmd *cobra.Command, newDialer func(validator atls.V
 	if err != nil {
 		return fmt.Errorf("getting Terraform output: %w", err)
 	}
-	releases, err := helmLoader.LoadReleases(conf, flags.conformance, flags.helmWaitMode, masterSecret, serviceAccURI, idFile, output)
-	if err != nil {
-		return fmt.Errorf("loading Helm charts: %w", err)
-	}
+
 	i.log.Debugf("Loaded Helm deployments")
+	i.spinner.Start("Installing Kubernetes components ", false)
+	releases, err := helmLoader.LoadReleases(conf, flags.conformance, flags.helmWaitMode, masterSecret, serviceAccURI, idFile, output)
 	if err != nil {
 		return fmt.Errorf("loading Helm charts: %w", err)
 	}
 	if err := i.helmInstaller.Install(cmd.Context(), releases); err != nil {
 		return fmt.Errorf("installing Helm charts: %w", err)
 	}
+	i.spinner.Stop()
+
 	cmd.Println(bufferedOutput.String())
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Our CLI currently runs through 3 phases during `constellation init`:
* Connecting to the cluster
* Running the init RPC
* Installing Helm charts

Only the first two phases have a spinner dedicated to them.
During the helm chart installation no spinner is shown.
Additionally, the spinner for the init RPC is stopped, so the user is left with a unresponsive looking CLI.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a spinner to helm chart installation

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- The CLI will show `Installing Kubernetes components`, feel free to suggest another status message if you feel this is not optimal.