### PR TITLE
docs: fix sigstore doc links

### DIFF
--- a/docs/docs/workflows/sbom.md
+++ b/docs/docs/workflows/sbom.md
@@ -11,13 +11,15 @@ SBOMs for Constellation are generated using [Syft](https://github.com/anchore/sy
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
+
 ```
 -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEf8F1hpmwE+YCFXzjGtaQcrL6XZVT
 JmEe5iSLvG1SyQSAew7WdMKF6o9t8e2TFuCkzlOhhlws2OHWbiFZnFWCFw==
 -----END PUBLIC KEY-----
 ```
-The public key is also available for download at https://edgeless.systems/es.pub and in the Twitter profile [@EdgelessSystems](https://twitter.com/EdgelessSystems).
+
+The public key is also available for download at <https://edgeless.systems/es.pub> and in the Twitter profile [@EdgelessSystems](https://twitter.com/EdgelessSystems).
 
 Make sure the key is available in a file named `cosign.pub` to execute the following examples.
 :::
@@ -38,7 +40,7 @@ cosign verify-blob --key cosign.pub --signature constellation.spdx.sbom.sig cons
 
 ### Container Images
 
-SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
+SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/docs/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
 
 As a consumer, use cosign to download and verify the SBOM:
 

--- a/docs/docs/workflows/verify-cli.md
+++ b/docs/docs/workflows/verify-cli.md
@@ -8,7 +8,7 @@ This recording presents the essence of this page. It's recommended to read it in
 
 ---
 
-Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/signing/quickstart), [Rekor](https://docs.sigstore.dev/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
+Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/docs/signing/quickstart), [Rekor](https://docs.sigstore.dev/docs/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
@@ -33,7 +33,7 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
-First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
+First, [install the Cosign CLI](https://docs.sigstore.dev/docs/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session
 $ cosign verify-blob --key https://edgeless.systems/es.pub --signature constellation-linux-amd64.sig constellation-linux-amd64
@@ -54,7 +54,7 @@ Verified OK
 
 ### Optional: Manually inspect the transparency log
 
-To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
+To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/docs/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
 
 ```shell-session
 $ rekor-cli search --artifact constellation-linux-amd64

--- a/docs/versioned_docs/version-2.0/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.0/workflows/verify-cli.md
@@ -1,6 +1,6 @@
 # Verify the CLI
 
-Edgeless Systems uses [sigstore](https://www.sigstore.dev/) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/signing/quickstart), [Rekor](https://docs.sigstore.dev/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
+Edgeless Systems uses [sigstore](https://www.sigstore.dev/) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/docs/signing/quickstart), [Rekor](https://docs.sigstore.dev/docs/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
@@ -25,7 +25,7 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
-First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
+First, [install the Cosign CLI](https://docs.sigstore.dev/docs/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session
 $ cosign verify-blob --key https://edgeless.systems/es.pub --signature constellation-linux-amd64.sig constellation-linux-amd64
@@ -46,7 +46,7 @@ Verified OK
 
 ## Optional: Manually inspect the transparency log
 
-To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
+To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/docs/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
 
 ```shell-session
 $ rekor-cli search --artifact constellation-linux-amd64

--- a/docs/versioned_docs/version-2.1/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.1/workflows/verify-cli.md
@@ -1,6 +1,6 @@
 # Verify the CLI
 
-Edgeless Systems uses [sigstore](https://www.sigstore.dev/) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/signing/quickstart), [Rekor](https://docs.sigstore.dev/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
+Edgeless Systems uses [sigstore](https://www.sigstore.dev/) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/docs/signing/quickstart), [Rekor](https://docs.sigstore.dev/docs/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
@@ -25,7 +25,7 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
-First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
+First, [install the Cosign CLI](https://docs.sigstore.dev/docs/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session
 $ cosign verify-blob --key https://edgeless.systems/es.pub --signature constellation-linux-amd64.sig constellation-linux-amd64
@@ -46,7 +46,7 @@ Verified OK
 
 ## Optional: Manually inspect the transparency log
 
-To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
+To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/docs/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
 
 ```shell-session
 $ rekor-cli search --artifact constellation-linux-amd64

--- a/docs/versioned_docs/version-2.10/workflows/sbom.md
+++ b/docs/versioned_docs/version-2.10/workflows/sbom.md
@@ -11,13 +11,15 @@ SBOMs for Constellation are generated using [Syft](https://github.com/anchore/sy
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
+
 ```
 -----BEGIN PUBLIC KEY-----
 MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEf8F1hpmwE+YCFXzjGtaQcrL6XZVT
 JmEe5iSLvG1SyQSAew7WdMKF6o9t8e2TFuCkzlOhhlws2OHWbiFZnFWCFw==
 -----END PUBLIC KEY-----
 ```
-The public key is also available for download at https://edgeless.systems/es.pub and in the Twitter profile [@EdgelessSystems](https://twitter.com/EdgelessSystems).
+
+The public key is also available for download at <https://edgeless.systems/es.pub> and in the Twitter profile [@EdgelessSystems](https://twitter.com/EdgelessSystems).
 
 Make sure the key is available in a file named `cosign.pub` to execute the following examples.
 :::
@@ -38,7 +40,7 @@ cosign verify-blob --key cosign.pub --signature constellation.spdx.sbom.sig cons
 
 ### Container Images
 
-SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
+SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/docs/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
 
 As a consumer, use cosign to download and verify the SBOM:
 

--- a/docs/versioned_docs/version-2.10/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.10/workflows/verify-cli.md
@@ -8,7 +8,7 @@ This recording presents the essence of this page. It's recommended to read it in
 
 ---
 
-Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/signing/quickstart), [Rekor](https://docs.sigstore.dev/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
+Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/docs/signing/quickstart), [Rekor](https://docs.sigstore.dev/docs/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
@@ -33,7 +33,7 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
-First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
+First, [install the Cosign CLI](https://docs.sigstore.dev/docs/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session
 $ cosign verify-blob --key https://edgeless.systems/es.pub --signature constellation-linux-amd64.sig constellation-linux-amd64
@@ -54,7 +54,7 @@ Verified OK
 
 ### Optional: Manually inspect the transparency log
 
-To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
+To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/docs/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
 
 ```shell-session
 $ rekor-cli search --artifact constellation-linux-amd64

--- a/docs/versioned_docs/version-2.2/workflows/sbom.md
+++ b/docs/versioned_docs/version-2.2/workflows/sbom.md
@@ -36,7 +36,7 @@ cosign verify-blob --key cosign.pub --signature constellation.spdx.sbom.sig cons
 
 ### Container Images
 
-SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
+SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/docs/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
 
 As a consumer, use cosign to download and verify the SBOM:
 

--- a/docs/versioned_docs/version-2.2/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.2/workflows/verify-cli.md
@@ -1,6 +1,6 @@
 # Verify the CLI
 
-Edgeless Systems uses [sigstore](https://www.sigstore.dev/) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/signing/quickstart), [Rekor](https://docs.sigstore.dev/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
+Edgeless Systems uses [sigstore](https://www.sigstore.dev/) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/docs/signing/quickstart), [Rekor](https://docs.sigstore.dev/docs/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
@@ -25,7 +25,7 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
-First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
+First, [install the Cosign CLI](https://docs.sigstore.dev/docs/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session
 $ cosign verify-blob --key https://edgeless.systems/es.pub --signature constellation-linux-amd64.sig constellation-linux-amd64
@@ -46,7 +46,7 @@ Verified OK
 
 ## Optional: Manually inspect the transparency log
 
-To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
+To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/docs/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
 
 ```shell-session
 $ rekor-cli search --artifact constellation-linux-amd64

--- a/docs/versioned_docs/version-2.3/workflows/sbom.md
+++ b/docs/versioned_docs/version-2.3/workflows/sbom.md
@@ -36,7 +36,7 @@ cosign verify-blob --key cosign.pub --signature constellation.spdx.sbom.sig cons
 
 ### Container Images
 
-SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
+SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/docs/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
 
 As a consumer, use cosign to download and verify the SBOM:
 

--- a/docs/versioned_docs/version-2.3/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.3/workflows/verify-cli.md
@@ -1,6 +1,6 @@
 # Verify the CLI
 
-Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/signing/quickstart), [Rekor](https://docs.sigstore.dev/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
+Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/docs/signing/quickstart), [Rekor](https://docs.sigstore.dev/docs/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
@@ -25,7 +25,7 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
-First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
+First, [install the Cosign CLI](https://docs.sigstore.dev/docs/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session
 $ cosign verify-blob --key https://edgeless.systems/es.pub --signature constellation-linux-amd64.sig constellation-linux-amd64
@@ -46,7 +46,7 @@ Verified OK
 
 ### Optional: Manually inspect the transparency log
 
-To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
+To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/docs/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
 
 ```shell-session
 $ rekor-cli search --artifact constellation-linux-amd64

--- a/docs/versioned_docs/version-2.4/workflows/sbom.md
+++ b/docs/versioned_docs/version-2.4/workflows/sbom.md
@@ -36,7 +36,7 @@ cosign verify-blob --key cosign.pub --signature constellation.spdx.sbom.sig cons
 
 ### Container Images
 
-SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
+SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/docs/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
 
 As a consumer, use cosign to download and verify the SBOM:
 

--- a/docs/versioned_docs/version-2.4/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.4/workflows/verify-cli.md
@@ -1,6 +1,6 @@
 # Verify the CLI
 
-Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/signing/quickstart), [Rekor](https://docs.sigstore.dev/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
+Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/docs/signing/quickstart), [Rekor](https://docs.sigstore.dev/docs/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
@@ -25,7 +25,7 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
-First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
+First, [install the Cosign CLI](https://docs.sigstore.dev/docs/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session
 $ cosign verify-blob --key https://edgeless.systems/es.pub --signature constellation-linux-amd64.sig constellation-linux-amd64
@@ -46,7 +46,7 @@ Verified OK
 
 ### Optional: Manually inspect the transparency log
 
-To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
+To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/docs/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
 
 ```shell-session
 $ rekor-cli search --artifact constellation-linux-amd64

--- a/docs/versioned_docs/version-2.5/workflows/sbom.md
+++ b/docs/versioned_docs/version-2.5/workflows/sbom.md
@@ -36,7 +36,7 @@ cosign verify-blob --key cosign.pub --signature constellation.spdx.sbom.sig cons
 
 ### Container Images
 
-SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
+SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/docs/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
 
 As a consumer, use cosign to download and verify the SBOM:
 

--- a/docs/versioned_docs/version-2.5/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.5/workflows/verify-cli.md
@@ -1,6 +1,6 @@
 # Verify the CLI
 
-Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/signing/quickstart), [Rekor](https://docs.sigstore.dev/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
+Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/docs/signing/quickstart), [Rekor](https://docs.sigstore.dev/docs/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
@@ -25,7 +25,7 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
-First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
+First, [install the Cosign CLI](https://docs.sigstore.dev/docs/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session
 $ cosign verify-blob --key https://edgeless.systems/es.pub --signature constellation-linux-amd64.sig constellation-linux-amd64
@@ -46,7 +46,7 @@ Verified OK
 
 ### Optional: Manually inspect the transparency log
 
-To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
+To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/docs/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
 
 ```shell-session
 $ rekor-cli search --artifact constellation-linux-amd64

--- a/docs/versioned_docs/version-2.6/workflows/sbom.md
+++ b/docs/versioned_docs/version-2.6/workflows/sbom.md
@@ -40,7 +40,7 @@ cosign verify-blob --key cosign.pub --signature constellation.spdx.sbom.sig cons
 
 ### Container Images
 
-SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
+SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/docs/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
 
 As a consumer, use cosign to download and verify the SBOM:
 

--- a/docs/versioned_docs/version-2.6/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.6/workflows/verify-cli.md
@@ -8,7 +8,7 @@ This recording presents the essence of this page. It's recommended to read it in
 
 ---
 
-Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/signing/quickstart), [Rekor](https://docs.sigstore.dev/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
+Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/docs/signing/quickstart), [Rekor](https://docs.sigstore.dev/docs/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
@@ -33,7 +33,7 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
-First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
+First, [install the Cosign CLI](https://docs.sigstore.dev/docs/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session
 $ cosign verify-blob --key https://edgeless.systems/es.pub --signature constellation-linux-amd64.sig constellation-linux-amd64
@@ -54,7 +54,7 @@ Verified OK
 
 ### Optional: Manually inspect the transparency log
 
-To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
+To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/docs/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
 
 ```shell-session
 $ rekor-cli search --artifact constellation-linux-amd64

--- a/docs/versioned_docs/version-2.7/workflows/sbom.md
+++ b/docs/versioned_docs/version-2.7/workflows/sbom.md
@@ -40,7 +40,7 @@ cosign verify-blob --key cosign.pub --signature constellation.spdx.sbom.sig cons
 
 ### Container Images
 
-SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
+SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/docs/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
 
 As a consumer, use cosign to download and verify the SBOM:
 

--- a/docs/versioned_docs/version-2.7/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.7/workflows/verify-cli.md
@@ -8,7 +8,7 @@ This recording presents the essence of this page. It's recommended to read it in
 
 ---
 
-Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/signing/quickstart), [Rekor](https://docs.sigstore.dev/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
+Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/docs/signing/quickstart), [Rekor](https://docs.sigstore.dev/docs/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
@@ -33,7 +33,7 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
-First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
+First, [install the Cosign CLI](https://docs.sigstore.dev/docs/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session
 $ cosign verify-blob --key https://edgeless.systems/es.pub --signature constellation-linux-amd64.sig constellation-linux-amd64
@@ -54,7 +54,7 @@ Verified OK
 
 ### Optional: Manually inspect the transparency log
 
-To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
+To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/docs/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
 
 ```shell-session
 $ rekor-cli search --artifact constellation-linux-amd64

--- a/docs/versioned_docs/version-2.8/workflows/sbom.md
+++ b/docs/versioned_docs/version-2.8/workflows/sbom.md
@@ -40,7 +40,7 @@ cosign verify-blob --key cosign.pub --signature constellation.spdx.sbom.sig cons
 
 ### Container Images
 
-SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
+SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/docs/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
 
 As a consumer, use cosign to download and verify the SBOM:
 

--- a/docs/versioned_docs/version-2.8/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.8/workflows/verify-cli.md
@@ -8,7 +8,7 @@ This recording presents the essence of this page. It's recommended to read it in
 
 ---
 
-Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/signing/quickstart), [Rekor](https://docs.sigstore.dev/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
+Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/docs/signing/quickstart), [Rekor](https://docs.sigstore.dev/docs/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
@@ -33,7 +33,7 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
-First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
+First, [install the Cosign CLI](https://docs.sigstore.dev/docs/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session
 $ cosign verify-blob --key https://edgeless.systems/es.pub --signature constellation-linux-amd64.sig constellation-linux-amd64
@@ -54,7 +54,7 @@ Verified OK
 
 ### Optional: Manually inspect the transparency log
 
-To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
+To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/docs/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
 
 ```shell-session
 $ rekor-cli search --artifact constellation-linux-amd64

--- a/docs/versioned_docs/version-2.9/workflows/sbom.md
+++ b/docs/versioned_docs/version-2.9/workflows/sbom.md
@@ -40,7 +40,7 @@ cosign verify-blob --key cosign.pub --signature constellation.spdx.sbom.sig cons
 
 ### Container Images
 
-SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
+SBOMs for container images are [attached to the image using Cosign](https://docs.sigstore.dev/docs/signing/other_types#sboms-software-bill-of-materials) and uploaded to the same registry.
 
 As a consumer, use cosign to download and verify the SBOM:
 

--- a/docs/versioned_docs/version-2.9/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.9/workflows/verify-cli.md
@@ -8,7 +8,7 @@ This recording presents the essence of this page. It's recommended to read it in
 
 ---
 
-Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/signing/quickstart), [Rekor](https://docs.sigstore.dev/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
+Edgeless Systems uses [sigstore](https://www.sigstore.dev/) and [SLSA](https://slsa.dev) to ensure supply-chain security for the Constellation CLI and node images ("artifacts"). sigstore consists of three components: [Cosign](https://docs.sigstore.dev/docs/signing/quickstart), [Rekor](https://docs.sigstore.dev/docs/logging/overview), and Fulcio. Edgeless Systems uses Cosign to sign artifacts. All signatures are uploaded to the public Rekor transparency log, which resides at <https://rekor.sigstore.dev/>.
 
 :::note
 The public key for Edgeless Systems' long-term code-signing key is:
@@ -33,7 +33,7 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
-First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
+First, [install the Cosign CLI](https://docs.sigstore.dev/docs/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session
 $ cosign verify-blob --key https://edgeless.systems/es.pub --signature constellation-linux-amd64.sig constellation-linux-amd64
@@ -54,7 +54,7 @@ Verified OK
 
 ### Optional: Manually inspect the transparency log
 
-To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
+To further inspect the public Rekor transparency log, [install the Rekor CLI](https://docs.sigstore.dev/docs/logging/installation). A search for the CLI executable  should give a single UUID. (Note that this UUID contains the UUID from the previous `cosign` command.)
 
 ```shell-session
 $ rekor-cli search --artifact constellation-linux-amd64


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Sigstore updated their website again.
All documentation is now found under `docs.sigstore.dev/docs/<topic>` instead of the previous `docs.sigstore.dev/<topic>`, breaking all of our sigstore links.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Update the sigstore links to include `/docs/`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
