### PR TITLE
ci: fix ccm build when no new version are found

### DIFF
--- a/.github/actions/gcpccm_vers_to_build/findvers.sh
+++ b/.github/actions/gcpccm_vers_to_build/findvers.sh
@@ -81,4 +81,5 @@ for major in "${allMajorVersions[@]}"; do
   versionsToBuild+=("${latest}")
 done
 
-printf '%s\n' "${versionsToBuild[@]}" | jq -R | jq -sc
+# Print one elem per line | quote elems | create array | remove empty elems and print compact.
+printf '%s' "${versionsToBuild[@]}" | jq -R | jq -s | jq -c 'map(select(length > 0))'

--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -52,6 +52,8 @@ jobs:
           echo "latest=${lastest}" | tee -a "$GITHUB_OUTPUT"
 
   build-ccm-gcp:
+    # matrix cannot handle empty lists
+    if: needs.find-ccm-versions.outputs.versions != '[]'
     runs-on: ubuntu-22.04
     permissions:
       contents: read


### PR DESCRIPTION
Previous output of findvers.sh would be [""] in case no version were found, now the output is []. Also, GitHub cannot handle empty arrays in the matrix field, so we add an if and check if the array is empty.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)