### PR TITLE
cli: cleanup terraform files when create fails

### DIFF
--- a/cli/internal/cloudcmd/rollback.go
+++ b/cli/internal/cloudcmd/rollback.go
@@ -13,6 +13,7 @@ import (
 	"io"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 )
 
 // rollbacker does a rollback.
@@ -39,8 +40,10 @@ type rollbackerTerraform struct {
 	client tfCommonClient
 }
 
-func (r *rollbackerTerraform) rollback(ctx context.Context, logLevel terraform.LogLevel) error {
+func (r *rollbackerTerraform) rollback(ctx context.Context, w io.Writer, logLevel terraform.LogLevel) error {
 	if err := r.client.Destroy(ctx, logLevel); err != nil {
+		fmt.Fprintf(w, "Could not destroy the resources. Please delete the %q directory manually if no resources were created\n",
+			constants.TerraformWorkingDir)
 		return err
 	}
 	return r.client.CleanUpWorkspace()


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
If `constellation create` fails due to terraform validation (the validation specified in variables.tf) triggering an abort, a constellation-terraform folder is left behind. No resources should be created at this point and thus no state folder should be left behind.

Example:
set cluster name with capital letter in gcp:

```
An error occurred: terraform apply: exit status 1

Error: "name" ("adrianGCP-5cfcb64c") doesn't match regexp "^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$"
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- defer the cleanup of tf files

### Related issue
- [AB#3282](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3282)

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
