### PR TITLE
cli: store kubernetes version as strong type in config

### DIFF
--- a/cli/internal/cmd/configgenerate.go
+++ b/cli/internal/cmd/configgenerate.go
@@ -133,7 +133,7 @@ func parseGenerateFlags(cmd *cobra.Command) (generateFlags, error) {
 	if err != nil {
 		return generateFlags{}, fmt.Errorf("parsing Kubernetes flag: %w", err)
 	}
-	resolvedVersion, err := versions.NewValidK8sVersion(k8sVersion, true) // allow versions without specified patch
+	resolvedVersion, err := versions.NewValidK8sVersion(k8sVersion, true)
 	if err != nil {
 		return generateFlags{}, fmt.Errorf("resolving Kubernetes version from flag: %w", err)
 	}

--- a/cli/internal/cmd/configgenerate.go
+++ b/cli/internal/cmd/configgenerate.go
@@ -14,13 +14,12 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
-	"golang.org/x/mod/semver"
-
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/versions"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
 )
 
 func newConfigGenerateCmd() *cobra.Command {

--- a/cli/internal/cmd/configgenerate.go
+++ b/cli/internal/cmd/configgenerate.go
@@ -13,14 +13,13 @@ import (
 	"github.com/edgelesssys/constellation/v2/cli/internal/cmd/pathprefix"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
-	"github.com/edgelesssys/constellation/v2/internal/compatibility"
 	"github.com/edgelesssys/constellation/v2/internal/config"
+
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/versions"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"golang.org/x/mod/semver"
 )
 
 func newConfigGenerateCmd() *cobra.Command {
@@ -35,7 +34,7 @@ func newConfigGenerateCmd() *cobra.Command {
 		ValidArgsFunction: generateCompletion,
 		RunE:              runConfigGenerate,
 	}
-	cmd.Flags().StringP("kubernetes", "k", semver.MajorMinor(config.Default().KubernetesVersion), "Kubernetes version to use in format MAJOR.MINOR")
+	cmd.Flags().StringP("kubernetes", "k", string(config.Default().KubernetesVersion), "Kubernetes version to use in format MAJOR.MINOR")
 	cmd.Flags().StringP("attestation", "a", "", fmt.Sprintf("attestation variant to use %s. If not specified, the default for the cloud provider is used", printFormattedSlice(variant.GetAvailableAttestationVariants())))
 
 	return cmd
@@ -43,7 +42,7 @@ func newConfigGenerateCmd() *cobra.Command {
 
 type generateFlags struct {
 	pf                 pathprefix.PathPrefixer
-	k8sVersion         string
+	k8sVersion         versions.ValidK8sVersion
 	attestationVariant variant.Variant
 }
 
@@ -124,19 +123,6 @@ func createConfig(provider cloudprovider.Provider) *config.Config {
 	return res
 }
 
-// supportedVersions prints the supported version without v prefix and without patch version.
-// Should only be used when accepting Kubernetes versions from --kubernetes.
-func supportedVersions() string {
-	builder := strings.Builder{}
-	for i, version := range versions.SupportedK8sVersions() {
-		if i > 0 {
-			builder.WriteString(" ")
-		}
-		builder.WriteString(strings.TrimPrefix(semver.MajorMinor(version), "v"))
-	}
-	return builder.String()
-}
-
 func parseGenerateFlags(cmd *cobra.Command) (generateFlags, error) {
 	workDir, err := cmd.Flags().GetString("workspace")
 	if err != nil {
@@ -144,11 +130,11 @@ func parseGenerateFlags(cmd *cobra.Command) (generateFlags, error) {
 	}
 	k8sVersion, err := cmd.Flags().GetString("kubernetes")
 	if err != nil {
-		return generateFlags{}, fmt.Errorf("parsing kuberentes flag: %w", err)
+		return generateFlags{}, fmt.Errorf("parsing Kubernetes flag: %w", err)
 	}
-	resolvedVersion, err := resolveK8sVersion(k8sVersion)
+	resolvedVersion, err := versions.NewValidK8sVersion(k8sVersion, true) // allow versions without specified patch
 	if err != nil {
-		return generateFlags{}, fmt.Errorf("resolving kuberentes version from flag: %w", err)
+		return generateFlags{}, fmt.Errorf("resolving Kubernetes version from flag: %w", err)
 	}
 
 	attestationString, err := cmd.Flags().GetString("attestation")
@@ -182,22 +168,6 @@ func generateCompletion(_ *cobra.Command, args []string, _ string) ([]string, co
 	default:
 		return []string{}, cobra.ShellCompDirectiveError
 	}
-}
-
-// resolveK8sVersion takes the user input from --kubernetes and transforms a MAJOR.MINOR definition into a supported
-// MAJOR.MINOR.PATCH release.
-func resolveK8sVersion(k8sVersion string) (string, error) {
-	prefixedVersion := compatibility.EnsurePrefixV(k8sVersion)
-	if !semver.IsValid(prefixedVersion) {
-		return "", fmt.Errorf("kubernetes flag does not specify a valid semantic version: %s", k8sVersion)
-	}
-
-	extendedVersion := config.K8sVersionFromMajorMinor(prefixedVersion)
-	if extendedVersion == "" {
-		return "", fmt.Errorf("--kubernetes (%s) does not specify a valid Kubernetes version. Supported versions: %s", strings.TrimPrefix(k8sVersion, "v"), supportedVersions())
-	}
-
-	return extendedVersion, nil
 }
 
 func printFormattedSlice[T any](input []T) string {

--- a/cli/internal/cmd/configgenerate.go
+++ b/cli/internal/cmd/configgenerate.go
@@ -14,6 +14,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
+	"golang.org/x/mod/semver"
 
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
@@ -34,7 +35,7 @@ func newConfigGenerateCmd() *cobra.Command {
 		ValidArgsFunction: generateCompletion,
 		RunE:              runConfigGenerate,
 	}
-	cmd.Flags().StringP("kubernetes", "k", string(config.Default().KubernetesVersion), "Kubernetes version to use in format MAJOR.MINOR")
+	cmd.Flags().StringP("kubernetes", "k", semver.MajorMinor(string(config.Default().KubernetesVersion)), "Kubernetes version to use in format MAJOR.MINOR")
 	cmd.Flags().StringP("attestation", "a", "", fmt.Sprintf("attestation variant to use %s. If not specified, the default for the cloud provider is used", printFormattedSlice(variant.GetAvailableAttestationVariants())))
 
 	return cmd

--- a/cli/internal/cmd/configgenerate.go
+++ b/cli/internal/cmd/configgenerate.go
@@ -133,7 +133,11 @@ func parseGenerateFlags(cmd *cobra.Command) (generateFlags, error) {
 	if err != nil {
 		return generateFlags{}, fmt.Errorf("parsing Kubernetes flag: %w", err)
 	}
-	resolvedVersion, err := versions.NewValidK8sVersion(k8sVersion, true)
+	resolvedVersion, err := versions.ResolveK8sPatchVersion(k8sVersion)
+	if err != nil {
+		return generateFlags{}, fmt.Errorf("resolving kubernetes patch version from flag: %w", err)
+	}
+	validK8sVersion, err := versions.NewValidK8sVersion(resolvedVersion, true)
 	if err != nil {
 		return generateFlags{}, fmt.Errorf("resolving Kubernetes version from flag: %w", err)
 	}
@@ -155,7 +159,7 @@ func parseGenerateFlags(cmd *cobra.Command) (generateFlags, error) {
 	}
 	return generateFlags{
 		pf:                 pathprefix.New(workDir),
-		k8sVersion:         resolvedVersion,
+		k8sVersion:         validK8sVersion,
 		attestationVariant: attestationVariant,
 	}, nil
 }

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -24,7 +24,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfigapi"
 	"github.com/edgelesssys/constellation/v2/internal/atls"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
-	"github.com/edgelesssys/constellation/v2/internal/compatibility"
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -170,10 +169,7 @@ func (i *initCmd) initialize(
 
 	// config validation does not check k8s patch version since upgrade may accept an outdated patch version.
 	// init only supported up-to-date versions.
-	k8sVersion, err := versions.NewValidK8sVersion(compatibility.EnsurePrefixV(conf.KubernetesVersion), true)
-	if err != nil {
-		return err
-	}
+	k8sVersion := conf.KubernetesVersion
 	i.log.Debugf("Validated k8s version as %s", k8sVersion)
 	if versions.IsPreviewK8sVersion(k8sVersion) {
 		cmd.PrintErrf("Warning: Constellation with Kubernetes %v is still in preview. Use only for evaluation purposes.\n", k8sVersion)
@@ -275,7 +271,7 @@ func (i *initCmd) initialize(
 	if err != nil {
 		return fmt.Errorf("creating Helm client: %w", err)
 	}
-	executor, includesUpgrades, err := helmApplier.PrepareApply(conf, k8sVersion, idFile, options, output,
+	executor, includesUpgrades, err := helmApplier.PrepareApply(conf, idFile, options, output,
 		serviceAccURI, masterSecret)
 	if err != nil {
 		return fmt.Errorf("getting Helm chart executor: %w", err)
@@ -629,7 +625,7 @@ type attestationConfigApplier interface {
 }
 
 type helmApplier interface {
-	PrepareApply(conf *config.Config, validK8sversion versions.ValidK8sVersion, idFile clusterid.File, flags helm.Options, tfOutput terraform.ApplyOutput, serviceAccURI string, masterSecret uri.MasterSecret) (helm.Applier, bool, error)
+	PrepareApply(conf *config.Config, idFile clusterid.File, flags helm.Options, tfOutput terraform.ApplyOutput, serviceAccURI string, masterSecret uri.MasterSecret) (helm.Applier, bool, error)
 }
 
 type clusterShower interface {

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -153,7 +153,7 @@ func (i *initCmd) initialize(
 		return err
 	}
 	// cfg validation does not check k8s patch version since upgrade may accept an outdated patch version.
-	_, err = versions.NewValidK8sVersion(string(conf.KubernetesVersion), true)
+	k8sVersion, err := versions.NewValidK8sVersion(string(conf.KubernetesVersion), true)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,6 @@ func (i *initCmd) initialize(
 		return fmt.Errorf("reading cluster ID file: %w", err)
 	}
 
-	k8sVersion := conf.KubernetesVersion
 	i.log.Debugf("Validated k8s version as %s", k8sVersion)
 	if versions.IsPreviewK8sVersion(k8sVersion) {
 		cmd.PrintErrf("Warning: Constellation with Kubernetes %v is still in preview. Use only for evaluation purposes.\n", k8sVersion)

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -153,7 +153,7 @@ func (i *initCmd) initialize(
 		return err
 	}
 	// cfg validation does not check k8s patch version since upgrade may accept an outdated patch version.
-	conf.KubernetesVersion, err = versions.NewValidK8sVersion(string(conf.KubernetesVersion), true)
+	_, err = versions.NewValidK8sVersion(string(conf.KubernetesVersion), true)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -152,8 +152,8 @@ func (i *initCmd) initialize(
 	if err != nil {
 		return err
 	}
-	conf.KubernetesVersion, err = versions.NewValidK8sVersion(string(conf.KubernetesVersion), true)
 	// cfg validation does not check k8s patch version since upgrade may accept an outdated patch version.
+	conf.KubernetesVersion, err = versions.NewValidK8sVersion(string(conf.KubernetesVersion), true)
 	if err != nil {
 		return err
 	}
@@ -172,8 +172,6 @@ func (i *initCmd) initialize(
 		return fmt.Errorf("reading cluster ID file: %w", err)
 	}
 
-	// config validation does not check k8s patch version since upgrade may accept an outdated patch version.
-	// init only supported up-to-date versions.
 	k8sVersion := conf.KubernetesVersion
 	i.log.Debugf("Validated k8s version as %s", k8sVersion)
 	if versions.IsPreviewK8sVersion(k8sVersion) {

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -152,6 +152,11 @@ func (i *initCmd) initialize(
 	if err != nil {
 		return err
 	}
+	conf.KubernetesVersion, err = versions.NewValidK8sVersion(string(conf.KubernetesVersion), true)
+	// cfg validation does not check k8s patch version since upgrade may accept an outdated patch version.
+	if err != nil {
+		return err
+	}
 	if !flags.force {
 		if err := validateCLIandConstellationVersionAreEqual(constants.BinaryVersion(), conf.Image, conf.MicroserviceVersion); err != nil {
 			return err

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -135,9 +135,7 @@ func TestInitialize(t *testing.T) {
 			initServerAPI: &stubInitServer{res: &initproto.InitResponse{Kind: &initproto.InitResponse_InitSuccess{InitSuccess: testInitResp}}},
 			configMutator: func(c *config.Config) {
 				res, err := versions.NewValidK8sVersion(strings.TrimPrefix(string(versions.Default), "v"), true)
-				if err != nil {
-					panic("invalid k8s version")
-				}
+				require.NoError(t, err)
 				c.KubernetesVersion = res
 			},
 		},

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -133,7 +133,13 @@ func TestInitialize(t *testing.T) {
 			provider:      cloudprovider.Azure,
 			idFile:        &clusterid.File{IP: "192.0.2.1"},
 			initServerAPI: &stubInitServer{res: &initproto.InitResponse{Kind: &initproto.InitResponse_InitSuccess{InitSuccess: testInitResp}}},
-			configMutator: func(c *config.Config) { c.KubernetesVersion = strings.TrimPrefix(string(versions.Default), "v") },
+			configMutator: func(c *config.Config) {
+				res, err := versions.NewValidK8sVersion(strings.TrimPrefix(string(versions.Default), "v"), true)
+				if err != nil {
+					panic("invalid k8s version")
+				}
+				c.KubernetesVersion = res
+			},
 		},
 	}
 
@@ -222,7 +228,7 @@ type stubApplier struct {
 	err error
 }
 
-func (s stubApplier) PrepareApply(_ *config.Config, _ versions.ValidK8sVersion, _ clusterid.File, _ helm.Options, _ terraform.ApplyOutput, _ string, _ uri.MasterSecret) (helm.Applier, bool, error) {
+func (s stubApplier) PrepareApply(_ *config.Config, _ clusterid.File, _ helm.Options, _ terraform.ApplyOutput, _ string, _ uri.MasterSecret) (helm.Applier, bool, error) {
 	return stubRunner{}, false, s.err
 }
 

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -166,9 +166,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 			}
 		}
 	}
-	if versions.IsPreviewK8sVersion(conf.KubernetesVersion) {
-		cmd.PrintErrf("Warning: Constellation with Kubernetes %q is still in preview. Use only for evaluation purposes.\n", conf.KubernetesVersion)
-	}
+	conf.KubernetesVersion, err = validK8sVersion(cmd, string(conf.KubernetesVersion), flags.yes)
 	if err != nil {
 		return err
 	}
@@ -335,6 +333,27 @@ func (u *upgradeApplyCmd) migrateTerraform(cmd *cobra.Command, conf *config.Conf
 		return tfOutput, fmt.Errorf("getting Terraform output: %w", err)
 	}
 	return tfOutput, nil
+}
+
+// validK8sVersion checks if the Kubernetes patch version is supported and asks for confirmation if not.
+func validK8sVersion(cmd *cobra.Command, version string, yes bool) (validVersion versions.ValidK8sVersion, err error) {
+	validVersion, err = versions.NewValidK8sVersion(version, true)
+	if versions.IsPreviewK8sVersion(validVersion) {
+		cmd.PrintErrf("Warning: Constellation with Kubernetes %v is still in preview. Use only for evaluation purposes.\n", validVersion)
+	}
+	valid := err == nil
+
+	if !valid && !yes {
+		confirmed, err := askToConfirm(cmd, fmt.Sprintf("WARNING: The Kubernetes patch version %s is not supported. If you continue, Kubernetes upgrades will be skipped. Do you want to continue anyway?", version))
+		if err != nil {
+			return validVersion, fmt.Errorf("asking for confirmation: %w", err)
+		}
+		if !confirmed {
+			return validVersion, fmt.Errorf("aborted by user")
+		}
+	}
+
+	return validVersion, nil
 }
 
 // confirmAndUpgradeAttestationConfig checks if the locally configured measurements are different from the cluster's measurements.

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -166,7 +166,9 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 			}
 		}
 	}
-	validK8sVersion, err := validK8sVersion(cmd, conf.KubernetesVersion, flags.yes)
+	if versions.IsPreviewK8sVersion(conf.KubernetesVersion) {
+		cmd.PrintErrf("Warning: Constellation with Kubernetes %q is still in preview. Use only for evaluation purposes.\n", conf.KubernetesVersion)
+	}
 	if err != nil {
 		return err
 	}
@@ -223,7 +225,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 
 	var upgradeErr *compatibility.InvalidUpgradeError
 	if !flags.skipPhases.contains(skipHelmPhase) {
-		err = u.handleServiceUpgrade(cmd, conf, idFile, tfOutput, validK8sVersion, upgradeDir, flags)
+		err = u.handleServiceUpgrade(cmd, conf, idFile, tfOutput, upgradeDir, flags)
 		switch {
 		case errors.As(err, &upgradeErr):
 			cmd.PrintErrln(err)
@@ -335,27 +337,6 @@ func (u *upgradeApplyCmd) migrateTerraform(cmd *cobra.Command, conf *config.Conf
 	return tfOutput, nil
 }
 
-// validK8sVersion checks if the Kubernetes patch version is supported and asks for confirmation if not.
-func validK8sVersion(cmd *cobra.Command, version string, yes bool) (validVersion versions.ValidK8sVersion, err error) {
-	validVersion, err = versions.NewValidK8sVersion(version, true)
-	if versions.IsPreviewK8sVersion(validVersion) {
-		cmd.PrintErrf("Warning: Constellation with Kubernetes %v is still in preview. Use only for evaluation purposes.\n", validVersion)
-	}
-	valid := err == nil
-
-	if !valid && !yes {
-		confirmed, err := askToConfirm(cmd, fmt.Sprintf("WARNING: The Kubernetes patch version %s is not supported. If you continue, Kubernetes upgrades will be skipped. Do you want to continue anyway?", version))
-		if err != nil {
-			return validVersion, fmt.Errorf("asking for confirmation: %w", err)
-		}
-		if !confirmed {
-			return validVersion, fmt.Errorf("aborted by user")
-		}
-	}
-
-	return validVersion, nil
-}
-
 // confirmAndUpgradeAttestationConfig checks if the locally configured measurements are different from the cluster's measurements.
 // If so the function will ask the user to confirm (if --yes is not set) and upgrade the cluster's config.
 func (u *upgradeApplyCmd) confirmAndUpgradeAttestationConfig(
@@ -400,7 +381,7 @@ func (u *upgradeApplyCmd) confirmAndUpgradeAttestationConfig(
 
 func (u *upgradeApplyCmd) handleServiceUpgrade(
 	cmd *cobra.Command, conf *config.Config, idFile clusterid.File, tfOutput terraform.ApplyOutput,
-	validK8sVersion versions.ValidK8sVersion, upgradeDir string, flags upgradeApplyFlags,
+	upgradeDir string, flags upgradeApplyFlags,
 ) error {
 	var secret uri.MasterSecret
 	if err := u.fileHandler.ReadJSON(constants.MasterSecretFilename, &secret); err != nil {
@@ -418,7 +399,7 @@ func (u *upgradeApplyCmd) handleServiceUpgrade(
 
 	prepareApply := func(allowDestructive bool) (helm.Applier, bool, error) {
 		options.AllowDestructive = allowDestructive
-		executor, includesUpgrades, err := u.helmApplier.PrepareApply(conf, validK8sVersion, idFile, options,
+		executor, includesUpgrades, err := u.helmApplier.PrepareApply(conf, idFile, options,
 			tfOutput, serviceAccURI, secret)
 		var upgradeErr *compatibility.InvalidUpgradeError
 		switch {

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -117,8 +117,8 @@ func TestUpgradeApply(t *testing.T) {
 				require.NoError(t, err)
 				return semver.NewFromInt(v.Major(), v.Minor(), v.Patch()-1, "").String()
 			}(),
-			wantErr: false,
 			flags:   upgradeApplyFlags{yes: true},
+			wantErr: false,
 		},
 		"outdated K8s version": {
 			kubeUpgrader: &stubKubernetesUpgrader{
@@ -127,8 +127,8 @@ func TestUpgradeApply(t *testing.T) {
 			helmUpgrader:      stubApplier{},
 			terraformUpgrader: &stubTerraformUpgrader{},
 			customK8sVersion:  "v1.20.0",
-			wantErr:           true,
 			flags:             upgradeApplyFlags{yes: true},
+			wantErr:           true,
 		},
 		"skip all upgrade phases": {
 			kubeUpgrader: &stubKubernetesUpgrader{

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/kms/uri"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
+	"github.com/edgelesssys/constellation/v2/internal/semver"
 	"github.com/edgelesssys/constellation/v2/internal/versions"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,7 @@ func TestUpgradeApply(t *testing.T) {
 		kubeUpgrader      *stubKubernetesUpgrader
 		terraformUpgrader clusterUpgrader
 		wantErr           bool
+		customK8sVersion  string
 		flags             upgradeApplyFlags
 		stdin             string
 	}{
@@ -104,6 +106,30 @@ func TestUpgradeApply(t *testing.T) {
 			wantErr: true,
 			flags:   upgradeApplyFlags{yes: true},
 		},
+		"outdated K8s patch version": {
+			kubeUpgrader: &stubKubernetesUpgrader{
+				currentConfig: config.DefaultForAzureSEVSNP(),
+			},
+			helmUpgrader:      stubApplier{},
+			terraformUpgrader: &stubTerraformUpgrader{},
+			customK8sVersion: func() string {
+				v, err := semver.New(versions.SupportedK8sVersions()[0])
+				require.NoError(t, err)
+				return semver.NewFromInt(v.Major(), v.Minor(), v.Patch()-1, "").String()
+			}(),
+			wantErr: false,
+			flags:   upgradeApplyFlags{yes: true},
+		},
+		"outdated K8s version": {
+			kubeUpgrader: &stubKubernetesUpgrader{
+				currentConfig: config.DefaultForAzureSEVSNP(),
+			},
+			helmUpgrader:      stubApplier{},
+			terraformUpgrader: &stubTerraformUpgrader{},
+			customK8sVersion:  "v1.20.0",
+			wantErr:           true,
+			flags:             upgradeApplyFlags{yes: true},
+		},
 		"skip all upgrade phases": {
 			kubeUpgrader: &stubKubernetesUpgrader{
 				currentConfig: config.DefaultForAzureSEVSNP(),
@@ -138,7 +164,9 @@ func TestUpgradeApply(t *testing.T) {
 			handler := file.NewHandler(afero.NewMemMapFs())
 
 			cfg := defaultConfigWithExpectedMeasurements(t, config.Default(), cloudprovider.Azure)
-
+			if tc.customK8sVersion != "" {
+				cfg.KubernetesVersion = versions.ValidK8sVersion(tc.customK8sVersion)
+			}
 			require.NoError(handler.WriteYAML(constants.ConfigFilename, cfg))
 			require.NoError(handler.WriteJSON(constants.ClusterIDsFilename, clusterid.File{MeasurementSalt: []byte("measurementSalt")}))
 			require.NoError(handler.WriteJSON(constants.MasterSecretFilename, uri.MasterSecret{}))
@@ -251,7 +279,7 @@ type mockApplier struct {
 	mock.Mock
 }
 
-func (m *mockApplier) PrepareApply(cfg *config.Config, k8sVersion versions.ValidK8sVersion, clusterID clusterid.File, helmOpts helm.Options, terraformOut terraform.ApplyOutput, str string, masterSecret uri.MasterSecret) (helm.Applier, bool, error) {
-	args := m.Called(cfg, k8sVersion, clusterID, helmOpts, terraformOut, str, masterSecret)
+func (m *mockApplier) PrepareApply(cfg *config.Config, clusterID clusterid.File, helmOpts helm.Options, terraformOut terraform.ApplyOutput, str string, masterSecret uri.MasterSecret) (helm.Applier, bool, error) {
+	args := m.Called(cfg, clusterID, helmOpts, terraformOut, str, masterSecret)
 	return args.Get(0).(helm.Applier), args.Bool(1), args.Error(2)
 }

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -576,7 +576,7 @@ func (v *versionUpgrade) writeConfig(conf *config.Config, fileHandler file.Handl
 		conf.MicroserviceVersion = v.newServices
 	}
 	if len(v.newKubernetes) > 0 {
-		conf.KubernetesVersion = v.newKubernetes[0]
+		conf.KubernetesVersion = versions.ValidK8sVersion(v.newKubernetes[0])
 	}
 	if len(v.newImages) > 0 {
 		imageUpgrade := sortedMapKeys(v.newImages)[0]

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -576,7 +576,11 @@ func (v *versionUpgrade) writeConfig(conf *config.Config, fileHandler file.Handl
 		conf.MicroserviceVersion = v.newServices
 	}
 	if len(v.newKubernetes) > 0 {
-		conf.KubernetesVersion = versions.ValidK8sVersion(v.newKubernetes[0])
+		var err error
+		conf.KubernetesVersion, err = versions.NewValidK8sVersion(v.newKubernetes[0], true)
+		if err != nil {
+			return fmt.Errorf("parsing Kubernetes version: %w", err)
+		}
 	}
 	if len(v.newImages) > 0 {
 		imageUpgrade := sortedMapKeys(v.newImages)[0]

--- a/cli/internal/helm/BUILD.bazel
+++ b/cli/internal/helm/BUILD.bazel
@@ -473,7 +473,6 @@ go_test(
         "//internal/kms/uri",
         "//internal/logger",
         "//internal/semver",
-        "//internal/versions",
         "@com_github_pkg_errors//:errors",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//mock",

--- a/cli/internal/helm/helm.go
+++ b/cli/internal/helm/helm.go
@@ -40,7 +40,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/kms/uri"
 	"github.com/edgelesssys/constellation/v2/internal/kubernetes/kubectl"
 	"github.com/edgelesssys/constellation/v2/internal/semver"
-	"github.com/edgelesssys/constellation/v2/internal/versions"
 )
 
 const (
@@ -87,11 +86,10 @@ type Options struct {
 
 // PrepareApply loads the charts and returns the executor to apply them.
 // TODO(elchead): remove validK8sVersion by putting ValidK8sVersion into config.Config, see AB#3374.
-func (h Client) PrepareApply(
-	conf *config.Config, validK8sversion versions.ValidK8sVersion, idFile clusterid.File,
-	flags Options, tfOutput terraform.ApplyOutput, serviceAccURI string, masterSecret uri.MasterSecret,
+func (h Client) PrepareApply(conf *config.Config, idFile clusterid.File, flags Options, tfOutput terraform.ApplyOutput,
+	serviceAccURI string, masterSecret uri.MasterSecret,
 ) (Applier, bool, error) {
-	releases, err := h.loadReleases(conf, masterSecret, validK8sversion, idFile, flags, tfOutput, serviceAccURI)
+	releases, err := h.loadReleases(conf, masterSecret, idFile, flags, tfOutput, serviceAccURI)
 	if err != nil {
 		return nil, false, fmt.Errorf("loading Helm releases: %w", err)
 	}
@@ -100,11 +98,10 @@ func (h Client) PrepareApply(
 	return &ChartApplyExecutor{actions: actions, log: h.log}, includesUpgrades, err
 }
 
-func (h Client) loadReleases(
-	conf *config.Config, secret uri.MasterSecret, validK8sVersion versions.ValidK8sVersion,
-	idFile clusterid.File, flags Options, tfOutput terraform.ApplyOutput, serviceAccURI string,
+func (h Client) loadReleases(conf *config.Config, secret uri.MasterSecret, idFile clusterid.File, flags Options,
+	tfOutput terraform.ApplyOutput, serviceAccURI string,
 ) ([]Release, error) {
-	helmLoader := newLoader(conf, idFile, validK8sVersion, h.cliVersion)
+	helmLoader := newLoader(conf, idFile, h.cliVersion)
 	h.log.Debugf("Created new Helm loader")
 	return helmLoader.loadReleases(flags.Conformance, flags.HelmWaitMode, secret,
 		serviceAccURI, tfOutput)

--- a/cli/internal/helm/helm_test.go
+++ b/cli/internal/helm/helm_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/kms/uri"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/internal/semver"
-	"github.com/edgelesssys/constellation/v2/internal/versions"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"helm.sh/helm/v3/pkg/action"
@@ -208,7 +207,7 @@ func TestHelmApply(t *testing.T) {
 			helmListVersion(lister, "aws-load-balancer-controller", awsLbVersion)
 
 			options.AllowDestructive = tc.allowDestructive
-			ex, includesUpgrade, err := sut.PrepareApply(cfg, versions.ValidK8sVersion("v1.27.4"),
+			ex, includesUpgrade, err := sut.PrepareApply(cfg,
 				clusterid.File{UID: "testuid", MeasurementSalt: []byte("measurementSalt")}, options,
 				fakeTerraformOutput(csp), fakeServiceAccURI(csp),
 				uri.MasterSecret{Key: []byte("secret"), Salt: []byte("masterSalt")})

--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -77,11 +77,12 @@ type chartLoader struct {
 }
 
 // newLoader creates a new ChartLoader.
-func newLoader(config *config.Config, idFile clusterid.File, k8sVersion versions.ValidK8sVersion, cliVersion semver.Semver) *chartLoader {
+func newLoader(config *config.Config, idFile clusterid.File, cliVersion semver.Semver) *chartLoader {
 	// TODO(malt3): Allow overriding container image registry + prefix for all images
 	// (e.g. for air-gapped environments).
 	var ccmImage, cnmImage string
 	csp := config.GetProvider()
+	k8sVersion := config.KubernetesVersion
 	switch csp {
 	case cloudprovider.AWS:
 		ccmImage = versions.VersionConfigs[k8sVersion].CloudControllerManagerImageAWS

--- a/cli/internal/helm/loader_test.go
+++ b/cli/internal/helm/loader_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/kms/uri"
 	"github.com/edgelesssys/constellation/v2/internal/semver"
-	"github.com/edgelesssys/constellation/v2/internal/versions"
 )
 
 func fakeServiceAccURI(provider cloudprovider.Provider) string {
@@ -67,9 +66,8 @@ func TestLoadReleases(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	config := &config.Config{Provider: config.ProviderConfig{GCP: &config.GCPConfig{}}}
-	k8sVersion := versions.ValidK8sVersion("v1.27.4")
 	chartLoader := newLoader(config, clusterid.File{UID: "testuid", MeasurementSalt: []byte("measurementSalt")},
-		k8sVersion, semver.NewFromInt(2, 10, 0, ""))
+		semver.NewFromInt(2, 10, 0, ""))
 	helmReleases, err := chartLoader.loadReleases(
 		true, WaitModeAtomic,
 		uri.MasterSecret{Key: []byte("secret"), Salt: []byte("masterSalt")},

--- a/cli/internal/kubecmd/kubecmd.go
+++ b/cli/internal/kubecmd/kubecmd.go
@@ -145,8 +145,14 @@ func (k *KubeCmd) UpgradeNodeVersion(ctx context.Context, conf *config.Config, f
 			err = compatibility.NewInvalidUpgradeError(nodeVersion.Spec.KubernetesClusterVersion,
 				string(conf.KubernetesVersion), innerErr)
 		} else {
-			versionConfig := versions.VersionConfigs[conf.KubernetesVersion]
-			components, err = k.updateK8s(&nodeVersion, versionConfig.ClusterVersion, versionConfig.KubernetesComponents, force)
+			versionConfig, ok := versions.VersionConfigs[conf.KubernetesVersion]
+			if !ok {
+				err = compatibility.NewInvalidUpgradeError(nodeVersion.Spec.KubernetesClusterVersion,
+					string(conf.KubernetesVersion), fmt.Errorf("no version config matching K8s %s", conf.KubernetesVersion))
+			} else {
+				components, err = k.prepareUpdateK8s(&nodeVersion, versionConfig.ClusterVersion,
+					versionConfig.KubernetesComponents, force)
+			}
 		}
 
 		switch {
@@ -161,7 +167,6 @@ func (k *KubeCmd) UpgradeNodeVersion(ctx context.Context, conf *config.Config, f
 			return fmt.Errorf("updating Kubernetes version: %w", err)
 		}
 	}
-
 	if len(upgradeErrs) == 2 {
 		return errors.Join(upgradeErrs...)
 	}
@@ -423,7 +428,7 @@ func (k *KubeCmd) isValidImageUpgrade(nodeVersion updatev1alpha1.NodeVersion, ne
 	return nil
 }
 
-func (k *KubeCmd) updateK8s(nodeVersion *updatev1alpha1.NodeVersion, newClusterVersion string, components components.Components, force bool) (*corev1.ConfigMap, error) {
+func (k *KubeCmd) prepareUpdateK8s(nodeVersion *updatev1alpha1.NodeVersion, newClusterVersion string, components components.Components, force bool) (*corev1.ConfigMap, error) {
 	configMap, err := internalk8s.ConstructK8sComponentsCM(components, newClusterVersion)
 	if err != nil {
 		return nil, fmt.Errorf("constructing k8s-components ConfigMap: %w", err)

--- a/cli/internal/kubecmd/kubecmd.go
+++ b/cli/internal/kubecmd/kubecmd.go
@@ -138,12 +138,14 @@ func (k *KubeCmd) UpgradeNodeVersion(ctx context.Context, conf *config.Config, f
 		// We have to allow users to specify outdated k8s patch versions.
 		// Therefore, this code has to skip k8s updates if a user configures an outdated (i.e. invalid) k8s version.
 		var components *corev1.ConfigMap
-		currentK8sVersion, err := versions.NewValidK8sVersion(conf.KubernetesVersion, true)
+		_, err = versions.NewValidK8sVersion(string(conf.KubernetesVersion), true)
 		if err != nil {
-			innerErr := fmt.Errorf("unsupported Kubernetes version, supported versions are %s", strings.Join(versions.SupportedK8sVersions(), ", "))
-			err = compatibility.NewInvalidUpgradeError(nodeVersion.Spec.KubernetesClusterVersion, conf.KubernetesVersion, innerErr)
+			innerErr := fmt.Errorf("unsupported Kubernetes version, supported versions are %s",
+				strings.Join(versions.SupportedK8sVersions(), ", "))
+			err = compatibility.NewInvalidUpgradeError(nodeVersion.Spec.KubernetesClusterVersion,
+				string(conf.KubernetesVersion), innerErr)
 		} else {
-			versionConfig := versions.VersionConfigs[currentK8sVersion]
+			versionConfig := versions.VersionConfigs[conf.KubernetesVersion]
 			components, err = k.updateK8s(&nodeVersion, versionConfig.ClusterVersion, versionConfig.KubernetesComponents, force)
 		}
 

--- a/cli/internal/kubecmd/kubecmd_test.go
+++ b/cli/internal/kubecmd/kubecmd_test.go
@@ -444,7 +444,7 @@ func TestUpdateK8s(t *testing.T) {
 				},
 			}
 
-			_, err := upgrader.updateK8s(&nodeVersion, tc.newClusterVersion, components.Components{}, false)
+			_, err := upgrader.prepareUpdateK8s(&nodeVersion, tc.newClusterVersion, components.Components{}, false)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/kubecmd/kubecmd_test.go
+++ b/cli/internal/kubecmd/kubecmd_test.go
@@ -56,11 +56,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
+				conf.KubernetesVersion = supportedValidK8sVersions()[1]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
+			currentClusterVersion: supportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -72,11 +72,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.2"
-				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
+				conf.KubernetesVersion = supportedValidK8sVersions()[1]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
+			currentClusterVersion: supportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -93,11 +93,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[0]
+				conf.KubernetesVersion = supportedValidK8sVersions()[0]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
+			currentClusterVersion: supportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -114,11 +114,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.2"
-				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[0]
+				conf.KubernetesVersion = supportedValidK8sVersions()[0]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
+			currentClusterVersion: supportedValidK8sVersions()[0],
 			kubectl:               &stubKubectl{},
 			wantErr:               true,
 			assertCorrectError: func(t *testing.T, err error) bool {
@@ -130,7 +130,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
+				conf.KubernetesVersion = supportedValidK8sVersions()[1]
 				return conf
 			}(),
 			conditions: []metav1.Condition{{
@@ -138,7 +138,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 				Status: metav1.ConditionTrue,
 			}},
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
+			currentClusterVersion: supportedValidK8sVersions()[0],
 			kubectl:               &stubKubectl{},
 			wantErr:               true,
 			assertCorrectError: func(t *testing.T, err error) bool {
@@ -149,7 +149,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
+				conf.KubernetesVersion = supportedValidK8sVersions()[1]
 				return conf
 			}(),
 			conditions: []metav1.Condition{{
@@ -157,7 +157,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 				Status: metav1.ConditionTrue,
 			}},
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
+			currentClusterVersion: supportedValidK8sVersions()[0],
 			kubectl:               &stubKubectl{},
 			force:                 true,
 			wantUpdate:            true,
@@ -166,11 +166,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
+				conf.KubernetesVersion = supportedValidK8sVersions()[1]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
+			currentClusterVersion: supportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -186,12 +186,12 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.4.2"
-				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
+				conf.KubernetesVersion = supportedValidK8sVersions()[1]
 				return conf
 			}(),
 			newImageReference:     "path/to/image:v1.4.2",
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
+			currentClusterVersion: supportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":true}}`),
@@ -208,12 +208,12 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.4.2"
-				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
+				conf.KubernetesVersion = supportedValidK8sVersions()[1]
 				return conf
 			}(),
 			newImageReference:     "path/to/image:v1.4.2",
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
+			currentClusterVersion: supportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -226,11 +226,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
+				conf.KubernetesVersion = supportedValidK8sVersions()[1]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
+			currentClusterVersion: supportedValidK8sVersions()[0],
 			badImageVersion:       "v3.2.1",
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
@@ -252,7 +252,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
+			currentClusterVersion: supportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -269,11 +269,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
+				conf.KubernetesVersion = supportedValidK8sVersions()[1]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
+			currentClusterVersion: supportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -817,4 +817,12 @@ func (f *fakeConfigMapClient) CreateConfigMap(_ context.Context, configMap *core
 	}
 	f.configMaps[configMap.ObjectMeta.Name] = configMap
 	return nil
+}
+
+// supportedValidK8sVersions returns a typed list of supported Kubernetes versions.
+func supportedValidK8sVersions() (res []versions.ValidK8sVersion) {
+	for _, v := range versions.SupportedK8sVersions() {
+		res = append(res, versions.ValidK8sVersion(v))
+	}
+	return
 }

--- a/cli/internal/kubecmd/kubecmd_test.go
+++ b/cli/internal/kubecmd/kubecmd_test.go
@@ -43,7 +43,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 		currentImageVersion   string
 		newImageReference     string
 		badImageVersion       string
-		currentClusterVersion string
+		currentClusterVersion versions.ValidK8sVersion
 		conf                  *config.Config
 		force                 bool
 		getCRErr              error
@@ -56,11 +56,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedK8sVersions()[1]
+				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -72,11 +72,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.2"
-				conf.KubernetesVersion = versions.SupportedK8sVersions()[1]
+				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -93,11 +93,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedK8sVersions()[0]
+				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[0]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -114,11 +114,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.2"
-				conf.KubernetesVersion = versions.SupportedK8sVersions()[0]
+				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[0]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
 			kubectl:               &stubKubectl{},
 			wantErr:               true,
 			assertCorrectError: func(t *testing.T, err error) bool {
@@ -130,7 +130,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedK8sVersions()[1]
+				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
 				return conf
 			}(),
 			conditions: []metav1.Condition{{
@@ -138,7 +138,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 				Status: metav1.ConditionTrue,
 			}},
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
 			kubectl:               &stubKubectl{},
 			wantErr:               true,
 			assertCorrectError: func(t *testing.T, err error) bool {
@@ -149,7 +149,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedK8sVersions()[1]
+				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
 				return conf
 			}(),
 			conditions: []metav1.Condition{{
@@ -157,7 +157,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 				Status: metav1.ConditionTrue,
 			}},
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
 			kubectl:               &stubKubectl{},
 			force:                 true,
 			wantUpdate:            true,
@@ -166,11 +166,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedK8sVersions()[1]
+				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -186,12 +186,12 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.4.2"
-				conf.KubernetesVersion = versions.SupportedK8sVersions()[1]
+				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
 				return conf
 			}(),
 			newImageReference:     "path/to/image:v1.4.2",
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":true}}`),
@@ -208,12 +208,12 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.4.2"
-				conf.KubernetesVersion = versions.SupportedK8sVersions()[1]
+				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
 				return conf
 			}(),
 			newImageReference:     "path/to/image:v1.4.2",
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -226,11 +226,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedK8sVersions()[1]
+				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
 			badImageVersion:       "v3.2.1",
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
@@ -252,7 +252,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -269,11 +269,11 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			conf: func() *config.Config {
 				conf := config.Default()
 				conf.Image = "v1.2.3"
-				conf.KubernetesVersion = versions.SupportedK8sVersions()[1]
+				conf.KubernetesVersion = versions.SupportedValidK8sVersions()[1]
 				return conf
 			}(),
 			currentImageVersion:   "v1.2.2",
-			currentClusterVersion: versions.SupportedK8sVersions()[0],
+			currentClusterVersion: versions.SupportedValidK8sVersions()[0],
 			kubectl: &stubKubectl{
 				configMaps: map[string]*corev1.ConfigMap{
 					constants.JoinConfigMap: newJoinConfigMap(`{"0":{"expected":"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","warnOnly":false}}`),
@@ -298,7 +298,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 			nodeVersion := updatev1alpha1.NodeVersion{
 				Spec: updatev1alpha1.NodeVersionSpec{
 					ImageVersion:             tc.currentImageVersion,
-					KubernetesClusterVersion: tc.currentClusterVersion,
+					KubernetesClusterVersion: string(tc.currentClusterVersion),
 				},
 				Status: updatev1alpha1.NodeVersionStatus{
 					Conditions: tc.conditions,

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -79,7 +79,7 @@ constellation config generate {aws|azure|gcp|openstack|qemu|stackit} [flags]
 ```
   -a, --attestation string   attestation variant to use {aws-sev-snp|aws-nitro-tpm|azure-sev-snp|azure-trustedlaunch|gcp-sev-es|qemu-vtpm}. If not specified, the default for the cloud provider is used
   -h, --help                 help for generate
-  -k, --kubernetes string    Kubernetes version to use in format MAJOR.MINOR (default "v1.27")
+  -k, --kubernetes string    Kubernetes version to use in format MAJOR.MINOR (default "v1.27.4")
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -79,7 +79,7 @@ constellation config generate {aws|azure|gcp|openstack|qemu|stackit} [flags]
 ```
   -a, --attestation string   attestation variant to use {aws-sev-snp|aws-nitro-tpm|azure-sev-snp|azure-trustedlaunch|gcp-sev-es|qemu-vtpm}. If not specified, the default for the cloud provider is used
   -h, --help                 help for generate
-  -k, --kubernetes string    Kubernetes version to use in format MAJOR.MINOR (default "v1.27.4")
+  -k, --kubernetes string    Kubernetes version to use in format MAJOR.MINOR (default "v1.27")
 ```
 
 ### Options inherited from parent commands

--- a/e2e/internal/upgrade/upgrade_test.go
+++ b/e2e/internal/upgrade/upgrade_test.go
@@ -277,8 +277,7 @@ func writeUpgradeConfig(require *require.Assertions, image string, kubernetes st
 	if kubernetes == "" {
 		kubernetesVersion = defaultConfig.KubernetesVersion
 	} else {
-		kubernetesVersion, err = versions.NewValidK8sVersion(kubernetes, true)
-		require.NoError(err)
+		kubernetesVersion = versions.ValidK8sVersion(kubernetes) // ignore validation because the config is only written to file
 	}
 
 	var microserviceVersion semver.Semver

--- a/internal/config/BUILD.bazel
+++ b/internal/config/BUILD.bazel
@@ -62,7 +62,6 @@ go_test(
         "//internal/constants",
         "//internal/file",
         "//internal/semver",
-        "//internal/versions",
         "@com_github_go_playground_locales//en",
         "@com_github_go_playground_universal_translator//:universal-translator",
         "@com_github_go_playground_validator_v10//:validator",

--- a/internal/config/BUILD.bazel
+++ b/internal/config/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "//internal/constants",
         "//internal/file",
         "//internal/semver",
+        "//internal/versions",
         "@com_github_go_playground_locales//en",
         "@com_github_go_playground_universal_translator//:universal-translator",
         "@com_github_go_playground_validator_v10//:validator",
@@ -69,6 +70,7 @@ go_test(
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v3//:yaml_v3",
+        "@org_golang_x_mod//semver",
         "@org_uber_go_goleak//:goleak",
     ],
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -315,7 +315,7 @@ func Default() *Config {
 		Image:               defaultImage,
 		Name:                defaultName,
 		MicroserviceVersion: constants.BinaryVersion(),
-		KubernetesVersion:   string(versions.Default),
+		KubernetesVersion:   versions.Default,
 		DebugCluster:        toPtr(false),
 		Provider: ProviderConfig{
 			AWS: &AWSConfig{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,7 +69,7 @@ type Config struct {
 	Name string `yaml:"name" validate:"valid_name,required"`
 	// description: |
 	//   Kubernetes version to be installed into the cluster.
-	KubernetesVersion string `yaml:"kubernetesVersion" validate:"required,supported_k8s_version"`
+	KubernetesVersion versions.ValidK8sVersion `yaml:"kubernetesVersion" validate:"required,supported_k8s_version"`
 	// description: |
 	//   Microservice version to be installed into the cluster. Defaults to the version of the CLI.
 	MicroserviceVersion semver.Semver `yaml:"microserviceVersion" validate:"required"`

--- a/internal/config/config_doc.go
+++ b/internal/config/config_doc.go
@@ -52,7 +52,7 @@ func init() {
 	ConfigDoc.Fields[2].Description = "Name of the cluster."
 	ConfigDoc.Fields[2].Comments[encoder.LineComment] = "Name of the cluster."
 	ConfigDoc.Fields[3].Name = "kubernetesVersion"
-	ConfigDoc.Fields[3].Type = "string"
+	ConfigDoc.Fields[3].Type = "ValidK8sVersion"
 	ConfigDoc.Fields[3].Note = ""
 	ConfigDoc.Fields[3].Description = "Kubernetes version to be installed into the cluster."
 	ConfigDoc.Fields[3].Comments[encoder.LineComment] = "Kubernetes version to be installed into the cluster."

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/semver"
-	"github.com/edgelesssys/constellation/v2/internal/versions"
 )
 
 func TestMain(m *testing.M) {
@@ -249,16 +248,17 @@ func TestFromFile(t *testing.T) {
 			configName: "wrong-name.yaml",
 			wantErr:    true,
 		},
-		"custom config from default file": {
-			config: &Config{
-				Version: Version4,
-			},
-			configName: constants.ConfigFilename,
-			wantResult: &Config{
-				Version:    Version4,
-				NodeGroups: map[string]NodeGroup{},
-			},
-		},
+		// TODO why do we support an empty file?
+		//"custom config from default file": {
+		//	config: &Config{
+		//		Version: Version4,
+		//	},
+		//	configName: constants.ConfigFilename,
+		//	wantResult: &Config{
+		//		Version:    Version4,
+		//		NodeGroups: map[string]NodeGroup{},
+		//	},
+		//},
 		"modify default config": {
 			config: func() *Config {
 				conf := Default()
@@ -316,19 +316,6 @@ func TestValidate(t *testing.T) {
 			cnf: func() *Config {
 				cnf := Default()
 				cnf.Image = ""
-				return cnf
-			}(),
-			wantErr:      true,
-			wantErrCount: defaultErrCount,
-		},
-		"outdated k8s patch version is allowed": {
-			cnf: func() *Config {
-				cnf := Default()
-				cnf.Image = ""
-				ver, err := semver.New(versions.SupportedK8sVersions()[0])
-				require.NoError(t, err)
-				ver = semver.NewFromInt(ver.Major(), ver.Minor(), ver.Patch()-1, "")
-				cnf.KubernetesVersion = ver.String()
 				return cnf
 			}(),
 			wantErr:      true,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -248,17 +248,6 @@ func TestFromFile(t *testing.T) {
 			configName: "wrong-name.yaml",
 			wantErr:    true,
 		},
-		// TODO why do we support an empty file?
-		//"custom config from default file": {
-		//	config: &Config{
-		//		Version: Version4,
-		//	},
-		//	configName: constants.ConfigFilename,
-		//	wantResult: &Config{
-		//		Version:    Version4,
-		//		NodeGroups: map[string]NodeGroup{},
-		//	},
-		//},
 		"modify default config": {
 			config: func() *Config {
 				conf := Default()

--- a/internal/config/migration/BUILD.bazel
+++ b/internal/config/migration/BUILD.bazel
@@ -12,5 +12,6 @@ go_library(
         "//internal/file",
         "//internal/role",
         "//internal/semver",
+        "//internal/versions",
     ],
 )

--- a/internal/config/migration/migration.go
+++ b/internal/config/migration/migration.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/role"
 	"github.com/edgelesssys/constellation/v2/internal/semver"
+	"github.com/edgelesssys/constellation/v2/internal/versions"
 )
 
 const (
@@ -335,7 +336,7 @@ func V3ToV4(path string, fileHandler file.Handler) error {
 	cfgV4.Version = config.Version4
 	cfgV4.Image = cfgV3.Image
 	cfgV4.Name = cfgV3.Name
-	cfgV4.KubernetesVersion = cfgV3.KubernetesVersion
+	cfgV4.KubernetesVersion = versions.ValidK8sVersion(cfgV3.KubernetesVersion)
 	cfgV4.MicroserviceVersion = cfgV3.MicroserviceVersion
 	cfgV4.DebugCluster = cfgV3.DebugCluster
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -637,22 +637,6 @@ func (c *Config) validateK8sVersion(fl validator.FieldLevel) bool {
 	return err == nil
 }
 
-// K8sVersionFromMajorMinor takes a semver in format MAJOR.MINOR
-// and returns the version in format MAJOR.MINOR.PATCH with the
-// supported patch version as PATCH.
-func K8sVersionFromMajorMinor(version string) string {
-	switch version {
-	case semver.MajorMinor(string(versions.V1_26)):
-		return string(versions.V1_26)
-	case semver.MajorMinor(string(versions.V1_27)):
-		return string(versions.V1_27)
-	case semver.MajorMinor(string(versions.V1_28)):
-		return string(versions.V1_28)
-	default:
-		return ""
-	}
-}
-
 func registerImageCompatibilityError(ut ut.Translator) error {
 	return ut.Add("image_compatibility", "{0} specifies an invalid version: {1}", true)
 }

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -36,14 +36,6 @@ func SupportedK8sVersions() []string {
 	return validVersionsSorted
 }
 
-// SupportedValidK8sVersions returns a typed list of supported Kubernetes versions.
-func SupportedValidK8sVersions() (res []ValidK8sVersion) {
-	for _, v := range SupportedK8sVersions() {
-		res = append(res, ValidK8sVersion(v))
-	}
-	return
-}
-
 // ValidK8sVersion represents any of the three currently supported k8s versions.
 type ValidK8sVersion string
 

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -77,6 +77,9 @@ func (v *ValidK8sVersion) UnmarshalYAML(unmarshal func(interface{}) error) error
 	if err := unmarshal(&version); err != nil {
 		return err
 	}
+	if !hasPatchVersion(version) {
+		return fmt.Errorf("Kubernetes version %s does not specify a patch, supported versions are %s", version, strings.Join(SupportedK8sVersions(), ", "))
+	}
 	valid, err := NewValidK8sVersion(version, false) // allow any patch version to not force K8s patch upgrades
 	if err != nil {
 		return fmt.Errorf("unsupported Kubernetes version %s, supported versions are %s", version, strings.Join(SupportedK8sVersions(), ", "))

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -66,11 +66,6 @@ func NewValidK8sVersion(k8sVersion string, strict bool) (ValidK8sVersion, error)
 	return ValidK8sVersion(prefixedVersion), nil
 }
 
-// hasPatchVersion returns if the given version has specified a patch version.
-func hasPatchVersion(version string) bool {
-	return semver.MajorMinor(version) != version
-}
-
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (v *ValidK8sVersion) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var version string
@@ -160,6 +155,11 @@ func isSupportedK8sVersionStrict(version string) bool {
 // IsPreviewK8sVersion checks if a given Kubernetes version is still in preview and not fully supported.
 func IsPreviewK8sVersion(_ ValidK8sVersion) bool {
 	return false
+}
+
+// hasPatchVersion returns if the given version has specified a patch version.
+func hasPatchVersion(version string) bool {
+	return semver.MajorMinor(version) != version
 }
 
 const (

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -48,10 +48,11 @@ func SupportedValidK8sVersions() (res []ValidK8sVersion) {
 type ValidK8sVersion string
 
 // NewValidK8sVersion validates the given string and produces a new ValidK8sVersion object.
+// It accepts a major minor version (e.g. 1.26) and transforms it into a supported patch version (e.g. 1.26.7).
+// It also accepts a full version (e.g. 1.26.7) and validates it.
 // Returns an empty string if the given version is invalid.
 // strict controls whether the patch version is checked or not.
-// If strict is false, the patch version is ignored and the returned
-// TODO(elchead): only allow strict mode?
+// If strict is false, the patch version is ignored and the returned.
 func NewValidK8sVersion(k8sVersion string, strict bool) (ValidK8sVersion, error) {
 	prefixedVersion := compatibility.EnsurePrefixV(k8sVersion)
 	parsedVersion, err := resolveK8sPatchVersion(prefixedVersion)
@@ -86,7 +87,6 @@ func (v *ValidK8sVersion) UnmarshalYAML(unmarshal func(interface{}) error) error
 
 // resolveK8sPatchVersion takes the user input from --kubernetes and transforms a MAJOR.MINOR definition into a supported
 // MAJOR.MINOR.PATCH release.
-// TODO(elchead): should we support this resolvement also for the config?
 func resolveK8sPatchVersion(k8sVersion string) (string, error) {
 	if !semver.IsValid(k8sVersion) {
 		return "", fmt.Errorf("kubernetes flag does not specify a valid semantic version: %s", k8sVersion)

--- a/internal/versions/versions.go
+++ b/internal/versions/versions.go
@@ -85,7 +85,7 @@ func ResolveK8sPatchVersion(k8sVersion string) (string, error) {
 	if hasPatchVersion(k8sVersion) {
 		return k8sVersion, nil
 	}
-	extendedVersion := K8sVersionFromMajorMinor(k8sVersion)
+	extendedVersion := k8sVersionFromMajorMinor(k8sVersion)
 	if extendedVersion == "" {
 		return "", fmt.Errorf("Kubernetes version %s is not valid. Supported versions: %s",
 			strings.TrimPrefix(k8sVersion, "v"), supportedVersions())
@@ -94,10 +94,10 @@ func ResolveK8sPatchVersion(k8sVersion string) (string, error) {
 	return extendedVersion, nil
 }
 
-// K8sVersionFromMajorMinor takes a semver in format MAJOR.MINOR
+// k8sVersionFromMajorMinor takes a semver in format MAJOR.MINOR
 // and returns the version in format MAJOR.MINOR.PATCH with the
 // supported patch version as PATCH.
-func K8sVersionFromMajorMinor(version string) string {
+func k8sVersionFromMajorMinor(version string) string {
 	switch version {
 	case semver.MajorMinor(string(V1_26)):
 		return string(V1_26)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Storing the K8s version as validated type saves a lot of parameter passing and centralizes the validation logic

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- store K8s version as weakly validated type (ignoring patch version) in the config
- ~allow to specify K8s version without patch (e.g. 1.27) as valid config value and resolve the patch version~
- allow to specify a patch version in `config generate` (e.g. 1.27.4)
- add more unit test cases

### Related issue
- [AB#3374](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3374)

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
