### PR TITLE
docs: publish fixes in performance section to 2.10

### DIFF
--- a/docs/versioned_docs/version-2.10/overview/performance/application.md
+++ b/docs/versioned_docs/version-2.10/overview/performance/application.md
@@ -26,7 +26,7 @@ Minimum and maximum mark the range within which latency varies each run.
 The benchmark was configured with 1300 workers and 10 seconds per run.
 Those numbers were chosen empirically.
 The latency was stabilizing at 10 seconds runtime, not changing with further increase.
-Increasing the number of workers beyond 1300 leads to request failures marking the limit Vault was able to handle in our setup.
+Increasing the number of workers beyond 1300 leads to request failures, marking the limit Vault was able to handle in this setup.
 All results are based on 100 runs.
 
 The following data was generated while running five replicas, one primary, and four standby nodes.

--- a/docs/versioned_docs/version-2.10/overview/performance/io.md
+++ b/docs/versioned_docs/version-2.10/overview/performance/io.md
@@ -193,8 +193,12 @@ When comparing Constellation on GCP with GKE, Constellation has similar bandwidt
 
 ## Conclusion
 
-Despite the added [security benefits](../security-benefits.md) that Constellation provides, it only incurs a slight performance overhead when compared to managed Kubernetes offerings such as AKS and GKE. In most compute benchmarks, Constellation is on par, and while it may be slightly slower in certain I/O scenarios due to network and storage encryption, we're confident that we can reduce this overhead to single digits.
+Despite the added [security benefits](../security-benefits.md) that Constellation provides, it only incurs a slight performance overhead when compared to managed Kubernetes offerings such as AKS and GKE. In most compute benchmarks, Constellation is on par with it's alternatives.
+While it may be slightly slower in certain I/O scenarios due to network and storage encryption, there is ongoing work to reduce this overhead to single digits.
 
-For instance, storage encryption only adds between 10% to 15% overhead in terms of bandwidth and IOPS. Meanwhile, the biggest performance impact that Constellation currently faces is network encryption, which can incur up to 58% overhead on a 10 Gbps network. However, the Cilium team has conducted [benchmarks with Cilium using WireGuard encryption](https://docs.cilium.io/en/latest/operations/performance/benchmark/#encryption-wireguard-ipsec) on a 100 Gbps network that yielded over 15 Gbps, and we're confident that we can provide a similar level of performance with Constellation in our upcoming releases.
+For instance, storage encryption only adds between 10% to 15% overhead in terms of bandwidth and IOPS.
+Meanwhile, the biggest performance impact that Constellation currently faces is network encryption, which can incur up to 58% overhead on a 10 Gbps network.
+However, the Cilium team has conducted [benchmarks with Cilium using WireGuard encryption](https://docs.cilium.io/en/latest/operations/performance/benchmark/#encryption-wireguard-ipsec) on a 100 Gbps network that yielded over 15 Gbps.
+We're confident that Constellation will provide a similar level of performance with an upcoming release.
 
 Overall, Constellation strikes a great balance between security and performance, and we're continuously working to improve its performance capabilities while maintaining its high level of security.

--- a/docs/versioned_docs/version-2.10/overview/performance/performance.md
+++ b/docs/versioned_docs/version-2.10/overview/performance/performance.md
@@ -16,8 +16,10 @@ Similarly, AMD and Google have jointly released a [performance benchmark](https:
 
 ## I/O performance benchmarks
 
-We evaluated the [I/O performance](io.md) of Constellation, utilizing a collection of synthetic benchmarks targeting networking and storage. We further compared this performance to native managed Kubernetes offerings from various cloud providers, to better understand how Constellation stands in relation to standard practices.
+We evaluated the [I/O performance](io.md) of Constellation, utilizing a collection of synthetic benchmarks targeting networking and storage.
+We further compared this performance to native managed Kubernetes offerings from various cloud providers, to better understand how Constellation stands in relation to standard practices.
 
-## Real-world application benchmarking
+## Application benchmarking
 
-To gauge Constellation's real-world applicability, we performed a specific benchmarking of [HashiCorp Vault](application.md) running on Constellation. The results were then compared to deployments on the managed Kubernetes offerings from different cloud providers, providing a tangible perspective on Constellation's performance in actual deployment scenarios.
+To gauge Constellation's applicability to well-known applications, we performed a [benchmark of HashiCorp Vault](application.md) running on Constellation.
+The results were then compared to deployments on the managed Kubernetes offerings from different cloud providers, providing a tangible perspective on Constellation's performance in actual deployment scenarios.


### PR DESCRIPTION
some of the fixes made during review of #2271 haven't been applied to 2.10