### PR TITLE
cli: disable smt on AWS via cpu_options

### DIFF
--- a/cli/internal/terraform/terraform/aws/modules/instance_group/main.tf
+++ b/cli/internal/terraform/terraform/aws/modules/instance_group/main.tf
@@ -51,6 +51,14 @@ resource "aws_launch_template" "launch_template" {
     # use "disabled" to disable SEV-SNP (but still require SNP-capable hardware)
     # use null to leave the setting unset (allows non-SNP-capable hardware to be used)
     amd_sev_snp = var.enable_snp ? "enabled" : null
+    # Disable SMT. We are already disabling it inside the image.
+    # Disabling SMT only in the image, not in the Hypervisor creates problems.
+    # Thus, also disable it in the Hypervisor.
+    threads_per_core = 1
+    # When setting threads_per_core we also have to set core_count.
+    # For the currently supported SNP instance families (C6a, M6a, R6a) default_cores
+    # equals the maximum number of available cores.
+    core_count = data.aws_ec2_instance_type.instance_data.default_cores
   }
 
   lifecycle {
@@ -94,4 +102,8 @@ resource "aws_autoscaling_group" "autoscaling_group" {
       desired_capacity,          # required. autoscaling modifies the instance count externally
     ]
   }
+}
+
+data "aws_ec2_instance_type" "instance_data" {
+  instance_type = var.instance_type
 }

--- a/image/mkosi.conf.d/mkosi.conf
+++ b/image/mkosi.conf.d/mkosi.conf
@@ -6,7 +6,7 @@ Release=38
 Format=disk
 ManifestFormat=json,changelog
 Bootable=yes
-KernelCommandLine=mitigations=auto,nosmt preempt=full rd.shell=0 rd.emergency=reboot loglevel=8 console=ttyS0
+KernelCommandLine=mitigations=auto idle=poll preempt=full rd.shell=0 rd.emergency=reboot loglevel=8 console=ttyS0
 SplitArtifacts=yes
 # Enable Secure Boot with own PKI
 SecureBoot=yes


### PR DESCRIPTION
### Context
There are problems with VMs not booting on AWS. AWS told us that this is related to us dynamically disabling SMT inside the image. The recommended way is to disable it via the hypervisor, using `cpu_options`.
There may also be other problems that they are still investigating. 
The changes in this PR will increase our launch success rate in the meanwhile.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Set `threads_per_core` to 1 in AWS launch_templates. Disables SMT through the VMM.
- Remove `nosmt` from kernel cmdline.
- Add `idle=poll` to cmdline. AWS recommendation.

### Additional info
- Best test run _ever_: https://github.com/edgelesssys/constellation/actions/runs/6008714416
- `mitigation=auto idle=poll`: https://github.com/edgelesssys/constellation/actions/runs/6021239936
- Testruns: 1/20 nodes failed. Worst run with `nosmt` I have seen: 6/10 failed.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
