### PR TITLE
ci: fix incorrect signing key for sbom signature and wrong public key in release artifacts

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -225,9 +225,9 @@ jobs:
           grype constellation.spdx.sbom --fail-on high --only-fixed --add-cpes-if-none
         env:
           COSIGN_EXPERIMENTAL: 1
-          COSIGN_PUBLIC_KEY: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
-          COSIGN_PRIVATE_KEY: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PRIVATE_KEY || secrets.COSIGN_DEV_PRIVATE_KEY }}
-          COSIGN_PASSWORD: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PASSWORD || secrets.COSIGN_DEV_PASSWORD }}
+          COSIGN_PUBLIC_KEY: ${{ inputs.key == 'release' && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
+          COSIGN_PRIVATE_KEY: ${{ inputs.key == 'release' && secrets.COSIGN_PRIVATE_KEY || secrets.COSIGN_DEV_PRIVATE_KEY }}
+          COSIGN_PASSWORD: ${{ inputs.key == 'release' && secrets.COSIGN_PASSWORD || secrets.COSIGN_DEV_PASSWORD }}
 
       - name: Upload Constellation CLI SBOM
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
@@ -335,7 +335,7 @@ jobs:
       - name: Write cosign public key
         run: echo "$COSIGN_PUBLIC_KEY" > cosign.pub
         env:
-          COSIGN_PUBLIC_KEY: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
+          COSIGN_PUBLIC_KEY: ${{ inputs.key == 'release' && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
 
       - name: Download CLI binaries darwin-amd64
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Since release `v2.9.0`, our releases incorrectly use our development cosign key to sign the sboms for that release, and also include the public part of that development cosign key in the release.


### Proposed change(s)
Update the `release-cli`  workflow to not rely on branch naming, but on workflow inputs for selecting the correct key.
* This was already done for signing the CLI binaries

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
Other release artifacts (CLI binaries) are not affected, as they were correctly signed using our production key

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
