### PR TITLE
image: move idle and nosmt to aws-only images

### DIFF
--- a/image/mkosi.conf.d/mkosi.aws.conf
+++ b/image/mkosi.conf.d/mkosi.aws.conf
@@ -1,2 +1,5 @@
 [Match]
 PathExists=../.csp/aws
+
+[Output]
+KernelCommandLine=mitigations=auto idle=poll

--- a/image/mkosi.conf.d/mkosi.azure.conf
+++ b/image/mkosi.conf.d/mkosi.azure.conf
@@ -1,2 +1,5 @@
 [Match]
 PathExists=../.csp/azure
+
+[Output]
+KernelCommandLine=mitigations=auto,nosmt

--- a/image/mkosi.conf.d/mkosi.conf
+++ b/image/mkosi.conf.d/mkosi.conf
@@ -6,7 +6,7 @@ Release=38
 Format=disk
 ManifestFormat=json,changelog
 Bootable=yes
-KernelCommandLine=mitigations=auto idle=poll preempt=full rd.shell=0 rd.emergency=reboot loglevel=8 console=ttyS0
+KernelCommandLine=preempt=full rd.shell=0 rd.emergency=reboot loglevel=8 console=ttyS0
 SplitArtifacts=yes
 # Enable Secure Boot with own PKI
 SecureBoot=yes

--- a/image/mkosi.conf.d/mkosi.gcp.conf
+++ b/image/mkosi.conf.d/mkosi.gcp.conf
@@ -1,2 +1,5 @@
 [Match]
 PathExists=../.csp/gcp
+
+[Output]
+KernelCommandLine=mitigations=auto,nosmt

--- a/image/mkosi.conf.d/mkosi.openstack.conf
+++ b/image/mkosi.conf.d/mkosi.openstack.conf
@@ -2,7 +2,7 @@
 PathExists=../.csp/openstack
 
 [Output]
-KernelCommandLine=mem_encrypt=on kvm_amd.sev=1 module_blacklist=qemu_fw_cfg console=tty0 console=ttyS0
+KernelCommandLine=mem_encrypt=on kvm_amd.sev=1 module_blacklist=qemu_fw_cfg console=tty0 console=ttyS0 mitigations=auto,nosmt
 
 [Content]
 Autologin=yes

--- a/image/mkosi.conf.d/mkosi.qemu.conf
+++ b/image/mkosi.conf.d/mkosi.qemu.conf
@@ -4,3 +4,6 @@ PathExists=../.csp/qemu
 [Content]
 Autologin=yes
 Environment=CONSOLE_MOTD=true
+
+[Output]
+KernelCommandLine=mitigations=auto,nosmt


### PR DESCRIPTION
### Context
<!-- Please add background information on why this PR is opened. -->
Amends #2291. We don't want these options on other CSPs. This is temporary until AWS fixed some background issues.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Move `idle=poll mitigations=auto` options to aws-only config


### Additional info
- Pipeline: https://github.com/edgelesssys/constellation/actions/runs/6070948107

