### PR TITLE
ci: add hint about cleaning up lingering resources on failure

### DIFF
--- a/.github/failure_project_template.md
+++ b/.github/failure_project_template.md
@@ -8,3 +8,7 @@
 - [ ] Correlate to existing bug tickets *or*
 - [ ] Add new bug ticket
 - [ ] Update title to contain ticket number and a short description of the issue (AB#123 foo bar)
+
+**If `terminate` failed**:
+
+- [ ] Clean up left over Constellation resources


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
e2e tests may leave behind resources when terminating the cluster fails.
In that case, manual cleanup by a dev is required.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a hint about cleaning up left over resources if terminate failed

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
