### PR TITLE
cli: print ordered measurements list during `verify`

### DIFF
--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -160,6 +160,7 @@ go_test(
         "//internal/versions",
         "//operators/constellation-node-operator/api/v1alpha1",
         "//verify/verifyproto",
+        "@com_github_google_go_tpm_tools//proto/tpm",
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_stretchr_testify//assert",

--- a/internal/attestation/aws/snp/validator.go
+++ b/internal/attestation/aws/snp/validator.go
@@ -80,12 +80,18 @@ func (v *Validator) tpmEnabled(attestation vtpm.AttestationDocument, _ *attest.M
 	if err != nil {
 		return err
 	}
+	if len(imageOutput.Images) == 0 {
+		return fmt.Errorf("aws image %s not found", imageID)
+	}
+	if len(imageOutput.Images) > 1 {
+		return fmt.Errorf("found multiple image references for image ID %s", imageID)
+	}
 
 	if imageOutput.Images[0].TpmSupport == "v2.0" {
 		return nil
 	}
 
-	return fmt.Errorf("iam image %s does not support TPM v2.0", imageID)
+	return fmt.Errorf("aws image %s does not support TPM v2.0", imageID)
 }
 
 func getEC2Client(ctx context.Context, region string) (awsMetadataAPI, error) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
`constellation verify` prints a list of expected and actual measurements for a Constellation cluster.
Currently, the measurements in that list are not ordered.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Print the measurements list ordered
  - Remove redundant nil check in parsing code
  - Fix incorrect error check when parsing PCRs from quote
- Fix a potential panic in the AWS validator code by introducing a slice length check when checking for an image's tpm2 support

### Additional info

- [AB#3411](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/3411)