### PR TITLE
cli: temporarily disable nosmt via VMM 

### DIFF
--- a/cli/internal/terraform/terraform/aws/modules/instance_group/main.tf
+++ b/cli/internal/terraform/terraform/aws/modules/instance_group/main.tf
@@ -54,11 +54,12 @@ resource "aws_launch_template" "launch_template" {
     # Disable SMT. We are already disabling it inside the image.
     # Disabling SMT only in the image, not in the Hypervisor creates problems.
     # Thus, also disable it in the Hypervisor.
-    threads_per_core = 1
+    # TODO (derpsteb): reenable once AWS confirms it's safe to do so.
+    # threads_per_core = 1
     # When setting threads_per_core we also have to set core_count.
     # For the currently supported SNP instance families (C6a, M6a, R6a) default_cores
     # equals the maximum number of available cores.
-    core_count = data.aws_ec2_instance_type.instance_data.default_cores
+    # core_count = data.aws_ec2_instance_type.instance_data.default_cores
   }
 
   lifecycle {


### PR DESCRIPTION

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
AWS asked us to disable these options temporarily until they resolve some internal issues that sometimes prevents these instances from starting.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Disable nosmt via VMM for a while.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
