### PR TITLE
cli: save Helm charts to disk before running upgrades

### DIFF
--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -232,6 +232,10 @@ func (s stubRunner) Apply(_ context.Context) error {
 	return nil
 }
 
+func (s stubRunner) SaveCharts(_ string, _ file.Handler) error {
+	return nil
+}
+
 func TestGetLogs(t *testing.T) {
 	someErr := errors.New("failed")
 

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -422,6 +422,13 @@ func (u *upgradeApplyCmd) handleServiceUpgrade(
 		}
 	}
 
+	// Save the Helm charts for the upgrade to disk
+	chartDir := filepath.Join(upgradeDir, "helm-charts")
+	if err := executor.SaveCharts(chartDir, u.fileHandler); err != nil {
+		return fmt.Errorf("saving Helm charts to disk: %w", err)
+	}
+	u.log.Debugf("Helm charts saved to %s", chartDir)
+
 	if includesUpgrades {
 		u.log.Debugf("Creating backup of CRDs and CRs")
 		crds, err := u.kubeUpgrader.BackupCRDs(cmd.Context(), upgradeDir)

--- a/cli/internal/helm/BUILD.bazel
+++ b/cli/internal/helm/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "action.go",
         "actionfactory.go",
+        "chartutil.go",
         "ciliumhelper.go",
         "helm.go",
         "loader.go",
@@ -429,6 +430,7 @@ go_library(
         "//internal/compatibility",
         "//internal/config",
         "//internal/constants",
+        "//internal/file",
         "//internal/kms/uri",
         "//internal/kubernetes/kubectl",
         "//internal/retry",
@@ -444,6 +446,7 @@ go_library(
         "@sh_helm_helm_v3//pkg/action",
         "@sh_helm_helm_v3//pkg/chart",
         "@sh_helm_helm_v3//pkg/chart/loader",
+        "@sh_helm_helm_v3//pkg/chartutil",
         "@sh_helm_helm_v3//pkg/cli",
         "@sh_helm_helm_v3//pkg/release",
     ],

--- a/cli/internal/helm/chartutil.go
+++ b/cli/internal/helm/chartutil.go
@@ -1,0 +1,86 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package helm
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/edgelesssys/constellation/v2/internal/file"
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/chartutil"
+)
+
+// saveChartToDisk saves a chart as files in a directory.
+//
+// This takes the chart name, and creates a new subdirectory inside of the given dest
+// directory, writing the chart's contents to that subdirectory.
+// Dependencies are written using the same format, instead of writing them as tar files
+//
+// View the SaveDir implementation in chartutil as reference: https://github.com/helm/helm/blob/3a31588ad33fe3b89af5a2a54ee1d25bfe6eaa5e/pkg/chartutil/save.go#L40
+func saveChartToDisk(c *chart.Chart, dest string, fileHandler file.Handler) error {
+	// Create the chart directory
+	outdir := filepath.Join(dest, c.Name())
+	if fi, err := fileHandler.Stat(outdir); err == nil && !fi.IsDir() {
+		return fmt.Errorf("file %s already exists and is not a directory", outdir)
+	}
+	if err := fileHandler.MkdirAll(outdir); err != nil {
+		return err
+	}
+
+	// Save the chart file.
+	if err := chartutil.SaveChartfile(filepath.Join(outdir, chartutil.ChartfileName), c.Metadata); err != nil {
+		return err
+	}
+
+	// Save values.yaml
+	for _, f := range c.Raw {
+		if f.Name == chartutil.ValuesfileName {
+			vf := filepath.Join(outdir, chartutil.ValuesfileName)
+			if err := writeFile(vf, f.Data, fileHandler); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Save values.schema.json if it exists
+	if c.Schema != nil {
+		filename := filepath.Join(outdir, chartutil.SchemafileName)
+		if err := writeFile(filename, c.Schema, fileHandler); err != nil {
+			return err
+		}
+	}
+
+	// Save templates and files
+	for _, o := range [][]*chart.File{c.Templates, c.Files} {
+		for _, f := range o {
+			n := filepath.Join(outdir, f.Name)
+			if err := writeFile(n, f.Data, fileHandler); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Save dependencies
+	base := filepath.Join(outdir, chartutil.ChartsDir)
+	for _, dep := range c.Dependencies() {
+		// Don't write dependencies as tar files
+		// Instead recursively use saveChartToDisk
+		if err := saveChartToDisk(dep, base, fileHandler); err != nil {
+			return fmt.Errorf("saving %s: %w", dep.ChartFullPath(), err)
+		}
+	}
+
+	return nil
+}
+
+func writeFile(name string, content []byte, fileHandler file.Handler) error {
+	if err := fileHandler.MkdirAll(filepath.Dir(name)); err != nil {
+		return err
+	}
+	return fileHandler.Write(name, content)
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
`constellation upgrade apply` upgrades and/or installs chart to the cluster.
What charts are used for this, and how the values look can be rather hard to determine for a user, making potential troubleshooting difficult.
Additionally, the values used to apply these upgrades are not shown or saved anywhere.

### Proposed change(s)
- Save the charts, values and override values used during `constellation upgrade apply` to disk before running said operation
  - Adds a new `SaveCharts` method to the Helm interface
  - Charts are saved to `constellation-upgrade/upgrade-<timestamp>-<uid>`
  - Each action defines a `SaveChart` method that is called by the interface
    - install actions save their charts to `<dir>/helm-install`
    - upgrade actions save their charts to `<dir>/helm-upgrade`
  - override values (values generated by our CLI and are merged with the charts values) are saved as `overrides.yaml` in the chart directory

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- I copied and adjusted the [`SaveDir`](https://pkg.go.dev/helm.sh/helm/v3/pkg/chartutil#SaveDir) function from helm's  `chartutil` package because the original function saved dependencies as tar files instead of writing chart files directly. 
- [AB#3409](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/3409)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs): 
  - See [Azure boards ticket](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/3413)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
