### PR TITLE
ci: use virtee project for sev-snp-measure-go

### DIFF
--- a/.github/workflows/aws-snp-launchmeasurement.yml
+++ b/.github/workflows/aws-snp-launchmeasurement.yml
@@ -52,8 +52,8 @@ jobs:
 
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       with:
-        repository: edgelesssys/sev-snp-measure-go.git
-        ref: main
+        repository: virtee/sev-snp-measure-go.git
+        ref: e42b6f8991ed5a671d5d1e02a6b61f6373f9f8d8
         path: sev-snp-measure-go
 
 


### PR DESCRIPTION
### Context
<!-- Please add background information on why this PR is opened. -->
We have added our sev-snp-measure port to the virtee org. To keep it up to date we should use it.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Switch from our sev-snp-measure-go repo to the virtee one. Pipeline [run](https://github.com/edgelesssys/constellation/actions/runs/6086300397) :green_circle: 
### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
