### PR TITLE
cli: new flag to skip phases of upgrade

### DIFF
--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -164,6 +164,7 @@ go_test(
         "@com_github_spf13_afero//:afero",
         "@com_github_spf13_cobra//:cobra",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//mock",
         "@com_github_stretchr_testify//require",
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:apiextensions",

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
@@ -609,7 +610,7 @@ type skipPhases []skipPhase
 // Contains returns true if the list of phases contains the given phase.
 func (s skipPhases) Contains(phase skipPhase) bool {
 	for _, p := range s {
-		if strings.EqualFold(p, phase) {
+		if strings.EqualFold(string(p), string(phase)) {
 			return true
 		}
 	}

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -38,18 +38,18 @@ import (
 )
 
 const (
-	// SkipInfrastructurePhase skips the terraform apply of the upgrade process.
-	SkipInfrastructurePhase SkipPhase = "infrastructure"
-	// SkipHelmPhase skips the helm upgrade of the upgrade process.
-	SkipHelmPhase SkipPhase = "helm"
-	// SkipNodePhase skips the node upgrade of the upgrade process.
-	SkipNodePhase SkipPhase = "node"
-	// SkipK8sPhase skips the k8s upgrade of the upgrade process.
-	SkipK8sPhase SkipPhase = "k8s"
+	// skipInfrastructurePhase skips the terraform apply of the upgrade process.
+	skipInfrastructurePhase skipPhase = "infrastructure"
+	// skipHelmPhase skips the helm upgrade of the upgrade process.
+	skipHelmPhase skipPhase = "helm"
+	// skipNodePhase skips the node upgrade of the upgrade process.
+	skipNodePhase skipPhase = "node"
+	// skipK8sPhase skips the k8s upgrade of the upgrade process.
+	skipK8sPhase skipPhase = "k8s"
 )
 
-// SkipPhase is a phase of the upgrade process that can be skipped.
-type SkipPhase string
+// skipPhase is a phase of the upgrade process that can be skipped.
+type skipPhase string
 
 func newUpgradeApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -188,7 +188,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 	}
 
 	var tfOutput terraform.ApplyOutput
-	if flags.SkipPhases.Contains(SkipInfrastructurePhase) {
+	if flags.skipPhases.Contains(skipInfrastructurePhase) {
 		tfOutput, err = u.clusterShower.ShowCluster(cmd.Context(), conf.GetProvider())
 		if err != nil {
 			return fmt.Errorf("getting Terraform output: %w", err)
@@ -220,7 +220,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 	}
 
 	var upgradeErr *compatibility.InvalidUpgradeError
-	if !flags.SkipPhases.Contains(SkipHelmPhase) {
+	if !flags.skipPhases.Contains(skipHelmPhase) {
 		err = u.handleServiceUpgrade(cmd, conf, idFile, tfOutput, validK8sVersion, upgradeDir, flags)
 		switch {
 		case errors.As(err, &upgradeErr):
@@ -232,7 +232,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 		}
 	}
 
-	if !flags.SkipPhases.Contains(SkipNodePhase) {
+	if !flags.skipPhases.Contains(skipNodePhase) {
 		err = u.kubeUpgrader.UpgradeNodeVersion(cmd.Context(), conf, flags.force)
 		switch {
 		case errors.Is(err, kubecmd.ErrInProgress):
@@ -547,11 +547,11 @@ func parseUpgradeApplyFlags(cmd *cobra.Command) (upgradeApplyFlags, error) {
 	if err != nil {
 		return upgradeApplyFlags{}, fmt.Errorf("parsing skip-phases flag: %w", err)
 	}
-	skipPhases := []SkipPhase{}
+	skipPhases := []skipPhase{}
 	for _, phase := range rawSkipPhases {
-		switch SkipPhase(phase) {
-		case SkipInfrastructurePhase, SkipHelmPhase, SkipNodePhase, SkipK8sPhase:
-			skipPhases = append(skipPhases, SkipPhase(phase))
+		switch skipPhase(phase) {
+		case skipInfrastructurePhase, skipHelmPhase, skipNodePhase, skipK8sPhase:
+			skipPhases = append(skipPhases, skipPhase(phase))
 		default:
 			return upgradeApplyFlags{}, fmt.Errorf("invalid phase %s", phase)
 		}
@@ -565,7 +565,7 @@ func parseUpgradeApplyFlags(cmd *cobra.Command) (upgradeApplyFlags, error) {
 		terraformLogLevel: logLevel,
 		conformance:       conformance,
 		helmWaitMode:      helmWaitMode,
-		SkipPhases:        skipPhases,
+		skipPhases:        skipPhases,
 	}, nil
 }
 
@@ -600,14 +600,14 @@ type upgradeApplyFlags struct {
 	terraformLogLevel terraform.LogLevel
 	conformance       bool
 	helmWaitMode      helm.WaitMode
-	SkipPhases        SkipPhases
+	skipPhases        skipPhases
 }
 
-// SkipPhases is a list of phases that can be skipped during the upgrade process.
-type SkipPhases []SkipPhase
+// skipPhases is a list of phases that can be skipped during the upgrade process.
+type skipPhases []skipPhase
 
 // Contains returns true if the list of phases contains the given phase.
-func (s SkipPhases) Contains(phase SkipPhase) bool {
+func (s skipPhases) Contains(phase skipPhase) bool {
 	for _, p := range s {
 		if strings.EqualFold(p, phase) {
 			return true

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -609,7 +609,7 @@ type SkipPhases []SkipPhase
 // Contains returns true if the list of phases contains the given phase.
 func (s SkipPhases) Contains(phase SkipPhase) bool {
 	for _, p := range s {
-		if p == phase {
+		if strings.EqualFold(p, phase) {
 			return true
 		}
 	}

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -189,7 +189,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 	}
 
 	var tfOutput terraform.ApplyOutput
-	if flags.skipPhases.Contains(skipInfrastructurePhase) {
+	if flags.skipPhases.contains(skipInfrastructurePhase) {
 		tfOutput, err = u.clusterShower.ShowCluster(cmd.Context(), conf.GetProvider())
 		if err != nil {
 			return fmt.Errorf("getting Terraform output: %w", err)
@@ -221,7 +221,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 	}
 
 	var upgradeErr *compatibility.InvalidUpgradeError
-	if !flags.skipPhases.Contains(skipHelmPhase) {
+	if !flags.skipPhases.contains(skipHelmPhase) {
 		err = u.handleServiceUpgrade(cmd, conf, idFile, tfOutput, validK8sVersion, upgradeDir, flags)
 		switch {
 		case errors.As(err, &upgradeErr):
@@ -233,7 +233,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 		}
 	}
 
-	if !flags.skipPhases.Contains(skipNodePhase) {
+	if !flags.skipPhases.contains(skipNodePhase) {
 		err = u.kubeUpgrader.UpgradeNodeVersion(cmd.Context(), conf, flags.force)
 		switch {
 		case errors.Is(err, kubecmd.ErrInProgress):
@@ -607,8 +607,8 @@ type upgradeApplyFlags struct {
 // skipPhases is a list of phases that can be skipped during the upgrade process.
 type skipPhases []skipPhase
 
-// Contains returns true if the list of phases contains the given phase.
-func (s skipPhases) Contains(phase skipPhase) bool {
+// contains returns true if the list of phases contains the given phase.
+func (s skipPhases) contains(phase skipPhase) bool {
 	for _, p := range s {
 		if strings.EqualFold(string(p), string(phase)) {
 			return true

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -68,7 +68,8 @@ func newUpgradeApplyCmd() *cobra.Command {
 		"Might be useful for slow connections or big clusters.")
 	cmd.Flags().Bool("conformance", false, "enable conformance mode")
 	cmd.Flags().Bool("skip-helm-wait", false, "install helm charts without waiting for deployments to be ready")
-	cmd.Flags().StringSlice("skip-phases", []string{}, "skip one or multiple phases of the upgrade process {infrastructure|helm|node|k8s}\n")
+	cmd.Flags().StringSlice("skip-phases", nil, "comma-separated list of upgrade phases to skip\n"+
+		"one or multiple of { infrastructure | helm | node | k8s }")
 	if err := cmd.Flags().MarkHidden("timeout"); err != nil {
 		panic(err)
 	}

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -549,7 +549,7 @@ func parseUpgradeApplyFlags(cmd *cobra.Command) (upgradeApplyFlags, error) {
 	if err != nil {
 		return upgradeApplyFlags{}, fmt.Errorf("parsing skip-phases flag: %w", err)
 	}
-	skipPhases := []skipPhase{}
+	var skipPhases []skipPhase
 	for _, phase := range rawSkipPhases {
 		switch skipPhase(phase) {
 		case skipInfrastructurePhase, skipHelmPhase, skipNodePhase, skipK8sPhase:

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -111,7 +111,7 @@ func TestUpgradeApply(t *testing.T) {
 			helmUpgrader:      &mockApplier{}, // mocks ensure that no methods are called
 			terraformUpgrader: &mockTerraformUpgrader{},
 			flags: upgradeApplyFlags{
-				SkipPhases: []SkipPhase{SkipInfrastructurePhase, SkipHelmPhase, SkipK8sPhase, SkipNodePhase},
+				skipPhases: []skipPhase{skipInfrastructurePhase, skipHelmPhase, skipK8sPhase, skipNodePhase},
 				yes:        true,
 			},
 		},
@@ -122,7 +122,7 @@ func TestUpgradeApply(t *testing.T) {
 			helmUpgrader:      &mockApplier{}, // mocks ensure that no methods are called
 			terraformUpgrader: &mockTerraformUpgrader{},
 			flags: upgradeApplyFlags{
-				SkipPhases: []SkipPhase{SkipInfrastructurePhase, SkipHelmPhase, SkipK8sPhase},
+				skipPhases: []skipPhase{skipInfrastructurePhase, skipHelmPhase, skipK8sPhase},
 				yes:        true,
 			},
 		},
@@ -159,7 +159,7 @@ func TestUpgradeApply(t *testing.T) {
 				return
 			}
 			assert.NoError(err)
-			assert.Equal(!tc.flags.SkipPhases.Contains(SkipNodePhase), tc.kubeUpgrader.calledNodeUpgrade,
+			assert.Equal(!tc.flags.skipPhases.Contains(skipNodePhase), tc.kubeUpgrader.calledNodeUpgrade,
 				"incorrect node upgrade skipping behavior")
 		})
 	}
@@ -175,7 +175,7 @@ func TestUpgradeApplyFlagsForSkipPhases(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error while parsing flags: %v", err)
 	}
-	assert.ElementsMatch(t, []SkipPhase{SkipInfrastructurePhase, SkipHelmPhase, SkipK8sPhase, SkipNodePhase}, result.SkipPhases)
+	assert.ElementsMatch(t, []skipPhase{skipInfrastructurePhase, skipHelmPhase, skipK8sPhase, skipNodePhase}, result.skipPhases)
 }
 
 type stubKubernetesUpgrader struct {

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
+	"github.com/edgelesssys/constellation/v2/cli/internal/helm"
 	"github.com/edgelesssys/constellation/v2/cli/internal/kubecmd"
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
@@ -22,17 +23,19 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/kms/uri"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
+	"github.com/edgelesssys/constellation/v2/internal/versions"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func TestUpgradeApply(t *testing.T) {
 	testCases := map[string]struct {
-		helmUpgrader      stubApplier
+		helmUpgrader      helmApplier
 		kubeUpgrader      *stubKubernetesUpgrader
-		terraformUpgrader *stubTerraformUpgrader
+		terraformUpgrader clusterUpgrader
 		wantErr           bool
 		flags             upgradeApplyFlags
 		stdin             string
@@ -101,6 +104,28 @@ func TestUpgradeApply(t *testing.T) {
 			wantErr: true,
 			flags:   upgradeApplyFlags{yes: true},
 		},
+		"skip all upgrade phases": {
+			kubeUpgrader: &stubKubernetesUpgrader{
+				currentConfig: config.DefaultForAzureSEVSNP(),
+			},
+			helmUpgrader:      &mockApplier{}, // mocks ensure that no methods are called
+			terraformUpgrader: &mockTerraformUpgrader{},
+			flags: upgradeApplyFlags{
+				SkipPhases: []SkipPhase{SkipInfrastructurePhase, SkipHelmPhase, SkipK8sPhase, SkipNodePhase},
+				yes:        true,
+			},
+		},
+		"skip all phases except node upgrade": {
+			kubeUpgrader: &stubKubernetesUpgrader{
+				currentConfig: config.DefaultForAzureSEVSNP(),
+			},
+			helmUpgrader:      &mockApplier{}, // mocks ensure that no methods are called
+			terraformUpgrader: &mockTerraformUpgrader{},
+			flags: upgradeApplyFlags{
+				SkipPhases: []SkipPhase{SkipInfrastructurePhase, SkipHelmPhase, SkipK8sPhase},
+				yes:        true,
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -134,46 +159,63 @@ func TestUpgradeApply(t *testing.T) {
 				return
 			}
 			assert.NoError(err)
+			assert.Equal(!tc.flags.SkipPhases.Contains(SkipNodePhase), tc.kubeUpgrader.calledNodeUpgrade,
+				"incorrect node upgrade skipping behavior")
 		})
 	}
 }
 
-type stubKubernetesUpgrader struct {
-	nodeVersionErr error
-	currentConfig  config.AttestationCfg
+func TestUpgradeApplyFlagsForSkipPhases(t *testing.T) {
+	cmd := newUpgradeApplyCmd()
+	cmd.Flags().String("workspace", "", "")  // register persistent flag manually
+	cmd.Flags().Bool("force", true, "")      // register persistent flag manually
+	cmd.Flags().String("tf-log", "NONE", "") // register persistent flag manually
+	require.NoError(t, cmd.Flags().Set("skip-phases", "infrastructure,helm,k8s,node"))
+	result, err := parseUpgradeApplyFlags(cmd)
+	if err != nil {
+		t.Fatalf("Error while parsing flags: %v", err)
+	}
+	assert.ElementsMatch(t, []SkipPhase{SkipInfrastructurePhase, SkipHelmPhase, SkipK8sPhase, SkipNodePhase}, result.SkipPhases)
 }
 
-func (u stubKubernetesUpgrader) BackupCRDs(_ context.Context, _ string) ([]apiextensionsv1.CustomResourceDefinition, error) {
+type stubKubernetesUpgrader struct {
+	nodeVersionErr    error
+	currentConfig     config.AttestationCfg
+	calledNodeUpgrade bool
+}
+
+func (u *stubKubernetesUpgrader) BackupCRDs(_ context.Context, _ string) ([]apiextensionsv1.CustomResourceDefinition, error) {
 	return []apiextensionsv1.CustomResourceDefinition{}, nil
 }
 
-func (u stubKubernetesUpgrader) BackupCRs(_ context.Context, _ []apiextensionsv1.CustomResourceDefinition, _ string) error {
+func (u *stubKubernetesUpgrader) BackupCRs(_ context.Context, _ []apiextensionsv1.CustomResourceDefinition, _ string) error {
 	return nil
 }
 
-func (u stubKubernetesUpgrader) UpgradeNodeVersion(_ context.Context, _ *config.Config, _ bool) error {
+func (u *stubKubernetesUpgrader) UpgradeNodeVersion(_ context.Context, _ *config.Config, _ bool) error {
+	u.calledNodeUpgrade = true
 	return u.nodeVersionErr
 }
 
-func (u stubKubernetesUpgrader) ApplyJoinConfig(_ context.Context, _ config.AttestationCfg, _ []byte) error {
+func (u *stubKubernetesUpgrader) ApplyJoinConfig(_ context.Context, _ config.AttestationCfg, _ []byte) error {
 	return nil
 }
 
-func (u stubKubernetesUpgrader) GetClusterAttestationConfig(_ context.Context, _ variant.Variant) (config.AttestationCfg, error) {
+func (u *stubKubernetesUpgrader) GetClusterAttestationConfig(_ context.Context, _ variant.Variant) (config.AttestationCfg, error) {
 	return u.currentConfig, nil
 }
 
-func (u stubKubernetesUpgrader) ExtendClusterConfigCertSANs(_ context.Context, _ []string) error {
+func (u *stubKubernetesUpgrader) ExtendClusterConfigCertSANs(_ context.Context, _ []string) error {
 	return nil
 }
 
 // TODO(v2.11): Remove this function.
-func (u stubKubernetesUpgrader) RemoveAttestationConfigHelmManagement(_ context.Context) error {
+func (u *stubKubernetesUpgrader) RemoveAttestationConfigHelmManagement(_ context.Context) error {
 	return nil
 }
 
 // TODO(v2.12): Remove this function.
-func (u stubKubernetesUpgrader) RemoveHelmKeepAnnotation(_ context.Context) error {
+func (u *stubKubernetesUpgrader) RemoveHelmKeepAnnotation(_ context.Context) error {
 	return nil
 }
 
@@ -189,4 +231,27 @@ func (u stubTerraformUpgrader) PlanClusterUpgrade(_ context.Context, _ io.Writer
 
 func (u stubTerraformUpgrader) ApplyClusterUpgrade(_ context.Context, _ cloudprovider.Provider) (terraform.ApplyOutput, error) {
 	return terraform.ApplyOutput{}, u.applyTerraformErr
+}
+
+type mockTerraformUpgrader struct {
+	mock.Mock
+}
+
+func (m *mockTerraformUpgrader) PlanClusterUpgrade(ctx context.Context, w io.Writer, variables terraform.Variables, provider cloudprovider.Provider) (bool, error) {
+	args := m.Called(ctx, w, variables, provider)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *mockTerraformUpgrader) ApplyClusterUpgrade(ctx context.Context, provider cloudprovider.Provider) (terraform.ApplyOutput, error) {
+	args := m.Called(ctx, provider)
+	return args.Get(0).(terraform.ApplyOutput), args.Error(1)
+}
+
+type mockApplier struct {
+	mock.Mock
+}
+
+func (m *mockApplier) PrepareApply(cfg *config.Config, k8sVersion versions.ValidK8sVersion, clusterID clusterid.File, helmOpts helm.Options, terraformOut terraform.ApplyOutput, str string, masterSecret uri.MasterSecret) (helm.Applier, bool, error) {
+	args := m.Called(cfg, k8sVersion, clusterID, helmOpts, terraformOut, str, masterSecret)
+	return args.Get(0).(helm.Applier), args.Bool(1), args.Error(2)
 }

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -159,7 +159,7 @@ func TestUpgradeApply(t *testing.T) {
 				return
 			}
 			assert.NoError(err)
-			assert.Equal(!tc.flags.skipPhases.Contains(skipNodePhase), tc.kubeUpgrader.calledNodeUpgrade,
+			assert.Equal(!tc.flags.skipPhases.contains(skipNodePhase), tc.kubeUpgrader.calledNodeUpgrade,
 				"incorrect node upgrade skipping behavior")
 		})
 	}

--- a/cli/internal/kubecmd/kubecmd_test.go
+++ b/cli/internal/kubecmd/kubecmd_test.go
@@ -332,7 +332,7 @@ func TestUpgradeNodeVersion(t *testing.T) {
 				outWriter:    io.Discard,
 			}
 
-			err = upgrader.UpgradeNodeVersion(context.Background(), tc.conf, tc.force)
+			err = upgrader.UpgradeNodeVersion(context.Background(), tc.conf, tc.force, false, false)
 			// Check upgrades first because if we checked err first, UpgradeImage may error due to other reasons and still trigger an upgrade.
 			if tc.wantUpdate {
 				assert.NotNil(unstructuredClient.updatedObject)

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -472,12 +472,14 @@ constellation upgrade apply [flags]
 ### Options
 
 ```
-      --conformance      enable conformance mode
-  -h, --help             help for apply
-      --skip-helm-wait   install helm charts without waiting for deployments to be ready
-  -y, --yes              run upgrades without further confirmation
-                         WARNING: might delete your resources in case you are using cert-manager in your cluster. Please read the docs.
-                         WARNING: might unintentionally overwrite measurements in the running cluster.
+      --conformance           enable conformance mode
+  -h, --help                  help for apply
+      --skip-helm-wait        install helm charts without waiting for deployments to be ready
+      --skip-phases strings   skip one or multiple phases of the upgrade process {infrastructure|helm|node|k8s}
+                              
+  -y, --yes                   run upgrades without further confirmation
+                              WARNING: might delete your resources in case you are using cert-manager in your cluster. Please read the docs.
+                              WARNING: might unintentionally overwrite measurements in the running cluster.
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -475,8 +475,8 @@ constellation upgrade apply [flags]
       --conformance           enable conformance mode
   -h, --help                  help for apply
       --skip-helm-wait        install helm charts without waiting for deployments to be ready
-      --skip-phases strings   skip one or multiple phases of the upgrade process {infrastructure|helm|node|k8s}
-                              
+      --skip-phases strings   comma-separated list of upgrade phases to skip
+                              one or multiple of { infrastructure | helm | image | k8s }
   -y, --yes                   run upgrades without further confirmation
                               WARNING: might delete your resources in case you are using cert-manager in your cluster. Please read the docs.
                               WARNING: might unintentionally overwrite measurements in the running cluster.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Currently it is not possible to select / deselect specific upgrades (terraform, helm, k8s, node image).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add a new `--skip-phases` flag that accepts a list of phases to skip during the upgrade

### Related issue
- [AB#3407](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3407)

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
