### PR TITLE
cli: move CSP logic to cloudcmd

### DIFF
--- a/cli/internal/cloudcmd/iamupgrade.go
+++ b/cli/internal/cloudcmd/iamupgrade.go
@@ -19,6 +19,14 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/file"
 )
 
+// UpgradeRequiresIAMMigration returns true if the given cloud provider requires an IAM migration.
+func UpgradeRequiresIAMMigration(provider cloudprovider.Provider) bool {
+	switch provider {
+	default:
+		return false
+	}
+}
+
 // IAMUpgrader handles upgrades to IAM resources required by Constellation.
 type IAMUpgrader struct {
 	tf                tfIAMUpgradeClient

--- a/cli/internal/cmd/iamupgradeapply.go
+++ b/cli/internal/cmd/iamupgradeapply.go
@@ -23,13 +23,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func upgradeRequiresIAMMigration(provider cloudprovider.Provider) bool {
-	switch provider {
-	default:
-		return false
-	}
-}
-
 func newIAMUpgradeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upgrade",

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -136,7 +136,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 	if err != nil {
 		return err
 	}
-	if upgradeRequiresIAMMigration(conf.GetProvider()) {
+	if cloudcmd.UpgradeRequiresIAMMigration(conf.GetProvider()) {
 		cmd.Println("WARNING: This upgrade requires an IAM migration. Please make sure you have applied the IAM migration using `iam upgrade apply` before continuing.")
 		if !flags.yes {
 			yes, err := askToConfirm(cmd, "Did you upgrade the IAM resources?")


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
cli/cloudcmd is our package to bundle CSP-specific code. In our current design all CSP-agnostic code should live in cli/cmd, csp-specific code should be bundled in cli/cloudcmd.

This separates responsibilities. User interaction & input validation <--> csp interaction.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- move remaining CSP code from `init` and `upgradeapply` to `cloudcmd`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Related issue
- [AB#3286](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3286)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
