### PR TITLE
csi: let constructor take care of setting up cryptsetup

### DIFF
--- a/csi/cryptmapper/cryptmapper.go
+++ b/csi/cryptmapper/cryptmapper.go
@@ -40,9 +40,9 @@ type CryptMapper struct {
 
 // New initializes a new CryptMapper with the given kms client and key-encryption-key ID.
 // kms is used to fetch data encryption keys for the dm-crypt volumes.
-func New(kms keyCreator, mapper deviceMapper) *CryptMapper {
+func New(kms keyCreator) *CryptMapper {
 	return &CryptMapper{
-		mapper:        mapper,
+		mapper:        cryptsetup.New(),
 		kms:           kms,
 		getDiskFormat: getDiskFormat,
 	}

--- a/csi/cryptmapper/cryptmapper_test.go
+++ b/csi/cryptmapper/cryptmapper_test.go
@@ -57,7 +57,11 @@ func TestCloseCryptDevice(t *testing.T) {
 		})
 	}
 
-	mapper := New(&fakeKMS{}, &stubCryptDevice{})
+	mapper := &CryptMapper{
+		mapper:        &stubCryptDevice{},
+		kms:           &fakeKMS{},
+		getDiskFormat: getDiskFormat,
+	}
 	err := mapper.CloseCryptDevice("volume01-unit-test")
 	assert.NoError(t, err)
 }
@@ -214,7 +218,11 @@ func TestOpenCryptDevice(t *testing.T) {
 		})
 	}
 
-	mapper := New(&fakeKMS{}, &stubCryptDevice{})
+	mapper := &CryptMapper{
+		mapper:        &stubCryptDevice{},
+		kms:           &fakeKMS{},
+		getDiskFormat: getDiskFormat,
+	}
 	_, err := mapper.OpenCryptDevice(context.Background(), "/dev/some-device", "volume01", false)
 	assert.NoError(t, err)
 }

--- a/csi/test/BUILD.bazel
+++ b/csi/test/BUILD.bazel
@@ -8,14 +8,12 @@ go_test(
     deps = select({
         "@io_bazel_rules_go//go/platform:android": [
             "//csi/cryptmapper",
-            "//internal/cryptsetup",
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
             "@org_uber_go_goleak//:goleak",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//csi/cryptmapper",
-            "//internal/cryptsetup",
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
             "@org_uber_go_goleak//:goleak",

--- a/csi/test/mount_integration_test.go
+++ b/csi/test/mount_integration_test.go
@@ -16,7 +16,6 @@ import (
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/csi/cryptmapper"
-	"github.com/edgelesssys/constellation/v2/internal/cryptsetup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/goleak"
@@ -67,7 +66,7 @@ func TestOpenAndClose(t *testing.T) {
 	setup()
 	defer teardown(devicePath)
 
-	mapper := cryptmapper.New(&fakeKMS{}, cryptsetup.New())
+	mapper := cryptmapper.New(&fakeKMS{})
 
 	newPath, err := mapper.OpenCryptDevice(context.Background(), devicePath, deviceName, false)
 	require.NoError(err)
@@ -107,7 +106,7 @@ func TestOpenAndCloseIntegrity(t *testing.T) {
 	setup()
 	defer teardown(devicePath)
 
-	mapper := cryptmapper.New(&fakeKMS{}, cryptsetup.New())
+	mapper := cryptmapper.New(&fakeKMS{})
 
 	newPath, err := mapper.OpenCryptDevice(context.Background(), devicePath, deviceName, true)
 	require.NoError(err)
@@ -146,7 +145,7 @@ func TestDeviceCloning(t *testing.T) {
 	setup()
 	defer teardown(devicePath)
 
-	mapper := cryptmapper.New(&dynamicKMS{}, cryptsetup.New())
+	mapper := cryptmapper.New(&dynamicKMS{})
 
 	_, err := mapper.OpenCryptDevice(context.Background(), devicePath, deviceName, false)
 	assert.NoError(err)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The common constructor for the `deviceMapper` interface used by the CSI package is defined in our internal package only.
This causes problems for external dependents of the CSI package.
Additionally, there is no good reason to let the caller handle setting up cryptsetup.

### Proposed change(s)
- Let the constructor (`cryptmapper.New()`) handle setting up cryptsetup, instead of expecting an interface which implements the required functionality.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->
