### PR TITLE
cli: check chart versions against target version in users config before upgrading

### DIFF
--- a/cli/internal/helm/BUILD.bazel
+++ b/cli/internal/helm/BUILD.bazel
@@ -455,6 +455,7 @@ go_library(
 go_test(
     name = "helm_test",
     srcs = [
+        "actionfactory_test.go",
         "helm_test.go",
         "loader_test.go",
     ],
@@ -478,6 +479,7 @@ go_test(
         "@com_github_stretchr_testify//mock",
         "@com_github_stretchr_testify//require",
         "@sh_helm_helm_v3//pkg/action",
+        "@sh_helm_helm_v3//pkg/chart",
         "@sh_helm_helm_v3//pkg/chartutil",
         "@sh_helm_helm_v3//pkg/engine",
     ],

--- a/cli/internal/helm/actionfactory.go
+++ b/cli/internal/helm/actionfactory.go
@@ -74,10 +74,12 @@ func (a actionFactory) appendNewAction(release Release, configTargetVersion semv
 	if err != nil {
 		return fmt.Errorf("parsing chart version: %w", err)
 	}
+	cliSupportsConfigVersion := configTargetVersion.Compare(newVersion) != 0
+
 	currentVersion, err := a.versionLister.currentVersion(release.ReleaseName)
 	if errors.Is(err, errReleaseNotFound) {
 		// Don't install a new release if the user's config specifies a different version than the CLI offers.
-		if !force && isCLIVersionedRelease(release.ReleaseName) && configTargetVersion.Compare(newVersion) != 0 {
+		if !force && isCLIVersionedRelease(release.ReleaseName) && cliSupportsConfigVersion {
 			return fmt.Errorf(
 				"unable to install release %s at %s: this CLI only supports microservice version %s for upgrading",
 				release.ReleaseName, configTargetVersion, newVersion,
@@ -104,7 +106,7 @@ func (a actionFactory) appendNewAction(release Release, configTargetVersion semv
 			}
 			// Target version is newer than current version, so we should perform an upgrade.
 			// Now make sure the target version is equal to the the CLI version.
-			if configTargetVersion.Compare(newVersion) != 0 {
+			if cliSupportsConfigVersion {
 				return fmt.Errorf(
 					"unable to upgrade release %s to %s: this CLI only supports microservice version %s for upgrading",
 					release.ReleaseName, configTargetVersion, newVersion,

--- a/cli/internal/helm/actionfactory.go
+++ b/cli/internal/helm/actionfactory.go
@@ -80,9 +80,10 @@ func (a actionFactory) appendNewAction(release Release, configTargetVersion semv
 	if errors.Is(err, errReleaseNotFound) {
 		// Don't install a new release if the user's config specifies a different version than the CLI offers.
 		if !force && isCLIVersionedRelease(release.ReleaseName) && cliSupportsConfigVersion {
-			return fmt.Errorf(
-				"unable to install release %s at %s: this CLI only supports microservice version %s for upgrading",
-				release.ReleaseName, configTargetVersion, newVersion,
+			return compatibility.NewInvalidUpgradeError(
+				currentVersion.String(),
+				configTargetVersion.String(),
+				fmt.Errorf("this CLI only supports installing microservice version %s", newVersion),
 			)
 		}
 
@@ -107,9 +108,10 @@ func (a actionFactory) appendNewAction(release Release, configTargetVersion semv
 			// Target version is newer than current version, so we should perform an upgrade.
 			// Now make sure the target version is equal to the the CLI version.
 			if cliSupportsConfigVersion {
-				return fmt.Errorf(
-					"unable to upgrade release %s to %s: this CLI only supports microservice version %s for upgrading",
-					release.ReleaseName, configTargetVersion, newVersion,
+				return compatibility.NewInvalidUpgradeError(
+					currentVersion.String(),
+					configTargetVersion.String(),
+					fmt.Errorf("this CLI only supports upgrading to microservice version %s", newVersion),
 				)
 			}
 		} else {

--- a/cli/internal/helm/actionfactory_test.go
+++ b/cli/internal/helm/actionfactory_test.go
@@ -178,10 +178,7 @@ func TestAppendNewAction(t *testing.T) {
 			},
 			configTargetVersion: semver.NewFromInt(1, 1, 0, ""),
 			wantErr:             true,
-			assertErr: func(assert *assert.Assertions, err error) {
-				var invalidUpgrade *compatibility.InvalidUpgradeError
-				assert.False(errors.As(err, &invalidUpgrade))
-			},
+			assertErr:           assertUpgradeErr,
 		},
 		"config version matches CLI version on upgrade": {
 			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
@@ -220,6 +217,7 @@ func TestAppendNewAction(t *testing.T) {
 			},
 			configTargetVersion: semver.NewFromInt(1, 0, 0, ""),
 			wantErr:             true,
+			assertErr:           assertUpgradeErr,
 		},
 		"config - CLI version mismatch for new releases can be forced through": {
 			lister: stubLister{err: errReleaseNotFound},

--- a/cli/internal/helm/actionfactory_test.go
+++ b/cli/internal/helm/actionfactory_test.go
@@ -1,0 +1,267 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package helm
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/edgelesssys/constellation/v2/internal/compatibility"
+	"github.com/edgelesssys/constellation/v2/internal/logger"
+	"github.com/edgelesssys/constellation/v2/internal/semver"
+	"github.com/stretchr/testify/assert"
+	"helm.sh/helm/v3/pkg/action"
+	"helm.sh/helm/v3/pkg/chart"
+)
+
+func TestAppendNewAction(t *testing.T) {
+	assertUpgradeErr := func(assert *assert.Assertions, err error) {
+		var invalidUpgrade *compatibility.InvalidUpgradeError
+		assert.True(errors.As(err, &invalidUpgrade))
+	}
+
+	testCases := map[string]struct {
+		lister              stubLister
+		release             Release
+		configTargetVersion semver.Semver
+		force               bool
+		allowDestructive    bool
+		wantErr             bool
+		assertErr           func(*assert.Assertions, error)
+	}{
+		"upgrade release": {
+			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
+			release: Release{
+				ReleaseName: "test",
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.1.0",
+					},
+				},
+			},
+			configTargetVersion: semver.NewFromInt(1, 1, 0, ""),
+		},
+		"upgrade to same version": {
+			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
+			release: Release{
+				ReleaseName: "test",
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.0.0",
+					},
+				},
+			},
+			configTargetVersion: semver.NewFromInt(1, 1, 0, ""),
+			wantErr:             true,
+			assertErr:           assertUpgradeErr,
+		},
+		"upgrade to older version": {
+			lister: stubLister{version: semver.NewFromInt(1, 1, 0, "")},
+			release: Release{
+				ReleaseName: "test",
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.0.0",
+					},
+				},
+			},
+			configTargetVersion: semver.NewFromInt(1, 0, 0, ""),
+			wantErr:             true,
+			assertErr:           assertUpgradeErr,
+		},
+		"upgrade to older version can be forced": {
+			lister: stubLister{version: semver.NewFromInt(1, 1, 0, "")},
+			release: Release{
+				ReleaseName: "test",
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.0.0",
+					},
+				},
+			},
+			configTargetVersion: semver.NewFromInt(1, 0, 0, ""),
+			force:               true,
+		},
+		"non semver in chart metadata": {
+			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
+			release: Release{
+				ReleaseName: "test",
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "some-version",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		"listing release fails": {
+			lister: stubLister{err: assert.AnError},
+			release: Release{
+				ReleaseName: "test",
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.1.0",
+					},
+				},
+			},
+			configTargetVersion: semver.NewFromInt(1, 1, 0, ""),
+			wantErr:             true,
+		},
+		"release not installed": {
+			lister: stubLister{err: errReleaseNotFound},
+			release: Release{
+				ReleaseName: "test",
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.1.0",
+					},
+				},
+			},
+			configTargetVersion: semver.NewFromInt(1, 1, 0, ""),
+		},
+		"destructive release upgrade requires confirmation": {
+			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
+			release: Release{
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.1.0",
+					},
+				},
+				ReleaseName: certManagerInfo.releaseName,
+			},
+			configTargetVersion: semver.NewFromInt(1, 1, 0, ""),
+			wantErr:             true,
+			assertErr: func(assert *assert.Assertions, err error) {
+				assert.ErrorIs(err, ErrConfirmationMissing)
+			},
+		},
+		"destructive release upgrade can be accepted": {
+			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
+			release: Release{
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.1.0",
+					},
+				},
+				ReleaseName: certManagerInfo.releaseName,
+			},
+			configTargetVersion: semver.NewFromInt(1, 1, 0, ""),
+			allowDestructive:    true,
+		},
+		"config version takes precedence over CLI version": {
+			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
+			release: Release{
+				ReleaseName: constellationServicesInfo.releaseName,
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.1.0",
+					},
+				},
+			},
+			configTargetVersion: semver.NewFromInt(1, 0, 0, ""),
+			wantErr:             true,
+			assertErr:           assertUpgradeErr,
+		},
+		"error if CLI version does not match config version on upgrade": {
+			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
+			release: Release{
+				ReleaseName: constellationServicesInfo.releaseName,
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.1.5",
+					},
+				},
+			},
+			configTargetVersion: semver.NewFromInt(1, 1, 0, ""),
+			wantErr:             true,
+			assertErr: func(assert *assert.Assertions, err error) {
+				var invalidUpgrade *compatibility.InvalidUpgradeError
+				assert.False(errors.As(err, &invalidUpgrade))
+			},
+		},
+		"config version matches CLI version on upgrade": {
+			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
+			release: Release{
+				ReleaseName: constellationServicesInfo.releaseName,
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.1.5",
+					},
+				},
+			},
+			configTargetVersion: semver.NewFromInt(1, 1, 5, ""),
+		},
+		"config - CLI version mismatch can be forced through": {
+			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
+			release: Release{
+				ReleaseName: constellationServicesInfo.releaseName,
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.1.5",
+					},
+				},
+			},
+			configTargetVersion: semver.NewFromInt(1, 1, 0, ""),
+			force:               true,
+		},
+		"installing new release requires matching config and CLI version": {
+			lister: stubLister{err: errReleaseNotFound},
+			release: Release{
+				ReleaseName: constellationServicesInfo.releaseName,
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.1.0",
+					},
+				},
+			},
+			configTargetVersion: semver.NewFromInt(1, 0, 0, ""),
+			wantErr:             true,
+		},
+		"config - CLI version mismatch for new releases can be forced through": {
+			lister: stubLister{err: errReleaseNotFound},
+			release: Release{
+				ReleaseName: constellationServicesInfo.releaseName,
+				Chart: &chart.Chart{
+					Metadata: &chart.Metadata{
+						Version: "1.1.0",
+					},
+				},
+			},
+			configTargetVersion: semver.NewFromInt(1, 0, 0, ""),
+			force:               true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			actions := []applyAction{}
+			actionFactory := newActionFactory(nil, tc.lister, &action.Configuration{}, logger.NewTest(t))
+
+			err := actionFactory.appendNewAction(tc.release, tc.configTargetVersion, tc.force, tc.allowDestructive, &actions)
+			if tc.wantErr {
+				assert.Error(err)
+				if tc.assertErr != nil {
+					tc.assertErr(assert, err)
+				}
+				return
+			}
+			assert.NoError(err)
+			assert.Len(actions, 1) // no error == actions gets appended
+		})
+	}
+}
+
+type stubLister struct {
+	err     error
+	version semver.Semver
+}
+
+func (s stubLister) currentVersion(_ string) (semver.Semver, error) {
+	return s.version, s.err
+}

--- a/cli/internal/helm/helm.go
+++ b/cli/internal/helm/helm.go
@@ -73,7 +73,7 @@ func NewClient(kubeConfigPath string, log debugLog) (*Client, error) {
 	}
 	lister := ReleaseVersionClient{actionConfig}
 	cliVersion := constants.BinaryVersion()
-	factory := newActionFactory(kubeClient, lister, actionConfig, cliVersion, log)
+	factory := newActionFactory(kubeClient, lister, actionConfig, log)
 	return &Client{factory, cliVersion, log}, nil
 }
 
@@ -96,7 +96,7 @@ func (h Client) PrepareApply(
 		return nil, false, fmt.Errorf("loading Helm releases: %w", err)
 	}
 	h.log.Debugf("Loaded Helm releases")
-	actions, includesUpgrades, err := h.factory.GetActions(releases, flags.Force, flags.AllowDestructive)
+	actions, includesUpgrades, err := h.factory.GetActions(releases, conf.MicroserviceVersion, flags.Force, flags.AllowDestructive)
 	return &ChartApplyExecutor{actions: actions, log: h.log}, includesUpgrades, err
 }
 

--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -195,17 +195,21 @@ func (i *chartLoader) loadRelease(info chartInfo, helmWaitMode WaitMode) (Releas
 	case certManagerInfo.releaseName:
 		values = i.loadCertManagerValues()
 	case constellationOperatorsInfo.releaseName:
-		updateVersions(chart, i.cliVersion)
 		values = i.loadOperatorsValues()
 	case constellationServicesInfo.releaseName:
-		updateVersions(chart, i.cliVersion)
 		values = i.loadConstellationServicesValues()
 	case awsLBControllerInfo.releaseName:
 		values = i.loadAWSLBControllerValues()
 	case csiInfo.releaseName:
-		updateVersions(chart, i.cliVersion)
 		values = i.loadCSIValues()
 	}
+
+	// Charts we package ourselves have version 0.0.0.
+	// Before use, we need to update the version of the chart to the current CLI version.
+	if isCLIVersionedRelease(info.releaseName) {
+		updateVersions(chart, i.cliVersion)
+	}
+
 	return Release{Chart: chart, Values: values, ReleaseName: info.releaseName, WaitMode: helmWaitMode}, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Our CLI embeds the Helm charts used for the Kubernetes cluster.
For charts we pull in from external providers, the version of these charts is dependent on the version we set for that release.
For charts we package ourselves, the version of the chart is dependent on the version of the CLI binary.
For these charts, on `constellation upgrade apply`, we should only apply an upgrade if the version specifies in the user's config is an upgrade to the version running in their cluster. And only to the version set in the config.
For this the Helm code is currently missing some checks.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Check if config version matches CLI version when installing new charts
- Check if version specified in config is a valid upgrade to the chart running in the Kubernetes cluster
- If a chart is a valid upgrade, check that the version specified in the user's config matches the version of charts embedded in the CLI
- Add unit tests for the `appendNewAction` method

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- From what I can tell, this bug was not present in the v2.10 releases

