### PR TITLE
cli: retry helm apply on any error

### DIFF
--- a/cli/internal/helm/BUILD.bazel
+++ b/cli/internal/helm/BUILD.bazel
@@ -438,7 +438,6 @@ go_library(
         "//internal/versions",
         "@com_github_pkg_errors//:errors",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
-        "@io_k8s_apimachinery//pkg/util/wait",
         "@io_k8s_client_go//kubernetes",
         "@io_k8s_client_go//tools/clientcmd",
         "@io_k8s_client_go//util/retry",
@@ -457,6 +456,7 @@ go_test(
     srcs = [
         "helm_test.go",
         "loader_test.go",
+        "retryaction_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":helm"],

--- a/cli/internal/helm/action.go
+++ b/cli/internal/helm/action.go
@@ -21,7 +21,8 @@ import (
 
 const (
 	// timeout is the maximum time given per helm action.
-	timeout = 10 * time.Minute
+	timeout            = 10 * time.Minute
+	applyRetryInterval = 30 * time.Second
 )
 
 type applyAction interface {
@@ -85,7 +86,7 @@ func (a *installAction) Apply(ctx context.Context) error {
 			return err
 		}
 	}
-	if err := retryApply(ctx, a, a.log); err != nil {
+	if err := retryApply(ctx, a, applyRetryInterval, a.log); err != nil {
 		return err
 	}
 
@@ -142,7 +143,7 @@ func (a *upgradeAction) Apply(ctx context.Context) error {
 			return err
 		}
 	}
-	if err := retryApply(ctx, a, a.log); err != nil {
+	if err := retryApply(ctx, a, applyRetryInterval, a.log); err != nil {
 		return err
 	}
 	if a.postUpgrade != nil {

--- a/cli/internal/helm/retryaction_test.go
+++ b/cli/internal/helm/retryaction_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package helm
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/edgelesssys/constellation/v2/internal/logger"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRetryApply(t *testing.T) {
+	testCases := map[string]struct {
+		applier *stubRetriableApplier
+		wantErr bool
+	}{
+		"success": {
+			applier: &stubRetriableApplier{
+				atomic: true,
+			},
+		},
+		"two errors": {
+			applier: &stubRetriableApplier{
+				applyErrs: []error{
+					assert.AnError,
+					assert.AnError,
+					nil,
+				},
+				atomic: true,
+			},
+		},
+		"retries are aborted after maximumRetryAttempts": {
+			applier: &stubRetriableApplier{
+				applyErrs: []error{
+					assert.AnError,
+					assert.AnError,
+					assert.AnError,
+					assert.AnError,
+				},
+				atomic: true,
+			},
+			wantErr: true,
+		},
+		"non atomic actions are not retried": {
+			applier: &stubRetriableApplier{
+				atomic: false,
+				applyErrs: []error{
+					assert.AnError,
+					assert.AnError,
+					nil,
+				},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			err := retryApply(context.Background(), tc.applier, time.Millisecond, logger.NewTest(t))
+			if tc.wantErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+		})
+	}
+}
+
+type stubRetriableApplier struct {
+	atomic    bool
+	applyErrs []error
+}
+
+func (s *stubRetriableApplier) apply(context.Context) error {
+	if len(s.applyErrs) == 0 {
+		return nil
+	}
+
+	// return the first error in the list
+	// and remove it from the list
+	err := s.applyErrs[0]
+	if len(s.applyErrs) > 1 {
+		s.applyErrs = s.applyErrs[1:]
+	} else {
+		s.applyErrs = nil
+	}
+	return err
+}
+
+func (s *stubRetriableApplier) ReleaseName() string {
+	return ""
+}
+
+func (s *stubRetriableApplier) IsAtomic() bool {
+	return s.atomic
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
We have retry logic for installing/upgrading helm charts.
However, we have a rather restrictive check for what errors are retried in case installing/upgrading fails.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Instead of checking for specific errors to retry, retry on any error
  - If we ever encounter some error cases we definitely don't want to retry, we should just add exceptions for these errors, instead of keeping a list of errors we want to retry.

### Related issue
- [AB#3432](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/3432)

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
