### PR TITLE
cli: remove TF ApplyOutput dependency in CLI

### DIFF
--- a/cli/internal/cloudcmd/clients.go
+++ b/cli/internal/cloudcmd/clients.go
@@ -33,7 +33,7 @@ type tfCommonClient interface {
 
 type tfResourceClient interface {
 	tfCommonClient
-	ApplyCluster(ctx context.Context, provider cloudprovider.Provider, logLevel terraform.LogLevel) (terraform.ApplyOutput, error)
+	ApplyCluster(ctx context.Context, provider cloudprovider.Provider, logLevel terraform.LogLevel) (state.Infrastructure, error)
 	ShowInfrastructure(ctx context.Context, provider cloudprovider.Provider) (state.Infrastructure, error)
 }
 
@@ -56,7 +56,7 @@ type tfIAMUpgradeClient interface {
 
 type tfClusterUpgradeClient interface {
 	tfUpgradePlanner
-	ApplyCluster(ctx context.Context, provider cloudprovider.Provider, logLevel terraform.LogLevel) (terraform.ApplyOutput, error)
+	ApplyCluster(ctx context.Context, provider cloudprovider.Provider, logLevel terraform.LogLevel) (state.Infrastructure, error)
 }
 
 type libvirtRunner interface {

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -45,12 +45,12 @@ type stubTerraformClient struct {
 	showErr                error
 }
 
-func (c *stubTerraformClient) ApplyCluster(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (terraform.ApplyOutput, error) {
-	return terraform.ApplyOutput{
-		IP:     c.ip,
-		Secret: c.initSecret,
-		UID:    c.uid,
-		Azure: &terraform.AzureApplyOutput{
+func (c *stubTerraformClient) ApplyCluster(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (state.Infrastructure, error) {
+	return state.Infrastructure{
+		PublicIP:   c.ip,
+		InitSecret: c.initSecret,
+		UID:        c.uid,
+		Azure: &state.Azure{
 			AttestationURL: c.attestationURL,
 		},
 	}, c.createClusterErr

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -47,9 +47,9 @@ type stubTerraformClient struct {
 
 func (c *stubTerraformClient) ApplyCluster(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (state.Infrastructure, error) {
 	return state.Infrastructure{
-		PublicIP:   c.ip,
-		InitSecret: c.initSecret,
-		UID:        c.uid,
+		ClusterEndpoint: c.ip,
+		InitSecret:      c.initSecret,
+		UID:             c.uid,
 		Azure: &state.Azure{
 			AttestationURL: c.attestationURL,
 		},

--- a/cli/internal/cloudcmd/clusterupgrade_test.go
+++ b/cli/internal/cloudcmd/clusterupgrade_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
@@ -194,8 +195,8 @@ func (t *tfClusterUpgradeStub) ShowPlan(_ context.Context, _ terraform.LogLevel,
 	return t.showErr
 }
 
-func (t *tfClusterUpgradeStub) ApplyCluster(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (terraform.ApplyOutput, error) {
-	return terraform.ApplyOutput{}, t.applyErr
+func (t *tfClusterUpgradeStub) ApplyCluster(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (state.Infrastructure, error) {
+	return state.Infrastructure{}, t.applyErr
 }
 
 func (t *tfClusterUpgradeStub) PrepareUpgradeWorkspace(_, _ string, _ terraform.Variables) error {

--- a/cli/internal/cloudcmd/create.go
+++ b/cli/internal/cloudcmd/create.go
@@ -190,7 +190,6 @@ func normalizeAzureURIs(vars *terraform.AzureClusterVariables) *terraform.AzureC
 }
 
 func (c *Creator) createOpenStack(ctx context.Context, cl tfResourceClient, opts CreateOptions) (infraState state.Infrastructure, retErr error) {
-	// TODO(malt3): Remove this once OpenStack is supported.
 	if os.Getenv("CONSTELLATION_OPENSTACK_DEV") != "1" {
 		return state.Infrastructure{}, errors.New("Constellation must be fine-tuned to your OpenStack deployment. Please create an issue or contact Edgeless Systems at https://edgeless.systems/contact/")
 	}

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -590,7 +590,7 @@ func parseUpgradeApplyFlags(cmd *cobra.Command) (upgradeApplyFlags, error) {
 func updateClusterIDFile(infraState state.Infrastructure, fileHandler file.Handler) error {
 	newIDFile := clusterid.File{
 		InitSecret:        []byte(infraState.InitSecret),
-		IP:                infraState.PublicIP,
+		IP:                infraState.ClusterEndpoint,
 		APIServerCertSANs: infraState.APIServerCertSANs,
 		UID:               infraState.UID,
 	}

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -318,15 +318,14 @@ func (u *upgradeApplyCmd) migrateTerraform(cmd *cobra.Command, conf *config.Conf
 			}
 		}
 		u.log.Debugf("Applying Terraform migrations")
-		tfOutput, err := u.clusterUpgrader.ApplyClusterUpgrade(cmd.Context(), conf.GetProvider())
-		res = terraform.ConvertToInfrastructure(tfOutput)
+		infraState, err := u.clusterUpgrader.ApplyClusterUpgrade(cmd.Context(), conf.GetProvider())
 		if err != nil {
-			return res, fmt.Errorf("applying terraform migrations: %w", err)
+			return infraState, fmt.Errorf("applying terraform migrations: %w", err)
 		}
 
 		// Apply possible updates to cluster ID file
-		if err := updateClusterIDFile(tfOutput, u.fileHandler); err != nil {
-			return res, fmt.Errorf("merging cluster ID files: %w", err)
+		if err := updateClusterIDFile(infraState, u.fileHandler); err != nil {
+			return infraState, fmt.Errorf("merging cluster ID files: %w", err)
 		}
 
 		cmd.Printf("Terraform migrations applied successfully and output written to: %s\n"+
@@ -588,15 +587,15 @@ func parseUpgradeApplyFlags(cmd *cobra.Command) (upgradeApplyFlags, error) {
 	}, nil
 }
 
-func updateClusterIDFile(tfOutput terraform.ApplyOutput, fileHandler file.Handler) error {
+func updateClusterIDFile(infraState state.Infrastructure, fileHandler file.Handler) error {
 	newIDFile := clusterid.File{
-		InitSecret:        []byte(tfOutput.Secret),
-		IP:                tfOutput.IP,
-		APIServerCertSANs: tfOutput.APIServerCertSANs,
-		UID:               tfOutput.UID,
+		InitSecret:        []byte(infraState.InitSecret),
+		IP:                infraState.PublicIP,
+		APIServerCertSANs: infraState.APIServerCertSANs,
+		UID:               infraState.UID,
 	}
-	if tfOutput.Azure != nil {
-		newIDFile.AttestationURL = tfOutput.Azure.AttestationURL
+	if infraState.Azure != nil {
+		newIDFile.AttestationURL = infraState.Azure.AttestationURL
 	}
 
 	idFile := &clusterid.File{}
@@ -650,6 +649,6 @@ type kubernetesUpgrader interface {
 
 type clusterUpgrader interface {
 	PlanClusterUpgrade(ctx context.Context, outWriter io.Writer, vars terraform.Variables, csp cloudprovider.Provider) (bool, error)
-	ApplyClusterUpgrade(ctx context.Context, csp cloudprovider.Provider) (terraform.ApplyOutput, error)
+	ApplyClusterUpgrade(ctx context.Context, csp cloudprovider.Provider) (state.Infrastructure, error)
 	RestoreClusterWorkspace() error
 }

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -277,8 +277,8 @@ func (u stubTerraformUpgrader) PlanClusterUpgrade(_ context.Context, _ io.Writer
 	return u.terraformDiff, u.planTerraformErr
 }
 
-func (u stubTerraformUpgrader) ApplyClusterUpgrade(_ context.Context, _ cloudprovider.Provider) (terraform.ApplyOutput, error) {
-	return terraform.ApplyOutput{}, u.applyTerraformErr
+func (u stubTerraformUpgrader) ApplyClusterUpgrade(_ context.Context, _ cloudprovider.Provider) (state.Infrastructure, error) {
+	return state.Infrastructure{}, u.applyTerraformErr
 }
 
 func (u stubTerraformUpgrader) RestoreClusterWorkspace() error {
@@ -294,9 +294,9 @@ func (m *mockTerraformUpgrader) PlanClusterUpgrade(ctx context.Context, w io.Wri
 	return args.Bool(0), args.Error(1)
 }
 
-func (m *mockTerraformUpgrader) ApplyClusterUpgrade(ctx context.Context, provider cloudprovider.Provider) (terraform.ApplyOutput, error) {
+func (m *mockTerraformUpgrader) ApplyClusterUpgrade(ctx context.Context, provider cloudprovider.Provider) (state.Infrastructure, error) {
 	args := m.Called(ctx, provider)
-	return args.Get(0).(terraform.ApplyOutput), args.Error(1)
+	return args.Get(0).(state.Infrastructure), args.Error(1)
 }
 
 func (m *mockTerraformUpgrader) RestoreClusterWorkspace() error {

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -449,18 +449,18 @@ func TestCreateCluster(t *testing.T) {
 
 			path := path.Join(tc.pathBase, strings.ToLower(tc.provider.String()))
 			require.NoError(c.PrepareWorkspace(path, tc.vars))
-			tfOutput, err := c.ApplyCluster(context.Background(), tc.provider, LogLevelDebug)
+			infraState, err := c.ApplyCluster(context.Background(), tc.provider, LogLevelDebug)
 
 			if tc.wantErr {
 				assert.Error(err)
 				return
 			}
 			assert.NoError(err)
-			assert.Equal("192.0.2.100", tfOutput.IP)
-			assert.Equal("initSecret", tfOutput.Secret)
-			assert.Equal("12345abc", tfOutput.UID)
+			assert.Equal("192.0.2.100", infraState.PublicIP)
+			assert.Equal("initSecret", infraState.InitSecret)
+			assert.Equal("12345abc", infraState.UID)
 			if tc.provider == cloudprovider.Azure {
-				assert.Equal(tc.expectedAttestationURL, tfOutput.Azure.AttestationURL)
+				assert.Equal(tc.expectedAttestationURL, infraState.Azure.AttestationURL)
 			}
 		})
 	}

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -456,7 +456,7 @@ func TestCreateCluster(t *testing.T) {
 				return
 			}
 			assert.NoError(err)
-			assert.Equal("192.0.2.100", infraState.PublicIP)
+			assert.Equal("192.0.2.100", infraState.ClusterEndpoint)
 			assert.Equal("initSecret", infraState.InitSecret)
 			assert.Equal("12345abc", infraState.UID)
 			if tc.provider == cloudprovider.Azure {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
This is part of the effort to support self-managed infrastructure and decouple from Terraform state.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- removes the dependency on Terraform apply output throughout the CLI. Instead the new infrastructure state is used (#2281).

### Related issue
- [AB#3430](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3430)

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [x] Link to Milestone
