### PR TITLE
node-operator: fix data race in executor

### DIFF
--- a/operators/constellation-node-operator/internal/executor/executor.go
+++ b/operators/constellation-node-operator/internal/executor/executor.go
@@ -126,9 +126,6 @@ func (e *taskExecutor) Start(ctx context.Context) StopWaitFn {
 
 	// executor routine is responsible for executing the reconciliation
 	go func() {
-		defer func() {
-			e.running.Store(false)
-		}()
 		defer wg.Done()
 		defer close(nextScheduledReconcile)
 		defer logr.Info("Executor stopped")

--- a/operators/constellation-node-operator/internal/executor/executor.go
+++ b/operators/constellation-node-operator/internal/executor/executor.go
@@ -106,6 +106,9 @@ func (e *taskExecutor) Start(ctx context.Context) StopWaitFn {
 	// timer routine is responsible for triggering the reconciliation after the timer expires
 	// or when triggered externally
 	go func() {
+		defer func() {
+			e.running.Store(false)
+		}()
 		defer wg.Done()
 		defer close(execute)
 		defer logr.Info("Timer stopped")


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
A data race was found during unit tests in the CI pipeline:
```
188WARNING: DATA RACE
189Read at 0x00c0004fdd70 by goroutine 156:
190 github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/internal/executor.(*Executor).Trigger()
191 operators/constellation-node-operator/internal/executor/executor.go:178 +0x44
192 github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/internal/executor.(*Executor).Trigger-fm()
193 <autogenerated>:1 +0x1d
194 github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/sgreconciler.glob..func1.2.1()
195 operators/constellation-node-operator/sgreconciler/scalinggroup_controller_env_test.go:57 +0x234
196 github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
197 external/com_github_onsi_ginkgo_v2/internal/node.go:463 +0x30
198 github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
199 external/com_github_onsi_ginkgo_v2/internal/suite.go:865 +0x114
200
201Previous write at 0x00c0004fdd70 by goroutine 153:
202 github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/internal/executor.(*Executor).Start()
203 operators/constellation-node-operator/internal/executor/executor.go:87 +0x1bc
204 github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/sgreconciler.glob..func2.1()
205 operators/constellation-node-operator/sgreconciler/suite_test.go:95 +0x6c
206
207Goroutine 156 (running) created at:
208 github.com/onsi/ginkgo/v2/internal.(*Suite).runNode()
209 external/com_github_onsi_ginkgo_v2/internal/suite.go:852 +0x1359
210 github.com/onsi/ginkgo/v2/internal.(*group).attemptSpec()
211 external/com_github_onsi_ginkgo_v2/internal/group.go:199 +0x1144
212 github.com/onsi/ginkgo/v2/internal.(*group).run()
213 external/com_github_onsi_ginkgo_v2/internal/group.go:346 +0x1147
214 2023-09-05T12:40:43Z INFO reconciling external scaling groups
215 github.com/onsi/ginkgo/v2/internal.(*Suite).runSpecs()
216 external/com_github_onsi_ginkgo_v2/internal/suite.go:465 +0x10ee
217 github.com/onsi/ginkgo/v2/internal.(*Suite).Run()
218 external/com_github_onsi_ginkgo_v2/internal/suite.go:116 +0x615
219 github.com/onsi/ginkgo/v2.RunSpecs()
220 external/com_github_onsi_ginkgo_v2/core_dsl.go:319 +0x1724
221 github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/sgreconciler.TestAPIs()
222
223(12:40:46) INFO: From Testing //operators/constellation-node-operator/sgreconciler:sgreconciler_test:
224(12:40:46) [6,022 / 7,767] 26 / 128 tests, 1 failed; 7 actions, 6 running; last test: .../sgreconciler:sgreconciler_test
225 Testing //operators/constellation-node-operator/sgreconciler:sgreconciler_test; 13s remote-cache, processwrapper-sandbox
226 GoLink .../measurement-generator/measurement-generator_test_/measurement-generator_test; 13s remote-cache, processwrapper-sandbox
227 GoLink measurement-reader/internal/sorted/sorted_test_/sorted_test; 9s remote-cache, processwrapper-sandbox
228 GoCompilePkg external/com_github_go_playground_validator_v10/validator.a; Downloading external/com_github_go_playgrou...; 0s remote-cache
229 operators/constellation-node-operator/sgreconciler/suite_test.go:52 +0x245
230 testing.tRunner()
231 GOROOT/src/testing/testing.go:1576 +0x216
232 testing.(*T).Run.func1()
233 GOROOT/src/testing/testing.go:1629 +0x47
234
235Goroutine 153 (finished) created at:
236 github.com/edgelesssys/constellation/v2/operators/constellation-node-operator/v2/sgreconciler.glob..func2()
237 operators/constellation-node-operator/sgreconciler/suite_test.go:93 +0xf44
238 github.com/onsi/ginkgo/v2/internal.extractBodyFunction.func3()
239 external/com_github_onsi_ginkgo_v2/internal/node.go:463 +0x30
240 github.com/onsi/ginkgo/v2/internal.(*Suite).runNode.func3()
241 external/com_github_onsi_ginkgo_v2/internal/suite.go:865 +0x114

```
https://github.com/edgelesssys/constellation/actions/runs/6084678042/job/16507108767?pr=2287#step:7:189

Concurrent access of channels is safe, but the initialization of the channel itself is not 
(see ref to `operators/constellation-node-operator/internal/executor/executor.go:87 +0x1bc`).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- move the channel initialization to the constructor 
- enforce usage of the constructor for correct initialization

<!-- (uncomment if applicable)
### Related issue
- [AB#3414](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3414)

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [x] Link to Milestone
