### PR TITLE
api: rename references to moved hack/configapi

### DIFF
--- a/.github/actions/e2e_verify/action.yml
+++ b/.github/actions/e2e_verify/action.yml
@@ -97,5 +97,5 @@ runs:
         for file in $(ls maa-claims-*.json); do
           path=$(realpath "${file}")
           cat "${path}"
-          bazel run //hack/configapi -- --maa-claims-path "${path}"
+          bazel run //internal/api/attestationconfigapi -- --maa-claims-path "${path}"
         done

--- a/internal/api/attestationconfigapi/cli/main.go
+++ b/internal/api/attestationconfigapi/cli/main.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 /*
 This package provides a CLI to interact with the Attestationconfig API, a sub API of the Resource API.
 
-You can execute an e2e test by running: `bazel run //hack/configapi:configapi_e2e_test`.
+You can execute an e2e test by running: `bazel run //internal/api/attestationconfigapi:configapi_e2e_test`.
 The CLI is used in the CI pipeline. Actions that change the bucket's data shouldn't be executed manually.
 Notice that there is no synchronization on API operations.
 */


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Package was renamed in #2293.
Fixes 376bc6d39fd3bbb72d962f5ebe56158f9d493638.


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Renamed remaining occurrences of `hack/configapi`.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [failing e2e test](https://github.com/edgelesssys/constellation/actions/runs/6128529557/job/16635682883)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
