### PR TITLE
cli: refactor to separate K8s and image upgrade

### DIFF
--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -180,6 +180,7 @@ func TestUpgradeApplyFlagsForSkipPhases(t *testing.T) {
 
 type stubKubernetesUpgrader struct {
 	nodeVersionErr    error
+	k8sErr            error
 	currentConfig     config.AttestationCfg
 	calledNodeUpgrade bool
 }
@@ -192,9 +193,13 @@ func (u *stubKubernetesUpgrader) BackupCRs(_ context.Context, _ []apiextensionsv
 	return nil
 }
 
-func (u *stubKubernetesUpgrader) UpgradeNodeVersion(_ context.Context, _ *config.Config, _, _, _ bool) error {
+func (u *stubKubernetesUpgrader) UpgradeImageVersion(_ context.Context, _ *config.Config, _ bool) error {
 	u.calledNodeUpgrade = true
 	return u.nodeVersionErr
+}
+
+func (u *stubKubernetesUpgrader) UpgradeK8sVersion(_ context.Context, _ versions.ValidK8sVersion, _ bool) error {
+	return u.k8sErr
 }
 
 func (u *stubKubernetesUpgrader) ApplyJoinConfig(_ context.Context, _ config.AttestationCfg, _ []byte) error {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The new skip flag of #2310 allows to separately disable k8s and image upgrades.
This PR cleans up the code to reflect this separation of responsibilities.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- replace `UpgradeNodeVersion` with `UpgradeK8sVersion` and `UpgradeImageVersion`
- this change effectively implies 2 separate updates of the NodeVersion CRD instead of one unified request as done before
- the change allows to trigger a node image upgrade during a K8s upgrade. The reverse is still not possible however.

### Related issue
- [AB#3434](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3434)

### Additional info
K8s upgrade
https://github.com/edgelesssys/constellation/actions/runs/6158829291/job/16712399691

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
