### PR TITLE
ci: install helm when deploying log collection

### DIFF
--- a/.github/actions/deploy_logcollection/action.yml
+++ b/.github/actions/deploy_logcollection/action.yml
@@ -48,6 +48,13 @@ runs:
          --fields github.e2e-test-provider="${{ inputs.provider }}" \
          --fields deployment-type="k8s"
 
+    # Make sure that helm is installed
+    # This is not always the case, e.g. on MacOS runners
+    - name: Install Helm
+      uses: azure/setup-helm@v1
+      with:
+        version: latest
+
     - name: Deploy Logstash
       id: deploy-logstash
       shell: bash


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Helm is not installed per default on macos runners, see: https://github.com/actions/runner-images/blob/main/images/macos/macos-12-Readme.md

fixes: https://github.com/edgelesssys/constellation/commit/60bf770e62bc989133f58edaaf2705f7db43ad88
GHA run: https://github.com/edgelesssys/constellation/actions/runs/6144612499/job/16684592795 and https://github.com/edgelesssys/constellation/actions/runs/6144612499/job/16684593051

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
