### PR TITLE
ci: don't pull from detached head

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -41,20 +41,11 @@ jobs:
           echo "RELEASE_BRANCH=${RELEASE_BRANCH}" | tee -a "$GITHUB_ENV"
           echo "WORKING_BRANCH=${WORKING_BRANCH}" | tee -a "$GITHUB_ENV"
 
-      - name: Check if we are strictly ahead of the release branch (if it exists)
+      - name: Create or update release branch
         run: |
           git fetch
-          git pull
-          git checkout "${RELEASE_BRANCH}" || exit 0
-          git checkout "${WORKING_BRANCH}"
-          ahead=$(git rev-list HEAD --not "${RELEASE_BRANCH}"  | wc -l)
-          if [[ "${ahead}" -gt 0 ]]; then
-            echo "The current branch is not strictly ahead of the release branch. Cannot finish transaction without touching release branch history."
-            exit 1
-          fi
-
-      - name: Create or update release branch
-        run: git push origin "${WORKING_BRANCH}":"${RELEASE_BRANCH}"
+          git checkout "${WORKING_BRANCH}" # ensure branch exists locally
+          git push origin "${WORKING_BRANCH}":"${RELEASE_BRANCH}"
 
   update:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- The `complete-release-branch-transaction` step failed since it was not able to pull from a detached head state

Merged with the step after that since we don't force push anyway so there is no need to check.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
