### PR TITLE
ci: remove verify test for macos during release

### DIFF
--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -154,10 +154,12 @@ jobs:
           #
           # Tests on macOS runner
           #
-          - test: "verify"
-            provider: "azure"
-            kubernetes-version: "v1.28"
-            runner: "macos-12"
+          # Skipping verify test on MacOS since the runner uses a different version of sed
+          # TODO(3u13r): Update verify test to work on MacOS runners
+          # - test: "verify"
+          #  provider: "azure"
+          #  kubernetes-version: "v1.28"
+          #  runner: "macos-12"
           - test: "recover"
             provider: "gcp"
             kubernetes-version: "v1.28"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- macos runners use a different `sed` therefore the verify test breaks currently on macos: https://github.com/edgelesssys/constellation/actions/runs/6184742123/job/16788978904

Since we only need one test for macos anyway, removing the verify test for now. Still, we should fix the test for macos at some point.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
