### PR TITLE
cli: temporarily increase AWS ASG creation timeout

### DIFF
--- a/cli/internal/terraform/terraform/aws/modules/instance_group/main.tf
+++ b/cli/internal/terraform/terraform/aws/modules/instance_group/main.tf
@@ -84,6 +84,11 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   vpc_zone_identifier = [var.subnetwork]
   target_group_arns   = var.target_group_arns
 
+  # TODO(msanft): Remove this (to have the 10m default) once AWS SEV-SNP boot problems are resolved.
+  # Set a higher timeout for the ASG to fulfill the desired healthy capcity. Temporary workaround to
+  # long boot times on SEV-SNP machines on AWS.
+  wait_for_capacity_timeout = "20m"
+
   dynamic "tag" {
     for_each = var.tags
     content {

--- a/cli/internal/terraform/terraform/aws/modules/instance_group/main.tf
+++ b/cli/internal/terraform/terraform/aws/modules/instance_group/main.tf
@@ -87,7 +87,7 @@ resource "aws_autoscaling_group" "autoscaling_group" {
   # TODO(msanft): Remove this (to have the 10m default) once AWS SEV-SNP boot problems are resolved.
   # Set a higher timeout for the ASG to fulfill the desired healthy capcity. Temporary workaround to
   # long boot times on SEV-SNP machines on AWS.
-  wait_for_capacity_timeout = "20m"
+  wait_for_capacity_timeout = var.enable_snp ? "20m" : "10m"
 
   dynamic "tag" {
     for_each = var.tags


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We still have boot problems on AWS SEV-SNP-enabled machines. The problem is already forwarded and AWS is working on it, but in the meantime, we want to reduce CI failures caused by this. These failures are tracked in [AB#3299](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/3299/) and [AB#3412](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/3412).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Temporarily increase the timeout for ASG availability on SEV-SNP-enabled machines. This should allow the VMM to restart machines that fail to boot.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- E2E test runs:
  1. https://github.com/edgelesssys/constellation/actions/runs/6198924762
  2. https://github.com/edgelesssys/constellation/actions/runs/6198922072
  3. https://github.com/edgelesssys/constellation/actions/runs/6198918897


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
