### PR TITLE
bazel: mount AWS credentials file into Bazel container

### DIFF
--- a/bazel/container/container.sh
+++ b/bazel/container/container.sh
@@ -48,6 +48,7 @@ EOF
     -v "${HOME}/.cache/shared_bazel_repository_cache":"${HOME}/.cache/shared_bazel_repository_cache" \
     -v "${HOME}/.cache/shared_bazel_action_cache":"${HOME}/.cache/shared_bazel_action_cache" \
     -v "${HOME}/.docker/config.json":"/home/builder/.docker/config.json" \
+    -v "${HOME}/.aws":"/home/builder/.aws" \
     -v "/tmp/bazel-container/.bazelrc":"/etc/bazel.bazelrc" \
     --entrypoint=/bin/sleep \
     "${containerImage}" \


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Some internal CLI tools, like the `versionsapi` client, utilize the AWS API. For some operations, it thus is necessary to have AWS credentials available in the Bazel environment. Our Bazel container didn't have the AWS credentials available previously.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Mount the AWS credential / config directory into the Bazel container.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
