### PR TITLE
debugd: send requests over lb

### DIFF
--- a/debugd/internal/debugd/metadata/cloudprovider/cloudprovider.go
+++ b/debugd/internal/debugd/metadata/cloudprovider/cloudprovider.go
@@ -88,8 +88,8 @@ func (f *Fetcher) DiscoverDebugdIPs(ctx context.Context) ([]string, error) {
 	return ips, nil
 }
 
-// DiscoverLoadbalancerIP gets load balancer IP from metadata API.
-func (f *Fetcher) DiscoverLoadbalancerIP(ctx context.Context) (string, error) {
+// DiscoverLoadBalancerIP gets load balancer IP from metadata API.
+func (f *Fetcher) DiscoverLoadBalancerIP(ctx context.Context) (string, error) {
 	lbHost, _, err := f.metaAPI.GetLoadBalancerEndpoint(ctx)
 	if err != nil {
 		return "", fmt.Errorf("retrieving load balancer endpoint: %w", err)

--- a/debugd/internal/debugd/metadata/cloudprovider/cloudprovider_test.go
+++ b/debugd/internal/debugd/metadata/cloudprovider/cloudprovider_test.go
@@ -121,7 +121,7 @@ func TestDiscoverDebugIPs(t *testing.T) {
 	}
 }
 
-func TestDiscoverLoadbalancerIP(t *testing.T) {
+func TestDiscoverLoadBalancerIP(t *testing.T) {
 	ip := "192.0.2.1"
 	someErr := errors.New("failed")
 
@@ -148,7 +148,7 @@ func TestDiscoverLoadbalancerIP(t *testing.T) {
 				metaAPI: tc.metaAPI,
 			}
 
-			ip, err := fetcher.DiscoverLoadbalancerIP(context.Background())
+			ip, err := fetcher.DiscoverLoadBalancerIP(context.Background())
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/debugd/internal/debugd/server/server.go
+++ b/debugd/internal/debugd/server/server.go
@@ -133,9 +133,6 @@ func (s *debugdServer) UploadFiles(stream pb.Debugd_UploadFilesServer) error {
 // DownloadFiles streams the previously received files to other instances.
 func (s *debugdServer) DownloadFiles(_ *pb.DownloadFilesRequest, stream pb.Debugd_DownloadFilesServer) error {
 	s.log.Infof("Sending files to other instance")
-	if !s.transfer.CanSend() {
-		return errors.New("cannot send files at this time")
-	}
 	return s.transfer.SendFiles(stream)
 }
 
@@ -185,5 +182,4 @@ type fileTransferer interface {
 	RecvFiles(stream filetransfer.RecvFilesStream) error
 	SendFiles(stream filetransfer.SendFilesStream) error
 	GetFiles() []filetransfer.FileStat
-	CanSend() bool
 }

--- a/debugd/internal/debugd/server/server_test.go
+++ b/debugd/internal/debugd/server/server_test.go
@@ -228,10 +228,6 @@ func TestDownloadFiles(t *testing.T) {
 			canSend:           true,
 			wantSendFileCalls: 1,
 		},
-		"transfer is not ready for sending": {
-			request:     &pb.DownloadFilesRequest{},
-			wantRecvErr: true,
-		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove unnecessary `CanSend()` function, as `receiveFinished` is already checked during `transfer.SendFiles()`
- Adds loadbalancer IP to the ips to try to get the bootstrapper from

The second change is necessary as in the future, all nodes in the cluster are not allowed to send out unencrypted traffic to the node CIDR. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
