### PR TITLE
join: join over lb if available

### DIFF
--- a/bootstrapper/cmd/bootstrapper/run.go
+++ b/bootstrapper/cmd/bootstrapper/run.go
@@ -99,5 +99,4 @@ type clusterInitJoiner interface {
 type metadataAPI interface {
 	joinclient.MetadataAPI
 	initserver.MetadataAPI
-	GetLoadBalancerEndpoint(ctx context.Context) (host, port string, err error)
 }

--- a/bootstrapper/internal/joinclient/joinclient.go
+++ b/bootstrapper/internal/joinclient/joinclient.go
@@ -188,8 +188,14 @@ func (c *JoinClient) Stop() {
 func (c *JoinClient) tryJoinWithAvailableServices() error {
 	ips, err := c.getControlPlaneIPs()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get control plane IPs: %w", err)
 	}
+
+	ip, _, err := c.metadataAPI.GetLoadBalancerEndpoint(context.TODO())
+	if err != nil {
+		return fmt.Errorf("failed to get load balancer endpoint: %w", err)
+	}
+	ips = append(ips, ip)
 
 	if len(ips) == 0 {
 		return errors.New("no control plane IPs found")
@@ -425,6 +431,8 @@ type MetadataAPI interface {
 	List(ctx context.Context) ([]metadata.InstanceMetadata, error)
 	// Self retrieves the current instance.
 	Self(ctx context.Context) (metadata.InstanceMetadata, error)
+	// GetLoadBalancerEndpoint retrieves the load balancer endpoint.
+	GetLoadBalancerEndpoint(ctx context.Context) (host, port string, err error)
 }
 
 type encryptedDisk interface {

--- a/bootstrapper/internal/joinclient/joinclient.go
+++ b/bootstrapper/internal/joinclient/joinclient.go
@@ -186,23 +186,29 @@ func (c *JoinClient) Stop() {
 }
 
 func (c *JoinClient) tryJoinWithAvailableServices() error {
-	ips, err := c.getControlPlaneIPs()
-	if err != nil {
-		return fmt.Errorf("failed to get control plane IPs: %w", err)
-	}
+	ctx, cancel := c.timeoutCtx()
+	defer cancel()
 
-	ip, _, err := c.metadataAPI.GetLoadBalancerEndpoint(context.TODO())
+	var endpoints []string
+
+	ip, _, err := c.metadataAPI.GetLoadBalancerEndpoint(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get load balancer endpoint: %w", err)
 	}
-	ips = append(ips, ip)
+	endpoints = append(endpoints, net.JoinHostPort(ip, strconv.Itoa(constants.JoinServiceNodePort)))
 
-	if len(ips) == 0 {
+	ips, err := c.getControlPlaneIPs(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to get control plane IPs: %w", err)
+	}
+	endpoints = append(endpoints, ips...)
+
+	if len(endpoints) == 0 {
 		return errors.New("no control plane IPs found")
 	}
 
-	for _, ip := range ips {
-		err = c.join(net.JoinHostPort(ip, strconv.Itoa(constants.JoinServiceNodePort)))
+	for _, endpoint := range endpoints {
+		err = c.join(net.JoinHostPort(endpoint, strconv.Itoa(constants.JoinServiceNodePort)))
 		if err == nil {
 			return nil
 		}
@@ -363,10 +369,7 @@ func (c *JoinClient) getDiskUUID() (string, error) {
 	return c.disk.UUID()
 }
 
-func (c *JoinClient) getControlPlaneIPs() ([]string, error) {
-	ctx, cancel := c.timeoutCtx()
-	defer cancel()
-
+func (c *JoinClient) getControlPlaneIPs(ctx context.Context) ([]string, error) {
 	instances, err := c.metadataAPI.List(ctx)
 	if err != nil {
 		c.log.With(zap.Error(err)).Errorf("Failed to list instances from metadata API")

--- a/bootstrapper/internal/joinclient/joinclient_test.go
+++ b/bootstrapper/internal/joinclient/joinclient_test.go
@@ -330,6 +330,10 @@ func (s *stubRepeaterMetadataAPI) List(_ context.Context) ([]metadata.InstanceMe
 	return s.listInstances, s.listErr
 }
 
+func (s *stubRepeaterMetadataAPI) GetLoadBalancerEndpoint(_ context.Context) (string, string, error) {
+	return "", "", nil
+}
+
 type stubMetadataAPI struct {
 	selfAnswerC chan selfAnswer
 	listAnswerC chan listAnswer
@@ -350,6 +354,10 @@ func (s *stubMetadataAPI) Self(_ context.Context) (metadata.InstanceMetadata, er
 func (s *stubMetadataAPI) List(_ context.Context) ([]metadata.InstanceMetadata, error) {
 	answer := <-s.listAnswerC
 	return answer.instances, answer.err
+}
+
+func (s *stubMetadataAPI) GetLoadBalancerEndpoint(_ context.Context) (string, string, error) {
+	return "", "", nil
 }
 
 type selfAnswer struct {

--- a/cli/internal/terraform/terraform/aws/main.tf
+++ b/cli/internal/terraform/terraform/aws/main.tf
@@ -114,6 +114,10 @@ resource "aws_lb" "front_end" {
     }
   }
   enable_cross_zone_load_balancing = true
+
+  lifecycle {
+    ignore_changes = [security_groups]
+  }
 }
 
 resource "aws_security_group" "security_group" {

--- a/cli/internal/terraform/terraform/azure/main.tf
+++ b/cli/internal/terraform/terraform/azure/main.tf
@@ -32,6 +32,7 @@ locals {
   ports_konnectivity    = "8132"
   ports_verify          = "30081"
   ports_recovery        = "9999"
+  ports_join            = "30090"
   ports_debugd          = "4000"
   cidr_vpc_subnet_nodes = "192.168.178.0/24"
   cidr_vpc_subnet_pods  = "10.10.0.0/16"
@@ -182,6 +183,12 @@ module "loadbalancer_backend_control_plane" {
       protocol = "Tcp",
       path     = null
     },
+    {
+      name     = "join",
+      port     = local.ports_join,
+      protocol = "Tcp",
+      path     = null
+    },
     var.debug ? [{
       name     = "debugd",
       port     = local.ports_debugd,
@@ -231,8 +238,9 @@ resource "azurerm_network_security_group" "security_group" {
       { name = "kubernetes", priority = 101, dest_port_range = local.ports_kubernetes },
       { name = "bootstrapper", priority = 102, dest_port_range = local.ports_bootstrapper },
       { name = "konnectivity", priority = 103, dest_port_range = local.ports_konnectivity },
-      { name = "recovery", priority = 104, dest_port_range = local.ports_recovery },
-      var.debug ? [{ name = "debugd", priority = 105, dest_port_range = local.ports_debugd }] : [],
+      { name = "join", priority = 104, dest_port_range = local.ports_recovery },
+      { name = "recovery", priority = 105, dest_port_range = local.ports_join },
+      var.debug ? [{ name = "debugd", priority = 106, dest_port_range = local.ports_debugd }] : [],
     ])
     content {
       name                       = security_rule.value.name

--- a/disk-mapper/internal/rejoinclient/BUILD.bazel
+++ b/disk-mapper/internal/rejoinclient/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//disk-mapper:__subpackages__"],
     deps = [
         "//internal/cloud/metadata",
+        "//internal/constants",
         "//internal/logger",
         "//internal/role",
         "//joinservice/joinproto",

--- a/disk-mapper/internal/setup/interface.go
+++ b/disk-mapper/internal/setup/interface.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 package setup
 
 import (
+	"context"
 	"io/fs"
 	"os"
 
@@ -37,6 +38,7 @@ type ConfigurationGenerator interface {
 type MetadataAPI interface {
 	metadata.InstanceSelfer
 	metadata.InstanceLister
+	GetLoadBalancerEndpoint(ctx context.Context) (host, port string, err error)
 }
 
 // RecoveryDoer is an interface to perform key recovery operations.

--- a/internal/cloud/metadata/BUILD.bazel
+++ b/internal/cloud/metadata/BUILD.bazel
@@ -5,8 +5,5 @@ go_library(
     srcs = ["metadata.go"],
     importpath = "github.com/edgelesssys/constellation/v2/internal/cloud/metadata",
     visibility = ["//:__subpackages__"],
-    deps = [
-        "//internal/constants",
-        "//internal/role",
-    ],
+    deps = ["//internal/role"],
 )

--- a/internal/cloud/metadata/metadata.go
+++ b/internal/cloud/metadata/metadata.go
@@ -8,11 +8,7 @@ package metadata
 
 import (
 	"context"
-	"fmt"
-	"net"
-	"strconv"
 
-	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/role"
 )
 
@@ -42,22 +38,4 @@ type InstanceSelfer interface {
 type InstanceLister interface {
 	// List retrieves all instances belonging to the current constellation.
 	List(ctx context.Context) ([]InstanceMetadata, error)
-}
-
-// JoinServiceEndpoints returns the list of endpoints for the join service, which are running on the control plane nodes.
-func JoinServiceEndpoints(ctx context.Context, lister InstanceLister) ([]string, error) {
-	instances, err := lister.List(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("retrieving instances list from cloud provider: %w", err)
-	}
-	joinEndpoints := []string{}
-	for _, instance := range instances {
-		if instance.Role == role.ControlPlane {
-			if instance.VPCIP != "" {
-				joinEndpoints = append(joinEndpoints, net.JoinHostPort(instance.VPCIP, strconv.Itoa(constants.JoinServiceNodePort)))
-			}
-		}
-	}
-
-	return joinEndpoints, nil
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
This is needed since the upcoming node-to-node strict mode does not allow traffic which is not WireGuard encrypted by Cilium (with the exception of etcd). Therefore nodes cannot join via directly talking to another node.


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add join port to all LBs
- Let rejoinclient and joinclient join over LB (if available, otherwise fallback to node VPC IPs)

The fallback is needed to still support Miniconstellation as it does not have an LB.

e2e upgrade tests: 
azure: https://github.com/edgelesssys/constellation/actions/runs/6237449241
gcp: https://github.com/edgelesssys/constellation/actions/runs/6238824048
aws: https://github.com/edgelesssys/constellation/actions/runs/6238826460

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
