### PR TITLE
ci: fix racy logcollection in `nop` tests

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -268,7 +268,10 @@ runs:
     - name: Nop test payload
       if: inputs.test == 'nop'
       shell: bash
-      run: echo "::warning::This test has a nop payload. It doesn't run any tests."
+      run: |
+        echo "::warning::This test has a nop payload. It doesn't run any tests."
+        echo "Sleeping for 30 seconds to allow logs to propagate to the log collection service."
+        sleep 30
 
     - name: Run sonobuoy quick test
       if: inputs.test == 'sonobuoy quick'


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Tests with a `nop` on non-debug clusters directly terminate after deploying the logcollection to the cluster. Even if the pods are ready, they get terminated before being able to propagate their metrics / logs to OpenSearch. 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a 30 second wait after deploying the logcollection when a test has a `nop` payload.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [E2E run](https://github.com/edgelesssys/constellation/actions/runs/6246592076)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
