### PR TITLE
ci: add missing notification hook for MiniConstellation test

### DIFF
--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -157,3 +157,16 @@ jobs:
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify about failure
+        if: |
+          failure() &&
+          github.ref == 'refs/heads/main' &&
+          github.event_name == 'schedule'
+        continue-on-error: true
+        uses: ./.github/actions/notify_failure
+        with:
+          projectWriteToken: ${{ secrets.PROJECT_WRITE_TOKEN }}
+          teamsWebhookUri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          test: "MiniConstellation"
+          provider: "QEMU"

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -319,6 +319,19 @@ jobs:
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Notify about failure
+        if: |
+          failure() &&
+          github.ref == 'refs/heads/main' &&
+          github.event_name == 'schedule'
+        continue-on-error: true
+        uses: ./.github/actions/notify_failure
+        with:
+          projectWriteToken: ${{ secrets.PROJECT_WRITE_TOKEN }}
+          teamsWebhookUri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          test: "MiniConstellation"
+          provider: "QEMU"
+
   e2e-windows:
     name: Run Windows E2E test
     permissions:


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Our daily tests were not reporting failures of the MiniConstellation test.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
Add the "Notify about failure" hook to the MiniConstellation test

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- `refStream` and `kubernetesVersion` are left empty in the notification, since they are not configurable in the test.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
