### PR TITLE
cli: report log collection failure to user

### DIFF
--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net"
 	"strconv"
@@ -238,7 +237,6 @@ func TestInitialize(t *testing.T) {
 				})
 
 			if tc.wantErr {
-				fmt.Println(errOut.String())
 				assert.Error(err)
 				if !tc.retriable {
 					assert.Contains(errOut.String(), "This error is not recoverable")
@@ -616,7 +614,6 @@ func (s *stubInitServer) Init(_ *initproto.InitRequest, stream initproto.API_Ini
 	for _, r := range s.res {
 		_ = stream.Send(r)
 	}
-	// _ = stream.Send(s.res)
 	return s.initErr
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
During `constellation init`, if the init request and the subsequent log collection fails, the CLI reports "Fetched bootstrapper logs are stored in ...".
This is not true, since the log collection itself failed.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
Properly report log collection failed, if it did.

### Related issue
[AB#3272](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/3272)

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

