### PR TITLE
ci: fix kubectl version retrieval

### DIFF
--- a/.github/actions/e2e_benchmark/action.yml
+++ b/.github/actions/e2e_benchmark/action.yml
@@ -42,8 +42,8 @@ runs:
       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       with:
         fetch-depth: 0
-        repository: "InfraBuilder/k8s-bench-suite"
-        ref: 1698974913b7b18ad54cf5860838029c295c77b1
+        repository: "edgelesssys/k8s-bench-suite"
+        ref: 67c64c854841165b778979375444da1c02e02210
         path: k8s-bench-suite
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fixes a non-fatal error in the CI: https://github.com/edgelesssys/constellation/actions/runs/6281230175/job/17059392328#step:3:3857

``` 
error: unknown flag: --short
See 'kubectl version --help' for usage.
```

kubectl deprecated and now removed the flag. The default is now `--short`. Therefore simply removing the flag referencing the new version.

e2e test: https://github.com/edgelesssys/constellation/actions/runs/6297531935

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
