### PR TITLE
cli: remove state on terminate

### DIFF
--- a/cli/internal/cmd/terminate.go
+++ b/cli/internal/cmd/terminate.go
@@ -88,6 +88,10 @@ func terminate(cmd *cobra.Command, terminator cloudTerminator, fileHandler file.
 		removeErr = errors.Join(err, fmt.Errorf("failed to remove file: '%s', please remove it manually", pf.PrefixPrintablePath(constants.ClusterIDsFilename)))
 	}
 
+	if err := fileHandler.Remove(constants.StateFilename); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		removeErr = errors.Join(err, fmt.Errorf("failed to remove file: '%s', please remove it manually", pf.PrefixPrintablePath(constants.StateFilename)))
+	}
+
 	return removeErr
 }
 

--- a/cli/internal/cmd/terminate_test.go
+++ b/cli/internal/cmd/terminate_test.go
@@ -52,6 +52,7 @@ func TestTerminate(t *testing.T) {
 		fileHandler := file.NewHandler(fs)
 		require.NoError(fileHandler.Write(constants.AdminConfFilename, []byte{1, 2}, file.OptNone))
 		require.NoError(fileHandler.WriteJSON(constants.ClusterIDsFilename, idFile, file.OptNone))
+		require.NoError(fileHandler.Write(constants.StateFilename, []byte{3, 4}, file.OptNone))
 		return fs
 	}
 	someErr := errors.New("failed")
@@ -159,6 +160,8 @@ func TestTerminate(t *testing.T) {
 					_, err = fileHandler.Stat(constants.AdminConfFilename)
 					assert.Error(err)
 					_, err = fileHandler.Stat(constants.ClusterIDsFilename)
+					assert.Error(err)
+					_, err = fileHandler.Stat(constants.StateFilename)
 					assert.Error(err)
 				}
 			}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove dangling `constellation-state.yaml` file during `constellation terminate`. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
