### PR TITLE
ci: recreate coverage report on push

### DIFF
--- a/.github/workflows/test-unittest.yml
+++ b/.github/workflows/test-unittest.yml
@@ -73,6 +73,7 @@ jobs:
         with:
           header: coverage
           path: coverage_diff.md
+          recreate: true
 
       - name: Upload coverage
         if: github.ref_name == 'main'


### PR DESCRIPTION
This keeps the report in focus for PRs with longer discussion and repeated pushes.



### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)