### PR TITLE
cli: new flag for JSON output of `constellation verify`

### DIFF
--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -75,6 +75,7 @@ go_library(
         "//internal/semver",
         "//internal/sigstore",
         "//internal/sigstore/keyselect",
+        "//internal/verify",
         "//internal/versions",
         "//verify/verifyproto",
         "@com_github_golang_jwt_jwt_v5//:jwt",

--- a/cli/internal/cmd/verify.go
+++ b/cli/internal/cmd/verify.go
@@ -59,7 +59,7 @@ func NewVerifyCmd() *cobra.Command {
 	}
 	cmd.Flags().String("cluster-id", "", "expected cluster identifier")
 	cmd.Flags().Bool("raw", false, "print raw attestation document")
-	cmd.Flags().Bool("json", false, "print the attestation document as parsed json")
+	cmd.Flags().String("output", "", "print the attestation document in the output format {json}")
 	cmd.Flags().StringP("node-endpoint", "e", "", "endpoint of the node to verify, passed as HOST[:PORT]")
 	return cmd
 }
@@ -192,9 +192,17 @@ func (c *verifyCmd) parseVerifyFlags(cmd *cobra.Command, fileHandler file.Handle
 		return verifyFlags{}, fmt.Errorf("parsing raw argument: %w", err)
 	}
 	c.log.Debugf("Flag 'raw' set to %t", force)
-	json, err := cmd.Flags().GetBool("json")
+	output, err := cmd.Flags().GetString("output")
 	if err != nil {
 		return verifyFlags{}, fmt.Errorf("parsing raw argument: %w", err)
+	}
+
+	var json bool
+	if output != "" {
+		if output != "json" {
+			return verifyFlags{}, fmt.Errorf("invalid output format %q, expected 'json'", output)
+		}
+		json = true
 	}
 	c.log.Debugf("Flag 'json' set to %t", force)
 

--- a/cli/internal/cmd/verify.go
+++ b/cli/internal/cmd/verify.go
@@ -59,7 +59,7 @@ func NewVerifyCmd() *cobra.Command {
 	}
 	cmd.Flags().String("cluster-id", "", "expected cluster identifier")
 	cmd.Flags().Bool("raw", false, "print raw attestation document")
-	cmd.Flags().String("output", "", "print the attestation document in the output format {json}")
+	cmd.Flags().StringP("output", "o", "", "print the attestation document in the output format {json}")
 	cmd.Flags().StringP("node-endpoint", "e", "", "endpoint of the node to verify, passed as HOST[:PORT]")
 	return cmd
 }
@@ -155,7 +155,7 @@ func (c *verifyCmd) verify(cmd *cobra.Command, fileHandler file.Handler, verifyC
 		return fmt.Errorf("printing attestation document: %w", err)
 	}
 	cmd.Println(attDocOutput)
-	cmd.Println("Verification OK")
+	cmd.PrintErrln("Verification OK")
 
 	return nil
 }
@@ -217,11 +217,11 @@ func (c *verifyCmd) parseVerifyFlags(cmd *cobra.Command, fileHandler file.Handle
 	if emptyEndpoint || emptyIDs {
 		c.log.Debugf("Trying to supplement empty flag values from %q", pf.PrefixPrintablePath(constants.ClusterIDsFilename))
 		if emptyEndpoint {
-			cmd.Printf("Using endpoint from %q. Specify --node-endpoint to override this.\n", pf.PrefixPrintablePath(constants.ClusterIDsFilename))
+			cmd.PrintErrf("Using endpoint from %q. Specify --node-endpoint to override this.\n", pf.PrefixPrintablePath(constants.ClusterIDsFilename))
 			endpoint = idFile.IP
 		}
 		if emptyIDs {
-			cmd.Printf("Using ID from %q. Specify --cluster-id to override this.\n", pf.PrefixPrintablePath(constants.ClusterIDsFilename))
+			cmd.PrintErrf("Using ID from %q. Specify --cluster-id to override this.\n", pf.PrefixPrintablePath(constants.ClusterIDsFilename))
 			ownerID = idFile.OwnerID
 			clusterID = idFile.ClusterID
 		}

--- a/cli/internal/cmd/verify.go
+++ b/cli/internal/cmd/verify.go
@@ -89,8 +89,10 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 			return &jsonAttestationDocFormatter{log}, nil
 		case "raw":
 			return &rawAttestationDocFormatter{log}, nil
-		default:
+		case "":
 			return &defaultAttestationDocFormatter{log}, nil
+		default:
+			return nil, fmt.Errorf("invalid output value for formatter: %s", output)
 		}
 	}
 	v := &verifyCmd{log: log}

--- a/cli/internal/cmd/verify.go
+++ b/cli/internal/cmd/verify.go
@@ -291,10 +291,13 @@ type jsonAttestationDocFormatter struct {
 }
 
 // format returns the raw or formatted attestation doc depending on the rawOutput argument.
-func (f *jsonAttestationDocFormatter) format(ctx context.Context, docString string, _ bool,
+func (f *jsonAttestationDocFormatter) format(ctx context.Context, docString string, PCRsOnly bool,
 	_ bool, _ measurements.M, attestationServiceURL string,
 ) (string, error) {
-	instanceInfo, err := extractInstanceInfo(docString)
+	if PCRsOnly {
+		return "", fmt.Errorf("JSON output is currently only supported for Azure")
+	}
+	instanceInfo, err := extractAzureInstanceInfo(docString)
 	if err != nil {
 		return "", fmt.Errorf("unmarshal instance info: %w", err)
 	}
@@ -840,7 +843,7 @@ func newTCBVersion(tcbVersion kds.TCBVersion) (res verify.TCBVersion) {
 	}
 }
 
-func extractInstanceInfo(docString string) (azureInstanceInfo, error) {
+func extractAzureInstanceInfo(docString string) (azureInstanceInfo, error) {
 	var doc attestationDoc
 	if err := json.Unmarshal([]byte(docString), &doc); err != nil {
 		return azureInstanceInfo{}, fmt.Errorf("unmarshal attestation document: %w", err)

--- a/cli/internal/cmd/verify_test.go
+++ b/cli/internal/cmd/verify_test.go
@@ -167,8 +167,7 @@ func TestVerify(t *testing.T) {
 			cmd.Flags().String("workspace", "", "") // register persistent flag manually
 			cmd.Flags().Bool("force", true, "")     // register persistent flag manually
 			out := &bytes.Buffer{}
-			cmd.SetOut(out)
-			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetErr(out)
 			if tc.clusterIDFlag != "" {
 				require.NoError(cmd.Flags().Set("cluster-id", tc.clusterIDFlag))
 			}

--- a/cli/internal/cmd/verify_test.go
+++ b/cli/internal/cmd/verify_test.go
@@ -186,7 +186,10 @@ func TestVerify(t *testing.T) {
 			}
 
 			v := &verifyCmd{log: logger.NewTest(t)}
-			err := v.verify(cmd, fileHandler, tc.protoClient, tc.formatter, stubAttestationFetcher{})
+			formatterFac := func(_ bool) attestationDocFormatter {
+				return tc.formatter
+			}
+			err := v.verify(cmd, fileHandler, tc.protoClient, formatterFac, stubAttestationFetcher{})
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/cli/internal/cmd/verify_test.go
+++ b/cli/internal/cmd/verify_test.go
@@ -185,8 +185,8 @@ func TestVerify(t *testing.T) {
 			}
 
 			v := &verifyCmd{log: logger.NewTest(t)}
-			formatterFac := func(_ bool) attestationDocFormatter {
-				return tc.formatter
+			formatterFac := func(_ string, _ cloudprovider.Provider, _ debugLog) (attestationDocFormatter, error) {
+				return tc.formatter, nil
 			}
 			err := v.verify(cmd, fileHandler, tc.protoClient, formatterFac, stubAttestationFetcher{})
 			if tc.wantErr {
@@ -204,19 +204,19 @@ type stubAttDocFormatter struct {
 	formatErr error
 }
 
-func (f *stubAttDocFormatter) format(_ context.Context, _ string, _ bool, _ bool, _ measurements.M, _ string) (string, error) {
+func (f *stubAttDocFormatter) format(_ context.Context, _ string, _ bool, _ measurements.M, _ string) (string, error) {
 	return "", f.formatErr
 }
 
 func TestFormat(t *testing.T) {
-	formatter := func() *attestationDocFormatterImpl {
-		return &attestationDocFormatterImpl{
+	formatter := func() *defaultAttestationDocFormatter {
+		return &defaultAttestationDocFormatter{
 			log: logger.NewTest(t),
 		}
 	}
 
 	testCases := map[string]struct {
-		formatter *attestationDocFormatterImpl
+		formatter *defaultAttestationDocFormatter
 		doc       string
 		wantErr   bool
 	}{
@@ -229,7 +229,7 @@ func TestFormat(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			_, err := tc.formatter.format(context.Background(), tc.doc, false, false, nil, "")
+			_, err := tc.formatter.format(context.Background(), tc.doc, false, nil, "")
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -301,7 +301,7 @@ F/SjRih31+SAtWb42jueAA==
 			assert := assert.New(t)
 
 			b := &strings.Builder{}
-			formatter := &attestationDocFormatterImpl{
+			formatter := &defaultAttestationDocFormatter{
 				log: logger.NewTest(t),
 			}
 			err := formatter.parseCerts(b, "Some Cert", tc.cert)
@@ -547,7 +547,7 @@ func TestParseQuotes(t *testing.T) {
 			assert := assert.New(t)
 
 			b := &strings.Builder{}
-			parser := &attestationDocFormatterImpl{}
+			parser := &defaultAttestationDocFormatter{}
 
 			err := parser.parseQuotes(b, tc.quotes, tc.expectedPCRs)
 			if tc.wantErr {

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -391,6 +391,7 @@ constellation verify [flags]
 ```
       --cluster-id string      expected cluster identifier
   -h, --help                   help for verify
+      --json                   print the attestation document as parsed json
   -e, --node-endpoint string   endpoint of the node to verify, passed as HOST[:PORT]
       --raw                    print raw attestation document
 ```

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -391,8 +391,8 @@ constellation verify [flags]
 ```
       --cluster-id string      expected cluster identifier
   -h, --help                   help for verify
-      --json                   print the attestation document as parsed json
   -e, --node-endpoint string   endpoint of the node to verify, passed as HOST[:PORT]
+  -o, --output string          print the attestation document in the output format {json}
       --raw                    print raw attestation document
 ```
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -392,8 +392,7 @@ constellation verify [flags]
       --cluster-id string      expected cluster identifier
   -h, --help                   help for verify
   -e, --node-endpoint string   endpoint of the node to verify, passed as HOST[:PORT]
-  -o, --output string          print the attestation document in the output format {json}
-      --raw                    print raw attestation document
+  -o, --output string          print the attestation document in the output format {json|raw}
 ```
 
 ### Options inherited from parent commands

--- a/internal/verify/BUILD.bazel
+++ b/internal/verify/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "verify",
+    srcs = ["verify.go"],
+    importpath = "github.com/edgelesssys/constellation/v2/internal/verify",
+    visibility = ["//:__subpackages__"],
+    deps = ["@com_github_golang_jwt_jwt_v5//:jwt"],
+)

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -1,0 +1,179 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+/*
+Package verify provides the the types for the types of the verify report in JSON format.
+
+At the moment the package is concerned with providing an interface for constellation verify and the attestationconfigapi upload tool through JSON serialization.
+*/
+package verify
+
+import (
+	"crypto/x509"
+	"fmt"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+// Report contains the entire data reported by constellation verify.
+type Report struct {
+	SNPReport SNPReport      `json:"snp_report"`
+	VCEK      []Certificate  `json:"vcek"`
+	CertChain []Certificate  `json:"cert_chain"`
+	MAAToken  MaaTokenClaims `json:"maa_token"`
+}
+
+// Certificate contains the certificate data and additional information.
+type Certificate struct {
+	*x509.Certificate `json:"certificate"`
+	CertTypeName      string     `json:"cert_type_name"`
+	StructVersion     uint8      `json:"struct_version"`
+	ProductName       string     `json:"product_name"`
+	HardwareID        []byte     `json:"hardware_id"`
+	TCBVersion        TCBVersion `json:"tcb_version"`
+}
+
+// TCBVersion contains the TCB version data.
+type TCBVersion struct {
+	Bootloader uint8
+	TEE        uint8
+	SNP        uint8
+	Microcode  uint8
+	Spl4       uint8
+	Spl5       uint8
+	Spl6       uint8
+	Spl7       uint8
+	UcodeSpl   uint8 // UcodeSpl is the microcode security patch level.
+}
+
+// PlatformInfo contains the platform information.
+type PlatformInfo struct {
+	SMT  bool `json:"smt"`
+	TSME bool `json:"tsme"`
+}
+
+// SignerInfo contains the signer information.
+type SignerInfo struct {
+	AuthorKeyEn bool         `json:"author_key_en"`
+	MaskChipKey bool         `json:"mask_chip_key"`
+	SigningKey  fmt.Stringer `json:"signing_key"`
+}
+
+// SNPReport contains the SNP report data.
+type SNPReport struct {
+	Version              uint32       `json:"version"`
+	GuestSvn             uint32       `json:"guest_svn"`
+	PolicyABIMinor       uint8        `json:"policy_abi_minor"`
+	PolicyABIMajor       uint8        `json:"policy_abi_major"`
+	PolicySMT            bool         `json:"policy_symmetric_multi_threading"`
+	PolicyMigrationAgent bool         `json:"policy_migration_agent"`
+	PolicyDebug          bool         `json:"policy_debug"`
+	PolicySingleSocket   bool         `json:"policy_single_socket"`
+	FamilyID             []byte       `json:"family_id"`
+	ImageID              []byte       `json:"image_id"`
+	Vmpl                 uint32       `json:"vmpl"`
+	SignatureAlgo        uint32       `json:"signature_algo"`
+	CurrentTCB           TCBVersion   `json:"current_tcb"`
+	PlatformInfo         PlatformInfo `json:"platform_info"`
+	SignerInfo           SignerInfo   `json:"signer_info"`
+	ReportData           []byte       `json:"report_data"`
+	Measurement          []byte       `json:"measurement"`
+	HostData             []byte       `json:"host_data"`
+	IDKeyDigest          []byte       `json:"id_key_digest"`
+	AuthorKeyDigest      []byte       `json:"author_key_digest"`
+	ReportID             []byte       `json:"report_id"`
+	ReportIDMa           []byte       `json:"report_id_ma"`
+	ReportedTCB          TCBVersion   `json:"reported_tcb"`
+	ChipID               []byte       `json:"chip_id"`
+	CommittedTCB         TCBVersion   `json:"committed_tcb"`
+	CurrentBuild         uint32       `json:"current_build"`
+	CurrentMinor         uint32       `json:"current_minor"`
+	CurrentMajor         uint32       `json:"current_major"`
+	CommittedBuild       uint32       `json:"committed_build"`
+	CommittedMinor       uint32       `json:"committed_minor"`
+	CommittedMajor       uint32       `json:"committed_major"`
+	LaunchTCB            TCBVersion   `json:"launch_tcb"`
+	Signature            []byte       `json:"signature"`
+}
+
+// MaaTokenClaims contains the MAA token claims.
+type MaaTokenClaims struct {
+	jwt.RegisteredClaims
+	Secureboot                               bool   `json:"secureboot,omitempty"`
+	XMsAttestationType                       string `json:"x-ms-attestation-type,omitempty"`
+	XMsAzurevmAttestationProtocolVer         string `json:"x-ms-azurevm-attestation-protocol-ver,omitempty"`
+	XMsAzurevmAttestedPcrs                   []int  `json:"x-ms-azurevm-attested-pcrs,omitempty"`
+	XMsAzurevmBootdebugEnabled               bool   `json:"x-ms-azurevm-bootdebug-enabled,omitempty"`
+	XMsAzurevmDbvalidated                    bool   `json:"x-ms-azurevm-dbvalidated,omitempty"`
+	XMsAzurevmDbxvalidated                   bool   `json:"x-ms-azurevm-dbxvalidated,omitempty"`
+	XMsAzurevmDebuggersdisabled              bool   `json:"x-ms-azurevm-debuggersdisabled,omitempty"`
+	XMsAzurevmDefaultSecurebootkeysvalidated bool   `json:"x-ms-azurevm-default-securebootkeysvalidated,omitempty"`
+	XMsAzurevmElamEnabled                    bool   `json:"x-ms-azurevm-elam-enabled,omitempty"`
+	XMsAzurevmFlightsigningEnabled           bool   `json:"x-ms-azurevm-flightsigning-enabled,omitempty"`
+	XMsAzurevmHvciPolicy                     int    `json:"x-ms-azurevm-hvci-policy,omitempty"`
+	XMsAzurevmHypervisordebugEnabled         bool   `json:"x-ms-azurevm-hypervisordebug-enabled,omitempty"`
+	XMsAzurevmIsWindows                      bool   `json:"x-ms-azurevm-is-windows,omitempty"`
+	XMsAzurevmKerneldebugEnabled             bool   `json:"x-ms-azurevm-kerneldebug-enabled,omitempty"`
+	XMsAzurevmOsbuild                        string `json:"x-ms-azurevm-osbuild,omitempty"`
+	XMsAzurevmOsdistro                       string `json:"x-ms-azurevm-osdistro,omitempty"`
+	XMsAzurevmOstype                         string `json:"x-ms-azurevm-ostype,omitempty"`
+	XMsAzurevmOsversionMajor                 int    `json:"x-ms-azurevm-osversion-major,omitempty"`
+	XMsAzurevmOsversionMinor                 int    `json:"x-ms-azurevm-osversion-minor,omitempty"`
+	XMsAzurevmSigningdisabled                bool   `json:"x-ms-azurevm-signingdisabled,omitempty"`
+	XMsAzurevmTestsigningEnabled             bool   `json:"x-ms-azurevm-testsigning-enabled,omitempty"`
+	XMsAzurevmVmid                           string `json:"x-ms-azurevm-vmid,omitempty"`
+	XMsIsolationTee                          struct {
+		XMsAttestationType  string `json:"x-ms-attestation-type,omitempty"`
+		XMsComplianceStatus string `json:"x-ms-compliance-status,omitempty"`
+		XMsRuntime          struct {
+			Keys []struct {
+				E      string   `json:"e,omitempty"`
+				KeyOps []string `json:"key_ops,omitempty"`
+				Kid    string   `json:"kid,omitempty"`
+				Kty    string   `json:"kty,omitempty"`
+				N      string   `json:"n,omitempty"`
+			} `json:"keys,omitempty"`
+			VMConfiguration struct {
+				ConsoleEnabled bool   `json:"console-enabled,omitempty"`
+				CurrentTime    int    `json:"current-time,omitempty"`
+				SecureBoot     bool   `json:"secure-boot,omitempty"`
+				TpmEnabled     bool   `json:"tpm-enabled,omitempty"`
+				VMUniqueID     string `json:"vmUniqueId,omitempty"`
+			} `json:"vm-configuration,omitempty"`
+		} `json:"x-ms-runtime,omitempty"`
+		XMsSevsnpvmAuthorkeydigest   string `json:"x-ms-sevsnpvm-authorkeydigest,omitempty"`
+		XMsSevsnpvmBootloaderSvn     int    `json:"x-ms-sevsnpvm-bootloader-svn,omitempty"`
+		XMsSevsnpvmFamilyID          string `json:"x-ms-sevsnpvm-familyId,omitempty"`
+		XMsSevsnpvmGuestsvn          int    `json:"x-ms-sevsnpvm-guestsvn,omitempty"`
+		XMsSevsnpvmHostdata          string `json:"x-ms-sevsnpvm-hostdata,omitempty"`
+		XMsSevsnpvmIdkeydigest       string `json:"x-ms-sevsnpvm-idkeydigest,omitempty"`
+		XMsSevsnpvmImageID           string `json:"x-ms-sevsnpvm-imageId,omitempty"`
+		XMsSevsnpvmIsDebuggable      bool   `json:"x-ms-sevsnpvm-is-debuggable,omitempty"`
+		XMsSevsnpvmLaunchmeasurement string `json:"x-ms-sevsnpvm-launchmeasurement,omitempty"`
+		XMsSevsnpvmMicrocodeSvn      int    `json:"x-ms-sevsnpvm-microcode-svn,omitempty"`
+		XMsSevsnpvmMigrationAllowed  bool   `json:"x-ms-sevsnpvm-migration-allowed,omitempty"`
+		XMsSevsnpvmReportdata        string `json:"x-ms-sevsnpvm-reportdata,omitempty"`
+		XMsSevsnpvmReportid          string `json:"x-ms-sevsnpvm-reportid,omitempty"`
+		XMsSevsnpvmSmtAllowed        bool   `json:"x-ms-sevsnpvm-smt-allowed,omitempty"`
+		XMsSevsnpvmSnpfwSvn          int    `json:"x-ms-sevsnpvm-snpfw-svn,omitempty"`
+		XMsSevsnpvmTeeSvn            int    `json:"x-ms-sevsnpvm-tee-svn,omitempty"`
+		XMsSevsnpvmVmpl              int    `json:"x-ms-sevsnpvm-vmpl,omitempty"`
+	} `json:"x-ms-isolation-tee,omitempty"`
+	XMsPolicyHash string `json:"x-ms-policy-hash,omitempty"`
+	XMsRuntime    struct {
+		ClientPayload struct {
+			Nonce string `json:"nonce,omitempty"`
+		} `json:"client-payload,omitempty"`
+		Keys []struct {
+			E      string   `json:"e,omitempty"`
+			KeyOps []string `json:"key_ops,omitempty"`
+			Kid    string   `json:"kid,omitempty"`
+			Kty    string   `json:"kty,omitempty"`
+			N      string   `json:"n,omitempty"`
+		} `json:"keys,omitempty"`
+	} `json:"x-ms-runtime,omitempty"`
+	XMsVer string `json:"x-ms-ver,omitempty"`
+}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -38,15 +38,16 @@ type Certificate struct {
 
 // TCBVersion contains the TCB version data.
 type TCBVersion struct {
-	Bootloader uint8
-	TEE        uint8
-	SNP        uint8
-	Microcode  uint8
-	Spl4       uint8
-	Spl5       uint8
-	Spl6       uint8
-	Spl7       uint8
-	UcodeSpl   uint8 // UcodeSpl is the microcode security patch level.
+	Bootloader uint8 `json:"bootloader"`
+	TEE        uint8 `json:"tee"`
+	SNP        uint8 `json:"snp"`
+	Microcode  uint8 `json:"microcode"`
+	Spl4       uint8 `json:"spl4"`
+	Spl5       uint8 `json:"spl5"`
+	Spl6       uint8 `json:"spl6"`
+	Spl7       uint8 `json:"spl7"`
+	// UcodeSpl is the microcode security patch level.
+	UcodeSpl uint8 `json:"ucode_spl"`
 }
 
 // PlatformInfo contains the platform information.

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -5,9 +5,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 */
 
 /*
-Package verify provides the the types for the types of the verify report in JSON format.
+Package verify provides the types for the verify report in JSON format.
 
-At the moment the package is concerned with providing an interface for constellation verify and the attestationconfigapi upload tool through JSON serialization.
+The package provides an interface for constellation verify and
+the attestationconfigapi upload tool through JSON serialization.
 */
 package verify
 

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -46,8 +46,6 @@ type TCBVersion struct {
 	Spl5       uint8 `json:"spl5"`
 	Spl6       uint8 `json:"spl6"`
 	Spl7       uint8 `json:"spl7"`
-	// UcodeSpl is the microcode security patch level.
-	UcodeSpl uint8 `json:"ucode_spl"`
 }
 
 // PlatformInfo contains the platform information.
@@ -58,7 +56,7 @@ type PlatformInfo struct {
 
 // SignerInfo contains the signer information.
 type SignerInfo struct {
-	AuthorKeyEn bool         `json:"author_key_en"`
+	AuthorKey   bool         `json:"author_key_en"`
 	MaskChipKey bool         `json:"mask_chip_key"`
 	SigningKey  fmt.Stringer `json:"signing_key"`
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Motivated by https://github.com/edgelesssys/constellation/pull/2357, this PR provides a JSON output format as communication interface between the CLI and the attestationconfigapi upload tool through a new flag `constellation verify --output json`.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- new internal pkg `verify` to provide the types for JSON serialization. 
- new `--output` flag to support 'json' for Azure
- moved `--raw` to `--output raw`

### Related issue
- [AB#3462](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3462)

### Additional info
~To only obtain the JSON output needed for the upload tool, some lines need to be omitted:
`./constellation verify --force --json | tail -n +3 | head -n -1`~


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
