### PR TITLE
init: overwrite kubeconfig address

### DIFF
--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -172,6 +172,8 @@ go_test(
         "@io_k8s_api//core/v1:core",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:apiextensions",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:meta",
+        "@io_k8s_client_go//tools/clientcmd",
+        "@io_k8s_client_go//tools/clientcmd/api",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Since the bootstrapper discovers the load balancer itself and does not receives the endpoint used from the init request, it is possible that the bootstrapper "sees the world differently than the CLI". 

This is especially true for privateIP deployments. Since the lb discovers the internal load balancer but the CLI side might want to query another endpoint which redirects to the internal load balancer. Therefore the client side should always use the cluster endpoint from the `constellation-id.json` or `constellation-state.yaml` file as those are the truths for the CLI. 

The kubeconfig is generated by the cluster. Therefore it points to the endpoint used by the cluster. When we receive the kubeconfig we therefore replace it's endpoint with the endpoint from the `constellation-id.json`. 


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- We automatically overwrite the server address in the kubeconfig with the cluster endpoint from the `constellation-id.json` (later: constellation-state.yaml`) 

This is the minimal change I need to continue with https://github.com/edgelesssys/constellation/pull/2388. For publicIP deployments we don't change anything as we replace the value with itself.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

<!-- (uncomment if applicable)
### Additional info
- Any additional information or context
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
