### PR TITLE
cli: use state file on init and upgrade

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -181,7 +181,7 @@ runs:
         CSP: ${{ inputs.cloudProvider }}
       run: |
         echo "::group::Download boot logs"
-        CONSTELL_UID=$(yq '.uid' constellation-id.json)
+        CONSTELL_UID=$(yq '.infrastructure.uid' constellation-state.yaml)
         case $CSP in
           azure)
             AZURE_RESOURCE_GROUP=$(yq eval ".provider.azure.resourceGroup" constellation-conf.yaml)

--- a/.github/actions/e2e_verify/action.yml
+++ b/.github/actions/e2e_verify/action.yml
@@ -39,14 +39,14 @@ runs:
 
     - name: Constellation verify
       shell: bash
-      run: constellation verify --cluster-id $(jq -r ".clusterID" constellation-id.json) --force
+      run: constellation verify --cluster-id $(jq -r ".clusterValues.clusterID" constellation-state.yaml) --force
 
     - name: Verify all nodes
       shell: bash
       env:
         KUBECONFIG: ${{ inputs.kubeconfig }}
       run: |
-        clusterID=$(jq -r ".clusterID" constellation-id.json)
+        clusterID=$(jq -r ".clusterValues.clusterID" constellation-state.yaml)
         nodes=$(kubectl get nodes -o json | jq -r ".items[].metadata.name")
 
         for node in $nodes ; do

--- a/bazel/toolchains/go_module_deps.bzl
+++ b/bazel/toolchains/go_module_deps.bzl
@@ -15,6 +15,14 @@ def go_dependencies():
         sum = "h1:tdpHgTbmbvEIARu+bixzmleMi14+3imnpoFXz+Qzjp4=",
         version = "v1.31.0-20230802163732-1c33ebd9ecfa.1",
     )
+    go_repository(
+        name = "cat_dario_mergo",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable_global",
+        importpath = "dario.cat/mergo",
+        sum = "h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=",
+        version = "v1.0.0",
+    )
 
     go_repository(
         name = "cc_mvdan_editorconfig",

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -48,7 +48,7 @@ type stubTerraformClient struct {
 func (c *stubTerraformClient) ApplyCluster(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (state.Infrastructure, error) {
 	return state.Infrastructure{
 		ClusterEndpoint: c.ip,
-		InitSecret:      c.initSecret,
+		InitSecret:      []byte(c.initSecret),
 		UID:             c.uid,
 		Azure: &state.Azure{
 			AttestationURL: c.attestationURL,

--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -151,6 +151,7 @@ go_test(
         "//internal/cloud/gcpshared",
         "//internal/config",
         "//internal/constants",
+        "//internal/crypto",
         "//internal/crypto/testvector",
         "//internal/file",
         "//internal/grpc/atlscredentials",

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -172,14 +172,15 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 	}
 	c.log.Debugf("Successfully created the cloud resources for the cluster")
 
+	// TODO(msanft): Remove IDFile as per AB#3354
 	idFile := convertToIDFile(infraState, provider)
 	if err := fileHandler.WriteJSON(constants.ClusterIDsFilename, idFile, file.OptNone); err != nil {
 		return err
 	}
-	state := state.NewState(infraState)
 
-	if err := fileHandler.WriteYAML(constants.StateFilename, state, file.OptNone); err != nil {
-		return err
+	state := state.NewState().SetInfrastructure(infraState)
+	if err := state.WriteToFile(fileHandler, constants.StateFilename); err != nil {
+		return fmt.Errorf("writing state file: %w", err)
 	}
 
 	cmd.Println("Your Constellation cluster was created successfully.")

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -172,13 +172,13 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 	}
 	c.log.Debugf("Successfully created the cloud resources for the cluster")
 
-	// TODO(msanft): Remove IDFile as per AB#3354
+	// TODO(msanft): Remove IDFile as per AB#3425
 	idFile := convertToIDFile(infraState, provider)
 	if err := fileHandler.WriteJSON(constants.ClusterIDsFilename, idFile, file.OptNone); err != nil {
 		return err
 	}
 
-	state := state.NewState().SetInfrastructure(infraState)
+	state := state.New().SetInfrastructure(infraState)
 	if err := state.WriteToFile(fileHandler, constants.StateFilename); err != nil {
 		return fmt.Errorf("writing state file: %w", err)
 	}

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -12,14 +12,12 @@ import (
 	"io/fs"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/cmd/pathprefix"
 	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfigapi"
 	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
-	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
@@ -172,12 +170,6 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 	}
 	c.log.Debugf("Successfully created the cloud resources for the cluster")
 
-	// TODO(msanft): Remove IDFile as per AB#3425
-	idFile := convertToIDFile(infraState, provider)
-	if err := fileHandler.WriteJSON(constants.ClusterIDsFilename, idFile, file.OptNone); err != nil {
-		return err
-	}
-
 	state := state.New().SetInfrastructure(infraState)
 	if err := state.WriteToFile(fileHandler, constants.StateFilename); err != nil {
 		return fmt.Errorf("writing state file: %w", err)
@@ -185,21 +177,6 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 
 	cmd.Println("Your Constellation cluster was created successfully.")
 	return nil
-}
-
-func convertToIDFile(infra state.Infrastructure, provider cloudprovider.Provider) clusterid.File {
-	var file clusterid.File
-	file.CloudProvider = provider
-	file.IP = infra.ClusterEndpoint
-	file.APIServerCertSANs = infra.APIServerCertSANs
-	file.InitSecret = []byte(infra.InitSecret) // Convert string to []byte
-	file.UID = infra.UID
-
-	if infra.Azure != nil {
-		file.AttestationURL = infra.Azure.AttestationURL
-	}
-
-	return file
 }
 
 // parseCreateFlags parses the flags of the create command.
@@ -257,9 +234,9 @@ func (c *createCmd) checkDirClean(fileHandler file.Handler) error {
 	if _, err := fileHandler.Stat(constants.MasterSecretFilename); !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("file '%s' already exists in working directory. Constellation won't overwrite previous master secrets. Move it somewhere or delete it before creating a new cluster", c.pf.PrefixPrintablePath(constants.MasterSecretFilename))
 	}
-	c.log.Debugf("Checking cluster IDs file")
-	if _, err := fileHandler.Stat(constants.ClusterIDsFilename); !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("file '%s' already exists in working directory. Constellation won't overwrite previous cluster IDs. Move it somewhere or delete it before creating a new cluster", c.pf.PrefixPrintablePath(constants.ClusterIDsFilename))
+	c.log.Debugf("Checking state file")
+	if _, err := fileHandler.Stat(constants.StateFilename); !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("file '%s' already exists in working directory. Constellation won't overwrite previous cluster state. Move it somewhere or delete it before creating a new cluster", c.pf.PrefixPrintablePath(constants.StateFilename))
 	}
 
 	return nil

--- a/cli/internal/cmd/create_test.go
+++ b/cli/internal/cmd/create_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
@@ -154,22 +153,16 @@ func TestCreate(t *testing.T) {
 					assert.False(tc.creator.createCalled)
 				} else {
 					assert.True(tc.creator.createCalled)
-					var gotIDFile clusterid.File
-					require.NoError(fileHandler.ReadJSON(constants.ClusterIDsFilename, &gotIDFile))
-					assert.Equal(gotIDFile, clusterid.File{
-						IP:            infraState.ClusterEndpoint,
-						CloudProvider: tc.provider,
-					})
 
 					var gotState state.State
 					expectedState := state.Infrastructure{
 						ClusterEndpoint:   "192.0.2.1",
 						APIServerCertSANs: []string{},
+						InitSecret:        []byte{},
 					}
 					require.NoError(fileHandler.ReadYAML(constants.StateFilename, &gotState))
 					assert.Equal("v1", gotState.Version)
 					assert.Equal(expectedState, gotState.Infrastructure)
-
 				}
 			}
 		})

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -67,10 +67,10 @@ func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destr
 	if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("file %q still exists, please make sure to terminate your cluster before destroying your IAM configuration", c.pf.PrefixPrintablePath(constants.AdminConfFilename))
 	}
-	c.log.Debugf("Checking if %q exists", c.pf.PrefixPrintablePath(constants.ClusterIDsFilename))
-	_, err = fsHandler.Stat(constants.ClusterIDsFilename)
+	c.log.Debugf("Checking if %q exists", c.pf.PrefixPrintablePath(constants.StateFilename))
+	_, err = fsHandler.Stat(constants.StateFilename)
 	if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("file %q still exists, please make sure to terminate your cluster before destroying your IAM configuration", c.pf.PrefixPrintablePath(constants.ClusterIDsFilename))
+		return fmt.Errorf("file %q still exists, please make sure to terminate your cluster before destroying your IAM configuration", c.pf.PrefixPrintablePath(constants.StateFilename))
 	}
 
 	gcpFileExists := false

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -36,9 +36,9 @@ func TestIAMDestroy(t *testing.T) {
 		require.NoError(fh.Write(constants.AdminConfFilename, []byte("")))
 		return fh
 	}
-	newFsWithClusterIDFile := func() file.Handler {
+	newFsWithStateFile := func() file.Handler {
 		fh := file.NewHandler(afero.NewMemMapFs())
-		require.NoError(fh.Write(constants.ClusterIDsFilename, []byte("")))
+		require.NoError(fh.Write(constants.StateFilename, []byte("")))
 		return fh
 	}
 
@@ -56,8 +56,8 @@ func TestIAMDestroy(t *testing.T) {
 			yesFlag:      "false",
 			wantErr:      true,
 		},
-		"cluster running cluster ids": {
-			fh:           newFsWithClusterIDFile(),
+		"cluster running cluster state": {
+			fh:           newFsWithStateFile(),
 			iamDestroyer: &stubIAMDestroyer{},
 			yesFlag:      "false",
 			wantErr:      true,

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -9,7 +9,6 @@ package cmd
 import (
 	"bytes"
 	"context"
-	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -157,7 +156,7 @@ func (i *initCmd) initialize(
 		cmd.PrintErrln("WARNING: Attestation temporarily relies on AWS nitroTPM. See https://docs.edgeless.systems/constellation/workflows/config#choosing-a-vm-type for more information.")
 	}
 
-	// TODO(msanft): Remove IDFile as per AB#3354
+	// TODO(msanft): Remove IDFile as per AB#3425
 	i.log.Debugf("Checking cluster ID file")
 	var idFile clusterid.File
 	if err := i.fileHandler.ReadJSON(constants.ClusterIDsFilename, &idFile); err != nil {
@@ -208,7 +207,7 @@ func (i *initCmd) initialize(
 	idFile.MeasurementSalt = measurementSalt
 
 	stateFile.SetClusterValues(state.ClusterValues{
-		MeasurementSalt: base64.StdEncoding.EncodeToString(measurementSalt),
+		MeasurementSalt: measurementSalt,
 	})
 
 	clusterName := clusterid.GetClusterName(conf, idFile)
@@ -246,7 +245,7 @@ func (i *initCmd) initialize(
 	}
 	i.log.Debugf("Initialization request succeeded")
 
-	// TODO(msanft): Remove IDFile as per AB#3354
+	// TODO(msanft): Remove IDFile as per AB#3425
 	i.log.Debugf("Writing Constellation ID file")
 	idFile.CloudProvider = provider
 

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/edgelesssys/constellation/v2/bootstrapper/initproto"
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/cmd/pathprefix"
 	"github.com/edgelesssys/constellation/v2/cli/internal/helm"
 	"github.com/edgelesssys/constellation/v2/cli/internal/kubecmd"
@@ -156,13 +155,6 @@ func (i *initCmd) initialize(
 		cmd.PrintErrln("WARNING: Attestation temporarily relies on AWS nitroTPM. See https://docs.edgeless.systems/constellation/workflows/config#choosing-a-vm-type for more information.")
 	}
 
-	// TODO(msanft): Remove IDFile as per AB#3425
-	i.log.Debugf("Checking cluster ID file")
-	var idFile clusterid.File
-	if err := i.fileHandler.ReadJSON(constants.ClusterIDsFilename, &idFile); err != nil {
-		return fmt.Errorf("reading cluster ID file: %w", err)
-	}
-
 	stateFile, err := state.ReadFromFile(i.fileHandler, constants.StateFilename)
 	if err != nil {
 		return fmt.Errorf("reading state file: %w", err)
@@ -181,7 +173,10 @@ func (i *initCmd) initialize(
 	}
 	i.log.Debugf("Checked license")
 
-	conf.UpdateMAAURL(idFile.AttestationURL)
+	if stateFile.Infrastructure.Azure != nil {
+		conf.UpdateMAAURL(stateFile.Infrastructure.Azure.AttestationURL)
+	}
+
 	i.log.Debugf("Creating aTLS Validator for %s", conf.GetAttestationConfig().GetVariant())
 	validator, err := cloudcmd.NewValidator(cmd, conf.GetAttestationConfig(), i.log)
 	if err != nil {
@@ -199,15 +194,14 @@ func (i *initCmd) initialize(
 	if err != nil {
 		return fmt.Errorf("generating master secret: %w", err)
 	}
-	i.log.Debugf("Generated measurement salt")
+
+	i.log.Debugf("Generating measurement salt")
 	measurementSalt, err := crypto.GenerateRandomBytes(crypto.RNGLengthDefault)
 	if err != nil {
 		return fmt.Errorf("generating measurement salt: %w", err)
 	}
-	idFile.MeasurementSalt = measurementSalt
 
-	clusterName := clusterid.GetClusterName(conf, idFile)
-	i.log.Debugf("Setting cluster name to %s", clusterName)
+	i.log.Debugf("Setting cluster name to %s", stateFile.Infrastructure.Name)
 
 	cmd.PrintErrln("Note: If you just created the cluster, it can take a few minutes to connect.")
 	i.spinner.Start("Connecting ", false)
@@ -218,12 +212,12 @@ func (i *initCmd) initialize(
 		KubernetesVersion:    versions.VersionConfigs[k8sVersion].ClusterVersion,
 		KubernetesComponents: versions.VersionConfigs[k8sVersion].KubernetesComponents.ToInitProto(),
 		ConformanceMode:      flags.conformance,
-		InitSecret:           idFile.InitSecret,
-		ClusterName:          clusterName,
-		ApiserverCertSans:    idFile.APIServerCertSANs,
+		InitSecret:           stateFile.Infrastructure.InitSecret,
+		ClusterName:          stateFile.Infrastructure.Name,
+		ApiserverCertSans:    stateFile.Infrastructure.APIServerCertSANs,
 	}
 	i.log.Debugf("Sending initialization request")
-	resp, err := i.initCall(cmd.Context(), newDialer(validator), idFile.IP, req)
+	resp, err := i.initCall(cmd.Context(), newDialer(validator), stateFile.Infrastructure.ClusterEndpoint, req)
 	i.spinner.Stop()
 
 	if err != nil {
@@ -241,12 +235,8 @@ func (i *initCmd) initialize(
 	}
 	i.log.Debugf("Initialization request succeeded")
 
-	// TODO(msanft): Remove IDFile as per AB#3425
-	i.log.Debugf("Writing Constellation ID file")
-	idFile.CloudProvider = provider
-
 	bufferedOutput := &bytes.Buffer{}
-	if err := i.writeOutput(idFile, stateFile, resp, flags.mergeConfigs, bufferedOutput, measurementSalt); err != nil {
+	if err := i.writeOutput(stateFile, resp, flags.mergeConfigs, bufferedOutput, measurementSalt); err != nil {
 		return err
 	}
 
@@ -449,7 +439,6 @@ func (d *initDoer) handleGRPCStateChanges(ctx context.Context, wg *sync.WaitGrou
 // writeOutput writes the output of a cluster initialization to the
 // state- / id- / kubeconfig-file and saves it to disk.
 func (i *initCmd) writeOutput(
-	idFile clusterid.File,
 	stateFile *state.State,
 	initResp *initproto.InitSuccessResponse,
 	mergeConfig bool, wr io.Writer,
@@ -458,17 +447,21 @@ func (i *initCmd) writeOutput(
 	fmt.Fprint(wr, "Your Constellation cluster was successfully initialized.\n\n")
 
 	ownerID := hex.EncodeToString(initResp.GetOwnerId())
-	// i.log.Debugf("Owner id is %s", ownerID)
 	clusterID := hex.EncodeToString(initResp.GetClusterId())
 
+	stateFile.SetClusterValues(state.ClusterValues{
+		MeasurementSalt: measurementSalt,
+		OwnerID:         ownerID,
+		ClusterID:       clusterID,
+	})
+
 	tw := tabwriter.NewWriter(wr, 0, 0, 2, ' ', 0)
-	// writeRow(tw, "Constellation cluster's owner identifier", ownerID)
 	writeRow(tw, "Constellation cluster identifier", clusterID)
 	writeRow(tw, "Kubernetes configuration", i.pf.PrefixPrintablePath(constants.AdminConfFilename))
 	tw.Flush()
 	fmt.Fprintln(wr)
 
-	i.log.Debugf("Rewriting cluster server address in kubeconfig to %s", idFile.IP)
+	i.log.Debugf("Rewriting cluster server address in kubeconfig to %s", stateFile.Infrastructure.ClusterEndpoint)
 	kubeconfig, err := clientcmd.Load(initResp.GetKubeconfig())
 	if err != nil {
 		return fmt.Errorf("loading kubeconfig: %w", err)
@@ -481,7 +474,7 @@ func (i *initCmd) writeOutput(
 		if err != nil {
 			return fmt.Errorf("parsing kubeconfig server URL: %w", err)
 		}
-		kubeEndpoint.Host = net.JoinHostPort(idFile.IP, kubeEndpoint.Port())
+		kubeEndpoint.Host = net.JoinHostPort(stateFile.Infrastructure.ClusterEndpoint, kubeEndpoint.Port())
 		cluster.Server = kubeEndpoint.String()
 	}
 	kubeconfigBytes, err := clientcmd.Write(*kubeconfig)
@@ -503,23 +496,11 @@ func (i *initCmd) writeOutput(
 		}
 	}
 
-	idFile.OwnerID = ownerID
-	idFile.ClusterID = clusterID
-
-	stateFile.SetClusterValues(state.ClusterValues{
-		MeasurementSalt: measurementSalt,
-		OwnerID:         ownerID,
-		ClusterID:       clusterID,
-	})
-
 	if err := stateFile.WriteToFile(i.fileHandler, constants.StateFilename); err != nil {
-		return fmt.Errorf("writing state file: %w", err)
+		return fmt.Errorf("writing Constellation state file: %w", err)
 	}
 
-	if err := i.fileHandler.WriteJSON(constants.ClusterIDsFilename, idFile, file.OptOverwrite); err != nil {
-		return fmt.Errorf("writing Constellation ID file: %w", err)
-	}
-	i.log.Debugf("Constellation ID file written to %s", i.pf.PrefixPrintablePath(constants.ClusterIDsFilename))
+	i.log.Debugf("Constellation state file written to %s", i.pf.PrefixPrintablePath(constants.StateFilename))
 
 	if !mergeConfig {
 		fmt.Fprintln(wr, "You can now connect to your cluster by executing:")

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -798,14 +798,6 @@ func (c stubInitClient) Recv() (*initproto.InitResponse, error) {
 	return res, err
 }
 
-type stubShowInfrastructure struct {
-	showInfraErr error
-}
-
-func (s *stubShowInfrastructure) ShowInfrastructure(context.Context, cloudprovider.Provider) (state.Infrastructure, error) {
-	return state.Infrastructure{}, s.showInfraErr
-}
-
 type stubAttestationApplier struct {
 	applyErr error
 }

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -406,6 +406,7 @@ func TestWriteOutput(t *testing.T) {
 
 	ownerID := hex.EncodeToString(resp.GetInitSuccess().GetOwnerId())
 	clusterID := hex.EncodeToString(resp.GetInitSuccess().GetClusterId())
+	measurementSalt := []byte{0x41}
 
 	expectedIDFile := clusterid.File{
 		ClusterID: clusterID,
@@ -419,7 +420,7 @@ func TestWriteOutput(t *testing.T) {
 		ClusterValues: state.ClusterValues{
 			ClusterID:       clusterID,
 			OwnerID:         ownerID,
-			MeasurementSalt: []byte{},
+			MeasurementSalt: []byte{0x41},
 		},
 		Infrastructure: state.Infrastructure{APIServerCertSANs: []string{}},
 	}
@@ -435,7 +436,7 @@ func TestWriteOutput(t *testing.T) {
 	stateFile := state.New()
 
 	i := newInitCmd(fileHandler, &nopSpinner{}, &stubMerger{}, logger.NewTest(t))
-	err = i.writeOutput(idFile, stateFile, resp.GetInitSuccess(), false, &out)
+	err = i.writeOutput(idFile, stateFile, resp.GetInitSuccess(), false, &out, measurementSalt)
 	require.NoError(err)
 	// assert.Contains(out.String(), ownerID)
 	assert.Contains(out.String(), clusterID)
@@ -463,7 +464,7 @@ func TestWriteOutput(t *testing.T) {
 
 	// test custom workspace
 	i.pf = pathprefix.New("/some/path")
-	err = i.writeOutput(idFile, stateFile, resp.GetInitSuccess(), true, &out)
+	err = i.writeOutput(idFile, stateFile, resp.GetInitSuccess(), true, &out, measurementSalt)
 	require.NoError(err)
 	// assert.Contains(out.String(), ownerID)
 	assert.Contains(out.String(), clusterID)
@@ -474,7 +475,7 @@ func TestWriteOutput(t *testing.T) {
 	i.pf = pathprefix.PathPrefixer{}
 
 	// test config merging
-	err = i.writeOutput(idFile, stateFile, resp.GetInitSuccess(), true, &out)
+	err = i.writeOutput(idFile, stateFile, resp.GetInitSuccess(), true, &out, measurementSalt)
 	require.NoError(err)
 	// assert.Contains(out.String(), ownerID)
 	assert.Contains(out.String(), clusterID)
@@ -486,7 +487,7 @@ func TestWriteOutput(t *testing.T) {
 
 	// test config merging with env vars set
 	i.merger = &stubMerger{envVar: "/some/path/to/kubeconfig"}
-	err = i.writeOutput(idFile, stateFile, resp.GetInitSuccess(), true, &out)
+	err = i.writeOutput(idFile, stateFile, resp.GetInitSuccess(), true, &out, measurementSalt)
 	require.NoError(err)
 	// assert.Contains(out.String(), ownerID)
 	assert.Contains(out.String(), clusterID)

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/edgelesssys/constellation/v2/bootstrapper/initproto"
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/cmd/pathprefix"
 	"github.com/edgelesssys/constellation/v2/cli/internal/helm"
 	"github.com/edgelesssys/constellation/v2/cli/internal/state"
@@ -92,7 +91,6 @@ func TestInitialize(t *testing.T) {
 
 	testCases := map[string]struct {
 		provider                cloudprovider.Provider
-		idFile                  *clusterid.File
 		stateFile               *state.State
 		configMutator           func(*config.Config)
 		serviceAccKey           *gcpshared.ServiceAccountKey
@@ -103,7 +101,6 @@ func TestInitialize(t *testing.T) {
 	}{
 		"initialize some gcp instances": {
 			provider:      cloudprovider.GCP,
-			idFile:        &clusterid.File{IP: "192.0.2.1"},
 			stateFile:     &state.State{Version: state.Version1, Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.1"}},
 			configMutator: func(c *config.Config) { c.Provider.GCP.ServiceAccountKeyPath = serviceAccPath },
 			serviceAccKey: gcpServiceAccKey,
@@ -111,19 +108,16 @@ func TestInitialize(t *testing.T) {
 		},
 		"initialize some azure instances": {
 			provider:      cloudprovider.Azure,
-			idFile:        &clusterid.File{IP: "192.0.2.1"},
 			stateFile:     &state.State{Version: state.Version1, Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.1"}},
 			initServerAPI: &stubInitServer{res: []*initproto.InitResponse{{Kind: &initproto.InitResponse_InitSuccess{InitSuccess: testInitResp}}}},
 		},
 		"initialize some qemu instances": {
 			provider:      cloudprovider.QEMU,
-			idFile:        &clusterid.File{IP: "192.0.2.1"},
 			stateFile:     &state.State{Version: state.Version1, Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.1"}},
 			initServerAPI: &stubInitServer{res: []*initproto.InitResponse{{Kind: &initproto.InitResponse_InitSuccess{InitSuccess: testInitResp}}}},
 		},
 		"non retriable error": {
 			provider:                cloudprovider.QEMU,
-			idFile:                  &clusterid.File{IP: "192.0.2.1"},
 			stateFile:               &state.State{Version: state.Version1, Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.1"}},
 			initServerAPI:           &stubInitServer{initErr: &nonRetriableError{err: assert.AnError}},
 			retriable:               false,
@@ -132,7 +126,6 @@ func TestInitialize(t *testing.T) {
 		},
 		"non retriable error with failed log collection": {
 			provider:  cloudprovider.QEMU,
-			idFile:    &clusterid.File{IP: "192.0.2.1"},
 			stateFile: &state.State{Version: state.Version1, Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.1"}},
 			initServerAPI: &stubInitServer{
 				res: []*initproto.InitResponse{
@@ -156,22 +149,27 @@ func TestInitialize(t *testing.T) {
 			masterSecretShouldExist: true,
 			wantErr:                 true,
 		},
-		"empty id file": {
+		"state file with only version": {
 			provider:      cloudprovider.GCP,
-			idFile:        &clusterid.File{},
+			stateFile:     &state.State{Version: state.Version1},
+			initServerAPI: &stubInitServer{},
+			retriable:     true,
+			wantErr:       true,
+		},
+		"empty state file": {
+			provider:      cloudprovider.GCP,
 			stateFile:     &state.State{},
 			initServerAPI: &stubInitServer{},
 			retriable:     true,
 			wantErr:       true,
 		},
-		"no id file": {
+		"no state file": {
 			provider:  cloudprovider.GCP,
 			retriable: true,
 			wantErr:   true,
 		},
 		"init call fails": {
 			provider:      cloudprovider.GCP,
-			idFile:        &clusterid.File{IP: "192.0.2.1"},
 			stateFile:     &state.State{Version: state.Version1, Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.1"}},
 			initServerAPI: &stubInitServer{initErr: assert.AnError},
 			retriable:     true,
@@ -179,7 +177,6 @@ func TestInitialize(t *testing.T) {
 		},
 		"k8s version without v works": {
 			provider:      cloudprovider.Azure,
-			idFile:        &clusterid.File{IP: "192.0.2.1"},
 			stateFile:     &state.State{Version: state.Version1, Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.1"}},
 			initServerAPI: &stubInitServer{res: []*initproto.InitResponse{{Kind: &initproto.InitResponse_InitSuccess{InitSuccess: testInitResp}}}},
 			configMutator: func(c *config.Config) {
@@ -190,7 +187,6 @@ func TestInitialize(t *testing.T) {
 		},
 		"outdated k8s patch version doesn't work": {
 			provider:      cloudprovider.Azure,
-			idFile:        &clusterid.File{IP: "192.0.2.1"},
 			stateFile:     &state.State{Version: state.Version1, Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.1"}},
 			initServerAPI: &stubInitServer{res: []*initproto.InitResponse{{Kind: &initproto.InitResponse_InitSuccess{InitSuccess: testInitResp}}}},
 			configMutator: func(c *config.Config) {
@@ -241,10 +237,6 @@ func TestInitialize(t *testing.T) {
 			require.NoError(fileHandler.WriteYAML(constants.ConfigFilename, config, file.OptNone))
 			stateFile := state.New()
 			require.NoError(stateFile.WriteToFile(fileHandler, constants.StateFilename))
-			if tc.idFile != nil {
-				tc.idFile.CloudProvider = tc.provider
-				require.NoError(fileHandler.WriteJSON(constants.ClusterIDsFilename, tc.idFile, file.OptNone))
-			}
 			if tc.stateFile != nil {
 				require.NoError(tc.stateFile.WriteToFile(fileHandler, constants.StateFilename))
 			}
@@ -408,13 +400,6 @@ func TestWriteOutput(t *testing.T) {
 	clusterID := hex.EncodeToString(resp.GetInitSuccess().GetClusterId())
 	measurementSalt := []byte{0x41}
 
-	expectedIDFile := clusterid.File{
-		ClusterID: clusterID,
-		OwnerID:   ownerID,
-		IP:        clusterEndpoint,
-		UID:       "test-uid",
-	}
-
 	expectedStateFile := &state.State{
 		Version: state.Version1,
 		ClusterValues: state.ClusterValues{
@@ -422,23 +407,24 @@ func TestWriteOutput(t *testing.T) {
 			OwnerID:         ownerID,
 			MeasurementSalt: []byte{0x41},
 		},
-		Infrastructure: state.Infrastructure{APIServerCertSANs: []string{}},
+		Infrastructure: state.Infrastructure{
+			APIServerCertSANs: []string{},
+			InitSecret:        []byte{},
+			ClusterEndpoint:   clusterEndpoint,
+		},
 	}
 
 	var out bytes.Buffer
 	testFs := afero.NewMemMapFs()
 	fileHandler := file.NewHandler(testFs)
 
-	idFile := clusterid.File{
-		UID: "test-uid",
-		IP:  clusterEndpoint,
-	}
-	stateFile := state.New()
+	stateFile := state.New().SetInfrastructure(state.Infrastructure{
+		ClusterEndpoint: clusterEndpoint,
+	})
 
 	i := newInitCmd(fileHandler, &nopSpinner{}, &stubMerger{}, logger.NewTest(t))
-	err = i.writeOutput(idFile, stateFile, resp.GetInitSuccess(), false, &out, measurementSalt)
+	err = i.writeOutput(stateFile, resp.GetInitSuccess(), false, &out, measurementSalt)
 	require.NoError(err)
-	// assert.Contains(out.String(), ownerID)
 	assert.Contains(out.String(), clusterID)
 	assert.Contains(out.String(), constants.AdminConfFilename)
 
@@ -447,13 +433,6 @@ func TestWriteOutput(t *testing.T) {
 	assert.NoError(err)
 	assert.Contains(string(adminConf), clusterEndpoint)
 	assert.Equal(string(expectedKubeconfigBytes), string(adminConf))
-
-	idsFile, err := afs.ReadFile(constants.ClusterIDsFilename)
-	assert.NoError(err)
-	var testIDFile clusterid.File
-	err = json.Unmarshal(idsFile, &testIDFile)
-	assert.NoError(err)
-	assert.Equal(expectedIDFile, testIDFile)
 
 	fh := file.NewHandler(afs)
 	readStateFile, err := state.ReadFromFile(fh, constants.StateFilename)
@@ -464,9 +443,8 @@ func TestWriteOutput(t *testing.T) {
 
 	// test custom workspace
 	i.pf = pathprefix.New("/some/path")
-	err = i.writeOutput(idFile, stateFile, resp.GetInitSuccess(), true, &out, measurementSalt)
+	err = i.writeOutput(stateFile, resp.GetInitSuccess(), true, &out, measurementSalt)
 	require.NoError(err)
-	// assert.Contains(out.String(), ownerID)
 	assert.Contains(out.String(), clusterID)
 	assert.Contains(out.String(), i.pf.PrefixPrintablePath(constants.AdminConfFilename))
 	out.Reset()
@@ -475,9 +453,8 @@ func TestWriteOutput(t *testing.T) {
 	i.pf = pathprefix.PathPrefixer{}
 
 	// test config merging
-	err = i.writeOutput(idFile, stateFile, resp.GetInitSuccess(), true, &out, measurementSalt)
+	err = i.writeOutput(stateFile, resp.GetInitSuccess(), true, &out, measurementSalt)
 	require.NoError(err)
-	// assert.Contains(out.String(), ownerID)
 	assert.Contains(out.String(), clusterID)
 	assert.Contains(out.String(), constants.AdminConfFilename)
 	assert.Contains(out.String(), "Constellation kubeconfig merged with default config")
@@ -487,9 +464,8 @@ func TestWriteOutput(t *testing.T) {
 
 	// test config merging with env vars set
 	i.merger = &stubMerger{envVar: "/some/path/to/kubeconfig"}
-	err = i.writeOutput(idFile, stateFile, resp.GetInitSuccess(), true, &out, measurementSalt)
+	err = i.writeOutput(stateFile, resp.GetInitSuccess(), true, &out, measurementSalt)
 	require.NoError(err)
-	// assert.Contains(out.String(), ownerID)
 	assert.Contains(out.String(), clusterID)
 	assert.Contains(out.String(), constants.AdminConfFilename)
 	assert.Contains(out.String(), "Constellation kubeconfig merged with default config")
@@ -568,7 +544,7 @@ func TestAttestation(t *testing.T) {
 			},
 		},
 	}}
-	existingIDFile := &clusterid.File{IP: "192.0.2.4", CloudProvider: cloudprovider.QEMU}
+
 	existingStateFile := &state.State{Version: state.Version1, Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.4"}}
 
 	netDialer := testdialer.NewBufconnDialer()
@@ -600,7 +576,6 @@ func TestAttestation(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	fileHandler := file.NewHandler(fs)
-	require.NoError(fileHandler.WriteJSON(constants.ClusterIDsFilename, existingIDFile, file.OptNone))
 	require.NoError(existingStateFile.WriteToFile(fileHandler, constants.StateFilename))
 
 	cfg := config.Default()

--- a/cli/internal/cmd/minidown.go
+++ b/cli/internal/cmd/minidown.go
@@ -11,8 +11,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
-	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
+	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/spf13/afero"
@@ -44,14 +43,12 @@ func runDown(cmd *cobra.Command, args []string) error {
 }
 
 func checkForMiniCluster(fileHandler file.Handler) error {
-	var idFile clusterid.File
-	if err := fileHandler.ReadJSON(constants.ClusterIDsFilename, &idFile); err != nil {
-		return err
+	stateFile, err := state.ReadFromFile(fileHandler, constants.StateFilename)
+	if err != nil {
+		return fmt.Errorf("reading state file: %w", err)
 	}
-	if idFile.CloudProvider != cloudprovider.QEMU {
-		return errors.New("cluster is not a QEMU based Constellation")
-	}
-	if idFile.UID != constants.MiniConstellationUID {
+
+	if stateFile.Infrastructure.UID != constants.MiniConstellationUID {
 		return errors.New("cluster is not a MiniConstellation cluster")
 	}
 

--- a/cli/internal/cmd/miniup.go
+++ b/cli/internal/cmd/miniup.go
@@ -208,18 +208,13 @@ func (m *miniUpCmd) initializeMiniCluster(cmd *cobra.Command, fileHandler file.H
 	m.log.Debugf("Created new logger")
 	defer log.Sync()
 
-	tfClient, err := terraform.New(cmd.Context(), constants.TerraformWorkingDir)
-	if err != nil {
-		return fmt.Errorf("creating Terraform client: %w", err)
-	}
-
 	newAttestationApplier := func(w io.Writer, kubeConfig string, log debugLog) (attestationConfigApplier, error) {
 		return kubecmd.New(w, kubeConfig, fileHandler, log)
 	}
 	newHelmClient := func(kubeConfigPath string, log debugLog) (helmApplier, error) {
 		return helm.NewClient(kubeConfigPath, log)
 	} // need to defer helm client instantiation until kubeconfig is available
-	i := newInitCmd(tfClient, fileHandler, spinner, &kubeconfigMerger{log: log}, log)
+	i := newInitCmd(fileHandler, spinner, &kubeconfigMerger{log: log}, log)
 	if err := i.initialize(cmd, newDialer, license.NewClient(), m.configFetcher,
 		newAttestationApplier, newHelmClient); err != nil {
 		return err

--- a/cli/internal/cmd/recover.go
+++ b/cli/internal/cmd/recover.go
@@ -24,7 +24,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
-	"github.com/edgelesssys/constellation/v2/internal/crypto"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/grpc/dialer"
 	grpcRetry "github.com/edgelesssys/constellation/v2/internal/grpc/retry"
@@ -254,10 +253,4 @@ func (r *recoverCmd) parseRecoverFlags(cmd *cobra.Command, fileHandler file.Hand
 		maaURL:   idFile.AttestationURL,
 		force:    force,
 	}, nil
-}
-
-func getStateDiskKeyFunc(masterKey, salt []byte) func(uuid string) ([]byte, error) {
-	return func(uuid string) ([]byte, error) {
-		return crypto.DeriveKey(masterKey, salt, []byte(crypto.DEKPrefix+uuid), crypto.StateDiskKeyLength)
-	}
 }

--- a/cli/internal/cmd/recover.go
+++ b/cli/internal/cmd/recover.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/cmd/pathprefix"
+	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/disk-mapper/recoverproto"
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfigapi"
 	"github.com/edgelesssys/constellation/v2/internal/atls"
@@ -224,33 +224,40 @@ func (r *recoverCmd) parseRecoverFlags(cmd *cobra.Command, fileHandler file.Hand
 	r.log.Debugf("Workspace set to %q", workDir)
 	r.pf = pathprefix.New(workDir)
 
-	var idFile clusterid.File
-	if err := fileHandler.ReadJSON(constants.ClusterIDsFilename, &idFile); err != nil && !errors.Is(err, afero.ErrFileNotFound) {
-		return recoverFlags{}, err
-	}
-
 	endpoint, err := cmd.Flags().GetString("endpoint")
 	r.log.Debugf("Endpoint flag is %s", endpoint)
 	if err != nil {
 		return recoverFlags{}, fmt.Errorf("parsing endpoint argument: %w", err)
 	}
-	if endpoint == "" {
-		endpoint = idFile.IP
-	}
-	endpoint, err = addPortIfMissing(endpoint, constants.RecoveryPort)
-	if err != nil {
-		return recoverFlags{}, fmt.Errorf("validating endpoint argument: %w", err)
-	}
-	r.log.Debugf("Endpoint value after parsing is %s", endpoint)
 
 	force, err := cmd.Flags().GetBool("force")
 	if err != nil {
 		return recoverFlags{}, fmt.Errorf("parsing force argument: %w", err)
 	}
 
+	var attestationURL string
+	stateFile := state.New()
+	if endpoint == "" {
+		stateFile, err = state.ReadFromFile(fileHandler, constants.StateFilename)
+		if err != nil {
+			return recoverFlags{}, fmt.Errorf("reading state file: %w", err)
+		}
+		endpoint = stateFile.Infrastructure.ClusterEndpoint
+	}
+
+	endpoint, err = addPortIfMissing(endpoint, constants.RecoveryPort)
+	if err != nil {
+		return recoverFlags{}, fmt.Errorf("validating endpoint argument: %w", err)
+	}
+	r.log.Debugf("Endpoint value after parsing is %s", endpoint)
+
+	if stateFile.Infrastructure.Azure != nil {
+		attestationURL = stateFile.Infrastructure.Azure.AttestationURL
+	}
+
 	return recoverFlags{
 		endpoint: endpoint,
-		maaURL:   idFile.AttestationURL,
+		maaURL:   attestationURL,
 		force:    force,
 	}, nil
 }

--- a/cli/internal/cmd/recover_test.go
+++ b/cli/internal/cmd/recover_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
+	"github.com/edgelesssys/constellation/v2/internal/crypto"
 	"github.com/edgelesssys/constellation/v2/internal/crypto/testvector"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/edgelesssys/constellation/v2/internal/grpc/atlscredentials"
@@ -306,6 +307,12 @@ func TestDeriveStateDiskKey(t *testing.T) {
 			assert.NoError(err)
 			assert.Equal(tc.masterSecret.Output, stateDiskKey)
 		})
+	}
+}
+
+func getStateDiskKeyFunc(masterKey, salt []byte) func(uuid string) ([]byte, error) {
+	return func(uuid string) ([]byte, error) {
+		return crypto.DeriveKey(masterKey, salt, []byte(crypto.DEKPrefix+uuid), crypto.StateDiskKeyLength)
 	}
 }
 

--- a/cli/internal/cmd/terminate.go
+++ b/cli/internal/cmd/terminate.go
@@ -84,6 +84,7 @@ func terminate(cmd *cobra.Command, terminator cloudTerminator, fileHandler file.
 		removeErr = errors.Join(err, fmt.Errorf("failed to remove file: '%s', please remove it manually", pf.PrefixPrintablePath(constants.AdminConfFilename)))
 	}
 
+	// TODO(msanft): Once v2.12.0 is released, remove the ID-file-removal here.
 	if err := fileHandler.Remove(constants.ClusterIDsFilename); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		removeErr = errors.Join(err, fmt.Errorf("failed to remove file: '%s', please remove it manually", pf.PrefixPrintablePath(constants.ClusterIDsFilename)))
 	}

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -213,6 +213,8 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 	// the Terraform migrations.
 	var postMigrationInfraState state.Infrastructure
 	if flags.skipPhases.contains(skipInfrastructurePhase) {
+		// TODO(msanft): Once v2.12.0 is released, this should be removed and the state should be read
+		// from the state file instead, as it will be the only source of truth for the cluster's infrastructure.
 		postMigrationInfraState, err = u.clusterShower.ShowInfrastructure(cmd.Context(), conf.GetProvider())
 		if err != nil {
 			return fmt.Errorf("getting Terraform state: %w", err)

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -230,10 +230,9 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 		return fmt.Errorf("writing state file: %w", err)
 	}
 
-	cmd.Printf("Infrastructure migrations applied successfully and output written to: %s and %s\n"+
+	cmd.Printf("Infrastructure migrations applied successfully and output written to: %s\n"+
 		"A backup of the pre-upgrade state has been written to: %s\n",
 		flags.pf.PrefixPrintablePath(constants.StateFilename),
-		flags.pf.PrefixPrintablePath(constants.ClusterIDsFilename),
 		flags.pf.PrefixPrintablePath(filepath.Join(upgradeDir, constants.TerraformUpgradeBackupDir)),
 	)
 

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -188,7 +188,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 			return fmt.Errorf("reading cluster ID file: %w", err)
 		}
 		// Convert id-file to state file
-		stateFile = state.NewFromIDFile(idFile)
+		stateFile = state.NewFromIDFile(idFile, conf)
 		if stateFile.Infrastructure.Azure != nil {
 			conf.UpdateMAAURL(stateFile.Infrastructure.Azure.AttestationURL)
 		}

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -230,12 +230,6 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 		return fmt.Errorf("writing state file: %w", err)
 	}
 
-	cmd.Printf("Infrastructure migrations applied successfully and output written to: %s\n"+
-		"A backup of the pre-upgrade state has been written to: %s\n",
-		flags.pf.PrefixPrintablePath(constants.StateFilename),
-		flags.pf.PrefixPrintablePath(filepath.Join(upgradeDir, constants.TerraformUpgradeBackupDir)),
-	)
-
 	// extend the clusterConfig cert SANs with any of the supported endpoints:
 	// - (legacy) public IP
 	// - fallback endpoint
@@ -350,7 +344,11 @@ func (u *upgradeApplyCmd) migrateTerraform(
 			return state.Infrastructure{}, fmt.Errorf("applying terraform migrations: %w", err)
 		}
 
-		cmd.Printf("Terraform migrations applied successfully.")
+		cmd.Printf("Infrastructure migrations applied successfully and output written to: %s\n"+
+			"A backup of the pre-upgrade state has been written to: %s\n",
+			flags.pf.PrefixPrintablePath(constants.StateFilename),
+			flags.pf.PrefixPrintablePath(filepath.Join(upgradeDir, constants.TerraformUpgradeBackupDir)),
+		)
 		return infraState, nil
 	}
 

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -243,6 +243,7 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 	// - (legacy) public IP
 	// - fallback endpoint
 	// - custom (user-provided) endpoint
+	// TODO(msanft): Remove the comment below once v2.12.0 is released.
 	// At this point, state file and id-file should have been merged, so we can use the state file.
 	sans := append([]string{stateFile.Infrastructure.ClusterEndpoint, conf.CustomEndpoint}, stateFile.Infrastructure.APIServerCertSANs...)
 	if err := u.kubeUpgrader.ExtendClusterConfigCertSANs(cmd.Context(), sans); err != nil {

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -239,6 +239,13 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 		return fmt.Errorf("writing state file: %w", err)
 	}
 
+	// TODO(msanft): Remove this after v2.12.0 is released, as we do not support
+	// the id-file starting from v2.13.0.
+	err = u.fileHandler.RenameFile(constants.ClusterIDsFilename, constants.ClusterIDsFilename+".old")
+	if !errors.Is(err, fs.ErrNotExist) && err != nil {
+		return fmt.Errorf("removing cluster ID file: %w", err)
+	}
+
 	// extend the clusterConfig cert SANs with any of the supported endpoints:
 	// - (legacy) public IP
 	// - fallback endpoint

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -298,6 +298,7 @@ func diffAttestationCfg(currentAttestationCfg config.AttestationCfg, newAttestat
 
 // migrateTerraform checks if the Constellation version the cluster is being upgraded to requires a migration
 // of cloud resources with Terraform. If so, the migration is performed and the post-migration infrastructure state is returned.
+// If no migration is required, the current (pre-upgrade) infrastructure state is returned.
 func (u *upgradeApplyCmd) migrateTerraform(
 	cmd *cobra.Command, conf *config.Config, upgradeDir string, flags upgradeApplyFlags,
 ) (state.Infrastructure, error) {
@@ -325,7 +326,7 @@ func (u *upgradeApplyCmd) migrateTerraform(
 	}
 	if !hasDiff {
 		u.log.Debugf("No Terraform diff detected")
-		return state.Infrastructure{}, nil
+		return u.clusterShower.ShowInfrastructure(cmd.Context(), conf.GetProvider())
 	}
 
 	// If there are any Terraform migrations to apply, ask for confirmation

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -346,3 +346,11 @@ func (m *mockApplier) PrepareApply(cfg *config.Config, stateFile *state.State,
 	args := m.Called(cfg, stateFile, helmOpts, str, masterSecret)
 	return args.Get(0).(helm.Applier), args.Bool(1), args.Error(2)
 }
+
+type stubShowInfrastructure struct {
+	showInfraErr error
+}
+
+func (s *stubShowInfrastructure) ShowInfrastructure(context.Context, cloudprovider.Provider) (state.Infrastructure, error) {
+	return state.Infrastructure{}, s.showInfraErr
+}

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -38,6 +38,7 @@ func TestUpgradeApply(t *testing.T) {
 		SetInfrastructure(state.Infrastructure{
 			APIServerCertSANs: []string{},
 			UID:               "uid",
+			Name:              "kubernetes-uid", // default test cfg uses "kubernetes" prefix
 		}).
 		SetClusterValues(state.ClusterValues{MeasurementSalt: []byte{0x41}})
 	defaultIDFile := clusterid.File{

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -40,13 +40,13 @@ func TestUpgradeApply(t *testing.T) {
 			UID:               "uid",
 		}).
 		SetClusterValues(state.ClusterValues{MeasurementSalt: []byte{0x41}})
-	defaultIdFile := clusterid.File{
+	defaultIDFile := clusterid.File{
 		MeasurementSalt: []byte{0x41},
 		UID:             "uid",
 	}
-	fsWithIdFile := func() file.Handler {
+	fsWithIDFile := func() file.Handler {
 		fh := file.NewHandler(afero.NewMemMapFs())
-		require.NoError(t, fh.WriteJSON(constants.ClusterIDsFilename, defaultIdFile))
+		require.NoError(t, fh.WriteJSON(constants.ClusterIDsFilename, defaultIDFile))
 		return fh
 	}
 	fsWithStateFile := func() file.Handler {
@@ -87,7 +87,7 @@ func TestUpgradeApply(t *testing.T) {
 			terraformUpgrader:    &stubTerraformUpgrader{},
 			flags:                upgradeApplyFlags{yes: true},
 			infrastructureShower: &stubShowInfrastructure{},
-			fh:                   fsWithIdFile,
+			fh:                   fsWithIDFile,
 			fhAssertions: func(require *require.Assertions, assert *assert.Assertions, fh file.Handler) {
 				gotState, err := state.ReadFromFile(fh, constants.StateFilename)
 				require.NoError(err)

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -39,11 +39,13 @@ func TestUpgradeApply(t *testing.T) {
 			APIServerCertSANs: []string{},
 			UID:               "uid",
 			Name:              "kubernetes-uid", // default test cfg uses "kubernetes" prefix
+			InitSecret:        []byte{0x42},
 		}).
 		SetClusterValues(state.ClusterValues{MeasurementSalt: []byte{0x41}})
 	defaultIDFile := clusterid.File{
 		MeasurementSalt: []byte{0x41},
 		UID:             "uid",
+		InitSecret:      []byte{0x42},
 	}
 	fsWithIDFile := func() file.Handler {
 		fh := file.NewHandler(afero.NewMemMapFs())
@@ -94,6 +96,10 @@ func TestUpgradeApply(t *testing.T) {
 				require.NoError(err)
 				assert.Equal("v1", gotState.Version)
 				assert.Equal(defaultState, gotState)
+				var oldIDFile clusterid.File
+				err = fh.ReadJSON(constants.ClusterIDsFilename+".old", &oldIDFile)
+				assert.NoError(err)
+				assert.Equal(defaultIDFile, oldIDFile)
 			},
 		},
 		"id file and state file do not exist": {

--- a/cli/internal/cmd/verify.go
+++ b/cli/internal/cmd/verify.go
@@ -26,8 +26,8 @@ import (
 	tpmProto "github.com/google/go-tpm-tools/proto/tpm"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/cmd/pathprefix"
+	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfigapi"
 	"github.com/edgelesssys/constellation/v2/internal/atls"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
@@ -54,7 +54,7 @@ func NewVerifyCmd() *cobra.Command {
 		Use:   "verify",
 		Short: "Verify the confidential properties of a Constellation cluster",
 		Long: "Verify the confidential properties of a Constellation cluster.\n" +
-			"If arguments aren't specified, values are read from `" + constants.ClusterIDsFilename + "`.",
+			"If arguments aren't specified, values are read from `" + constants.StateFilename + "`.",
 		Args: cobra.ExactArgs(0),
 		RunE: runVerify,
 	}
@@ -204,25 +204,34 @@ func (c *verifyCmd) parseVerifyFlags(cmd *cobra.Command, fileHandler file.Handle
 	}
 	c.log.Debugf("Flag 'output' set to %t", output)
 
-	var idFile clusterid.File
-	if err := fileHandler.ReadJSON(constants.ClusterIDsFilename, &idFile); err != nil && !errors.Is(err, afero.ErrFileNotFound) {
-		return verifyFlags{}, fmt.Errorf("reading cluster ID file: %w", err)
+	// Get empty values from state file
+	stateFile, err := state.ReadFromFile(fileHandler, constants.StateFilename)
+	isFileNotFound := errors.Is(err, afero.ErrFileNotFound)
+	if isFileNotFound {
+		c.log.Debugf("State file %q not found, using empty state", pf.PrefixPrintablePath(constants.StateFilename))
+		stateFile = state.New() // error compat
+	} else if err != nil {
+		return verifyFlags{}, fmt.Errorf("reading state file: %w", err)
 	}
 
-	// Get empty values from ID file
 	emptyEndpoint := endpoint == ""
 	emptyIDs := ownerID == "" && clusterID == ""
 	if emptyEndpoint || emptyIDs {
-		c.log.Debugf("Trying to supplement empty flag values from %q", pf.PrefixPrintablePath(constants.ClusterIDsFilename))
+		c.log.Debugf("Trying to supplement empty flag values from %q", pf.PrefixPrintablePath(constants.StateFilename))
 		if emptyEndpoint {
-			cmd.PrintErrf("Using endpoint from %q. Specify --node-endpoint to override this.\n", pf.PrefixPrintablePath(constants.ClusterIDsFilename))
-			endpoint = idFile.IP
+			cmd.PrintErrf("Using endpoint from %q. Specify --node-endpoint to override this.\n", pf.PrefixPrintablePath(constants.StateFilename))
+			endpoint = stateFile.Infrastructure.ClusterEndpoint
 		}
 		if emptyIDs {
-			cmd.PrintErrf("Using ID from %q. Specify --cluster-id to override this.\n", pf.PrefixPrintablePath(constants.ClusterIDsFilename))
-			ownerID = idFile.OwnerID
-			clusterID = idFile.ClusterID
+			cmd.PrintErrf("Using ID from %q. Specify --cluster-id to override this.\n", pf.PrefixPrintablePath(constants.StateFilename))
+			ownerID = stateFile.ClusterValues.OwnerID
+			clusterID = stateFile.ClusterValues.ClusterID
 		}
+	}
+
+	var attestationURL string
+	if stateFile.Infrastructure.Azure != nil {
+		attestationURL = stateFile.Infrastructure.Azure.AttestationURL
 	}
 
 	// Validate
@@ -239,8 +248,8 @@ func (c *verifyCmd) parseVerifyFlags(cmd *cobra.Command, fileHandler file.Handle
 		pf:        pf,
 		ownerID:   ownerID,
 		clusterID: clusterID,
-		maaURL:    idFile.AttestationURL,
 		output:    output,
+		maaURL:    attestationURL,
 		force:     force,
 	}, nil
 }

--- a/cli/internal/helm/BUILD.bazel
+++ b/cli/internal/helm/BUILD.bazel
@@ -416,7 +416,6 @@ go_library(
     importpath = "github.com/edgelesssys/constellation/v2/cli/internal/helm",
     visibility = ["//cli:__subpackages__"],
     deps = [
-        "//cli/internal/clusterid",
         "//cli/internal/helm/imageversion",
         "//cli/internal/state",
         "//internal/cloud/azureshared",
@@ -458,7 +457,6 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":helm"],
     deps = [
-        "//cli/internal/clusterid",
         "//cli/internal/state",
         "//internal/attestation/measurements",
         "//internal/cloud/azureshared",

--- a/cli/internal/helm/helm.go
+++ b/cli/internal/helm/helm.go
@@ -32,7 +32,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
@@ -87,10 +86,10 @@ type Options struct {
 // PrepareApply loads the charts and returns the executor to apply them.
 // TODO(elchead): remove validK8sVersion by putting ValidK8sVersion into config.Config, see AB#3374.
 func (h Client) PrepareApply(
-	conf *config.Config, idFile clusterid.File,
-	flags Options, infra state.Infrastructure, serviceAccURI string, masterSecret uri.MasterSecret,
+	conf *config.Config, stateFile *state.State,
+	flags Options, serviceAccURI string, masterSecret uri.MasterSecret,
 ) (Applier, bool, error) {
-	releases, err := h.loadReleases(conf, masterSecret, idFile, flags, infra, serviceAccURI)
+	releases, err := h.loadReleases(conf, masterSecret, stateFile, flags, serviceAccURI)
 	if err != nil {
 		return nil, false, fmt.Errorf("loading Helm releases: %w", err)
 	}
@@ -101,12 +100,11 @@ func (h Client) PrepareApply(
 
 func (h Client) loadReleases(
 	conf *config.Config, secret uri.MasterSecret,
-	idFile clusterid.File, flags Options, infra state.Infrastructure, serviceAccURI string,
+	stateFile *state.State, flags Options, serviceAccURI string,
 ) ([]Release, error) {
-	helmLoader := newLoader(conf, idFile, h.cliVersion)
+	helmLoader := newLoader(conf, stateFile, h.cliVersion)
 	h.log.Debugf("Created new Helm loader")
-	return helmLoader.loadReleases(flags.Conformance, flags.HelmWaitMode, secret,
-		serviceAccURI, infra)
+	return helmLoader.loadReleases(flags.Conformance, flags.HelmWaitMode, secret, serviceAccURI)
 }
 
 // Applier runs the Helm actions.

--- a/cli/internal/helm/helm_test.go
+++ b/cli/internal/helm/helm_test.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/compatibility"
@@ -208,8 +207,10 @@ func TestHelmApply(t *testing.T) {
 
 			options.AllowDestructive = tc.allowDestructive
 			ex, includesUpgrade, err := sut.PrepareApply(cfg,
-				clusterid.File{UID: "testuid", MeasurementSalt: []byte("measurementSalt")}, options,
-				fakeInfraOutput(csp), fakeServiceAccURI(csp),
+				state.NewState().
+					SetInfrastructure(state.Infrastructure{UID: "testuid"}).
+					SetClusterValues(state.ClusterValues{MeasurementSalt: "measurementSalt"}),
+				options, fakeServiceAccURI(csp),
 				uri.MasterSecret{Key: []byte("secret"), Salt: []byte("masterSalt")})
 			var upgradeErr *compatibility.InvalidUpgradeError
 			if tc.expectError {

--- a/cli/internal/helm/helm_test.go
+++ b/cli/internal/helm/helm_test.go
@@ -207,9 +207,9 @@ func TestHelmApply(t *testing.T) {
 
 			options.AllowDestructive = tc.allowDestructive
 			ex, includesUpgrade, err := sut.PrepareApply(cfg,
-				state.NewState().
+				state.New().
 					SetInfrastructure(state.Infrastructure{UID: "testuid"}).
-					SetClusterValues(state.ClusterValues{MeasurementSalt: "measurementSalt"}),
+					SetClusterValues(state.ClusterValues{MeasurementSalt: []byte{0x41}}),
 				options, fakeServiceAccURI(csp),
 				uri.MasterSecret{Key: []byte("secret"), Salt: []byte("masterSalt")})
 			var upgradeErr *compatibility.InvalidUpgradeError
@@ -223,17 +223,6 @@ func TestHelmApply(t *testing.T) {
 			assert.True(t, ok)
 			assert.ElementsMatch(t, tc.expectedActions, getActionReleaseNames(chartExecutor.actions))
 		})
-	}
-}
-
-func fakeInfraOutput(csp cloudprovider.Provider) state.Infrastructure {
-	switch csp {
-	case cloudprovider.AWS:
-		return state.Infrastructure{}
-	case cloudprovider.GCP:
-		return state.Infrastructure{GCP: &state.GCP{}}
-	default:
-		panic("invalid csp")
 	}
 }
 

--- a/cli/internal/helm/loader.go
+++ b/cli/internal/helm/loader.go
@@ -215,7 +215,7 @@ func (i *chartLoader) loadRelease(info chartInfo, helmWaitMode WaitMode) (Releas
 
 func (i *chartLoader) loadAWSLBControllerValues() map[string]any {
 	return map[string]any{
-		"clusterName":  i.stateFile.ClusterName(i.config),
+		"clusterName":  i.stateFile.Infrastructure.Name,
 		"tolerations":  controlPlaneTolerations,
 		"nodeSelector": controlPlaneNodeSelector,
 	}

--- a/cli/internal/helm/loader_test.go
+++ b/cli/internal/helm/loader_test.go
@@ -95,7 +95,7 @@ func TestLoadAWSLoadBalancerValues(t *testing.T) {
 	sut := chartLoader{
 		config:      &config.Config{Name: "testCluster"},
 		clusterName: "testCluster",
-		stateFile:   state.New().SetInfrastructure(state.Infrastructure{UID: "testuid"}),
+		stateFile:   state.New().SetInfrastructure(state.Infrastructure{UID: "testuid", Name: "testCluster-testuid"}),
 	}
 	val := sut.loadAWSLBControllerValues()
 	assert.Equal(t, "testCluster-testuid", val["clusterName"])

--- a/cli/internal/helm/loader_test.go
+++ b/cli/internal/helm/loader_test.go
@@ -65,9 +65,9 @@ func TestLoadReleases(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	config := &config.Config{Provider: config.ProviderConfig{GCP: &config.GCPConfig{}}}
-	chartLoader := newLoader(config, state.NewState().
+	chartLoader := newLoader(config, state.New().
 		SetInfrastructure(state.Infrastructure{UID: "testuid"}).
-		SetClusterValues(state.ClusterValues{MeasurementSalt: "measurementSalt"}),
+		SetClusterValues(state.ClusterValues{MeasurementSalt: []byte{0x41}}),
 		semver.NewFromInt(2, 10, 0, ""),
 	)
 	helmReleases, err := chartLoader.loadReleases(
@@ -87,7 +87,7 @@ func TestLoadAWSLoadBalancerValues(t *testing.T) {
 	sut := chartLoader{
 		config:      &config.Config{Name: "testCluster"},
 		clusterName: "testCluster",
-		stateFile:   state.NewState().SetInfrastructure(state.Infrastructure{UID: "testuid"}),
+		stateFile:   state.New().SetInfrastructure(state.Infrastructure{UID: "testuid"}),
 	}
 	val := sut.loadAWSLBControllerValues()
 	assert.Equal(t, "testCluster-testuid", val["clusterName"])

--- a/cli/internal/helm/loader_test.go
+++ b/cli/internal/helm/loader_test.go
@@ -65,9 +65,17 @@ func TestLoadReleases(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 	config := &config.Config{Provider: config.ProviderConfig{GCP: &config.GCPConfig{}}}
-	chartLoader := newLoader(config, state.New().
-		SetInfrastructure(state.Infrastructure{UID: "testuid"}).
-		SetClusterValues(state.ClusterValues{MeasurementSalt: []byte{0x41}}),
+	chartLoader := newLoader(
+		config,
+		state.New().
+			SetInfrastructure(state.Infrastructure{
+				GCP: &state.GCP{
+					ProjectID:  "test-project-id",
+					IPCidrNode: "test-node-cidr",
+					IPCidrPod:  "test-pod-cidr",
+				},
+			}).
+			SetClusterValues(state.ClusterValues{MeasurementSalt: []byte{0x41}}),
 		semver.NewFromInt(2, 10, 0, ""),
 	)
 	helmReleases, err := chartLoader.loadReleases(

--- a/cli/internal/helm/overrides.go
+++ b/cli/internal/helm/overrides.go
@@ -54,7 +54,7 @@ func extraCiliumValues(provider cloudprovider.Provider, conformanceMode bool, ou
 // extraConstellationServicesValues extends the given values map by some values depending on user input.
 // Values set inside this function are only applied during init, not during upgrade.
 func extraConstellationServicesValues(
-	cfg *config.Config, masterSecret uri.MasterSecret, uid, serviceAccURI string, output state.Infrastructure,
+	cfg *config.Config, masterSecret uri.MasterSecret, serviceAccURI string, output state.Infrastructure,
 ) (map[string]any, error) {
 	extraVals := map[string]any{}
 	extraVals["join-service"] = map[string]any{
@@ -102,7 +102,7 @@ func extraConstellationServicesValues(
 		extraVals["ccm"] = map[string]any{
 			"GCP": map[string]any{
 				"projectID":         output.GCP.ProjectID,
-				"uid":               uid,
+				"uid":               output.UID,
 				"secretData":        string(rawKey),
 				"subnetworkPodCIDR": output.GCP.IPCidrPod,
 			},

--- a/cli/internal/state/BUILD.bazel
+++ b/cli/internal/state/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     importpath = "github.com/edgelesssys/constellation/v2/cli/internal/state",
     visibility = ["//cli:__subpackages__"],
     deps = [
+        "//cli/internal/clusterid",
         "//internal/config",
         "//internal/file",
         "@cat_dario_mergo//:mergo",
@@ -18,6 +19,7 @@ go_test(
     srcs = ["state_test.go"],
     embed = [":state"],
     deps = [
+        "//cli/internal/clusterid",
         "//internal/constants",
         "//internal/file",
         "@com_github_spf13_afero//:afero",

--- a/cli/internal/state/BUILD.bazel
+++ b/cli/internal/state/BUILD.bazel
@@ -1,8 +1,27 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//bazel/go:go_test.bzl", "go_test")
 
 go_library(
     name = "state",
     srcs = ["state.go"],
     importpath = "github.com/edgelesssys/constellation/v2/cli/internal/state",
     visibility = ["//cli:__subpackages__"],
+    deps = [
+        "//internal/config",
+        "//internal/file",
+        "@cat_dario_mergo//:mergo",
+    ],
+)
+
+go_test(
+    name = "state_test",
+    srcs = ["state_test.go"],
+    embed = [":state"],
+    deps = [
+        "//internal/constants",
+        "//internal/file",
+        "@com_github_spf13_afero//:afero",
+        "@com_github_stretchr_testify//assert",
+        "@in_gopkg_yaml_v3//:yaml_v3",
+    ],
 )

--- a/cli/internal/state/BUILD.bazel
+++ b/cli/internal/state/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     embed = [":state"],
     deps = [
         "//cli/internal/clusterid",
+        "//internal/config",
         "//internal/constants",
         "//internal/file",
         "@com_github_spf13_afero//:afero",

--- a/cli/internal/state/state.go
+++ b/cli/internal/state/state.go
@@ -44,8 +44,8 @@ func New() *State {
 	}
 }
 
-// NewFromIDFile creates a new cluster state file from the given ID file.
-func NewFromIDFile(idFile clusterid.File) *State {
+// NewFromIDFile creates a new cluster state file from the given ID file and config.
+func NewFromIDFile(idFile clusterid.File, cfg *config.Config) *State {
 	s := New().
 		SetClusterValues(ClusterValues{
 			OwnerID:         idFile.OwnerID,
@@ -57,6 +57,7 @@ func NewFromIDFile(idFile clusterid.File) *State {
 			ClusterEndpoint:   idFile.IP,
 			APIServerCertSANs: idFile.APIServerCertSANs,
 			InitSecret:        string(idFile.InitSecret),
+			Name:              clusterid.GetClusterName(cfg, idFile),
 		})
 
 	if idFile.AttestationURL != "" {
@@ -97,11 +98,6 @@ func (s *State) Merge(other *State) (*State, error) {
 	return s, nil
 }
 
-// ClusterName returns the name of the cluster.
-func (s *State) ClusterName(cfg *config.Config) string {
-	return cfg.Name + "-" + s.Infrastructure.UID
-}
-
 // ClusterValues describe the (Kubernetes) cluster state, set during initialization of the cluster.
 type ClusterValues struct {
 	// ClusterID is the unique identifier of the cluster.
@@ -118,8 +114,10 @@ type Infrastructure struct {
 	ClusterEndpoint   string   `yaml:"clusterEndpoint"`
 	InitSecret        string   `yaml:"initSecret"`
 	APIServerCertSANs []string `yaml:"apiServerCertSANs"`
-	Azure             *Azure   `yaml:"azure,omitempty"`
-	GCP               *GCP     `yaml:"gcp,omitempty"`
+	// Name is the name of the cluster.
+	Name  string `yaml:"name"`
+	Azure *Azure `yaml:"azure,omitempty"`
+	GCP   *GCP   `yaml:"gcp,omitempty"`
 }
 
 // GCP describes the infra state related to GCP.

--- a/cli/internal/state/state.go
+++ b/cli/internal/state/state.go
@@ -24,7 +24,7 @@ const (
 // ReadFromFile reads the state file at the given path and returns the state.
 func ReadFromFile(fileHandler file.Handler, path string) (*State, error) {
 	state := &State{}
-	if err := fileHandler.ReadYAML(path, &state); err != nil {
+	if err := fileHandler.ReadYAML(path, state); err != nil {
 		return nil, fmt.Errorf("reading state file: %w", err)
 	}
 	return state, nil

--- a/cli/internal/state/state.go
+++ b/cli/internal/state/state.go
@@ -7,23 +7,84 @@ SPDX-License-Identifier: AGPL-3.0-only
 // package state defines the structure of the Constellation state file.
 package state
 
+import (
+	"fmt"
+
+	"dario.cat/mergo"
+	"github.com/edgelesssys/constellation/v2/internal/config"
+	"github.com/edgelesssys/constellation/v2/internal/file"
+)
+
 const (
 	// Version1 is the first version of the state file.
 	Version1 = "v1"
 )
 
+// ReadFromFile reads the state file at the given path and returns the state.
+func ReadFromFile(fileHandler file.Handler, path string) (*State, error) {
+	state := &State{}
+	if err := fileHandler.ReadYAML(path, &state); err != nil {
+		return nil, fmt.Errorf("reading state file: %w", err)
+	}
+	return state, nil
+}
+
 // State describe the entire state to describe a Constellation cluster.
 type State struct {
 	Version        string         `yaml:"version"`
 	Infrastructure Infrastructure `yaml:"infrastructure"`
+	ClusterValues  ClusterValues  `yaml:"clusterValues"`
 }
 
-// NewState creates a new state with the given infrastructure.
-func NewState(Infrastructure Infrastructure) State {
-	return State{
-		Version:        Version1,
-		Infrastructure: Infrastructure,
+// NewState creates a new cluster state (file).
+func NewState() *State {
+	return &State{
+		Version: Version1,
 	}
+}
+
+// SetInfrastructure sets the infrastructure state.
+func (s *State) SetInfrastructure(infrastructure Infrastructure) *State {
+	s.Infrastructure = infrastructure
+	return s
+}
+
+// SetClusterValues sets the cluster values.
+func (s *State) SetClusterValues(clusterValues ClusterValues) *State {
+	s.ClusterValues = clusterValues
+	return s
+}
+
+// WriteToFile writes the state to the given path, overwriting any existing file.
+func (s *State) WriteToFile(fileHandler file.Handler, path string) error {
+	if err := fileHandler.WriteYAML(path, s, file.OptMkdirAll, file.OptOverwrite); err != nil {
+		return fmt.Errorf("writing state file: %w", err)
+	}
+	return nil
+}
+
+// Merge merges the state information from other into the current state.
+// If a field is set in both states, the value of the other state is used.
+func (s *State) Merge(other *State) (*State, error) {
+	if err := mergo.Merge(s, other, mergo.WithOverride); err != nil {
+		return nil, fmt.Errorf("merging state file: %w", err)
+	}
+	return s, nil
+}
+
+// GetClusterName returns the name of the cluster.
+func (s *State) ClusterName(cfg *config.Config) string {
+	return cfg.Name + "-" + s.Infrastructure.UID
+}
+
+// ClusterValues describe the (Kubernetes) cluster state, set during initialization of the cluster.
+type ClusterValues struct {
+	// ClusterID is the unique identifier of the cluster.
+	ClusterID string `yaml:"clusterID"`
+	// OwnerID is the unique identifier of the owner of the cluster.
+	OwnerID string `yaml:"ownerID"`
+	// MeasurementSalt is the salt generated during cluster init.
+	MeasurementSalt string `yaml:"measurementSalt"`
 }
 
 // Infrastructure describe the state related to the cloud resources of the cluster.

--- a/cli/internal/state/state.go
+++ b/cli/internal/state/state.go
@@ -56,7 +56,7 @@ func NewFromIDFile(idFile clusterid.File, cfg *config.Config) *State {
 			UID:               idFile.UID,
 			ClusterEndpoint:   idFile.IP,
 			APIServerCertSANs: idFile.APIServerCertSANs,
-			InitSecret:        string(idFile.InitSecret),
+			InitSecret:        idFile.InitSecret,
 			Name:              clusterid.GetClusterName(cfg, idFile),
 		})
 
@@ -112,7 +112,7 @@ type ClusterValues struct {
 type Infrastructure struct {
 	UID               string   `yaml:"uid"`
 	ClusterEndpoint   string   `yaml:"clusterEndpoint"`
-	InitSecret        string   `yaml:"initSecret"`
+	InitSecret        []byte   `yaml:"initSecret"`
 	APIServerCertSANs []string `yaml:"apiServerCertSANs"`
 	// Name is the name of the cluster.
 	Name  string `yaml:"name"`

--- a/cli/internal/state/state_test.go
+++ b/cli/internal/state/state_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
+	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/spf13/afero"
@@ -331,6 +332,7 @@ func TestMerge(t *testing.T) {
 func TestNewFromIDFile(t *testing.T) {
 	testCases := map[string]struct {
 		idFile   clusterid.File
+		cfg      *config.Config
 		expected *State
 	}{
 		"success": {
@@ -338,10 +340,12 @@ func TestNewFromIDFile(t *testing.T) {
 				ClusterID: "test-cluster-id",
 				UID:       "test-uid",
 			},
+			cfg: config.Default(),
 			expected: &State{
 				Version: Version1,
 				Infrastructure: Infrastructure{
-					UID: "test-uid",
+					UID:  "test-uid",
+					Name: "constell-test-uid",
 				},
 				ClusterValues: ClusterValues{
 					ClusterID: "test-cluster-id",
@@ -350,7 +354,8 @@ func TestNewFromIDFile(t *testing.T) {
 		},
 		"empty id file": {
 			idFile:   clusterid.File{},
-			expected: &State{Version: Version1},
+			cfg:      config.Default(),
+			expected: &State{Version: Version1, Infrastructure: Infrastructure{Name: "constell-"}},
 		},
 		"nested pointer": {
 			idFile: clusterid.File{
@@ -358,6 +363,7 @@ func TestNewFromIDFile(t *testing.T) {
 				UID:            "test-uid",
 				AttestationURL: "test-maaUrl",
 			},
+			cfg: config.Default(),
 			expected: &State{
 				Version: Version1,
 				Infrastructure: Infrastructure{
@@ -365,6 +371,7 @@ func TestNewFromIDFile(t *testing.T) {
 					Azure: &Azure{
 						AttestationURL: "test-maaUrl",
 					},
+					Name: "constell-test-uid",
 				},
 				ClusterValues: ClusterValues{
 					ClusterID: "test-cluster-id",
@@ -377,7 +384,7 @@ func TestNewFromIDFile(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			state := NewFromIDFile(tc.idFile)
+			state := NewFromIDFile(tc.idFile, tc.cfg)
 
 			assert.Equal(tc.expected, state)
 		})

--- a/cli/internal/state/state_test.go
+++ b/cli/internal/state/state_test.go
@@ -1,0 +1,328 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package state
+
+import (
+	"testing"
+
+	"github.com/edgelesssys/constellation/v2/internal/constants"
+	"github.com/edgelesssys/constellation/v2/internal/file"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v3"
+)
+
+var defaultState = &State{
+	Version: "v1",
+	Infrastructure: Infrastructure{
+		UID:             "123",
+		ClusterEndpoint: "test-cluster-endpoint",
+		InitSecret:      "test-init-secret",
+		APIServerCertSANs: []string{
+			"api-server-cert-san-test",
+			"api-server-cert-san-test-2",
+		},
+		Azure: &Azure{
+			ResourceGroup:            "test-rg",
+			SubscriptionID:           "test-sub",
+			NetworkSecurityGroupName: "test-nsg",
+			LoadBalancerName:         "test-lb",
+			UserAssignedIdentity:     "test-uami",
+			AttestationURL:           "test-maaUrl",
+		},
+		GCP: &GCP{
+			ProjectID:  "test-project",
+			IPCidrNode: "test-cidr-node",
+			IPCidrPod:  "test-cidr-pod",
+		},
+	},
+	ClusterValues: ClusterValues{
+		ClusterID:       "test-cluster-id",
+		OwnerID:         "test-owner-id",
+		MeasurementSalt: "test-measurement-salt",
+	},
+}
+
+func TestWriteToFile(t *testing.T) {
+	prepareFs := func(existingFiles ...string) file.Handler {
+		fs := afero.NewMemMapFs()
+		fh := file.NewHandler(fs)
+		for _, name := range existingFiles {
+			if err := fh.Write(name, []byte{0x41}); err != nil {
+				t.Fatalf("failed to create file %s: %v", name, err)
+			}
+		}
+		return fh
+	}
+
+	testCases := map[string]struct {
+		state   *State
+		fh      file.Handler
+		wantErr bool
+	}{
+		"success": {
+			state: defaultState,
+			fh:    prepareFs(),
+		},
+		"overwrite": {
+			state: defaultState,
+			fh:    prepareFs(constants.StateFilename),
+		},
+		"empty state": {
+			state: &State{},
+			fh:    prepareFs(),
+		},
+		"rofs": {
+			state:   defaultState,
+			fh:      file.NewHandler(afero.NewReadOnlyFs(afero.NewMemMapFs())),
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			err := tc.state.WriteToFile(tc.fh, constants.StateFilename)
+
+			if tc.wantErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+				assert.Equal(mustMarshalYaml(t, tc.state), mustReadFromFile(t, tc.fh))
+			}
+		})
+	}
+}
+
+func TestReadFromFile(t *testing.T) {
+	prepareFs := func(existingFiles map[string][]byte) file.Handler {
+		fs := afero.NewMemMapFs()
+		fh := file.NewHandler(fs)
+		for name, content := range existingFiles {
+			if err := fh.Write(name, content); err != nil {
+				t.Fatalf("failed to create file %s: %v", name, err)
+			}
+		}
+		return fh
+	}
+
+	testCases := map[string]struct {
+		existingFiles map[string][]byte
+		wantErr       bool
+	}{
+		"success": {
+			existingFiles: map[string][]byte{
+				constants.StateFilename: mustMarshalYaml(t, defaultState),
+			},
+		},
+		"no state file present": {
+			existingFiles: map[string][]byte{},
+			wantErr:       true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			fh := prepareFs(tc.existingFiles)
+
+			state, err := ReadFromFile(fh, constants.StateFilename)
+
+			if tc.wantErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+				assert.Equal(tc.existingFiles[constants.StateFilename], mustMarshalYaml(t, state))
+			}
+		})
+	}
+}
+
+func mustMarshalYaml(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := yaml.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal yaml: %v", err)
+	}
+	return b
+}
+
+func mustReadFromFile(t *testing.T, fh file.Handler) []byte {
+	t.Helper()
+	b, err := fh.Read(constants.StateFilename)
+	if err != nil {
+		t.Fatalf("failed to read file: %v", err)
+	}
+	return b
+}
+
+func TestMerge(t *testing.T) {
+	testCases := map[string]struct {
+		state    *State
+		other    *State
+		expected *State
+		wantErr  bool
+	}{
+		"success": {
+			state: &State{
+				Infrastructure: Infrastructure{
+					ClusterEndpoint: "test-cluster-endpoint",
+					UID:             "123",
+				},
+			},
+			other: &State{
+				Version: "v1",
+				Infrastructure: Infrastructure{
+					UID: "456",
+				},
+				ClusterValues: ClusterValues{
+					ClusterID: "test-cluster-id",
+				},
+			},
+			expected: &State{
+				Version: "v1",
+				Infrastructure: Infrastructure{
+					ClusterEndpoint: "test-cluster-endpoint",
+					UID:             "456",
+				},
+				ClusterValues: ClusterValues{
+					ClusterID: "test-cluster-id",
+				},
+			},
+		},
+		"empty state": {
+			state: &State{},
+			other: &State{
+				Version: "v1",
+				Infrastructure: Infrastructure{
+					UID: "456",
+				},
+				ClusterValues: ClusterValues{
+					ClusterID: "test-cluster-id",
+				},
+			},
+			expected: &State{
+				Version: "v1",
+				Infrastructure: Infrastructure{
+					UID: "456",
+				},
+				ClusterValues: ClusterValues{
+					ClusterID: "test-cluster-id",
+				},
+			},
+		},
+		"empty other": {
+			state: &State{
+				Version: "v1",
+				Infrastructure: Infrastructure{
+					UID: "456",
+				},
+				ClusterValues: ClusterValues{
+					ClusterID: "test-cluster-id",
+				},
+			},
+			other: &State{},
+			expected: &State{
+				Version: "v1",
+				Infrastructure: Infrastructure{
+					UID: "456",
+				},
+				ClusterValues: ClusterValues{
+					ClusterID: "test-cluster-id",
+				},
+			},
+		},
+		"empty state and other": {
+			state:    &State{},
+			other:    &State{},
+			expected: &State{},
+		},
+		"identical": {
+			state: &State{
+				Version: "v1",
+				Infrastructure: Infrastructure{
+					UID: "456",
+				},
+				ClusterValues: ClusterValues{
+					ClusterID: "test-cluster-id",
+				},
+			},
+			other: &State{
+				Version: "v1",
+				Infrastructure: Infrastructure{
+					UID: "456",
+				},
+				ClusterValues: ClusterValues{
+					ClusterID: "test-cluster-id",
+				},
+			},
+			expected: &State{
+				Version: "v1",
+				Infrastructure: Infrastructure{
+					UID: "456",
+				},
+				ClusterValues: ClusterValues{
+					ClusterID: "test-cluster-id",
+				},
+			},
+		},
+		"nested pointer": {
+			state: &State{
+				Version: "v1",
+				Infrastructure: Infrastructure{
+					UID: "123",
+					Azure: &Azure{
+						AttestationURL: "test-maaUrl",
+					},
+				},
+				ClusterValues: ClusterValues{
+					ClusterID: "test-cluster-id",
+				},
+			},
+			other: &State{
+				Version: "v1",
+				Infrastructure: Infrastructure{
+					UID: "456",
+					Azure: &Azure{
+						AttestationURL: "test-maaUrl-2",
+					},
+				},
+				ClusterValues: ClusterValues{
+					ClusterID: "test-cluster-id",
+				},
+			},
+			expected: &State{
+				Version: "v1",
+				Infrastructure: Infrastructure{
+					UID: "456",
+					Azure: &Azure{
+						AttestationURL: "test-maaUrl-2",
+					},
+				},
+				ClusterValues: ClusterValues{
+					ClusterID: "test-cluster-id",
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			_, err := tc.state.Merge(tc.other)
+
+			if tc.wantErr {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+				assert.Equal(tc.expected, tc.state)
+			}
+		})
+	}
+}

--- a/cli/internal/state/state_test.go
+++ b/cli/internal/state/state_test.go
@@ -23,7 +23,7 @@ var defaultState = &State{
 	Infrastructure: Infrastructure{
 		UID:             "123",
 		ClusterEndpoint: "test-cluster-endpoint",
-		InitSecret:      "test-init-secret",
+		InitSecret:      []byte{0x41},
 		APIServerCertSANs: []string{
 			"api-server-cert-san-test",
 			"api-server-cert-san-test-2",

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -221,11 +221,21 @@ func (c *Client) ShowInfrastructure(ctx context.Context, provider cloudprovider.
 		return state.Infrastructure{}, errors.New("invalid type in uid output: not a string")
 	}
 
+	nameOutput, ok := tfState.Values.Outputs["name"]
+	if !ok {
+		return state.Infrastructure{}, errors.New("no name output found")
+	}
+	name, ok := nameOutput.Value.(string)
+	if !ok {
+		return state.Infrastructure{}, errors.New("invalid type in name output: not a string")
+	}
+
 	res := state.Infrastructure{
 		ClusterEndpoint:   ip,
 		APIServerCertSANs: apiServerCertSANs,
 		InitSecret:        secret,
 		UID:               uid,
+		Name:              name,
 	}
 
 	switch provider {

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -233,7 +233,7 @@ func (c *Client) ShowInfrastructure(ctx context.Context, provider cloudprovider.
 	res := state.Infrastructure{
 		ClusterEndpoint:   ip,
 		APIServerCertSANs: apiServerCertSANs,
-		InitSecret:        secret,
+		InitSecret:        []byte(secret),
 		UID:               uid,
 		Name:              name,
 	}

--- a/cli/internal/terraform/terraform/aws/outputs.tf
+++ b/cli/internal/terraform/terraform/aws/outputs.tf
@@ -14,3 +14,7 @@ output "initSecret" {
   value     = random_password.initSecret.result
   sensitive = true
 }
+
+output "name" {
+  value = local.name
+}

--- a/cli/internal/terraform/terraform/azure/outputs.tf
+++ b/cli/internal/terraform/terraform/azure/outputs.tf
@@ -39,3 +39,7 @@ output "resource_group" {
 output "subscription_id" {
   value = data.azurerm_subscription.current.subscription_id
 }
+
+output "name" {
+  value = local.name
+}

--- a/cli/internal/terraform/terraform/gcp/outputs.tf
+++ b/cli/internal/terraform/terraform/gcp/outputs.tf
@@ -30,3 +30,7 @@ output "ip_cidr_nodes" {
 output "ip_cidr_pods" {
   value = local.cidr_vpc_subnet_pods
 }
+
+output "name" {
+  value = local.name
+}

--- a/cli/internal/terraform/terraform/openstack/outputs.tf
+++ b/cli/internal/terraform/terraform/openstack/outputs.tf
@@ -14,3 +14,7 @@ output "initSecret" {
   value     = random_password.initSecret.result
   sensitive = true
 }
+
+output "name" {
+  value = local.name
+}

--- a/cli/internal/terraform/terraform/qemu/outputs.tf
+++ b/cli/internal/terraform/terraform/qemu/outputs.tf
@@ -38,3 +38,7 @@ output "validate_constellation_cmdline" {
     error_message = "constellation_cmdline must be set if constellation_boot_mode is 'direct-linux-boot'"
   }
 }
+
+output "name" {
+  value = "${var.name}-qemu" // placeholder, as per "uid" output
+}

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -223,6 +223,9 @@ func TestCreateCluster(t *testing.T) {
 					"api_server_cert_sans": {
 						Value: []any{"192.0.2.100"},
 					},
+					"name": {
+						Value: "constell-12345abc",
+					},
 				},
 			},
 		}
@@ -261,6 +264,9 @@ func TestCreateCluster(t *testing.T) {
 					},
 					"loadbalancer_name": {
 						Value: "test_lb_name",
+					},
+					"name": {
+						Value: "constell-12345abc",
 					},
 				},
 			},
@@ -392,6 +398,20 @@ func TestCreateCluster(t *testing.T) {
 				showState: &tfjson.State{
 					Values: &tfjson.StateValues{
 						Outputs: map[string]*tfjson.StateOutput{"uid": {Value: 42}},
+					},
+				},
+			},
+			fs:      afero.NewMemMapFs(),
+			wantErr: true,
+		},
+		"name has wrong type": {
+			pathBase: "terraform",
+			provider: cloudprovider.QEMU,
+			vars:     qemuVars,
+			tf: &stubTerraform{
+				showState: &tfjson.State{
+					Values: &tfjson.StateValues{
+						Outputs: map[string]*tfjson.StateOutput{"name": {Value: 42}},
 					},
 				},
 			},

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -477,7 +477,7 @@ func TestCreateCluster(t *testing.T) {
 			}
 			assert.NoError(err)
 			assert.Equal("192.0.2.100", infraState.ClusterEndpoint)
-			assert.Equal("initSecret", infraState.InitSecret)
+			assert.Equal([]byte("initSecret"), infraState.InitSecret)
 			assert.Equal("12345abc", infraState.UID)
 			if tc.provider == cloudprovider.Azure {
 				assert.Equal(tc.expectedAttestationURL, infraState.Azure.AttestationURL)

--- a/debugd/internal/cdbg/cmd/deploy.go
+++ b/debugd/internal/cdbg/cmd/deploy.go
@@ -113,11 +113,11 @@ func deploy(cmd *cobra.Command, fileHandler file.Handler, constellationConfig *c
 		return err
 	}
 	if len(ips) == 0 {
-		var idFile clusterIDsFile
-		if err := fileHandler.ReadJSON(constants.ClusterIDsFilename, &idFile); err != nil {
-			return fmt.Errorf("reading cluster IDs file: %w", err)
+		var stateFile clusterStateFile
+		if err := fileHandler.ReadYAML(constants.StateFilename, &stateFile); err != nil {
+			return fmt.Errorf("reading cluster state file: %w", err)
 		}
-		ips = []string{idFile.IP}
+		ips = []string{stateFile.Infrastructure.ClusterEndpoint}
 	}
 
 	info, err := cmd.Flags().GetStringToString("info")
@@ -285,8 +285,8 @@ type fileTransferer interface {
 	SetFiles(files []filetransfer.FileStat)
 }
 
-type clusterIDsFile struct {
-	ClusterID string
-	OwnerID   string
-	IP        string
+type clusterStateFile struct {
+	Infrastructure struct {
+		ClusterEndpoint string `yaml:"clusterEndpoint"`
+	} `yaml:"infrastructure"`
 }

--- a/docs/docs/architecture/orchestration.md
+++ b/docs/docs/architecture/orchestration.md
@@ -28,7 +28,7 @@ Altogether, the following files are generated during the creation of a Constella
 
 After the creation of your cluster, the CLI will provide you with a Kubernetes `kubeconfig` file.
 This file grants you access to your Kubernetes cluster and configures the [kubectl](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) tool.
-In addition, the cluster's [identifier](orchestration.md#post-installation-configuration) is returned and stored in a file called `constellation-id.json`
+In addition, the cluster's [identifier](orchestration.md#post-installation-configuration) is returned and stored in a file called `constellation-state.yaml`
 
 ### Creation process details
 

--- a/docs/docs/architecture/orchestration.md
+++ b/docs/docs/architecture/orchestration.md
@@ -8,7 +8,7 @@ The CLI is also used for updating your cluster.
 ## Workspaces
 
 Each Constellation cluster has an associated *workspace*.
-The workspace is where data such as the Constellation state, config, and ID files are stored.
+The workspace is where data such as the Constellation state and config files are stored.
 Each workspace is associated with a single cluster and configuration.
 The CLI stores state in the local filesystem making the current directory the active workspace.
 Multiple clusters require multiple workspaces, hence, multiple directories.
@@ -21,14 +21,14 @@ To allow for fine-grained configuration of your cluster and cloud environment, C
 Altogether, the following files are generated during the creation of a Constellation cluster and stored in the current workspace:
 
 * a configuration file
-* an ID file
+* a state file
 * a Base64-encoded master secret
 * [Terraform artifacts](../reference/terraform.md), stored in subdirectories
 * a Kubernetes `kubeconfig` file.
 
-After the creation of your cluster, the CLI will provide you with a Kubernetes `kubeconfig` file.
+After the initialization of your cluster, the CLI will provide you with a Kubernetes `kubeconfig` file.
 This file grants you access to your Kubernetes cluster and configures the [kubectl](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) tool.
-In addition, the cluster's [identifier](orchestration.md#post-installation-configuration) is returned and stored in a file called `constellation-state.yaml`
+In addition, the cluster's [identifier](orchestration.md#post-installation-configuration) is returned and stored in the state file.
 
 ### Creation process details
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -380,7 +380,7 @@ Verify the confidential properties of a Constellation cluster
 ### Synopsis
 
 Verify the confidential properties of a Constellation cluster.
-If arguments aren't specified, values are read from `constellation-id.json`.
+If arguments aren't specified, values are read from `constellation-state.yaml`.
 
 ```
 constellation verify [flags]

--- a/docs/docs/workflows/create.md
+++ b/docs/docs/workflows/create.md
@@ -65,14 +65,16 @@ terraform init
 terraform apply
 ```
 
-The Constellation [init step](#the-init-step) requires the already created `constellation-config.yaml` and the `constellation-id.json`.
-Create the `constellation-id.json` using the output from the Terraform state and the `constellation-conf.yaml`:
+The Constellation [init step](#the-init-step) requires the already created `constellation-config.yaml` and the `constellation-state.yaml`.
+Create the `constellation-state.yaml` using the output from the Terraform state and the `constellation-conf.yaml`:
 
 ```bash
 CONSTELL_IP=$(terraform output ip)
 CONSTELL_INIT_SECRET=$(terraform output initSecret | jq -r | tr -d '\n' | base64)
-CONSTELL_CSP=$(cat constellation-conf.yaml | yq ".provider | keys | .[0]")
-jq --null-input --arg cloudprovider "$CONSTELL_CSP" --arg ip "$CONSTELL_IP" --arg initsecret "$CONSTELL_INIT_SECRET" '{"cloudprovider":$cloudprovider,"ip":$ip,"initsecret":$initsecret}' > constellation-id.json
+touch constellation-state.yaml
+yq eval '.version ="v1"' --inplace constellation-state.yaml
+yq eval '.infrastructure.initSecret ="$CONSTELL_INIT_SECRET"' --inplace constellation-state.yaml
+yq eval '.infrastructure.clusterEndpoint ="$CONSTELL_IP"' --inplace constellation-state.yaml
 ```
 
 </tabItem>

--- a/docs/docs/workflows/recovery.md
+++ b/docs/docs/workflows/recovery.md
@@ -125,7 +125,7 @@ This means that you have to recover the node manually.
 
 Recovering a cluster requires the following parameters:
 
-* The `constellation-id.json` file in your working directory or the cluster's load balancer IP address
+* The `constellation-state.yaml` file in your working directory or the cluster's endpoint
 * The master secret of the cluster
 
 A cluster can be recovered like this:

--- a/docs/docs/workflows/terminate.md
+++ b/docs/docs/workflows/terminate.md
@@ -51,7 +51,7 @@ terraform destroy
 Delete all files that are no longer needed:
 
 ```bash
-rm constellation-id.json constellation-admin.conf
+rm constellation-state.yaml constellation-admin.conf
 ```
 
 Only the `constellation-mastersecret.json` and the configuration file remain.

--- a/docs/docs/workflows/verify-cluster.md
+++ b/docs/docs/workflows/verify-cluster.md
@@ -78,7 +78,7 @@ From the attestation statement, the command verifies the following properties:
 
 * The cluster is using the correct Confidential VM (CVM) type.
 * Inside the CVMs, the correct node images are running. The node images are identified through the measurements obtained in the previous step.
-* The unique ID of the cluster matches the one from your `constellation-id.json` file or passed in via `--cluster-id`.
+* The unique ID of the cluster matches the one from your `constellation-state.yaml` file or passed in via `--cluster-id`.
 
 Once the above properties are verified, you know that you are talking to the right Constellation cluster and it's in a good and trustworthy shape.
 

--- a/go.mod
+++ b/go.mod
@@ -135,6 +135,8 @@ require (
 	sigs.k8s.io/yaml v1.3.0
 )
 
+require dario.cat/mergo v1.0.0
+
 require (
 	cloud.google.com/go v0.110.2 // indirect
 	cloud.google.com/go/iam v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -133,9 +133,8 @@ require (
 	k8s.io/mount-utils v0.27.3
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
 	sigs.k8s.io/yaml v1.3.0
+	dario.cat/mergo v1.0.0
 )
-
-require dario.cat/mergo v1.0.0
 
 require (
 	cloud.google.com/go v0.110.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	cloud.google.com/go/logging v1.7.0
 	cloud.google.com/go/secretmanager v1.11.1
 	cloud.google.com/go/storage v1.31.0
+	dario.cat/mergo v1.0.0
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.3.0
@@ -133,7 +134,6 @@ require (
 	k8s.io/mount-utils v0.27.3
 	k8s.io/utils v0.0.0-20230505201702-9f6742963106
 	sigs.k8s.io/yaml v1.3.0
-	dario.cat/mergo v1.0.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ cloud.google.com/go/storage v1.31.0 h1:+S3LjjEN2zZ+L5hOwj4+1OkGCsLVe0NzpXKQ1pSdT
 cloud.google.com/go/storage v1.31.0/go.mod h1:81ams1PrhW16L4kF7qg+4mTq7SRs5HsbDTM0bWvrwJ0=
 code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c h1:5eeuG0BHx1+DHeT3AP+ISKZ2ht1UjGhm581ljqYpVeQ=
 code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c/go.mod h1:QD9Lzhd/ux6eNQVUDVRJX/RKTigpewimNYBi7ivZKY8=
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1 h1:EKPd1INOIyr5hWOWhvpmQpY6tKjeG0hT1s3AMC/9fic=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1/go.mod h1:VzwV+t+dZ9j/H867F1M2ziD+yLHtB46oM35FxxMJ4d0=

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -57,6 +57,7 @@ require (
 	cloud.google.com/go/compute v1.20.1 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c // indirect
+	dario.cat/mergo v1.0.0 // indirect
 	github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1 // indirect
 	github.com/Azure/azure-sdk-for-go v68.0.0+incompatible // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.6.1 // indirect

--- a/hack/go.sum
+++ b/hack/go.sum
@@ -47,6 +47,8 @@ cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c h1:5eeuG0BHx1+DHeT3AP+ISKZ2ht1UjGhm581ljqYpVeQ=
 code.cloudfoundry.org/clock v0.0.0-20180518195852-02e53af36e6c/go.mod h1:QD9Lzhd/ux6eNQVUDVRJX/RKTigpewimNYBi7ivZKY8=
+dario.cat/mergo v1.0.0 h1:AGCNq9Evsj31mOgNPcLyXc+4PNABt905YmuqPYYpBWk=
+dario.cat/mergo v1.0.0/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1 h1:EKPd1INOIyr5hWOWhvpmQpY6tKjeG0hT1s3AMC/9fic=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20230106234847-43070de90fa1/go.mod h1:VzwV+t+dZ9j/H867F1M2ziD+yLHtB46oM35FxxMJ4d0=

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -232,3 +232,8 @@ func (h *Handler) CopyFile(src, dst string, opts ...Option) error {
 
 	return nil
 }
+
+// RenameFile renames a file, overwriting any existing file at the destination.
+func (h *Handler) RenameFile(old, new string) error {
+	return h.fs.Rename(old, new)
+}

--- a/rfc/state-file.md
+++ b/rfc/state-file.md
@@ -91,6 +91,7 @@ clusterValues:
     clusterID: "00112233445566778899AABBCCDDEEFF" # cluster ID uniquely identifies this Constellation cluster.
     ownerID: "00112233445566778899AABBCCDDEEFF" # owner ID identifies this cluster as belonging to owner.
     measurementSalt: "c2VjcmV0Cg==" # measurement salt is used by nodes to derive their cluster ID.
+    name: "constell-001122" # name of the cluster, as used in e.g. cluster resource naming.
 ```
 
 ## Updates to the state file


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We are in the transition from the ID-File (`constellation-id.json`) to the state file (`constellation-state.yaml`). This PR aims to implement part of this transition by using the state-file instead of the ID-file in the init and upgrade operations of a cluster. This PR does not intend to remove the ID-file completely, which should be done in a follow-up PR aligned with [AB#3425](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/3425).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Implement basic read / write / merge handlers for the state file.
- Use the state file in `constellation init`, where the [`ClusterValues`](https://github.com/edgelesssys/constellation/blob/main/rfc/state-file.md) output is now being populated (in addition to populating the old ID-file)
- Use the state file in `constellation upgrade apply`, where the old, pre-upgrade `constellation-id.json` is being read. It's output, merged with the output of the upgrade itself is written to the state file.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [E2E Test](https://github.com/edgelesssys/constellation/actions/runs/6352260025)
- [E2E Test Upgrade](https://github.com/edgelesssys/constellation/actions/runs/6376515073)
- [AB#3424](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3424)
- This PR shows a bug in MiniConstellation, where the cluster is not able to initialize ("connection refused" when talking to the bootstrapper node), which is presumably caused by the bootstrapper not starting.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
