### PR TITLE
ci: use larger runners for os image pipeline

### DIFF
--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -132,9 +132,7 @@ jobs:
   make-os-image:
     name: "Build OS using mkosi"
     needs: [build-settings]
-    runs-on: ubuntu-22.04
-    # TODO(malt3): flatten outputs once possible
-    # https://github.com/community/community/discussions/17245
+    runs-on: ubuntu-latest-8-cores
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Currently, the pipeline fails most of the time with "no space left on device".
This indicates either a full disk or a full tmpfs (memory constraint).
Using a larger runner solves this issue.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: use larger runners for os image pipeline

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [pipeline run](https://github.com/edgelesssys/constellation/actions/runs/6403114423)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [x] Link to Milestone
