### PR TITLE
cli: remove id-file

### DIFF
--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -48,7 +48,7 @@ type stubTerraformClient struct {
 func (c *stubTerraformClient) ApplyCluster(_ context.Context, _ cloudprovider.Provider, _ terraform.LogLevel) (state.Infrastructure, error) {
 	return state.Infrastructure{
 		ClusterEndpoint: c.ip,
-		InitSecret:      c.initSecret,
+		InitSecret:      []byte(c.initSecret),
 		UID:             c.uid,
 		Azure: &state.Azure{
 			AttestationURL: c.attestationURL,

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -12,14 +12,12 @@ import (
 	"io/fs"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/cloudcmd"
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/cmd/pathprefix"
 	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/cli/internal/terraform"
 	"github.com/edgelesssys/constellation/v2/internal/api/attestationconfigapi"
 	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
-	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
@@ -172,12 +170,6 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 	}
 	c.log.Debugf("Successfully created the cloud resources for the cluster")
 
-	// TODO(msanft): Remove IDFile as per AB#3425
-	idFile := convertToIDFile(infraState, provider)
-	if err := fileHandler.WriteJSON(constants.ClusterIDsFilename, idFile, file.OptNone); err != nil {
-		return err
-	}
-
 	state := state.New().SetInfrastructure(infraState)
 	if err := state.WriteToFile(fileHandler, constants.StateFilename); err != nil {
 		return fmt.Errorf("writing state file: %w", err)
@@ -185,21 +177,6 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 
 	cmd.Println("Your Constellation cluster was created successfully.")
 	return nil
-}
-
-func convertToIDFile(infra state.Infrastructure, provider cloudprovider.Provider) clusterid.File {
-	var file clusterid.File
-	file.CloudProvider = provider
-	file.IP = infra.ClusterEndpoint
-	file.APIServerCertSANs = infra.APIServerCertSANs
-	file.InitSecret = []byte(infra.InitSecret) // Convert string to []byte
-	file.UID = infra.UID
-
-	if infra.Azure != nil {
-		file.AttestationURL = infra.Azure.AttestationURL
-	}
-
-	return file
 }
 
 // parseCreateFlags parses the flags of the create command.
@@ -257,9 +234,9 @@ func (c *createCmd) checkDirClean(fileHandler file.Handler) error {
 	if _, err := fileHandler.Stat(constants.MasterSecretFilename); !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("file '%s' already exists in working directory. Constellation won't overwrite previous master secrets. Move it somewhere or delete it before creating a new cluster", c.pf.PrefixPrintablePath(constants.MasterSecretFilename))
 	}
-	c.log.Debugf("Checking cluster IDs file")
-	if _, err := fileHandler.Stat(constants.ClusterIDsFilename); !errors.Is(err, fs.ErrNotExist) {
-		return fmt.Errorf("file '%s' already exists in working directory. Constellation won't overwrite previous cluster IDs. Move it somewhere or delete it before creating a new cluster", c.pf.PrefixPrintablePath(constants.ClusterIDsFilename))
+	c.log.Debugf("Checking state file")
+	if _, err := fileHandler.Stat(constants.StateFilename); !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("file '%s' already exists in working directory. Constellation won't overwrite previous cluster state. Move it somewhere or delete it before creating a new cluster", c.pf.PrefixPrintablePath(constants.StateFilename))
 	}
 
 	return nil

--- a/cli/internal/cmd/create_test.go
+++ b/cli/internal/cmd/create_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/edgelesssys/constellation/v2/internal/config"
@@ -154,12 +153,6 @@ func TestCreate(t *testing.T) {
 					assert.False(tc.creator.createCalled)
 				} else {
 					assert.True(tc.creator.createCalled)
-					var gotIDFile clusterid.File
-					require.NoError(fileHandler.ReadJSON(constants.ClusterIDsFilename, &gotIDFile))
-					assert.Equal(gotIDFile, clusterid.File{
-						IP:            infraState.ClusterEndpoint,
-						CloudProvider: tc.provider,
-					})
 
 					var gotState state.State
 					expectedState := state.Infrastructure{

--- a/cli/internal/cmd/create_test.go
+++ b/cli/internal/cmd/create_test.go
@@ -158,11 +158,11 @@ func TestCreate(t *testing.T) {
 					expectedState := state.Infrastructure{
 						ClusterEndpoint:   "192.0.2.1",
 						APIServerCertSANs: []string{},
+						InitSecret:        []byte{},
 					}
 					require.NoError(fileHandler.ReadYAML(constants.StateFilename, &gotState))
 					assert.Equal("v1", gotState.Version)
 					assert.Equal(expectedState, gotState.Infrastructure)
-
 				}
 			}
 		})

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -67,10 +67,10 @@ func (c *destroyCmd) iamDestroy(cmd *cobra.Command, spinner spinnerInterf, destr
 	if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("file %q still exists, please make sure to terminate your cluster before destroying your IAM configuration", c.pf.PrefixPrintablePath(constants.AdminConfFilename))
 	}
-	c.log.Debugf("Checking if %q exists", c.pf.PrefixPrintablePath(constants.ClusterIDsFilename))
-	_, err = fsHandler.Stat(constants.ClusterIDsFilename)
+	c.log.Debugf("Checking if %q exists", c.pf.PrefixPrintablePath(constants.StateFilename))
+	_, err = fsHandler.Stat(constants.StateFilename)
 	if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("file %q still exists, please make sure to terminate your cluster before destroying your IAM configuration", c.pf.PrefixPrintablePath(constants.ClusterIDsFilename))
+		return fmt.Errorf("file %q still exists, please make sure to terminate your cluster before destroying your IAM configuration", c.pf.PrefixPrintablePath(constants.StateFilename))
 	}
 
 	gcpFileExists := false

--- a/cli/internal/cmd/iamdestroy_test.go
+++ b/cli/internal/cmd/iamdestroy_test.go
@@ -36,9 +36,9 @@ func TestIAMDestroy(t *testing.T) {
 		require.NoError(fh.Write(constants.AdminConfFilename, []byte("")))
 		return fh
 	}
-	newFsWithClusterIDFile := func() file.Handler {
+	newFsWithStateFile := func() file.Handler {
 		fh := file.NewHandler(afero.NewMemMapFs())
-		require.NoError(fh.Write(constants.ClusterIDsFilename, []byte("")))
+		require.NoError(fh.Write(constants.StateFilename, []byte("")))
 		return fh
 	}
 
@@ -56,8 +56,8 @@ func TestIAMDestroy(t *testing.T) {
 			yesFlag:      "false",
 			wantErr:      true,
 		},
-		"cluster running cluster ids": {
-			fh:           newFsWithClusterIDFile(),
+		"cluster running cluster state": {
+			fh:           newFsWithStateFile(),
 			iamDestroyer: &stubIAMDestroyer{},
 			yesFlag:      "false",
 			wantErr:      true,

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -200,7 +200,6 @@ func (i *initCmd) initialize(
 	if err != nil {
 		return fmt.Errorf("generating measurement salt: %w", err)
 	}
-	stateFile.ClusterValues.MeasurementSalt = measurementSalt
 
 	i.log.Debugf("Setting cluster name to %s", stateFile.Infrastructure.Name)
 

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -202,8 +202,7 @@ func (i *initCmd) initialize(
 	}
 	stateFile.ClusterValues.MeasurementSalt = measurementSalt
 
-	clusterName := stateFile.ClusterName(conf)
-	i.log.Debugf("Setting cluster name to %s", clusterName)
+	i.log.Debugf("Setting cluster name to %s", stateFile.Infrastructure.Name)
 
 	cmd.PrintErrln("Note: If you just created the cluster, it can take a few minutes to connect.")
 	i.spinner.Start("Connecting ", false)
@@ -215,7 +214,7 @@ func (i *initCmd) initialize(
 		KubernetesComponents: versions.VersionConfigs[k8sVersion].KubernetesComponents.ToInitProto(),
 		ConformanceMode:      flags.conformance,
 		InitSecret:           stateFile.Infrastructure.InitSecret,
-		ClusterName:          clusterName,
+		ClusterName:          stateFile.Infrastructure.Name,
 		ApiserverCertSans:    stateFile.Infrastructure.APIServerCertSANs,
 	}
 	i.log.Debugf("Sending initialization request")

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -149,6 +149,13 @@ func TestInitialize(t *testing.T) {
 			masterSecretShouldExist: true,
 			wantErr:                 true,
 		},
+		"state file with only version": {
+			provider:      cloudprovider.GCP,
+			stateFile:     &state.State{Version: state.Version1},
+			initServerAPI: &stubInitServer{},
+			retriable:     true,
+			wantErr:       true,
+		},
 		"empty state file": {
 			provider:      cloudprovider.GCP,
 			stateFile:     &state.State{},

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/edgelesssys/constellation/v2/bootstrapper/initproto"
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
 	"github.com/edgelesssys/constellation/v2/cli/internal/cmd/pathprefix"
 	"github.com/edgelesssys/constellation/v2/cli/internal/helm"
 	"github.com/edgelesssys/constellation/v2/cli/internal/state"
@@ -538,7 +537,7 @@ func TestAttestation(t *testing.T) {
 			},
 		},
 	}}
-	existingIDFile := &clusterid.File{IP: "192.0.2.4", CloudProvider: cloudprovider.QEMU}
+
 	existingStateFile := &state.State{Version: state.Version1, Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.4"}}
 
 	netDialer := testdialer.NewBufconnDialer()
@@ -570,7 +569,6 @@ func TestAttestation(t *testing.T) {
 
 	fs := afero.NewMemMapFs()
 	fileHandler := file.NewHandler(fs)
-	require.NoError(fileHandler.WriteJSON(constants.ClusterIDsFilename, existingIDFile, file.OptNone))
 	require.NoError(existingStateFile.WriteToFile(fileHandler, constants.StateFilename))
 
 	cfg := config.Default()

--- a/cli/internal/cmd/minidown.go
+++ b/cli/internal/cmd/minidown.go
@@ -11,8 +11,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
-	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
+	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/spf13/afero"
@@ -44,14 +43,12 @@ func runDown(cmd *cobra.Command, args []string) error {
 }
 
 func checkForMiniCluster(fileHandler file.Handler) error {
-	var idFile clusterid.File
-	if err := fileHandler.ReadJSON(constants.ClusterIDsFilename, &idFile); err != nil {
-		return err
+	stateFile, err := state.ReadFromFile(fileHandler, constants.StateFilename)
+	if err != nil {
+		return fmt.Errorf("reading state file: %w", err)
 	}
-	if idFile.CloudProvider != cloudprovider.QEMU {
-		return errors.New("cluster is not a QEMU based Constellation")
-	}
-	if idFile.UID != constants.MiniConstellationUID {
+
+	if stateFile.Infrastructure.UID != constants.MiniConstellationUID {
 		return errors.New("cluster is not a MiniConstellation cluster")
 	}
 

--- a/cli/internal/cmd/terminate.go
+++ b/cli/internal/cmd/terminate.go
@@ -84,6 +84,7 @@ func terminate(cmd *cobra.Command, terminator cloudTerminator, fileHandler file.
 		removeErr = errors.Join(err, fmt.Errorf("failed to remove file: '%s', please remove it manually", pf.PrefixPrintablePath(constants.AdminConfFilename)))
 	}
 
+	// TODO(msanft): Once v2.12.0 is released, remove the ID-file-removal here.
 	if err := fileHandler.Remove(constants.ClusterIDsFilename); err != nil && !errors.Is(err, fs.ErrNotExist) {
 		removeErr = errors.Join(err, fmt.Errorf("failed to remove file: '%s', please remove it manually", pf.PrefixPrintablePath(constants.ClusterIDsFilename)))
 	}

--- a/cli/internal/cmd/terminate_test.go
+++ b/cli/internal/cmd/terminate_test.go
@@ -51,7 +51,6 @@ func TestTerminate(t *testing.T) {
 		fileHandler := file.NewHandler(fs)
 		require.NoError(fileHandler.Write(constants.AdminConfFilename, []byte{1, 2}, file.OptNone))
 		require.NoError(stateFile.WriteToFile(fileHandler, constants.StateFilename))
-		require.NoError(fileHandler.Write(constants.StateFilename, []byte{3, 4}, file.OptNone))
 		return fs
 	}
 	someErr := errors.New("failed")
@@ -157,8 +156,6 @@ func TestTerminate(t *testing.T) {
 				} else {
 					assert.True(tc.terminator.Called())
 					_, err = fileHandler.Stat(constants.AdminConfFilename)
-					assert.Error(err)
-					_, err = fileHandler.Stat(constants.StateFilename)
 					assert.Error(err)
 					_, err = fileHandler.Stat(constants.StateFilename)
 					assert.Error(err)

--- a/cli/internal/cmd/terminate_test.go
+++ b/cli/internal/cmd/terminate_test.go
@@ -11,8 +11,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
-	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
+	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
 	"github.com/spf13/afero"
@@ -47,65 +46,65 @@ func TestTerminateCmdArgumentValidation(t *testing.T) {
 }
 
 func TestTerminate(t *testing.T) {
-	setupFs := func(require *require.Assertions, idFile clusterid.File) afero.Fs {
+	setupFs := func(require *require.Assertions, stateFile *state.State) afero.Fs {
 		fs := afero.NewMemMapFs()
 		fileHandler := file.NewHandler(fs)
 		require.NoError(fileHandler.Write(constants.AdminConfFilename, []byte{1, 2}, file.OptNone))
-		require.NoError(fileHandler.WriteJSON(constants.ClusterIDsFilename, idFile, file.OptNone))
+		require.NoError(stateFile.WriteToFile(fileHandler, constants.StateFilename))
 		require.NoError(fileHandler.Write(constants.StateFilename, []byte{3, 4}, file.OptNone))
 		return fs
 	}
 	someErr := errors.New("failed")
 
 	testCases := map[string]struct {
-		idFile     clusterid.File
+		stateFile  *state.State
 		yesFlag    bool
 		stdin      string
-		setupFs    func(*require.Assertions, clusterid.File) afero.Fs
+		setupFs    func(*require.Assertions, *state.State) afero.Fs
 		terminator spyCloudTerminator
 		wantErr    bool
 		wantAbort  bool
 	}{
 		"success": {
-			idFile:     clusterid.File{CloudProvider: cloudprovider.GCP},
+			stateFile:  state.New(),
 			setupFs:    setupFs,
 			terminator: &stubCloudTerminator{},
 			yesFlag:    true,
 		},
 		"interactive": {
-			idFile:     clusterid.File{CloudProvider: cloudprovider.GCP},
+			stateFile:  state.New(),
 			setupFs:    setupFs,
 			terminator: &stubCloudTerminator{},
 			stdin:      "yes\n",
 		},
 		"interactive abort": {
-			idFile:     clusterid.File{CloudProvider: cloudprovider.GCP},
+			stateFile:  state.New(),
 			setupFs:    setupFs,
 			terminator: &stubCloudTerminator{},
 			stdin:      "no\n",
 			wantAbort:  true,
 		},
 		"files to remove do not exist": {
-			idFile: clusterid.File{CloudProvider: cloudprovider.GCP},
-			setupFs: func(require *require.Assertions, idFile clusterid.File) afero.Fs {
+			stateFile: state.New(),
+			setupFs: func(require *require.Assertions, stateFile *state.State) afero.Fs {
 				fs := afero.NewMemMapFs()
 				fileHandler := file.NewHandler(fs)
-				require.NoError(fileHandler.WriteJSON(constants.ClusterIDsFilename, idFile, file.OptNone))
+				require.NoError(stateFile.WriteToFile(fileHandler, constants.StateFilename))
 				return fs
 			},
 			terminator: &stubCloudTerminator{},
 			yesFlag:    true,
 		},
 		"terminate error": {
-			idFile:     clusterid.File{CloudProvider: cloudprovider.GCP},
+			stateFile:  state.New(),
 			setupFs:    setupFs,
 			terminator: &stubCloudTerminator{terminateErr: someErr},
 			yesFlag:    true,
 			wantErr:    true,
 		},
 		"missing id file does not error": {
-			idFile: clusterid.File{CloudProvider: cloudprovider.GCP},
-			setupFs: func(require *require.Assertions, idFile clusterid.File) afero.Fs {
+			stateFile: state.New(),
+			setupFs: func(require *require.Assertions, stateFile *state.State) afero.Fs {
 				fs := afero.NewMemMapFs()
 				fileHandler := file.NewHandler(fs)
 				require.NoError(fileHandler.Write(constants.AdminConfFilename, []byte{1, 2}, file.OptNone))
@@ -115,9 +114,9 @@ func TestTerminate(t *testing.T) {
 			yesFlag:    true,
 		},
 		"remove file fails": {
-			idFile: clusterid.File{CloudProvider: cloudprovider.GCP},
-			setupFs: func(require *require.Assertions, idFile clusterid.File) afero.Fs {
-				fs := setupFs(require, idFile)
+			stateFile: state.New(),
+			setupFs: func(require *require.Assertions, stateFile *state.State) afero.Fs {
+				fs := setupFs(require, stateFile)
 				return afero.NewReadOnlyFs(fs)
 			},
 			terminator: &stubCloudTerminator{},
@@ -141,7 +140,7 @@ func TestTerminate(t *testing.T) {
 			cmd.Flags().String("workspace", "", "")
 
 			require.NotNil(tc.setupFs)
-			fileHandler := file.NewHandler(tc.setupFs(require, tc.idFile))
+			fileHandler := file.NewHandler(tc.setupFs(require, tc.stateFile))
 
 			if tc.yesFlag {
 				require.NoError(cmd.Flags().Set("yes", "true"))
@@ -159,7 +158,7 @@ func TestTerminate(t *testing.T) {
 					assert.True(tc.terminator.Called())
 					_, err = fileHandler.Stat(constants.AdminConfFilename)
 					assert.Error(err)
-					_, err = fileHandler.Stat(constants.ClusterIDsFilename)
+					_, err = fileHandler.Stat(constants.StateFilename)
 					assert.Error(err)
 					_, err = fileHandler.Stat(constants.StateFilename)
 					assert.Error(err)

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -239,6 +239,13 @@ func (u *upgradeApplyCmd) upgradeApply(cmd *cobra.Command, upgradeDir string, fl
 		return fmt.Errorf("writing state file: %w", err)
 	}
 
+	// TODO(msanft): Remove this after v2.12.0 is released, as we do not support
+	// the id-file starting from v2.13.0.
+	err = u.fileHandler.RenameFile(constants.ClusterIDsFilename, constants.ClusterIDsFilename+".old")
+	if !errors.Is(err, fs.ErrNotExist) && err != nil {
+		return fmt.Errorf("removing cluster ID file: %w", err)
+	}
+
 	// extend the clusterConfig cert SANs with any of the supported endpoints:
 	// - (legacy) public IP
 	// - fallback endpoint

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -96,10 +96,10 @@ func TestUpgradeApply(t *testing.T) {
 				require.NoError(err)
 				assert.Equal("v1", gotState.Version)
 				assert.Equal(defaultState, gotState)
-				var oldIdFile clusterid.File
-				err = fh.ReadJSON(constants.ClusterIDsFilename+".old", &oldIdFile)
+				var oldIDFile clusterid.File
+				err = fh.ReadJSON(constants.ClusterIDsFilename+".old", &oldIDFile)
 				assert.NoError(err)
-				assert.Equal(defaultIdFile, oldIdFile)
+				assert.Equal(defaultIDFile, oldIDFile)
 			},
 		},
 		"id file and state file do not exist": {

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -39,11 +39,13 @@ func TestUpgradeApply(t *testing.T) {
 			APIServerCertSANs: []string{},
 			UID:               "uid",
 			Name:              "kubernetes-uid", // default test cfg uses "kubernetes" prefix
+			InitSecret:        []byte{0x42},
 		}).
 		SetClusterValues(state.ClusterValues{MeasurementSalt: []byte{0x41}})
 	defaultIDFile := clusterid.File{
 		MeasurementSalt: []byte{0x41},
 		UID:             "uid",
+		InitSecret:      []byte{0x42},
 	}
 	fsWithIDFile := func() file.Handler {
 		fh := file.NewHandler(afero.NewMemMapFs())

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -94,6 +94,10 @@ func TestUpgradeApply(t *testing.T) {
 				require.NoError(err)
 				assert.Equal("v1", gotState.Version)
 				assert.Equal(defaultState, gotState)
+				var oldIdFile clusterid.File
+				err = fh.ReadJSON(constants.ClusterIDsFilename+".old", &oldIdFile)
+				assert.NoError(err)
+				assert.Equal(defaultIdFile, oldIdFile)
 			},
 		},
 		"id file and state file do not exist": {

--- a/cli/internal/cmd/verify.go
+++ b/cli/internal/cmd/verify.go
@@ -190,6 +190,7 @@ func (c *verifyCmd) parseVerifyFlags(cmd *cobra.Command, fileHandler file.Handle
 	stateFile, err := state.ReadFromFile(fileHandler, constants.StateFilename)
 	isFileNotFound := errors.Is(err, afero.ErrFileNotFound)
 	if isFileNotFound {
+		c.log.Debugf("State file %q not found, using empty state", pf.PrefixPrintablePath(constants.StateFilename))
 		stateFile = state.New() // error compat
 	} else if err != nil {
 		return verifyFlags{}, fmt.Errorf("reading state file: %w", err)

--- a/cli/internal/cmd/verify_test.go
+++ b/cli/internal/cmd/verify_test.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/edgelesssys/constellation/v2/cli/internal/clusterid"
+	"github.com/edgelesssys/constellation/v2/cli/internal/state"
 	"github.com/edgelesssys/constellation/v2/internal/atls"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/measurements"
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
@@ -48,7 +48,7 @@ func TestVerify(t *testing.T) {
 		formatter          *stubAttDocFormatter
 		nodeEndpointFlag   string
 		clusterIDFlag      string
-		idFile             *clusterid.File
+		stateFile          *state.State
 		wantEndpoint       string
 		skipConfigCreation bool
 		wantErr            bool
@@ -84,11 +84,11 @@ func TestVerify(t *testing.T) {
 			formatter:     &stubAttDocFormatter{},
 			wantErr:       true,
 		},
-		"endpoint from id file": {
+		"endpoint from state file": {
 			provider:      cloudprovider.GCP,
 			clusterIDFlag: zeroBase64,
 			protoClient:   &stubVerifyClient{},
-			idFile:        &clusterid.File{IP: "192.0.2.1"},
+			stateFile:     &state.State{Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.1"}},
 			wantEndpoint:  "192.0.2.1:" + strconv.Itoa(constants.VerifyServiceNodePortGRPC),
 			formatter:     &stubAttDocFormatter{},
 		},
@@ -97,7 +97,7 @@ func TestVerify(t *testing.T) {
 			nodeEndpointFlag: "192.0.2.2:1234",
 			clusterIDFlag:    zeroBase64,
 			protoClient:      &stubVerifyClient{},
-			idFile:           &clusterid.File{IP: "192.0.2.1"},
+			stateFile:        &state.State{Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.1"}},
 			wantEndpoint:     "192.0.2.2:1234",
 			formatter:        &stubAttDocFormatter{},
 		},
@@ -115,11 +115,11 @@ func TestVerify(t *testing.T) {
 			formatter:        &stubAttDocFormatter{},
 			wantErr:          true,
 		},
-		"use owner id from id file": {
+		"use owner id from state file": {
 			provider:         cloudprovider.GCP,
 			nodeEndpointFlag: "192.0.2.1:1234",
 			protoClient:      &stubVerifyClient{},
-			idFile:           &clusterid.File{OwnerID: zeroBase64},
+			stateFile:        &state.State{ClusterValues: state.ClusterValues{OwnerID: zeroBase64}},
 			wantEndpoint:     "192.0.2.1:1234",
 			formatter:        &stubAttDocFormatter{},
 		},
@@ -181,8 +181,8 @@ func TestVerify(t *testing.T) {
 				cfg := defaultConfigWithExpectedMeasurements(t, config.Default(), tc.provider)
 				require.NoError(fileHandler.WriteYAML(constants.ConfigFilename, cfg))
 			}
-			if tc.idFile != nil {
-				require.NoError(fileHandler.WriteJSON(constants.ClusterIDsFilename, tc.idFile, file.OptNone))
+			if tc.stateFile != nil {
+				require.NoError(tc.stateFile.WriteToFile(fileHandler, constants.StateFilename))
 			}
 
 			v := &verifyCmd{log: logger.NewTest(t)}

--- a/cli/internal/state/state.go
+++ b/cli/internal/state/state.go
@@ -56,7 +56,7 @@ func NewFromIDFile(idFile clusterid.File, cfg *config.Config) *State {
 			UID:               idFile.UID,
 			ClusterEndpoint:   idFile.IP,
 			APIServerCertSANs: idFile.APIServerCertSANs,
-			InitSecret:        string(idFile.InitSecret),
+			InitSecret:        idFile.InitSecret,
 			Name:              clusterid.GetClusterName(cfg, idFile),
 		})
 
@@ -112,7 +112,7 @@ type ClusterValues struct {
 type Infrastructure struct {
 	UID               string   `yaml:"uid"`
 	ClusterEndpoint   string   `yaml:"clusterEndpoint"`
-	InitSecret        string   `yaml:"initSecret"`
+	InitSecret        []byte   `yaml:"initSecret"`
 	APIServerCertSANs []string `yaml:"apiServerCertSANs"`
 	// Name is the name of the cluster.
 	Name  string `yaml:"name"`

--- a/cli/internal/state/state_test.go
+++ b/cli/internal/state/state_test.go
@@ -23,7 +23,7 @@ var defaultState = &State{
 	Infrastructure: Infrastructure{
 		UID:             "123",
 		ClusterEndpoint: "test-cluster-endpoint",
-		InitSecret:      "test-init-secret",
+		InitSecret:      []byte{0x41},
 		APIServerCertSANs: []string{
 			"api-server-cert-san-test",
 			"api-server-cert-san-test-2",

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -233,7 +233,7 @@ func (c *Client) ShowInfrastructure(ctx context.Context, provider cloudprovider.
 	res := state.Infrastructure{
 		ClusterEndpoint:   ip,
 		APIServerCertSANs: apiServerCertSANs,
-		InitSecret:        secret,
+		InitSecret:        []byte(secret),
 		UID:               uid,
 		Name:              name,
 	}

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -477,7 +477,7 @@ func TestCreateCluster(t *testing.T) {
 			}
 			assert.NoError(err)
 			assert.Equal("192.0.2.100", infraState.ClusterEndpoint)
-			assert.Equal("initSecret", infraState.InitSecret)
+			assert.Equal([]byte("initSecret"), infraState.InitSecret)
 			assert.Equal("12345abc", infraState.UID)
 			if tc.provider == cloudprovider.Azure {
 				assert.Equal(tc.expectedAttestationURL, infraState.Azure.AttestationURL)

--- a/debugd/internal/cdbg/cmd/deploy.go
+++ b/debugd/internal/cdbg/cmd/deploy.go
@@ -113,11 +113,11 @@ func deploy(cmd *cobra.Command, fileHandler file.Handler, constellationConfig *c
 		return err
 	}
 	if len(ips) == 0 {
-		var idFile clusterIDsFile
-		if err := fileHandler.ReadJSON(constants.ClusterIDsFilename, &idFile); err != nil {
-			return fmt.Errorf("reading cluster IDs file: %w", err)
+		var stateFile clusterStateFile
+		if err := fileHandler.ReadYAML(constants.StateFilename, &stateFile); err != nil {
+			return fmt.Errorf("reading cluster state file: %w", err)
 		}
-		ips = []string{idFile.IP}
+		ips = []string{stateFile.Infrastructure.ClusterEndpoint}
 	}
 
 	info, err := cmd.Flags().GetStringToString("info")
@@ -285,8 +285,8 @@ type fileTransferer interface {
 	SetFiles(files []filetransfer.FileStat)
 }
 
-type clusterIDsFile struct {
-	ClusterID string
-	OwnerID   string
-	IP        string
+type clusterStateFile struct {
+	Infrastructure struct {
+		ClusterEndpoint string `yaml:"clusterEndpoint"`
+	} `yaml:"infrastructure"`
 }

--- a/docs/docs/architecture/orchestration.md
+++ b/docs/docs/architecture/orchestration.md
@@ -28,7 +28,7 @@ Altogether, the following files are generated during the creation of a Constella
 
 After the creation of your cluster, the CLI will provide you with a Kubernetes `kubeconfig` file.
 This file grants you access to your Kubernetes cluster and configures the [kubectl](https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/) tool.
-In addition, the cluster's [identifier](orchestration.md#post-installation-configuration) is returned and stored in a file called `constellation-id.json`
+In addition, the cluster's [identifier](orchestration.md#post-installation-configuration) is returned and stored in a file called `constellation-state.yaml`
 
 ### Creation process details
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -380,7 +380,7 @@ Verify the confidential properties of a Constellation cluster
 ### Synopsis
 
 Verify the confidential properties of a Constellation cluster.
-If arguments aren't specified, values are read from `constellation-id.json`.
+If arguments aren't specified, values are read from `constellation-state.yaml`.
 
 ```
 constellation verify [flags]

--- a/docs/docs/workflows/create.md
+++ b/docs/docs/workflows/create.md
@@ -65,14 +65,16 @@ terraform init
 terraform apply
 ```
 
-The Constellation [init step](#the-init-step) requires the already created `constellation-config.yaml` and the `constellation-id.json`.
-Create the `constellation-id.json` using the output from the Terraform state and the `constellation-conf.yaml`:
+The Constellation [init step](#the-init-step) requires the already created `constellation-config.yaml` and the `constellation-state.yaml`.
+Create the `constellation-state.yaml` using the output from the Terraform state and the `constellation-conf.yaml`:
 
 ```bash
 CONSTELL_IP=$(terraform output ip)
 CONSTELL_INIT_SECRET=$(terraform output initSecret | jq -r | tr -d '\n' | base64)
-CONSTELL_CSP=$(cat constellation-conf.yaml | yq ".provider | keys | .[0]")
-jq --null-input --arg cloudprovider "$CONSTELL_CSP" --arg ip "$CONSTELL_IP" --arg initsecret "$CONSTELL_INIT_SECRET" '{"cloudprovider":$cloudprovider,"ip":$ip,"initsecret":$initsecret}' > constellation-id.json
+touch constellation-state.yaml
+yq eval '.version ="v1"' --inplace constellation-state.yaml
+yq eval '.infrastructure.initSecret ="$CONSTELL_INIT_SECRET"' --inplace constellation-state.yaml
+yq eval '.infrastructure.clusterEndpoint ="$CONSTELL_IP"' --inplace constellation-state.yaml
 ```
 
 </tabItem>

--- a/docs/docs/workflows/recovery.md
+++ b/docs/docs/workflows/recovery.md
@@ -125,7 +125,7 @@ This means that you have to recover the node manually.
 
 Recovering a cluster requires the following parameters:
 
-* The `constellation-id.json` file in your working directory or the cluster's load balancer IP address
+* The `constellation-state.yaml` file in your working directory or the cluster's endpoint
 * The master secret of the cluster
 
 A cluster can be recovered like this:

--- a/docs/docs/workflows/terminate.md
+++ b/docs/docs/workflows/terminate.md
@@ -51,7 +51,7 @@ terraform destroy
 Delete all files that are no longer needed:
 
 ```bash
-rm constellation-id.json constellation-admin.conf
+rm constellation-state.yaml constellation-admin.conf
 ```
 
 Only the `constellation-mastersecret.json` and the configuration file remain.

--- a/docs/docs/workflows/verify-cluster.md
+++ b/docs/docs/workflows/verify-cluster.md
@@ -78,7 +78,7 @@ From the attestation statement, the command verifies the following properties:
 
 * The cluster is using the correct Confidential VM (CVM) type.
 * Inside the CVMs, the correct node images are running. The node images are identified through the measurements obtained in the previous step.
-* The unique ID of the cluster matches the one from your `constellation-id.json` file or passed in via `--cluster-id`.
+* The unique ID of the cluster matches the one from your `constellation-state.yaml` file or passed in via `--cluster-id`.
 
 Once the above properties are verified, you know that you are talking to the right Constellation cluster and it's in a good and trustworthy shape.
 

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -232,3 +232,8 @@ func (h *Handler) CopyFile(src, dst string, opts ...Option) error {
 
 	return nil
 }
+
+// RenameFile renames a file, overwriting any existing file at the destination.
+func (h *Handler) RenameFile(old, new string) error {
+	return h.fs.Rename(old, new)
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
As #2395 introduces the switch from the id-file to the more extensive state-file, the ID-file should be removed from the existing commands. (i.e. `constellation init` and `constellation upgrade apply`)

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Write to the state-file during `constellation create`
- Read / Write from / to the state-file during `constellation init`
- Move the ID-file to a backup on `constellation upgrade apply` (i.e. when upgrading from a id-file version to a state-file version)
- Read from state-file instead of ID-file in `constellation verify`
- Read from state-file instead of ID-file in `constellation mini`
- Read from state-file instead of ID-file in `constellation recover`
- Read from state-file instead of ID-file in `constellation terminate`
- Read from state-file instead of ID-file in `constellation iam destroy`
- Read from state-file instead of ID-file in `cdbg deploy`
- Remove references to the ID-file from the docs, without fully documenting the self-managed infrastructure workflow yet.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3425](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3425)


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
