### PR TITLE
ci: add msanft to list of possible e2e assignees

### DIFF
--- a/.github/actions/pick_assignee/action.yml
+++ b/.github/actions/pick_assignee/action.yml
@@ -19,6 +19,7 @@ runs:
           "3u13r"
           "daniel-weisse"
           "derpsteb"
+          "msanft"
         )
         assignee=${possibleAssignees[$RANDOM % ${#possibleAssignees[@]}]}
         echo "assignee=$assignee" | tee -a "$GITHUB_OUTPUT"

--- a/.github/teams_payload_template.json
+++ b/.github/teams_payload_template.json
@@ -21,6 +21,14 @@
                         },
                         {
                             "type": "mention",
+                            "text": "<at>msanft</at>",
+                            "mentioned": {
+                                "id": "1359ea62-4415-423e-b808-9d9acb96def0",
+                                "name": "Moritz Sanft"
+                            }
+                        },
+                        {
+                            "type": "mention",
                             "text": "<at>3u13r</at>",
                             "mentioned": {
                                 "id": "26869b29-b0d6-48f8-a9ed-7a6374410a53",


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
E2E failures are often not triaged in time, team of possible assignees does not reflect all engineers.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add `msanft` as possible e2e assignee

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

