### PR TITLE
ci: ensure API is only updated if image and measurements are uploaded

### DIFF
--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -649,7 +649,7 @@ jobs:
             --version=${{  needs.build-settings.outputs.imageVersion }} \
 
   add-image-version-to-versionsapi:
-    needs: [upload-artifacts, build-settings]
+    needs: [upload-artifacts, upload-pcrs, build-settings]
     name: "Add image version to versionsapi"
     if: needs.build-settings.outputs.ref != '-'
     permissions:


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
As part of our image build pipeline, our API is updated to include measurements and a reference to the image in the API.
Currently, the image build may fail when calculating the expected measurements, but the API is still updated.
This means our API reports a image as being available, even though the build pipeline failed.
While this does not impact regular users, it impacts our E2E tests which automatically use the latest available image version and try to fetch measurements for that version.
If the measurements are not available, the test fails.

### Proposed change(s)
- Ensure the API is only updated if both the image upload (+image lookup table upload) and the measurements upload was successful

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- AB#3338
- AB#3454

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
