### PR TITLE
renovate: relax rules to allow updates to minor versions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -21,6 +21,9 @@
     "operators/constellation-node-operator/config/manager/kustomization.yaml",
   ],
   "ignoreDeps": ["github.com/edgelesssys/constellation/v2"],
+  // Rules for changing renovates behaviour for different packages.
+  // The documentation for configuration options can be found here:
+  // https://docs.renovatebot.com/configuration-options/
   "packageRules": [
     {
       "matchManagers": ["gomod"],
@@ -103,6 +106,7 @@
     },
     {
       "matchPackageNames": ["kubernetes/kubernetes"],
+      // example match: v1.2.3 (1.2 -> compatibility, 3 -> patch)
       "versioning": "regex:^(?<compatibility>v?\\d+\\.\\d+\\.)(?<patch>\\d+)$",
       "groupName": "Kubernetes versions",
       "prPriority": 15,
@@ -111,6 +115,7 @@
       "matchPackageNames": [
         "registry.k8s.io/provider-aws/cloud-controller-manager",
       ],
+      // example match: v1.2.3 (1.2 -> compatibility, 3 -> patch)
       "versioning": "regex:^(?<compatibility>v?\\d+\\.\\d+\\.)(?<patch>\\d+)$",
       "groupName": "K8s constrained AWS versions",
       "prPriority": 15,
@@ -120,6 +125,7 @@
         "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager",
         "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager",
       ],
+      // example match: v1.2.3 (1.2 -> compatibility, 3 -> patch)
       "versioning": "regex:^(?<compatibility>v?\\d+\\.\\d+\\.)(?<patch>\\d+)$",
       "groupName": "K8s constrained Azure versions",
       "prPriority": 15,
@@ -128,18 +134,21 @@
       "matchPackageNames": [
         "docker.io/k8scloudprovider/openstack-cloud-controller-manager",
       ],
+      // example match: v1.2.3 (1.2 -> compatibility, 3 -> patch)
       "versioning": "regex:^(?<compatibility>v?\\d+\\.\\d+\\.)(?<patch>\\d+)$",
       "groupName": "K8s constrained OpenStack versions",
       "prPriority": 15,
     },
     {
       "matchPackageNames": ["registry.k8s.io/autoscaling/cluster-autoscaler"],
+      // example match: v1.2.3 (1.2 -> compatibility, 3 -> patch)
       "versioning": "regex:^(?<compatibility>v?\\d+\\.\\d+\\.)(?<patch>\\d+)$",
       "groupName": "K8s constrained GCP versions",
       "prPriority": 15,
     },
     {
       "matchPackageNames": ["ghcr.io/edgelesssys/cloud-provider-gcp"],
+      // example match: v1.2.3 (1. -> compatibility, 2 -> minor, 3 -> patch)
       "versioning": "regex:^(?<compatibility>v\\d+\\.)(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "groupName": "cloud-provider-gcp (K8s version constrained)",
       "prPriority": 15,
@@ -148,6 +157,11 @@
       "matchPackagePrefixes": ["ghcr.io/edgelesssys/"],
       "excludePackageNames": ["ghcr.io/edgelesssys/cloud-provider-gcp"],
       "versioning": "semver",
+      // Allow packages of ghcr.io/edgelesssys to update to unstable prereleases.
+      // This is necessary because renovate will not update minor versions of
+      // containers that are already tagged as a prerelease in the code
+      // if this is not set.
+      "ignoreUnstable": false,
       "groupName": "Constellation containers",
       "prPriority": 20,
     },
@@ -180,10 +194,16 @@
       "groupName": "{{packageName}}",
     },
   ],
+  // Regex Managers allow detection of other versions in files that renovate
+  // cannot parse by default. For more information, look at
+  // https://docs.renovatebot.com/modules/manager/regex/ .
   "regexManagers": [
     {
       "fileMatch": ["(^|\\/)versions.go$"],
       "matchStrings": [
+        // Match all container packages.
+        // example match:' "registry.io/owner/foo/bar:v1.2.3@sha256:somehash" // renovate:container'
+        // (registry.io/owner/foo/bar -> depName, v1.2.3 -> currentValue, sha256:somehash -> currentDigest)
         " \"(?<depName>[^\"]*?):(?<currentValue>[^\"]*?)@(?<currentDigest>sha256:[a-f0-9]+)\"[^\\n]+\\/\\/ renovate:container",
       ],
       "datasourceTemplate": "docker",
@@ -191,7 +211,13 @@
     {
       "fileMatch": ["(^|\\/)versions.go$"],
       "matchStrings": [
+        // Match kubernetes releases.
+        // example match:'  "https://storage.googleapis.com/kubernetes-release/release/v1.2.3/foo" // renovate:kubernetes-release'
+        // (v1.2.3 -> currentValue)
         " \"https:\\/\\/storage\\.googleapis\\.com\\/kubernetes-release\\/release\\/(?<currentValue>[^\\/\\s\"]+)\\/[^\"]+\"[^\\n]+\\/\\/ renovate:kubernetes-release",
+        // Match kubernetes releases.
+        // example match:' " "v1.2.3" // renovate:kubernetes-release"'
+        // (v1.2.3 -> currentValue)
         " \"(?<currentValue>v\\d+\\.\\d+\\.\\d+)\"[^\\n]+\\/\\/ renovate:kubernetes-release",
       ],
       "depNameTemplate": "kubernetes/kubernetes",
@@ -200,6 +226,9 @@
     {
       "fileMatch": ["(^|\\/)versions.go$"],
       "matchStrings": [
+        // Match github releases.
+        // example match:' "https://github.com/foo/bar/releases/download/v1.2.3/foo.bin" // renovate:github-release'
+        // (foo/bar -> depName, v1.2.3 -> currentValue)
         " \"https:\\/\\/github\\.com\\/(?<depName>[^\\/\\s\"]+\\/[^\\/\\s\"]+)\\/releases\\/download\\/(?<currentValue>[^\\/\\s\"]+)\\/[^\"]+\"[^\\n]+\\/\\/ renovate:github-release",
       ],
       "datasourceTemplate": "github-releases",
@@ -207,6 +236,9 @@
     {
       "fileMatch": ["(^|\\/)versions.go$"],
       "matchStrings": [
+        // Match kubernetes cri-tools releases (https://github.com/kubernetes-sigs/cri-tools).
+        // example Match:' "https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.2.3/foo"'
+        // (v1.2.3 -> currentValue)
         " \"https:\\/\\/github\\.com\\/kubernetes-sigs\\/cri-tools\\/releases\\/download\\/(?<currentValue>[^\\/\\s\"]+)\\/[^\"]+\"",
       ],
       "depNameTemplate": "kubernetes-sigs/cri-tools",
@@ -216,6 +248,9 @@
     {
       "fileMatch": ["versions.go$"],
       "matchStrings": [
+        // Match containernetworking plugin releases (https://github.com/containernetworking/plugins).
+        // example Match:' "https://github.com/containernetworking/plugins/releases/download/v1.2.3/foo"'
+        // (v1.2.3 -> currentValue)
         " \"https:\\/\\/github\\.com\\/containernetworking\\/plugins\\/releases\\/download\\/(?<currentValue>[^\\/\\s\"]+)\\/[^\"]+\"",
       ],
       "depNameTemplate": "containernetworking/plugins",
@@ -225,6 +260,9 @@
     {
       "fileMatch": ["\\.yaml$", "\\.yml$"],
       "matchStrings": [
+        // Match `go install` commands.
+        // example Match: "go install foo.bar@0000000000000000000000000000000000000000"
+        // (foo.bar -> depName, 0000000000000000000000000000000000000000 -> currentValue)
         "go install (?<depName>[^@]+?)@(?<currentValue>[0-9a-f]{40})",
       ],
       "datasourceTemplate": "go",


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Renovate fails to update minor versions of certain packages like filebeat-debugd.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add `"ignoreUnstable": false` to the package Rule that matches "ghcr.io/edgelesssys" to allow updates to later prereleases.
- add comments to the renovate.json5 file that make it easier to navigate.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- This will cause renovate to want to update some packages to unstable versions
- affected packages:
    - [ghcr.io/edgelesssys/gcp-guest-agent](https://github.com/edgelesssys/constellation/pkgs/container/gcp-guest-agent)
    - [ghcr.io/edgelesssys/constellation/logstash-debugd](https://github.com/edgelesssys/constellation/pkgs/container/constellation%2Flogstash-debugd)
    - [ghcr.io/edgelesssys/constellation/filebeat-debugd](https://github.com/edgelesssys/constellation/pkgs/container/constellation%2Ffilebeat-debugd)
    - [ghcr.io/edgelesssys/constellation/metricbeat-debugd](https://github.com/edgelesssys/constellation/pkgs/container/constellation%2Fmetricbeat-debugd)
- a working example can be found [here](https://github.com/malt3/renovate-regex-test/pull/17)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [X] Add labels (e.g., for changelog category)
- [X] Is PR title adequate for changelog?
- [X] Link to Milestone
