### PR TITLE
image: add rpm database as build output

### DIFF
--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -172,6 +172,7 @@ jobs:
           bazel build "${TARGET}"
           {
             echo "image-dir=$(bazel cquery --output=files "$TARGET")"
+            echo "rpmdb=$(bazel cquery --output=files //image/base:rpmdb)"
           } | tee -a "$GITHUB_OUTPUT"
           echo "::endgroup::"
 
@@ -189,6 +190,12 @@ jobs:
             ${{ steps.build.outputs.image-dir }}/constellation.efi
             ${{ steps.build.outputs.image-dir }}/constellation.initrd
             ${{ steps.build.outputs.image-dir }}/constellation.vmlinuz
+
+      - name: Upload sbom info as artifact
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: sbom-${{ matrix.csp }}-${{ matrix.attestation_variant }}
+          path: ${{ steps.build.outputs.rpmdb }}
 
   upload-os-image:
     name: "Upload OS image to CSP"
@@ -615,6 +622,35 @@ jobs:
             --measurements measurements.json \
             --signature measurements.json.sig
           echo "::endgroup::"
+
+  upload-sbom:
+    name: "Upload SBOM"
+    needs: [build-settings, make-os-image]
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Login to AWS
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: arn:aws:iam::795746500882:role/GitHubConstellationImagePipeline
+          aws-region: eu-central-1
+
+      - name: Download sbom
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          # downloading / using only the QEMU manifest is fine
+          # since the images only differ in the ESP partition
+          name: sbom-qemu-qemu-vtpm
+
+      - name: Upload SBOMs to S3
+        shell: bash
+        run: |
+          aws s3 cp \
+          rpmdb.tar \
+            "s3://cdn-constellation-backend/${{needs.build-settings.outputs.imageApiBasePath}}/${file}" \
+            --no-progress
 
   upload-artifacts:
     name: "Upload image lookup table and CLI compatibility info"

--- a/image/base/BUILD.bazel
+++ b/image/base/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//bazel/mkosi:mkosi_image.bzl", "mkosi_image")
 
 copy_to_directory(
@@ -40,6 +41,11 @@ mkosi_image(
     outs = [
         "image",
         "image.tar",
+        "image-.rpm.lock",
+        "image-packagemanifest",
+        "image-rpmdb.sqlite",
+        "image-rpmdb.sqlite-shm",
+        "image-rpmdb.sqlite-wal",
     ],
     extra_trees = [
         "//image:sysroot_tar",
@@ -56,5 +62,25 @@ mkosi_image(
         "manual",
         "no-cache",
     ],
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "rpmdb",
+    srcs = [
+        "image-.rpm.lock",
+        "image-packagemanifest",
+        "image-rpmdb.sqlite",
+        "image-rpmdb.sqlite-shm",
+        "image-rpmdb.sqlite-wal",
+    ],
+    remap_paths = {
+        "/image-.rpm.lock": "/var/lib/rpm/.rpm.lock",
+        "/image-packagemanifest": "/usr/share/constellation/packagemanifest",
+        "/image-rpmdb.sqlite": "/var/lib/rpm/rpmdb.sqlite",
+        "/image-rpmdb.sqlite-shm": "/var/lib/rpm/rpmdb.sqlite-shm",
+        "/image-rpmdb.sqlite-wal": "/var/lib/rpm/image-rpmdb.sqlite-wal",
+    },
+    tags = ["manual"],
     visibility = ["//visibility:public"],
 )

--- a/image/base/mkosi.conf
+++ b/image/base/mkosi.conf
@@ -61,10 +61,6 @@ Packages=passwd
 RemoveFiles=/var/log
 RemoveFiles=/var/cache
 RemoveFiles=/etc/pki/ca-trust/extracted/java/cacerts
-            /usr/lib/sysimage/libdnf5/transaction_history.sqlite*
             /var/cache/ldconfig/aux-cache
-# https://github.com/authselect/authselect/pull/348
-# RemoveFiles=/etc/authselect/*
 RemoveFiles=/etc/issue
 RemoveFiles=/etc/issue.net
-CleanPackageMetadata=true

--- a/image/base/mkosi.postinst
+++ b/image/base/mkosi.postinst
@@ -7,3 +7,11 @@ mkdir -p "${BUILDROOT}"/etc/{cni,kubernetes}
 # move issue files away from /etc
 # to allow /run/issue and /run/issue.d to take precedence
 mv "${BUILDROOT}/etc/issue.d" "${BUILDROOT}/usr/lib/issue.d" || true
+
+# generate reproducible package manifest
+mkdir -p "${BUILDROOT}/usr/share/constellation"
+rpm -qa --qf '%{name};%{version};%{license}\n' --dbpath "${BUILDROOT}/var/lib/rpm/" | LC_ALL=C sort | tee "${BUILDROOT}/usr/share/constellation/packagemanifest"
+cp "${BUILDROOT}/usr/share/constellation/packagemanifest" "${OUTPUTDIR}/"
+
+# copy rpmdb to outputs
+cp "${BUILDROOT}"/var/lib/rpm/{rpmdb.sqlite-wal,rpmdb.sqlite-shm,rpmdb.sqlite,.rpm.lock} "${OUTPUTDIR}/"

--- a/image/initrd/mkosi.conf
+++ b/image/initrd/mkosi.conf
@@ -36,6 +36,4 @@ RemoveFiles=/var/cache
 RemoveFiles=/etc/pki/ca-trust/extracted/java/cacerts
             /usr/lib/sysimage/libdnf5/transaction_history.sqlite*
             /var/cache/ldconfig/aux-cache
-# https://github.com/authselect/authselect/pull/348
-# RemoveFiles=/etc/authselect/*
 CleanPackageMetadata=true

--- a/image/system/BUILD.bazel
+++ b/image/system/BUILD.bazel
@@ -15,7 +15,7 @@ load(":variants.bzl", "CSPS", "STREAMS", "VARIANTS", "autologin", "constellation
             stream,
         ),
         base_trees = [
-            "//image/base",
+            "//image/base:image.tar",
         ],
         extra_trees = constellation_packages(stream),
         initrds = [

--- a/image/system/mkosi.conf
+++ b/image/system/mkosi.conf
@@ -19,6 +19,4 @@ RemoveFiles=/var/cache
 RemoveFiles=/etc/pki/ca-trust/extracted/java/cacerts
             /usr/lib/sysimage/libdnf5/transaction_history.sqlite*
             /var/cache/ldconfig/aux-cache
-# https://github.com/authselect/authselect/pull/348
-# RemoveFiles=/etc/authselect/*
 CleanPackageMetadata=true


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

For reproducibility reasons, the final OS image does not ship the rpm database in sqlite format. For supply chain security and license compliance reasons, we want to keep the rpm database of os images as a detached build artifact. We now ship a reproducible, human readable manifest of installed rpms in the image under "/usr/share/constellation/packagemanifest" and upload the full rpm database as a build artifact (rpmdb.tar).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- image: add rpm database as build output

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
- [x] [Build pipeline](https://github.com/edgelesssys/constellation/actions/runs/6482107875)
