### PR TITLE
deps: update go to 1.21.3

### DIFF
--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.21.1"
+          go-version: "1.21.3"
           cache: false
 
       - name: Install Crane

--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.21.1"
+          go-version: "1.21.3"
           cache: false
 
       - name: Determine version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.21.1"
+          go-version: "1.21.3"
           cache: false
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.21.1"
+          go-version: "1.21.3"
           cache: true
 
       - name: Build generateMeasurements tool

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.21.1"
+          go-version: "1.21.3"
           cache: true
 
       - name: Install Dependencies

--- a/.github/workflows/test-operator-codegen.yml
+++ b/.github/workflows/test-operator-codegen.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version: "1.21.1"
+          go-version: "1.21.3"
           cache: true
 
       - name: Run code generation

--- a/3rdparty/gcp-guest-agent/Dockerfile
+++ b/3rdparty/gcp-guest-agent/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
     git
 
 # Install Go
-ARG GO_VER=1.21.1
+ARG GO_VER=1.21.3
 RUN wget -q https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go${GO_VER}.linux-amd64.tar.gz && \
     rm go${GO_VER}.linux-amd64.tar.gz

--- a/bazel/nixos-support/nixos-support.bzl
+++ b/bazel/nixos-support/nixos-support.bzl
@@ -36,7 +36,7 @@ def cc_toolchain():
 load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains")
 
 def go_toolchain():
-    go_register_toolchains(version = "1.21.1")
+    go_register_toolchains(version = "1.21.3")
 
 def cc_toolchain():
     native.register_toolchains(

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
 go 1.21
 
-toolchain go1.21.1
+toolchain go1.21.3
 
 use (
 	.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

```
euler@work:~/projects/constellation$ govulncheck ./...
Scanning your code and 1749 packages across 292 dependent modules for known vulnerabilities...

Vulnerability #1: GO-2023-2102
    HTTP/2 rapid reset can cause excessive work in net/http
  More info: https://pkg.go.dev/vuln/GO-2023-2102
  Standard library
    Found in: net/http@go1.21.1
    Fixed in: net/http@go1.21.3
    Example traces found:
      #1: s3proxy/cmd/main.go:94:30: cmd.runServer calls http.Server.ListenAndServe
      #2: s3proxy/cmd/main.go:90:34: cmd.runServer calls http.Server.ListenAndServeTLS
      #3: verify/server/server.go:77:30: server.Run calls http.Server.Serve

Your code is affected by 1 vulnerability from the Go standard library.

Share feedback at https://go.dev/s/govulncheck-feedback.
```


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Bump Go version to 1.21.3

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- Any additional information or context

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
