### PR TITLE
cli: generate state file during `constellation config generate` 

### DIFF
--- a/cli/internal/cmd/configgenerate.go
+++ b/cli/internal/cmd/configgenerate.go
@@ -102,7 +102,7 @@ func (cg *configGenerateCmd) configGenerate(cmd *cobra.Command, fileHandler file
 	conf.KubernetesVersion = cg.flags.k8sVersion
 	cg.log.Debugf("Writing YAML data to configuration file")
 	if err := fileHandler.WriteYAML(constants.ConfigFilename, conf, file.OptMkdirAll); err != nil {
-		return err
+		return fmt.Errorf("writing config file: %w", err)
 	}
 
 	cmd.Println("Config file written to", cg.flags.pathPrefixer.PrefixPrintablePath(constants.ConfigFilename))
@@ -116,7 +116,9 @@ func (cg *configGenerateCmd) configGenerate(cmd *cobra.Command, fileHandler file
 	case cloudprovider.Azure:
 		stateFile.SetInfrastructure(state.Infrastructure{Azure: &state.Azure{}})
 	}
-	stateFile.WriteToFile(fileHandler, constants.StateFilename)
+	if err = stateFile.WriteToFile(fileHandler, constants.StateFilename); err != nil {
+		return fmt.Errorf("writing state file: %w", err)
+	}
 	cmd.Println("State file written to", cg.flags.pathPrefixer.PrefixPrintablePath(constants.StateFilename))
 
 	cmd.Println("For more information refer to the documentation:")

--- a/cli/internal/cmd/configgenerate.go
+++ b/cli/internal/cmd/configgenerate.go
@@ -26,8 +26,8 @@ import (
 func newConfigGenerateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "generate {aws|azure|gcp|openstack|qemu|stackit}",
-		Short: "Generate a default configuration file",
-		Long:  "Generate a default configuration file for your selected cloud provider.",
+		Short: "Generate a default configuration and state file",
+		Long:  "Generate a default configuration and state file for your selected cloud provider.",
 		Args: cobra.MatchAll(
 			cobra.ExactArgs(1),
 			isCloudProvider(0),

--- a/cli/internal/cmd/configgenerate_test.go
+++ b/cli/internal/cmd/configgenerate_test.go
@@ -169,32 +169,6 @@ func TestConfigGenerateDefaultProviderSpecific(t *testing.T) {
 	}
 }
 
-func TestConfigGenerateWithStackIt(t *testing.T) {
-	openStackProviders := []string{"stackit"}
-
-	for _, openStackProvider := range openStackProviders {
-		t.Run(openStackProvider, func(t *testing.T) {
-			assert := assert.New(t)
-			require := require.New(t)
-
-			fileHandler := file.NewHandler(afero.NewMemMapFs())
-			cmd := newConfigGenerateCmd()
-			cmd.Flags().String("workspace", "", "") // register persistent flag manually
-
-			wantConf := config.Default().WithOpenStackProviderDefaults(openStackProvider)
-			wantConf.RemoveProviderAndAttestationExcept(cloudprovider.OpenStack)
-
-			cg := &configGenerateCmd{log: logger.NewTest(t)}
-			require.NoError(cg.configGenerate(cmd, fileHandler, cloudprovider.OpenStack, openStackProvider))
-
-			var readConfig config.Config
-			err := fileHandler.ReadYAML(constants.ConfigFilename, &readConfig)
-			assert.NoError(err)
-			assert.Equal(*wantConf, readConfig)
-		})
-	}
-}
-
 func TestConfigGenerateDefaultExists(t *testing.T) {
 	require := require.New(t)
 

--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -13,7 +13,7 @@ If you encounter any problem with the following steps, make sure to use the [lat
 
 ## Create a cluster
 
-1. Create the [configuration file](../workflows/config.md) for your cloud provider.
+1. Create the [configuration file](../workflows/config.md) and state file for your cloud provider.
 
     <tabs groupId="csp">
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -12,7 +12,7 @@ constellation [command]
 Commands:
 
 * [config](#constellation-config): Work with the Constellation configuration file
-  * [generate](#constellation-config-generate): Generate a default configuration file
+  * [generate](#constellation-config-generate): Generate a default configuration and state file
   * [fetch-measurements](#constellation-config-fetch-measurements): Fetch measurements for configured cloud provider and image
   * [instance-types](#constellation-config-instance-types): Print the supported instance types for all cloud providers
   * [kubernetes-versions](#constellation-config-kubernetes-versions): Print the Kubernetes versions supported by this CLI
@@ -64,11 +64,11 @@ Work with the Constellation configuration file.
 
 ## constellation config generate
 
-Generate a default configuration file
+Generate a default configuration and state file
 
 ### Synopsis
 
-Generate a default configuration file for your selected cloud provider.
+Generate a default configuration and state file for your selected cloud provider.
 
 ```
 constellation config generate {aws|azure|gcp|openstack|qemu|stackit} [flags]


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
As a first step towards self-managed infrastructure support, it is necessary to provide the user with a way to generate a state file before the normal cluster creation would happen (as that step is not performed in the self-managed infrastructure case). 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Generate the state file for the specific CSP during `constellation config generate <CSP>` 
- Read from the exisiting state-file during `constellation create`, this is not necessary as the file would be overwritten, but creates a more coherent flow between Constellation-managed and self-managed infrastructure.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3490](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3490)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
