### PR TITLE
ci: add missing quotation marks for region flag

### DIFF
--- a/.github/actions/constellation_iam_create/action.yml
+++ b/.github/actions/constellation_iam_create/action.yml
@@ -39,14 +39,7 @@ runs:
     - name: Generate config
       id: generate-config
       shell: bash
-      # TODO(katexochen): Remove the generate-config flag once v2.10 is released.
       run: |
-        output=$(constellation iam create --help)
-        if [[ $output == *"generate-config"* ]]; then
-          echo "flag=--generate-config" | tee -a "$GITHUB_OUTPUT"
-          exit 0
-        fi
-
         kubernetesFlag=""
         if [[ ! -z "${{ inputs.kubernetesVersion }}" ]]; then
           kubernetesFlag="--kubernetes=${{ inputs.kubernetesVersion }}"
@@ -60,9 +53,9 @@ runs:
       if: inputs.cloudProvider == 'aws'
       run: |
         constellation iam create aws \
-          --zone=${{ inputs.awsZone }} \
-          --prefix=${{ inputs.namePrefix }} \
-          ${{ steps.generate-config.outputs.flag }} \
+          --zone="${{ inputs.awsZone }}" \
+          --prefix="${{ inputs.namePrefix }}" \
+          --update-config \
           --tf-log=DEBUG \
           --yes
 
@@ -71,10 +64,10 @@ runs:
       if: inputs.cloudProvider == 'azure'
       run: |
         constellation iam create azure \
-          --region=${{ inputs.azureRegion }} \
+          --region="${{ inputs.azureRegion }}" \
           --resourceGroup="${{ inputs.namePrefix }}-rg" \
           --servicePrincipal="${{ inputs.namePrefix }}-sp" \
-          ${{ steps.generate-config.outputs.flag }} \
+          --update-config \
           --tf-log=DEBUG \
           --yes
 
@@ -83,9 +76,9 @@ runs:
       if: inputs.cloudProvider == 'gcp'
       run: |
         constellation iam create gcp \
-          --projectID=${{ inputs.gcpProjectID }} \
-          --zone=${{ inputs.gcpZone }} \
+          --projectID="${{ inputs.gcpProjectID }}" \
+          --zone="${{ inputs.gcpZone }}" \
           --serviceAccountID="${{ inputs.namePrefix }}-sa" \
-          ${{ steps.generate-config.outputs.flag }} \
+          --update-config \
           --tf-log=DEBUG \
           --yes

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -209,7 +209,7 @@ runs:
         cloudProvider: ${{ inputs.cloudProvider }}
         namePrefix: ${{ steps.create-prefix.outputs.prefix }}
         awsZone: ${{ inputs.regionZone || 'us-east-2c' }}
-        azureRegion: ${{ inputs.regionZone || 'westus' }}
+        azureRegion: ${{ inputs.regionZone || 'northeurope' }}
         gcpProjectID: ${{ inputs.gcpProject }}
         gcpZone: ${{ inputs.regionZone || 'europe-west3-b' }}
         kubernetesVersion: ${{ inputs.kubernetesVersion }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Action was missing quotation marks for the region value when creating an IAM configuration.
This causes an error when setting the region to something containing spaces, e.g. "North Europe".

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add quotation marks
- Remove deprecated flag compatibility

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [Azure e2e test](https://github.com/edgelesssys/constellation/actions/runs/6534236026/job/17741011457) with region set to `North Europe`

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
