### PR TITLE
cli: create or read state file during `constellation create`

### DIFF
--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -191,7 +191,7 @@ func (c *createCmd) create(cmd *cobra.Command, creator cloudCreator, fileHandler
 	}
 	c.log.Debugf("Successfully created the cloud resources for the cluster")
 
-	stateFile, err := state.ReadFromFile(fileHandler, constants.StateFilename)
+	stateFile, err := state.CreateOrRead(fileHandler, constants.StateFilename)
 	if err != nil {
 		return fmt.Errorf("reading state file: %w", err)
 	}

--- a/cli/internal/cmd/create_test.go
+++ b/cli/internal/cmd/create_test.go
@@ -72,14 +72,14 @@ func TestCreate(t *testing.T) {
 		},
 		"interactive abort": {
 			setupFs:   fsWithDefaultConfigAndState,
-			creator:   &stubCloudCreator{},
+			creator:   &stubCloudCreator{state: infraState},
 			provider:  cloudprovider.GCP,
 			stdin:     "no\n",
 			wantAbort: true,
 		},
 		"interactive error": {
 			setupFs:  fsWithDefaultConfigAndState,
-			creator:  &stubCloudCreator{},
+			creator:  &stubCloudCreator{state: infraState},
 			provider: cloudprovider.GCP,
 			stdin:    "foo\nfoo\nfoo\n",
 			wantErr:  true,
@@ -92,7 +92,7 @@ func TestCreate(t *testing.T) {
 				require.NoError(fileHandler.WriteYAML(constants.ConfigFilename, defaultConfigWithExpectedMeasurements(t, config.Default(), csp)))
 				return fs
 			},
-			creator:  &stubCloudCreator{},
+			creator:  &stubCloudCreator{state: infraState},
 			provider: cloudprovider.GCP,
 			yesFlag:  true,
 			wantErr:  true,
@@ -105,24 +105,23 @@ func TestCreate(t *testing.T) {
 				require.NoError(fileHandler.WriteYAML(constants.ConfigFilename, defaultConfigWithExpectedMeasurements(t, config.Default(), csp)))
 				return fs
 			},
-			creator:  &stubCloudCreator{},
+			creator:  &stubCloudCreator{state: infraState},
 			provider: cloudprovider.GCP,
 			yesFlag:  true,
 			wantErr:  true,
 		},
 		"config does not exist": {
 			setupFs:  func(a *require.Assertions, p cloudprovider.Provider) afero.Fs { return afero.NewMemMapFs() },
-			creator:  &stubCloudCreator{},
+			creator:  &stubCloudCreator{state: infraState},
 			provider: cloudprovider.GCP,
 			yesFlag:  true,
 			wantErr:  true,
 		},
 		"state file does not exist": {
 			setupFs:  fsWithoutState,
-			creator:  &stubCloudCreator{},
+			creator:  &stubCloudCreator{state: infraState},
 			provider: cloudprovider.GCP,
 			yesFlag:  true,
-			wantErr:  true,
 		},
 		"create error": {
 			setupFs:  fsWithDefaultConfigAndState,
@@ -131,14 +130,14 @@ func TestCreate(t *testing.T) {
 			yesFlag:  true,
 			wantErr:  true,
 		},
-		"write id file error": {
+		"write state file error": {
 			setupFs: func(require *require.Assertions, csp cloudprovider.Provider) afero.Fs {
 				fs := afero.NewMemMapFs()
 				fileHandler := file.NewHandler(fs)
 				require.NoError(fileHandler.WriteYAML(constants.ConfigFilename, defaultConfigWithExpectedMeasurements(t, config.Default(), csp)))
 				return afero.NewReadOnlyFs(fs)
 			},
-			creator:  &stubCloudCreator{},
+			creator:  &stubCloudCreator{state: infraState},
 			provider: cloudprovider.GCP,
 			yesFlag:  true,
 			wantErr:  true,


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
https://github.com/edgelesssys/constellation/pull/2455 adds creation of the state file to `constellation config generate`.
However, not having an empty state file during `constellation create` now causes an error once the command finish executing.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use a `CreateOrRead` function to either read an existing state file, or create a new one during `constellation create` to ensure there is always a valid file

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->
