### PR TITLE
image: use systemd-dissect from the host when calculating measurements

### DIFF
--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -545,6 +545,10 @@ jobs:
         with:
           ref: ${{ inputs.ref || github.head_ref }}
 
+      - uses: ./.github/actions/setup_bazel_nix
+        with:
+          useCache: "false"
+
       - name: Download measurements
         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:

--- a/image/measured-boot/cmd/BUILD.bazel
+++ b/image/measured-boot/cmd/BUILD.bazel
@@ -21,8 +21,13 @@ go_binary(
     ],
     embed = [":cmd_lib"],
     # keep
-    env = {
-        "DISSECT_TOOLCHAIN": "$(rootpath @systemd//:bin/systemd-dissect)",
-    },
+    # TODO(malt3): The commented out env variable
+    # means we are using `systemd-dissect` from the host.
+    # `systemd-dissect` from nixpkgs breaks GitHub actions runners
+    # for unknown reasons.
+    # Fix this.
+    # env = {
+    #     "DISSECT_TOOLCHAIN": "$(rootpath @systemd//:bin/systemd-dissect)",
+    # },
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

A proper solution would be parsing the EFI partition directly in Go and not shelling out to `systemd-dissect` with root privileges. This needs more time.

When using `systemd-dissect` from nixpkgs, we see the following error:

```
  (10:03:53) INFO: Running command line: /bin/bash -c 'sudo -E bazel-bin/image/measured-boot/cmd/cmd_/cmd /home/runner/work/constellation/constellation/constellation.raw /home/runner/work/constellation/constellation/pcrs-aws-aws-nitro-tpm.json'
  failed to extract UKI: failed to extract /efi/EFI/BOOT/BOOTX64.EFI from /home/runner/work/constellation/constellation/constellation.raw: exit status 1
  Failed to open source path '/efi/EFI/BOOT/BOOTX64.EFI' in image '/home/runner/work/constellation/constellation/constellation.raw': No such file or directory
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- image: use systemd-dissect from the host when calculating measurements

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
- [ ] [os image build pipeline](https://github.com/edgelesssys/constellation/actions/runs/6546042423)