### PR TITLE
helm: add gcp ccm permissions for internal LBs

### DIFF
--- a/cli/internal/helm/BUILD.bazel
+++ b/cli/internal/helm/BUILD.bazel
@@ -411,6 +411,7 @@ go_library(
         "charts/edgeless/csi/charts/aws-csi-driver/templates/storageclass_integrity.yaml",
         "charts/edgeless/csi/charts/aws-csi-driver/templates/volumesnapshotclass.yaml",
         "charts/edgeless/csi/charts/aws-csi-driver/values.yaml",
+        "charts/edgeless/constellation-services/charts/ccm/templates/gcp-clusterrolebinding.yaml",
     ],
     importpath = "github.com/edgelesssys/constellation/v2/cli/internal/helm",
     visibility = ["//cli:__subpackages__"],

--- a/cli/internal/helm/charts/edgeless/constellation-services/charts/ccm/templates/gcp-clusterrolebinding.yaml
+++ b/cli/internal/helm/charts/edgeless/constellation-services/charts/ccm/templates/gcp-clusterrolebinding.yaml
@@ -1,0 +1,14 @@
+{{- if eq .Values.csp "GCP" -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-provider
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: cloud-provider
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/cli/internal/helm/testdata/GCP/constellation-services/charts/ccm/templates/gcp-clusterrolebinding.yaml
+++ b/cli/internal/helm/testdata/GCP/constellation-services/charts/ccm/templates/gcp-clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: system:cloud-provider
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: cloud-provider
+    namespace: testNamespace


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The GCP CCM hard-codes an outdated ClusterRole. We need to give it the required permissions again. See: https://github.com/kubernetes/cloud-provider-gcp/issues/611


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a ClusterRoleBinding linking the used service account to the role we use for the CCMs on other CSPs.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- Any additional information or context

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
