### PR TITLE
fix joining over lb

### DIFF
--- a/bootstrapper/internal/joinclient/joinclient.go
+++ b/bootstrapper/internal/joinclient/joinclient.go
@@ -191,11 +191,11 @@ func (c *JoinClient) tryJoinWithAvailableServices() error {
 
 	var endpoints []string
 
-	ip, _, err := c.metadataAPI.GetLoadBalancerEndpoint(ctx)
+	endpoint, _, err := c.metadataAPI.GetLoadBalancerEndpoint(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get load balancer endpoint: %w", err)
 	}
-	endpoints = append(endpoints, net.JoinHostPort(ip, strconv.Itoa(constants.JoinServiceNodePort)))
+	endpoints = append(endpoints, endpoint)
 
 	ips, err := c.getControlPlaneIPs(ctx)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
This is a fix needed for the strict node-to-node encryption. This bug had no effect until recently since we can still join via directly requesting the node in the local VPC.


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Don't append the port to the lb join endpoint twice.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- Any additional information or context

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
