### PR TITLE
ci: remove force flag from CLI commands

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -124,16 +124,13 @@ runs:
       run: |
         yq eval -i '(.internalLoadBalancer) = true' constellation-conf.yaml
 
-    # Uses --force flag since the CLI currently does not have a pre-release version and is always on the latest released version.
-    # However, many of our pipelines work on prerelease images. Thus the used images are newer than the CLI's version.
-    # This makes the version validation in the CLI fail.
     - name: Constellation create
       shell: bash
       run: |
         echo "Creating cluster using config:"
         cat constellation-conf.yaml
         sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts' || true
-        constellation create -y --force --debug --tf-log=DEBUG
+        constellation create -y --debug --tf-log=DEBUG
 
     - name: Cdbg deploy
       if: inputs.isDebugImage == 'true'
@@ -150,7 +147,7 @@ runs:
       id: constellation-init
       shell: bash
       run: |
-        constellation init --force --debug
+        constellation init --debug
         echo "KUBECONFIG=$(pwd)/constellation-admin.conf" | tee -a $GITHUB_OUTPUT
 
     - name: Wait for nodes to join and become ready

--- a/.github/actions/e2e_recover/action.yml
+++ b/.github/actions/e2e_recover/action.yml
@@ -27,7 +27,7 @@ runs:
         echo "Re-enabling the join-service and waiting for the node to be back up"
         kubectl patch daemonset -n kube-system join-service --type=json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/some-tag"}]'
         kubectl wait --for=condition=Ready=true --timeout=10m --all nodes
-      
+
     - name: Restart all control plane nodes
       shell: bash
       env:
@@ -37,7 +37,7 @@ runs:
         for CONTROL_PLANE_NODE in ${CONTROL_PLANE_NODES}; do
           kubectl debug node/$CONTROL_PLANE_NODE --image=ubuntu -- bash -c "echo reboot > reboot.sh && chroot /host < reboot.sh"
         done
-      
+
     - name: Constellation recover
       shell: bash
       run: |
@@ -45,7 +45,7 @@ runs:
         start_time=$(date +%s)
         recovered=0
         while true; do
-            output=$(constellation recover --force)
+            output=$(constellation recover)
             if echo "$output" | grep -q "Pushed recovery key."; then
                 echo "$output"
                 i=$(echo "$output" | grep -o "Pushed recovery key." | wc -l | sed 's/ //g')

--- a/.github/actions/e2e_verify/action.yml
+++ b/.github/actions/e2e_verify/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - name: Constellation verify
       shell: bash
-      run: constellation verify --cluster-id $(yq -r ".clusterValues.clusterID" constellation-state.yaml) --force
+      run: constellation verify --cluster-id $(yq -r ".clusterValues.clusterID" constellation-state.yaml)
 
     - name: Verify all nodes
       shell: bash
@@ -68,9 +68,9 @@ runs:
 
           if [[ ${{ inputs.cloudProvider }} == "azure" ]]; then
             echo "Extracting Azure TCB versions for API update"
-            constellation verify --cluster-id "${clusterID}" --force --node-endpoint localhost:9090 -o json > "snp-report-${node}.json"
+            constellation verify --cluster-id "${clusterID}" --node-endpoint localhost:9090 -o json > "snp-report-${node}.json"
           else
-            constellation verify --cluster-id "${clusterID}" --force --node-endpoint localhost:9090
+            constellation verify --cluster-id "${clusterID}" --node-endpoint localhost:9090
           fi
 
           kill $forwarderPID


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The CI was using the `--force` flag for CLI commands for a while.
Embedding the correct pseudo version in the binary has been fixed, so we can remove the flag.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove `--force` flag from CLI commands in the CI

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [e2e verify test](https://github.com/edgelesssys/constellation/actions/runs/6574988510/job/17861160374)
- [e2e recover test](https://github.com/edgelesssys/constellation/actions/runs/6575610715/job/17863166013)
