### PR TITLE
validation: add generic validation framework

### DIFF
--- a/internal/validation/BUILD.bazel
+++ b/internal/validation/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//bazel/go:go_test.bzl", "go_test")
+
+go_library(
+    name = "validation",
+    srcs = [
+        "constraints.go",
+        "errors.go",
+        "validation.go",
+    ],
+    importpath = "github.com/edgelesssys/constellation/v2/internal/validation",
+    visibility = ["//:__subpackages__"],
+)
+
+go_test(
+    name = "validation_test",
+    srcs = [
+        "errors_test.go",
+        "validation_test.go",
+    ],
+    embed = [":validation"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/internal/validation/constraints.go
+++ b/internal/validation/constraints.go
@@ -21,13 +21,15 @@ type Constraint struct {
 /*
 WithFieldTrace adds a well-formatted trace to the field to the error message
 shown when the constraint is not satisfied. Both "doc" and "field" must be pointers:
-	- "doc" must be a pointer to the top level document
-	- "field" must be a pointer to the field to be validated
+  - "doc" must be a pointer to the top level document
+  - "field" must be a pointer to the field to be validated
 
 Example for a non-pointer field:
+
 	Equal(d.IntField, 42).WithFieldTrace(d, &d.IntField)
 
 Example for a pointer field:
+
 	NotEmpty(d.StrPtrField).WithFieldTrace(d, d.StrPtrField)
 
 Due to Go's addressability limititations regarding maps, if a map field is
@@ -56,11 +58,12 @@ func (c *Constraint) WithFieldTrace(doc any, field any) Constraint {
 /*
 WithMapFieldTrace adds a well-formatted trace to the map field to the error message
 shown when the constraint is not satisfied. Both "doc" and "field" must be pointers:
-	- "doc" must be a pointer to the top level document
-	- "field" must be a pointer to the map containing the field to be validated
-	- "mapKey" must be the key of the field to be validated in the map pointed to by "field"
+  - "doc" must be a pointer to the top level document
+  - "field" must be a pointer to the map containing the field to be validated
+  - "mapKey" must be the key of the field to be validated in the map pointed to by "field"
 
 Example:
+
 	Equal(d.IntField, 42).WithMapFieldTrace(d, &d.IntField)
 
 For non-map fields, WithFieldTrace should be used instead of WithMapFieldTrace.

--- a/internal/validation/constraints.go
+++ b/internal/validation/constraints.go
@@ -95,7 +95,7 @@ func (c *Constraint) withTrace(docRef, fieldRef referenceableValue) Constraint {
 		Satisfied: func() (valid bool, err error) {
 			valid, err = c.Satisfied()
 			if err != nil {
-				return valid, newValidationError(docRef, fieldRef, err)
+				return valid, newError(docRef, fieldRef, err)
 			}
 			return valid, nil
 		},

--- a/internal/validation/constraints.go
+++ b/internal/validation/constraints.go
@@ -1,0 +1,57 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package validation
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// Constraint is a constraint on a document or a field of a document.
+type Constraint func() (valid bool, err error)
+
+// MatchRegex is a constraint that if s matches regex.
+func MatchRegex(s string, regex string) Constraint {
+	return func() (valid bool, err error) {
+		if !regexp.MustCompile(regex).MatchString(s) {
+			return false, fmt.Errorf("%s must match the pattern %s", s, regex)
+		}
+		return true, nil
+	}
+}
+
+// Equal is a constraint that if s is equal to t.
+func Equal[T comparable](s T, t T) Constraint {
+	return func() (valid bool, err error) {
+		if s != t {
+			return false, fmt.Errorf("%v must be equal to %v", s, t)
+		}
+		return true, nil
+	}
+}
+
+// NotEmpty is a constraint that if s is not empty.
+func NotEmpty[T comparable](s T) Constraint {
+	return func() (valid bool, err error) {
+		var zero T
+		if s == zero {
+			return false, fmt.Errorf("%v must not be empty", s)
+		}
+		return true, nil
+	}
+}
+
+// Empty is a constraint that if s is empty.
+func Empty[T comparable](s T) Constraint {
+	return func() (valid bool, err error) {
+		var zero T
+		if s != zero {
+			return false, fmt.Errorf("%v must be empty", s)
+		}
+		return true, nil
+	}
+}

--- a/internal/validation/constraints.go
+++ b/internal/validation/constraints.go
@@ -8,50 +8,119 @@ package validation
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 )
 
 // Constraint is a constraint on a document or a field of a document.
-type Constraint func() (valid bool, err error)
+type Constraint struct {
+	// Satisfied returns true if the constraint is satisfied.
+	Satisfied func() (valid bool, err error)
+}
+
+/*
+WithFieldTrace adds a well-formatted error message to the constraint,
+which will be displayed if the constraint is not satisfied on the validated document.
+*/
+func (c *Constraint) WithFieldTrace(doc any, field any) Constraint {
+	// we only want to dereference the needle once to dereference the pointer
+	// used to pass it to the function without losing reference to it, as the
+	// needle could be an arbitrarily long chain of pointers. The same
+	// applies to the haystack.
+	derefedField := pointerDeref(reflect.ValueOf(field))
+	fieldRef := referenceableValue{
+		value: derefedField,
+		addr:  derefedField.UnsafeAddr(),
+		_type: derefedField.Type(),
+	}
+	derefedDoc := pointerDeref(reflect.ValueOf(doc))
+	docRef := referenceableValue{
+		value: derefedDoc,
+		addr:  derefedDoc.UnsafeAddr(),
+		_type: derefedDoc.Type(),
+	}
+	return c.withErrorMessage(docRef, fieldRef)
+}
+
+func (c *Constraint) WithMapFieldTrace(doc any, field any, mapKey string) Constraint {
+	// we only want to dereference the needle once to dereference the pointer
+	// used to pass it to the function without losing reference to it, as the
+	// needle could be an arbitrarily long chain of pointers. The same
+	// applies to the haystack.
+	derefedField := pointerDeref(reflect.ValueOf(field))
+	fieldRef := referenceableValue{
+		value:  derefedField,
+		addr:   derefedField.UnsafeAddr(),
+		_type:  derefedField.Type(),
+		mapKey: mapKey,
+	}
+	derefedDoc := pointerDeref(reflect.ValueOf(doc))
+	docRef := referenceableValue{
+		value: derefedDoc,
+		addr:  derefedDoc.UnsafeAddr(),
+		_type: derefedDoc.Type(),
+	}
+	return c.withErrorMessage(docRef, fieldRef)
+}
+
+func (c *Constraint) withErrorMessage(docRef, fieldRef referenceableValue) Constraint {
+	return Constraint{
+		Satisfied: func() (valid bool, err error) {
+			valid, err = c.Satisfied()
+			if err != nil {
+				return valid, NewValidationError(docRef, fieldRef, err)
+			}
+			return valid, nil
+		},
+	}
+}
 
 // MatchRegex is a constraint that if s matches regex.
-func MatchRegex(s string, regex string) Constraint {
-	return func() (valid bool, err error) {
-		if !regexp.MustCompile(regex).MatchString(s) {
-			return false, fmt.Errorf("%s must match the pattern %s", s, regex)
-		}
-		return true, nil
+func MatchRegex(s string, regex string) *Constraint {
+	return &Constraint{
+		Satisfied: func() (valid bool, err error) {
+			if !regexp.MustCompile(regex).MatchString(s) {
+				return false, fmt.Errorf("%s must match the pattern %s", s, regex)
+			}
+			return true, nil
+		},
 	}
 }
 
 // Equal is a constraint that if s is equal to t.
-func Equal[T comparable](s T, t T) Constraint {
-	return func() (valid bool, err error) {
-		if s != t {
-			return false, fmt.Errorf("%v must be equal to %v", s, t)
-		}
-		return true, nil
+func Equal[T comparable](s T, t T) *Constraint {
+	return &Constraint{
+		Satisfied: func() (valid bool, err error) {
+			if s != t {
+				return false, fmt.Errorf("%v must be equal to %v", s, t)
+			}
+			return true, nil
+		},
 	}
 }
 
 // NotEmpty is a constraint that if s is not empty.
-func NotEmpty[T comparable](s T) Constraint {
-	return func() (valid bool, err error) {
-		var zero T
-		if s == zero {
-			return false, fmt.Errorf("%v must not be empty", s)
-		}
-		return true, nil
+func NotEmpty[T comparable](s T) *Constraint {
+	return &Constraint{
+		Satisfied: func() (valid bool, err error) {
+			var zero T
+			if s == zero {
+				return false, fmt.Errorf("%v must not be empty", s)
+			}
+			return true, nil
+		},
 	}
 }
 
 // Empty is a constraint that if s is empty.
-func Empty[T comparable](s T) Constraint {
-	return func() (valid bool, err error) {
-		var zero T
-		if s != zero {
-			return false, fmt.Errorf("%v must be empty", s)
-		}
-		return true, nil
+func Empty[T comparable](s T) *Constraint {
+	return &Constraint{
+		Satisfied: func() (valid bool, err error) {
+			var zero T
+			if s != zero {
+				return false, fmt.Errorf("%v must be empty", s)
+			}
+			return true, nil
+		},
 	}
 }

--- a/internal/validation/constraints.go
+++ b/internal/validation/constraints.go
@@ -64,7 +64,7 @@ shown when the constraint is not satisfied. Both "doc" and "field" must be point
 
 Example:
 
-	Equal(d.IntField, 42).WithMapFieldTrace(d, &d.IntField)
+	Equal(d.IntField, 42).WithMapFieldTrace(d, &d.MapField, mapKey)
 
 For non-map fields, WithFieldTrace should be used instead of WithMapFieldTrace.
 */

--- a/internal/validation/errors.go
+++ b/internal/validation/errors.go
@@ -45,6 +45,9 @@ func (e *ValidationError) Unwrap() error {
 // getDocumentPath finds the JSON / YAML path of field in doc.
 func getDocumentPath(doc any, field any) (string, error) {
 	needleVal := reflect.ValueOf(field)
+	// we only want to dereference the needle once to dereference the pointer 
+	// used to pass it to the function without losing reference to it, as the
+	// needle could be an arbitrarily long chain of pointers
 	derefedNeedle := pointerDeref(needleVal)
 	needleAddr := derefedNeedle.UnsafeAddr()
 	needleType := derefedNeedle.Type()

--- a/internal/validation/errors.go
+++ b/internal/validation/errors.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 )
 
+// ValidationError is returned when a document is not valid.
 type ValidationError struct {
 	Path string
 	Err  error
@@ -166,7 +167,7 @@ func recPointerDeref(val reflect.Value) reflect.Value {
 }
 
 // pointerDeref dereferences pointers and unpacks interfaces.
-// If the value is not a pointer, it is returned unchanged
+// If the value is not a pointer, it is returned unchanged.
 func pointerDeref(val reflect.Value) reflect.Value {
 	switch val.Kind() {
 	case reflect.Ptr, reflect.UnsafePointer, reflect.Interface:

--- a/internal/validation/errors.go
+++ b/internal/validation/errors.go
@@ -7,41 +7,41 @@ import (
 	"strings"
 )
 
-// ValidationError is returned when a document is not valid.
-type ValidationError struct {
+// Error is returned when a document is not valid.
+type Error struct {
 	Path string
 	Err  error
 }
 
 /*
-newValidationError creates a new ValidationError.
+newError creates a new validation Error.
 
 To find the path to the exported field that failed validation, it traverses "doc"
 recursively until it finds a field in "doc" that matches the reference to "field".
 */
-func newValidationError(doc, field referenceableValue, errMsg error) *ValidationError {
+func newError(doc, field referenceableValue, errMsg error) *Error {
 	// traverse the top level struct (i.e. the "haystack") until addr (i.e. the "needle") is found
 	path, err := traverse(doc, field, newPathBuilder(doc._type.Name()))
 	if err != nil {
-		return &ValidationError{
+		return &Error{
 			Path: "unknown",
 			Err:  fmt.Errorf("cannot find path to field: %v. original error: %w", err, errMsg),
 		}
 	}
 
-	return &ValidationError{
+	return &Error{
 		Path: path,
 		Err:  errMsg,
 	}
 }
 
 // Error implements the error interface.
-func (e *ValidationError) Error() string {
+func (e *Error) Error() string {
 	return fmt.Sprintf("validating %s: %s", e.Path, e.Err)
 }
 
 // Unwrap implements the error interface.
-func (e *ValidationError) Unwrap() error {
+func (e *Error) Unwrap() error {
 	return e.Err
 }
 

--- a/internal/validation/errors.go
+++ b/internal/validation/errors.go
@@ -67,7 +67,7 @@ func getDocumentPath(doc any, field any, mapKey string) (string, error) {
 	}
 
 	// traverse the top level struct (i.e. the "haystack") until addr (i.e. the "needle") is found
-	return traverse(haystackRef, needleRef, newPathBuilder())
+	return traverse(haystackRef, needleRef, newPathBuilder(haystackRef._type.Name()))
 }
 
 // traverse reverses haystack recursively until it finds a field that matches
@@ -240,10 +240,10 @@ type pathBuilder struct {
 	buf []string
 }
 
-// newPathBuilder creates a new pathBuilder.
-func newPathBuilder() pathBuilder {
+// newPathBuilder creates a new pathBuilder from the identifier of a top level document.
+func newPathBuilder(topLevelDoc string) pathBuilder {
 	return pathBuilder{
-		buf: []string{},
+		buf: []string{topLevelDoc},
 	}
 }
 

--- a/internal/validation/errors.go
+++ b/internal/validation/errors.go
@@ -45,7 +45,7 @@ func (e *ValidationError) Unwrap() error {
 // getDocumentPath finds the JSON / YAML path of field in doc.
 func getDocumentPath(doc any, field any) (string, error) {
 	needleVal := reflect.ValueOf(field)
-	derefedNeedle := recPointerDeref(needleVal)
+	derefedNeedle := pointerDeref(needleVal)
 	needleAddr := derefedNeedle.UnsafeAddr()
 	needleType := derefedNeedle.Type()
 
@@ -133,11 +133,21 @@ func appendByStructTag(path []string, field reflect.StructField) []string {
 	return path
 }
 
-// recPointerDeref recursively dereferences pointers until a non-pointer value is found.
+// recPointerDeref recursively dereferences pointers and unpacks interfaces until a non-pointer value is found.
 func recPointerDeref(val reflect.Value) reflect.Value {
 	switch val.Kind() {
 	case reflect.Ptr, reflect.UnsafePointer, reflect.Interface:
 		return recPointerDeref(val.Elem())
+	}
+	return val
+}
+
+// pointerDeref dereferences pointers and unpacks interfaces.
+// If the value is not a pointer, it is returned unchanged
+func pointerDeref(val reflect.Value) reflect.Value {
+	switch val.Kind() {
+	case reflect.Ptr, reflect.UnsafePointer, reflect.Interface:
+		return val.Elem()
 	}
 	return val
 }

--- a/internal/validation/errors.go
+++ b/internal/validation/errors.go
@@ -31,7 +31,7 @@ func newError(doc, field referenceableValue, errMsg error) *Error {
 	if err != nil {
 		return &Error{
 			Path: "unknown",
-			Err:  fmt.Errorf("cannot find path to field: %v. original error: %w", err, errMsg),
+			Err:  fmt.Errorf("cannot find path to field: %w. original error: %w", err, errMsg),
 		}
 	}
 
@@ -52,7 +52,7 @@ func (e *Error) Unwrap() error {
 }
 
 /*
-traverse reverses "haystack" recursively until it finds a field that matches
+traverse "haystack" recursively until it finds a field that matches
 the reference saved in "needle", while building a pseudo-JSONPath to the field.
 
 If it traverses a level down, it appends the name of the struct tag
@@ -256,8 +256,8 @@ func (p pathBuilder) appendMapKey(k string) pathBuilder {
 	return p
 }
 
-// String returns the path.
-func (p pathBuilder) String() string {
+// string returns the path.
+func (p pathBuilder) string() string {
 	// Remove struct tag prefix
 	return strings.TrimPrefix(
 		strings.Join(p.buf, ""),

--- a/internal/validation/errors.go
+++ b/internal/validation/errors.go
@@ -1,0 +1,123 @@
+package validation
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+type ValidationError struct {
+	Path string
+	Err  error
+}
+
+// NewValidationError creates a new ValidationError.
+//
+// To find the path to the field that failed validation, it traverses the
+// top level struct recursively until it finds a field that matches the
+// reference to the field that failed validation.
+func NewValidationError(topLevelStruct any, field any, errMsg error) *ValidationError {
+	path, err := getDocumentPath(topLevelStruct, field)
+	if err != nil {
+		panic(fmt.Sprintf("cannot find path to field: %v", err))
+	}
+
+	return &ValidationError{
+		Path: path,
+		Err:  errMsg,
+	}
+}
+
+// Error implements the error interface.
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("validating %s: %s", e.Path, e.Err)
+}
+
+// Unwrap implements the error interface.
+func (e *ValidationError) Unwrap() error {
+	return e.Err
+}
+
+// getDocumentPath finds the JSON / YAML path of field in doc.
+func getDocumentPath(doc any, field any) (string, error) {
+	needleAddr := reflect.ValueOf(field).Elem().UnsafeAddr()
+	needleType := reflect.TypeOf(field)
+
+	// traverse the top level struct (i.e. the "haystack") until addr (i.e. the "needle") is found
+	return traverse(doc, needleAddr, needleType, []string{})
+}
+
+// traverse reverses haystack recursively until it finds a field that matches
+// the reference in needle.
+//
+// If it traverses a level down, it
+// appends the name of the struct tag of the field to path.
+//
+// When a field matches the reference to the given field, it returns the
+// path to the field, joined with ".".
+func traverse(haystack any, needleAddr uintptr, needleType reflect.Type, path []string) (string, error) {
+	// recursion anchor: doc is the field we are looking for.
+	// Join the path and return. Since the first value of a struct has
+	// the same address as the struct itself, we need to check the type as well.
+	haystackAddr := reflect.ValueOf(haystack).Elem().UnsafeAddr()
+	haystackType := reflect.TypeOf(haystack)
+	if haystackAddr == needleAddr && haystackType == needleType {
+		return strings.Join(path, "."), nil
+	}
+
+	haystackVal := reflect.ValueOf(haystack)
+	kind := reflect.TypeOf(haystack).Kind()
+	switch kind {
+	case reflect.Pointer, reflect.UnsafePointer:
+		// Dereference pointer and continue.
+		return traverse(haystackVal.Elem(), needleAddr, needleType, path)
+	case reflect.Struct:
+		// Traverse all visible struct fields.
+		for _, field := range reflect.VisibleFields(reflect.TypeOf(haystack)) {
+			// skip unexported fields
+			if field.IsExported() {
+				// When a field is not the needle and cannot be traversed further,
+				// a errCannotTraverse is returned. Therefore, we only want to handle
+				// the case where the field is the needle.
+				if path, err := traverse(field, needleAddr, needleType, appendByStructTag(path, field)); err == nil {
+					return path, nil
+				}
+			}
+		}
+	case reflect.Slice, reflect.Array:
+		// Traverse slice / Array elements
+		for i := 0; i < haystackVal.Len(); i++ {
+			// see struct case
+			if path, err := traverse(haystackVal.Index(i), needleAddr, needleType, append(path, fmt.Sprintf("%d", i))); err == nil {
+				return path, nil
+			}
+		}
+	case reflect.Map:
+		// Traverse map elements
+		for _, key := range haystackVal.MapKeys() {
+			// see struct case
+			if path, err := traverse(haystackVal.MapIndex(key), needleAddr, needleType, append(path, key.String())); err == nil {
+				return path, nil
+			}
+		}
+	}
+	// Primitive type, but not the value we are looking for.
+	// Return a
+	return "", errCannotTraverse
+}
+
+// errCannotTraverse is returned when a field cannot be traversed further.
+var errCannotTraverse = errors.New("cannot traverse anymore")
+
+// appendByStructTag appends the name of the JSON / YAML struct tag of field to path.
+// If no struct tag is present, path is returned unchanged.
+func appendByStructTag(path []string, field reflect.StructField) []string {
+	switch {
+	case field.Tag.Get("json") != "":
+		return append(path, field.Tag.Get("json"))
+	case field.Tag.Get("yaml") != "":
+		return append(path, field.Tag.Get("yaml"))
+	}
+	return path
+}

--- a/internal/validation/errors.go
+++ b/internal/validation/errors.go
@@ -12,15 +12,13 @@ type ValidationError struct {
 	Err  error
 }
 
-// NewValidationError creates a new ValidationError.
-//
-// To find the path to the exported field that failed validation, it traverses the
-// top level struct recursively until it finds a field that matches the
-// reference to the field that failed validation.
-//
-// As a special case, since map values are not addressable in Go, also a map key is taken.
-// In the case of verifying a map value, "field" should contain a reference to the map.
-func NewValidationError(doc, field referenceableValue, errMsg error) *ValidationError {
+/*
+newValidationError creates a new ValidationError.
+
+To find the path to the exported field that failed validation, it traverses "doc"
+recursively until it finds a field in "doc" that matches the reference to "field".
+*/
+func newValidationError(doc, field referenceableValue, errMsg error) *ValidationError {
 	// traverse the top level struct (i.e. the "haystack") until addr (i.e. the "needle") is found
 	path, err := traverse(doc, field, newPathBuilder(doc._type.Name()))
 	if err != nil {
@@ -46,14 +44,16 @@ func (e *ValidationError) Unwrap() error {
 	return e.Err
 }
 
-// traverse reverses haystack recursively until it finds a field that matches
-// the reference in needle.
-//
-// If it traverses a level down, it
-// appends the name of the struct tag of the field to path.
-//
-// When a field matches the reference to the given field, it returns the
-// path to the field, joined with ".".
+/*
+traverse reverses "haystack" recursively until it finds a field that matches
+the reference saved in "needle", while building a pseudo-JSONPath to the field.
+
+If it traverses a level down, it appends the name of the struct tag
+or another entity like array index or map field to path.
+
+When a field matches the reference to the given field, it returns the
+path to the field.
+*/
 func traverse(haystack referenceableValue, needle referenceableValue, path pathBuilder) (string, error) {
 	// recursion anchor: doc is the field we are looking for.
 	// Join the path and return.

--- a/internal/validation/errors.go
+++ b/internal/validation/errors.go
@@ -1,3 +1,9 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
 package validation
 
 import (

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Tests for primitive / shallow fields
+
 func TestNewValidationErrorSingleField(t *testing.T) {
 	st := &ErrorTestDoc{
 		ExportedField: "abc",
@@ -57,6 +59,8 @@ func TestNewValidationErrorSingleFieldInexistent(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot find path to field: cannot traverse anymore")
 }
+
+// Tests for nested structs
 
 func TestNewValidationErrorNestedField(t *testing.T) {
 	st := &ErrorTestDoc{
@@ -171,6 +175,124 @@ func TestNewValidationErrorNestedPtrNestedFieldPtr(t *testing.T) {
 	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.nestedField.otherField: %s", assert.AnError))
 }
 
+// Tests for slices / arrays
+
+func TestNewValidationErrorPrimitiveSlice(t *testing.T) {
+	st := &SliceErrorTestDoc{
+		PrimitiveSlice: []string{"abc", "def"},
+	}
+
+	err := NewValidationError(st, &st.PrimitiveSlice[1], assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveSlice.[1]: %s", assert.AnError))
+}
+
+func TestNewValidationErrorPrimitiveArray(t *testing.T) {
+	st := &SliceErrorTestDoc{
+		PrimitiveArray: [3]int{1, 2, 3},
+	}
+
+	err := NewValidationError(st, &st.PrimitiveArray[1], assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveArray.[1]: %s", assert.AnError))
+}
+
+func TestNewValidationErrorStructSlice(t *testing.T) {
+	st := &SliceErrorTestDoc{
+		StructSlice: []ErrorTestDoc{
+			{
+				ExportedField: "abc",
+				OtherField:    123,
+			},
+			{
+				ExportedField: "def",
+				OtherField:    456,
+			},
+		},
+	}
+
+	err := NewValidationError(st, &st.StructSlice[1].OtherField, assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating structSlice.[1].otherField: %s", assert.AnError))
+}
+
+func TestNewValidationErrorStructArray(t *testing.T) {
+	st := &SliceErrorTestDoc{
+		StructArray: [3]ErrorTestDoc{
+			{
+				ExportedField: "abc",
+				OtherField:    123,
+			},
+			{
+				ExportedField: "def",
+				OtherField:    456,
+			},
+		},
+	}
+
+	err := NewValidationError(st, &st.StructArray[1].OtherField, assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating structArray.[1].otherField: %s", assert.AnError))
+}
+
+func TestNewValidationErrorStructPointerSlice(t *testing.T) {
+	st := &SliceErrorTestDoc{
+		StructPointerSlice: []*ErrorTestDoc{
+			{
+				ExportedField: "abc",
+				OtherField:    123,
+			},
+			{
+				ExportedField: "def",
+				OtherField:    456,
+			},
+		},
+	}
+
+	err := NewValidationError(st, &st.StructPointerSlice[1].OtherField, assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating structPointerSlice.[1].otherField: %s", assert.AnError))
+}
+
+func TestNewValidationErrorStructPointerArray(t *testing.T) {
+	st := &SliceErrorTestDoc{
+		StructPointerArray: [3]*ErrorTestDoc{
+			{
+				ExportedField: "abc",
+				OtherField:    123,
+			},
+			{
+				ExportedField: "def",
+				OtherField:    456,
+			},
+		},
+	}
+
+	err := NewValidationError(st, &st.StructPointerArray[1].OtherField, assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating structPointerArray.[1].otherField: %s", assert.AnError))
+}
+
+func TestNewValidationErrorPrimitiveSliceSlice(t *testing.T) {
+	st := &SliceErrorTestDoc{
+		PrimitiveSliceSlice: [][]string{
+			{"abc", "def"},
+			{"ghi", "jkl"},
+		},
+	}
+
+	err := NewValidationError(st, &st.PrimitiveSliceSlice[1][1], assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveSliceSlice.[1].[1]: %s", assert.AnError))
+}
+
 type ErrorTestDoc struct {
 	ExportedField      string              `json:"exportedField" yaml:"exportedField"`
 	OtherField         int                 `json:"otherField" yaml:"otherField"`
@@ -192,4 +314,14 @@ type NestedNestedErrorTestDoc struct {
 	ExportedField string `json:"exportedField" yaml:"exportedField"`
 	OtherField    int    `json:"otherField" yaml:"otherField"`
 	PointerField  *int   `json:"pointerField" yaml:"pointerField"`
+}
+
+type SliceErrorTestDoc struct {
+	PrimitiveSlice      []string         `json:"primitiveSlice" yaml:"primitiveSlice"`
+	PrimitiveArray      [3]int           `json:"primitiveArray" yaml:"primitiveArray"`
+	StructSlice         []ErrorTestDoc   `json:"structSlice" yaml:"structSlice"`
+	StructArray         [3]ErrorTestDoc  `json:"structArray" yaml:"structArray"`
+	StructPointerSlice  []*ErrorTestDoc  `json:"structPointerSlice" yaml:"structPointerSlice"`
+	StructPointerArray  [3]*ErrorTestDoc `json:"structPointerArray" yaml:"structPointerArray"`
+	PrimitiveSliceSlice [][]string       `json:"primitiveSliceSlice" yaml:"primitiveSliceSlice"`
 }

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -18,7 +18,7 @@ func TestNewValidationErrorSingleField(t *testing.T) {
 
 	err := NewValidationError(st, &st.OtherField, "", assert.AnError)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorSingleFieldPtr(t *testing.T) {
@@ -30,7 +30,7 @@ func TestNewValidationErrorSingleFieldPtr(t *testing.T) {
 
 	err := NewValidationError(st, &st.PointerField, "", assert.AnError)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating pointerField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.pointerField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorSingleFieldDoublePtr(t *testing.T) {
@@ -43,7 +43,7 @@ func TestNewValidationErrorSingleFieldDoublePtr(t *testing.T) {
 
 	err := NewValidationError(st, &st.DoublePointerField, "", assert.AnError)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating doublePointerField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.doublePointerField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorSingleFieldInexistent(t *testing.T) {
@@ -75,7 +75,7 @@ func TestNewValidationErrorNestedField(t *testing.T) {
 	err := NewValidationError(st, &st.NestedField.OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorPointerInNestedField(t *testing.T) {
@@ -92,7 +92,7 @@ func TestNewValidationErrorPointerInNestedField(t *testing.T) {
 	err := NewValidationError(st, &st.NestedField.PointerField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.pointerField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.pointerField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorNestedFieldPtr(t *testing.T) {
@@ -112,7 +112,7 @@ func TestNewValidationErrorNestedFieldPtr(t *testing.T) {
 	err := NewValidationError(st, &st.NestedPointerField.OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedPointerField.otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedPointerField.otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorNestedNestedField(t *testing.T) {
@@ -132,7 +132,7 @@ func TestNewValidationErrorNestedNestedField(t *testing.T) {
 	err := NewValidationError(st, &st.NestedField.NestedField.OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.nestedField.otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.nestedField.otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorNestedNestedFieldPtr(t *testing.T) {
@@ -152,7 +152,7 @@ func TestNewValidationErrorNestedNestedFieldPtr(t *testing.T) {
 	err := NewValidationError(st, &st.NestedField.NestedField.OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.nestedField.otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.nestedField.otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorNestedPtrNestedFieldPtr(t *testing.T) {
@@ -172,7 +172,7 @@ func TestNewValidationErrorNestedPtrNestedFieldPtr(t *testing.T) {
 	err := NewValidationError(st, &st.NestedField.NestedField.OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.nestedField.otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.nestedField.otherField: %s", assert.AnError))
 }
 
 // Tests for slices / arrays
@@ -185,7 +185,7 @@ func TestNewValidationErrorPrimitiveSlice(t *testing.T) {
 	err := NewValidationError(st, &st.PrimitiveSlice[1], "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveSlice[1]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.primitiveSlice[1]: %s", assert.AnError))
 }
 
 func TestNewValidationErrorPrimitiveArray(t *testing.T) {
@@ -196,7 +196,7 @@ func TestNewValidationErrorPrimitiveArray(t *testing.T) {
 	err := NewValidationError(st, &st.PrimitiveArray[1], "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveArray[1]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.primitiveArray[1]: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructSlice(t *testing.T) {
@@ -216,7 +216,7 @@ func TestNewValidationErrorStructSlice(t *testing.T) {
 	err := NewValidationError(st, &st.StructSlice[1].OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating structSlice[1].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structSlice[1].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructArray(t *testing.T) {
@@ -236,7 +236,7 @@ func TestNewValidationErrorStructArray(t *testing.T) {
 	err := NewValidationError(st, &st.StructArray[1].OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating structArray[1].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structArray[1].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructPointerSlice(t *testing.T) {
@@ -256,7 +256,7 @@ func TestNewValidationErrorStructPointerSlice(t *testing.T) {
 	err := NewValidationError(st, &st.StructPointerSlice[1].OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating structPointerSlice[1].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structPointerSlice[1].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructPointerArray(t *testing.T) {
@@ -276,7 +276,7 @@ func TestNewValidationErrorStructPointerArray(t *testing.T) {
 	err := NewValidationError(st, &st.StructPointerArray[1].OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating structPointerArray[1].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structPointerArray[1].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorPrimitiveSliceSlice(t *testing.T) {
@@ -290,7 +290,7 @@ func TestNewValidationErrorPrimitiveSliceSlice(t *testing.T) {
 	err := NewValidationError(st, &st.PrimitiveSliceSlice[1][1], "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveSliceSlice[1][1]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.primitiveSliceSlice[1][1]: %s", assert.AnError))
 }
 
 // Tests for maps
@@ -306,7 +306,7 @@ func TestNewValidationErrorPrimitiveMap(t *testing.T) {
 	err := NewValidationError(st, &st.PrimitiveMap, "ghi", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveMap[\"ghi\"]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating MapErrorTestDoc.primitiveMap[\"ghi\"]: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructPointerMap(t *testing.T) {
@@ -326,7 +326,7 @@ func TestNewValidationErrorStructPointerMap(t *testing.T) {
 	err := NewValidationError(st, &st.StructPointerMap["ghi"].OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating structPointerMap[\"ghi\"].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating MapErrorTestDoc.structPointerMap[\"ghi\"].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorNestedPrimitiveMap(t *testing.T) {
@@ -344,7 +344,45 @@ func TestNewValidationErrorNestedPrimitiveMap(t *testing.T) {
 	err := NewValidationError(st, st.NestedPointerMap["jkl"], "mno", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedPointerMap[\"jkl\"][\"mno\"]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating MapErrorTestDoc.nestedPointerMap[\"jkl\"][\"mno\"]: %s", assert.AnError))
+}
+
+// Special cases
+
+func TestNewValidationErrorTopLevelIsNeedle(t *testing.T) {
+	st := &ErrorTestDoc{
+		ExportedField: "abc",
+		OtherField:    42,
+	}
+
+	err := NewValidationError(st, st, "", assert.AnError)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc: %s", assert.AnError))
+}
+
+func TestNewValidationErrorUntaggedField(t *testing.T) {
+	st := &ErrorTestDoc{
+		ExportedField: "abc",
+		OtherField:    42,
+		NoTagField:    123,
+	}
+
+	err := NewValidationError(st, &st.NoTagField, "", assert.AnError)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.NoTagField: %s", assert.AnError))
+}
+
+func TestNewValidationErrorOnlyYamlTaggedField(t *testing.T) {
+	st := &ErrorTestDoc{
+		ExportedField: "abc",
+		OtherField:    42,
+		NoTagField:    123,
+		OnlyYamlKey:   "abc",
+	}
+
+	err := NewValidationError(st, &st.OnlyYamlKey, "", assert.AnError)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.onlyYamlKey: %s", assert.AnError))
 }
 
 type ErrorTestDoc struct {
@@ -354,6 +392,8 @@ type ErrorTestDoc struct {
 	DoublePointerField **int               `json:"doublePointerField" yaml:"doublePointerField"`
 	NestedField        NestedErrorTestDoc  `json:"nestedField" yaml:"nestedField"`
 	NestedPointerField *NestedErrorTestDoc `json:"nestedPointerField" yaml:"nestedPointerField"`
+	NoTagField         int
+	OnlyYamlKey        string `yaml:"onlyYamlKey"`
 }
 
 type NestedErrorTestDoc struct {

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -19,7 +19,20 @@ func TestNewValidationErrorSingleField(t *testing.T) {
 	require.Contains(t, err.Error(), fmt.Sprintf("validating otherField: %s", assert.AnError))
 }
 
+func TestNewValidationErrorSingleFieldPtr(t *testing.T) {
+	st := &ErrorTestDoc{
+		ExportedField: "abc",
+		OtherField:    42,
+		PointerField:  new(int),
+	}
+
+	err := NewValidationError(st, &st.PointerField, assert.AnError)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating pointerField: %s", assert.AnError))
+}
+
 type ErrorTestDoc struct {
 	ExportedField string `json:"exportedField" yaml:"exportedField"`
 	OtherField    int    `json:"otherField" yaml:"otherField"`
+	PointerField  *int   `json:"pointerField" yaml:"pointerField"`
 }

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -49,23 +49,61 @@ func TestNewValidationErrorNestedField(t *testing.T) {
 	st := &ErrorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
-		NestedErrorTestDoc: NestedErrorTestDoc{
+		NestedField: NestedErrorTestDoc{
 			ExportedField: "nested",
 			OtherField:    123,
 		},
 	}
 
-	err := NewValidationError(st, &st.NestedErrorTestDoc.OtherField, assert.AnError)
+	err := NewValidationError(st, &st.NestedField.OtherField, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedErrorTestDoc.otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.otherField: %s", assert.AnError))
+}
+
+func TestNewValidationErrorPointerInNestedField(t *testing.T) {
+	st := &ErrorTestDoc{
+		ExportedField: "abc",
+		OtherField:    42,
+		NestedField: NestedErrorTestDoc{
+			ExportedField: "nested",
+			OtherField:    123,
+			PointerField:  new(int),
+		},
+	}
+
+	err := NewValidationError(st, &st.NestedField.PointerField, assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.pointerField: %s", assert.AnError))
+}
+
+func TestNewValidationErrorNestedFieldPtr(t *testing.T) {
+	st := &ErrorTestDoc{
+		ExportedField: "abc",
+		OtherField:    42,
+		NestedField: NestedErrorTestDoc{
+			ExportedField: "nested",
+			OtherField:    123,
+		},
+		NestedPointerField: &NestedErrorTestDoc{
+			ExportedField: "nested",
+			OtherField:    123,
+		},
+	}
+
+	err := NewValidationError(st, &st.NestedPointerField.OtherField, assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedPointerField.otherField: %s", assert.AnError))
 }
 
 type ErrorTestDoc struct {
-	ExportedField      string             `json:"exportedField" yaml:"exportedField"`
-	OtherField         int                `json:"otherField" yaml:"otherField"`
-	PointerField       *int               `json:"pointerField" yaml:"pointerField"`
-	NestedErrorTestDoc NestedErrorTestDoc `json:"nestedErrorTestDoc" yaml:"nestedErrorTestDoc"`
+	ExportedField      string              `json:"exportedField" yaml:"exportedField"`
+	OtherField         int                 `json:"otherField" yaml:"otherField"`
+	PointerField       *int                `json:"pointerField" yaml:"pointerField"`
+	NestedField        NestedErrorTestDoc  `json:"nestedField" yaml:"nestedField"`
+	NestedPointerField *NestedErrorTestDoc `json:"nestedPointerField" yaml:"nestedPointerField"`
 }
 
 type NestedErrorTestDoc struct {

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -16,7 +16,7 @@ func TestNewValidationErrorSingleField(t *testing.T) {
 		OtherField:    42,
 	}
 
-	err := NewValidationError(st, &st.OtherField, assert.AnError)
+	err := NewValidationError(st, &st.OtherField, "", assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating otherField: %s", assert.AnError))
 }
@@ -28,7 +28,7 @@ func TestNewValidationErrorSingleFieldPtr(t *testing.T) {
 		PointerField:  new(int),
 	}
 
-	err := NewValidationError(st, &st.PointerField, assert.AnError)
+	err := NewValidationError(st, &st.PointerField, "", assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating pointerField: %s", assert.AnError))
 }
@@ -41,7 +41,7 @@ func TestNewValidationErrorSingleFieldDoublePtr(t *testing.T) {
 		DoublePointerField: &intp,
 	}
 
-	err := NewValidationError(st, &st.DoublePointerField, assert.AnError)
+	err := NewValidationError(st, &st.DoublePointerField, "", assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating doublePointerField: %s", assert.AnError))
 }
@@ -55,7 +55,7 @@ func TestNewValidationErrorSingleFieldInexistent(t *testing.T) {
 
 	inexistentField := 123
 
-	err := NewValidationError(st, &inexistentField, assert.AnError)
+	err := NewValidationError(st, &inexistentField, "", assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot find path to field: cannot traverse anymore")
 }
@@ -72,7 +72,7 @@ func TestNewValidationErrorNestedField(t *testing.T) {
 		},
 	}
 
-	err := NewValidationError(st, &st.NestedField.OtherField, assert.AnError)
+	err := NewValidationError(st, &st.NestedField.OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.otherField: %s", assert.AnError))
@@ -89,7 +89,7 @@ func TestNewValidationErrorPointerInNestedField(t *testing.T) {
 		},
 	}
 
-	err := NewValidationError(st, &st.NestedField.PointerField, assert.AnError)
+	err := NewValidationError(st, &st.NestedField.PointerField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.pointerField: %s", assert.AnError))
@@ -109,7 +109,7 @@ func TestNewValidationErrorNestedFieldPtr(t *testing.T) {
 		},
 	}
 
-	err := NewValidationError(st, &st.NestedPointerField.OtherField, assert.AnError)
+	err := NewValidationError(st, &st.NestedPointerField.OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedPointerField.otherField: %s", assert.AnError))
@@ -129,7 +129,7 @@ func TestNewValidationErrorNestedNestedField(t *testing.T) {
 		},
 	}
 
-	err := NewValidationError(st, &st.NestedField.NestedField.OtherField, assert.AnError)
+	err := NewValidationError(st, &st.NestedField.NestedField.OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.nestedField.otherField: %s", assert.AnError))
@@ -149,7 +149,7 @@ func TestNewValidationErrorNestedNestedFieldPtr(t *testing.T) {
 		},
 	}
 
-	err := NewValidationError(st, &st.NestedField.NestedField.OtherField, assert.AnError)
+	err := NewValidationError(st, &st.NestedField.NestedField.OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.nestedField.otherField: %s", assert.AnError))
@@ -169,7 +169,7 @@ func TestNewValidationErrorNestedPtrNestedFieldPtr(t *testing.T) {
 		},
 	}
 
-	err := NewValidationError(st, &st.NestedField.NestedField.OtherField, assert.AnError)
+	err := NewValidationError(st, &st.NestedField.NestedField.OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedField.nestedField.otherField: %s", assert.AnError))
@@ -182,10 +182,10 @@ func TestNewValidationErrorPrimitiveSlice(t *testing.T) {
 		PrimitiveSlice: []string{"abc", "def"},
 	}
 
-	err := NewValidationError(st, &st.PrimitiveSlice[1], assert.AnError)
+	err := NewValidationError(st, &st.PrimitiveSlice[1], "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveSlice.[1]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveSlice[1]: %s", assert.AnError))
 }
 
 func TestNewValidationErrorPrimitiveArray(t *testing.T) {
@@ -193,10 +193,10 @@ func TestNewValidationErrorPrimitiveArray(t *testing.T) {
 		PrimitiveArray: [3]int{1, 2, 3},
 	}
 
-	err := NewValidationError(st, &st.PrimitiveArray[1], assert.AnError)
+	err := NewValidationError(st, &st.PrimitiveArray[1], "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveArray.[1]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveArray[1]: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructSlice(t *testing.T) {
@@ -213,10 +213,10 @@ func TestNewValidationErrorStructSlice(t *testing.T) {
 		},
 	}
 
-	err := NewValidationError(st, &st.StructSlice[1].OtherField, assert.AnError)
+	err := NewValidationError(st, &st.StructSlice[1].OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating structSlice.[1].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating structSlice[1].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructArray(t *testing.T) {
@@ -233,10 +233,10 @@ func TestNewValidationErrorStructArray(t *testing.T) {
 		},
 	}
 
-	err := NewValidationError(st, &st.StructArray[1].OtherField, assert.AnError)
+	err := NewValidationError(st, &st.StructArray[1].OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating structArray.[1].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating structArray[1].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructPointerSlice(t *testing.T) {
@@ -253,10 +253,10 @@ func TestNewValidationErrorStructPointerSlice(t *testing.T) {
 		},
 	}
 
-	err := NewValidationError(st, &st.StructPointerSlice[1].OtherField, assert.AnError)
+	err := NewValidationError(st, &st.StructPointerSlice[1].OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating structPointerSlice.[1].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating structPointerSlice[1].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructPointerArray(t *testing.T) {
@@ -273,10 +273,10 @@ func TestNewValidationErrorStructPointerArray(t *testing.T) {
 		},
 	}
 
-	err := NewValidationError(st, &st.StructPointerArray[1].OtherField, assert.AnError)
+	err := NewValidationError(st, &st.StructPointerArray[1].OtherField, "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating structPointerArray.[1].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating structPointerArray[1].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorPrimitiveSliceSlice(t *testing.T) {
@@ -287,10 +287,64 @@ func TestNewValidationErrorPrimitiveSliceSlice(t *testing.T) {
 		},
 	}
 
-	err := NewValidationError(st, &st.PrimitiveSliceSlice[1][1], assert.AnError)
+	err := NewValidationError(st, &st.PrimitiveSliceSlice[1][1], "", assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveSliceSlice.[1].[1]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveSliceSlice[1][1]: %s", assert.AnError))
+}
+
+// Tests for maps
+
+func TestNewValidationErrorPrimitiveMap(t *testing.T) {
+	st := &MapErrorTestDoc{
+		PrimitiveMap: map[string]string{
+			"abc": "def",
+			"ghi": "jkl",
+		},
+	}
+
+	err := NewValidationError(st, &st.PrimitiveMap, "ghi", assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating primitiveMap[\"ghi\"]: %s", assert.AnError))
+}
+
+func TestNewValidationErrorStructPointerMap(t *testing.T) {
+	st := &MapErrorTestDoc{
+		StructPointerMap: map[string]*ErrorTestDoc{
+			"abc": {
+				ExportedField: "abc",
+				OtherField:    123,
+			},
+			"ghi": {
+				ExportedField: "ghi",
+				OtherField:    456,
+			},
+		},
+	}
+
+	err := NewValidationError(st, &st.StructPointerMap["ghi"].OtherField, "", assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating structPointerMap[\"ghi\"].otherField: %s", assert.AnError))
+}
+
+func TestNewValidationErrorNestedPrimitiveMap(t *testing.T) {
+	st := &MapErrorTestDoc{
+		NestedPointerMap: map[string]*map[string]string{
+			"abc": {
+				"def": "ghi",
+			},
+			"jkl": {
+				"mno": "pqr",
+			},
+		},
+	}
+
+	err := NewValidationError(st, st.NestedPointerMap["jkl"], "mno", assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedPointerMap[\"jkl\"][\"mno\"]: %s", assert.AnError))
 }
 
 type ErrorTestDoc struct {
@@ -324,4 +378,10 @@ type SliceErrorTestDoc struct {
 	StructPointerSlice  []*ErrorTestDoc  `json:"structPointerSlice" yaml:"structPointerSlice"`
 	StructPointerArray  [3]*ErrorTestDoc `json:"structPointerArray" yaml:"structPointerArray"`
 	PrimitiveSliceSlice [][]string       `json:"primitiveSliceSlice" yaml:"primitiveSliceSlice"`
+}
+
+type MapErrorTestDoc struct {
+	PrimitiveMap     map[string]string             `json:"primitiveMap" yaml:"primitiveMap"`
+	StructPointerMap map[string]*ErrorTestDoc      `json:"structPointerMap" yaml:"structPointerMap"`
+	NestedPointerMap map[string]*map[string]string `json:"nestedPointerMap" yaml:"nestedPointerMap"`
 }

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -1,8 +1,10 @@
 package validation
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -12,9 +14,9 @@ func TestNewValidationErrorSingleField(t *testing.T) {
 		OtherField:    42,
 	}
 
-	err := NewValidationError(st, &st.OtherField, nil)
+	err := NewValidationError(st, &st.OtherField, assert.AnError)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "validating otherField: <nil>")
+	require.Contains(t, err.Error(), fmt.Sprintf("validating otherField: %s", assert.AnError))
 }
 
 type ErrorTestDoc struct {

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -18,7 +18,7 @@ func TestNewValidationErrorSingleField(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.OtherField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.otherField: %s", assert.AnError))
 }
@@ -31,7 +31,7 @@ func TestNewValidationErrorSingleFieldPtr(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.PointerField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.pointerField: %s", assert.AnError))
 }
@@ -45,7 +45,7 @@ func TestNewValidationErrorSingleFieldDoublePtr(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.DoublePointerField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.doublePointerField: %s", assert.AnError))
 }
@@ -60,7 +60,7 @@ func TestNewValidationErrorSingleFieldInexistent(t *testing.T) {
 	inexistentField := 123
 
 	doc, field := references(t, st, &inexistentField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot find path to field: cannot traverse anymore")
 }
@@ -78,7 +78,7 @@ func TestNewValidationErrorNestedField(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NestedField.OtherField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.otherField: %s", assert.AnError))
@@ -96,7 +96,7 @@ func TestNewValidationErrorPointerInNestedField(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NestedField.PointerField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.pointerField: %s", assert.AnError))
@@ -117,7 +117,7 @@ func TestNewValidationErrorNestedFieldPtr(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NestedPointerField.OtherField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedPointerField.otherField: %s", assert.AnError))
@@ -138,7 +138,7 @@ func TestNewValidationErrorNestedNestedField(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NestedField.NestedField.OtherField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.nestedField.otherField: %s", assert.AnError))
@@ -159,7 +159,7 @@ func TestNewValidationErrorNestedNestedFieldPtr(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NestedField.NestedPointerField.OtherField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.nestedPointerField.otherField: %s", assert.AnError))
@@ -180,7 +180,7 @@ func TestNewValidationErrorNestedPtrNestedFieldPtr(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NestedPointerField.NestedPointerField.OtherField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedPointerField.nestedPointerField.otherField: %s", assert.AnError))
@@ -194,7 +194,7 @@ func TestNewValidationErrorPrimitiveSlice(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.PrimitiveSlice[1], "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.primitiveSlice[1]: %s", assert.AnError))
@@ -206,7 +206,7 @@ func TestNewValidationErrorPrimitiveArray(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.PrimitiveArray[1], "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.primitiveArray[1]: %s", assert.AnError))
@@ -227,7 +227,7 @@ func TestNewValidationErrorStructSlice(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.StructSlice[1].OtherField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structSlice[1].otherField: %s", assert.AnError))
@@ -248,7 +248,7 @@ func TestNewValidationErrorStructArray(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.StructArray[1].OtherField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structArray[1].otherField: %s", assert.AnError))
@@ -269,7 +269,7 @@ func TestNewValidationErrorStructPointerSlice(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.StructPointerSlice[1].OtherField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structPointerSlice[1].otherField: %s", assert.AnError))
@@ -290,7 +290,7 @@ func TestNewValidationErrorStructPointerArray(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.StructPointerArray[1].OtherField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structPointerArray[1].otherField: %s", assert.AnError))
@@ -305,7 +305,7 @@ func TestNewValidationErrorPrimitiveSliceSlice(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.PrimitiveSliceSlice[1][1], "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.primitiveSliceSlice[1][1]: %s", assert.AnError))
@@ -322,7 +322,7 @@ func TestNewValidationErrorPrimitiveMap(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.PrimitiveMap, "ghi")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating MapErrorTestDoc.primitiveMap[\"ghi\"]: %s", assert.AnError))
@@ -343,7 +343,7 @@ func TestNewValidationErrorStructPointerMap(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.StructPointerMap["ghi"].OtherField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating MapErrorTestDoc.structPointerMap[\"ghi\"].otherField: %s", assert.AnError))
@@ -362,7 +362,7 @@ func TestNewValidationErrorNestedPrimitiveMap(t *testing.T) {
 	}
 
 	doc, field := references(t, st, st.NestedPointerMap["jkl"], "mno")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating MapErrorTestDoc.nestedPointerMap[\"jkl\"][\"mno\"]: %s", assert.AnError))
@@ -377,7 +377,7 @@ func TestNewValidationErrorTopLevelIsNeedle(t *testing.T) {
 	}
 
 	doc, field := references(t, st, st, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc: %s", assert.AnError))
 }
@@ -390,7 +390,7 @@ func TestNewValidationErrorUntaggedField(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NoTagField, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.NoTagField: %s", assert.AnError))
 }
@@ -404,7 +404,7 @@ func TestNewValidationErrorOnlyYamlTaggedField(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.OnlyYamlKey, "")
-	err := newValidationError(doc, field, assert.AnError)
+	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.onlyYamlKey: %s", assert.AnError))
 }

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -18,7 +18,7 @@ func TestNewValidationErrorSingleField(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.OtherField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.otherField: %s", assert.AnError))
 }
@@ -31,7 +31,7 @@ func TestNewValidationErrorSingleFieldPtr(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.PointerField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.pointerField: %s", assert.AnError))
 }
@@ -45,7 +45,7 @@ func TestNewValidationErrorSingleFieldDoublePtr(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.DoublePointerField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.doublePointerField: %s", assert.AnError))
 }
@@ -60,7 +60,7 @@ func TestNewValidationErrorSingleFieldInexistent(t *testing.T) {
 	inexistentField := 123
 
 	doc, field := references(t, st, &inexistentField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "cannot find path to field: cannot traverse anymore")
 }
@@ -78,7 +78,7 @@ func TestNewValidationErrorNestedField(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NestedField.OtherField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.otherField: %s", assert.AnError))
@@ -96,7 +96,7 @@ func TestNewValidationErrorPointerInNestedField(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NestedField.PointerField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.pointerField: %s", assert.AnError))
@@ -117,7 +117,7 @@ func TestNewValidationErrorNestedFieldPtr(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NestedPointerField.OtherField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedPointerField.otherField: %s", assert.AnError))
@@ -138,7 +138,7 @@ func TestNewValidationErrorNestedNestedField(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NestedField.NestedField.OtherField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.nestedField.otherField: %s", assert.AnError))
@@ -159,7 +159,7 @@ func TestNewValidationErrorNestedNestedFieldPtr(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NestedField.NestedPointerField.OtherField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.nestedPointerField.otherField: %s", assert.AnError))
@@ -180,7 +180,7 @@ func TestNewValidationErrorNestedPtrNestedFieldPtr(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NestedPointerField.NestedPointerField.OtherField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedPointerField.nestedPointerField.otherField: %s", assert.AnError))
@@ -194,7 +194,7 @@ func TestNewValidationErrorPrimitiveSlice(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.PrimitiveSlice[1], "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.primitiveSlice[1]: %s", assert.AnError))
@@ -206,7 +206,7 @@ func TestNewValidationErrorPrimitiveArray(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.PrimitiveArray[1], "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.primitiveArray[1]: %s", assert.AnError))
@@ -227,7 +227,7 @@ func TestNewValidationErrorStructSlice(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.StructSlice[1].OtherField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structSlice[1].otherField: %s", assert.AnError))
@@ -248,7 +248,7 @@ func TestNewValidationErrorStructArray(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.StructArray[1].OtherField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structArray[1].otherField: %s", assert.AnError))
@@ -269,7 +269,7 @@ func TestNewValidationErrorStructPointerSlice(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.StructPointerSlice[1].OtherField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structPointerSlice[1].otherField: %s", assert.AnError))
@@ -290,7 +290,7 @@ func TestNewValidationErrorStructPointerArray(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.StructPointerArray[1].OtherField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structPointerArray[1].otherField: %s", assert.AnError))
@@ -305,7 +305,7 @@ func TestNewValidationErrorPrimitiveSliceSlice(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.PrimitiveSliceSlice[1][1], "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.primitiveSliceSlice[1][1]: %s", assert.AnError))
@@ -322,7 +322,7 @@ func TestNewValidationErrorPrimitiveMap(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.PrimitiveMap, "ghi")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating MapErrorTestDoc.primitiveMap[\"ghi\"]: %s", assert.AnError))
@@ -343,7 +343,7 @@ func TestNewValidationErrorStructPointerMap(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.StructPointerMap["ghi"].OtherField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating MapErrorTestDoc.structPointerMap[\"ghi\"].otherField: %s", assert.AnError))
@@ -362,7 +362,7 @@ func TestNewValidationErrorNestedPrimitiveMap(t *testing.T) {
 	}
 
 	doc, field := references(t, st, st.NestedPointerMap["jkl"], "mno")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating MapErrorTestDoc.nestedPointerMap[\"jkl\"][\"mno\"]: %s", assert.AnError))
@@ -377,7 +377,7 @@ func TestNewValidationErrorTopLevelIsNeedle(t *testing.T) {
 	}
 
 	doc, field := references(t, st, st, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc: %s", assert.AnError))
 }
@@ -390,7 +390,7 @@ func TestNewValidationErrorUntaggedField(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.NoTagField, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.NoTagField: %s", assert.AnError))
 }
@@ -404,7 +404,7 @@ func TestNewValidationErrorOnlyYamlTaggedField(t *testing.T) {
 	}
 
 	doc, field := references(t, st, &st.OnlyYamlKey, "")
-	err := NewValidationError(doc, field, assert.AnError)
+	err := newValidationError(doc, field, assert.AnError)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.onlyYamlKey: %s", assert.AnError))
 }

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -1,0 +1,23 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewValidationErrorSingleField(t *testing.T) {
+	st := &ErrorTestDoc{
+		ExportedField: "abc",
+		OtherField:    42,
+	}
+
+	err := NewValidationError(st, &st.OtherField, nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "validating otherField: <nil>")
+}
+
+type ErrorTestDoc struct {
+	ExportedField string `json:"exportedField" yaml:"exportedField"`
+	OtherField    int    `json:"otherField" yaml:"otherField"`
+}

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -18,7 +18,7 @@ import (
 // Tests for primitive / shallow fields
 
 func TestNewValidationErrorSingleField(t *testing.T) {
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
 	}
@@ -26,11 +26,11 @@ func TestNewValidationErrorSingleField(t *testing.T) {
 	doc, field := references(t, st, &st.OtherField, "")
 	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating errorTestDoc.otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorSingleFieldPtr(t *testing.T) {
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
 		PointerField:  new(int),
@@ -39,12 +39,12 @@ func TestNewValidationErrorSingleFieldPtr(t *testing.T) {
 	doc, field := references(t, st, &st.PointerField, "")
 	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.pointerField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating errorTestDoc.pointerField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorSingleFieldDoublePtr(t *testing.T) {
 	intp := new(int)
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField:      "abc",
 		OtherField:         42,
 		DoublePointerField: &intp,
@@ -53,11 +53,11 @@ func TestNewValidationErrorSingleFieldDoublePtr(t *testing.T) {
 	doc, field := references(t, st, &st.DoublePointerField, "")
 	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.doublePointerField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating errorTestDoc.doublePointerField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorSingleFieldInexistent(t *testing.T) {
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
 		PointerField:  new(int),
@@ -74,10 +74,10 @@ func TestNewValidationErrorSingleFieldInexistent(t *testing.T) {
 // Tests for nested structs
 
 func TestNewValidationErrorNestedField(t *testing.T) {
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
-		NestedField: NestedErrorTestDoc{
+		NestedField: nestederrorTestDoc{
 			ExportedField: "nested",
 			OtherField:    123,
 		},
@@ -87,14 +87,14 @@ func TestNewValidationErrorNestedField(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating errorTestDoc.nestedField.otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorPointerInNestedField(t *testing.T) {
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
-		NestedField: NestedErrorTestDoc{
+		NestedField: nestederrorTestDoc{
 			ExportedField: "nested",
 			OtherField:    123,
 			PointerField:  new(int),
@@ -105,18 +105,18 @@ func TestNewValidationErrorPointerInNestedField(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.pointerField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating errorTestDoc.nestedField.pointerField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorNestedFieldPtr(t *testing.T) {
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
-		NestedField: NestedErrorTestDoc{
+		NestedField: nestederrorTestDoc{
 			ExportedField: "nested",
 			OtherField:    123,
 		},
-		NestedPointerField: &NestedErrorTestDoc{
+		NestedPointerField: &nestederrorTestDoc{
 			ExportedField: "nested",
 			OtherField:    123,
 		},
@@ -126,17 +126,17 @@ func TestNewValidationErrorNestedFieldPtr(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedPointerField.otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating errorTestDoc.nestedPointerField.otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorNestedNestedField(t *testing.T) {
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
-		NestedField: NestedErrorTestDoc{
+		NestedField: nestederrorTestDoc{
 			ExportedField: "nested",
 			OtherField:    123,
-			NestedField: NestedNestedErrorTestDoc{
+			NestedField: nestedNestederrorTestDoc{
 				ExportedField: "nested",
 				OtherField:    123,
 			},
@@ -147,17 +147,17 @@ func TestNewValidationErrorNestedNestedField(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.nestedField.otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating errorTestDoc.nestedField.nestedField.otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorNestedNestedFieldPtr(t *testing.T) {
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
-		NestedField: NestedErrorTestDoc{
+		NestedField: nestederrorTestDoc{
 			ExportedField: "nested",
 			OtherField:    123,
-			NestedPointerField: &NestedNestedErrorTestDoc{
+			NestedPointerField: &nestedNestederrorTestDoc{
 				ExportedField: "nested",
 				OtherField:    123,
 			},
@@ -168,17 +168,17 @@ func TestNewValidationErrorNestedNestedFieldPtr(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedField.nestedPointerField.otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating errorTestDoc.nestedField.nestedPointerField.otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorNestedPtrNestedFieldPtr(t *testing.T) {
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
-		NestedPointerField: &NestedErrorTestDoc{
+		NestedPointerField: &nestederrorTestDoc{
 			ExportedField: "nested",
 			OtherField:    123,
-			NestedPointerField: &NestedNestedErrorTestDoc{
+			NestedPointerField: &nestedNestederrorTestDoc{
 				ExportedField: "nested",
 				OtherField:    123,
 			},
@@ -189,13 +189,13 @@ func TestNewValidationErrorNestedPtrNestedFieldPtr(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.nestedPointerField.nestedPointerField.otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating errorTestDoc.nestedPointerField.nestedPointerField.otherField: %s", assert.AnError))
 }
 
 // Tests for slices / arrays
 
 func TestNewValidationErrorPrimitiveSlice(t *testing.T) {
-	st := &SliceErrorTestDoc{
+	st := &sliceErrorTestDoc{
 		PrimitiveSlice: []string{"abc", "def"},
 	}
 
@@ -203,11 +203,11 @@ func TestNewValidationErrorPrimitiveSlice(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.primitiveSlice[1]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating sliceErrorTestDoc.primitiveSlice[1]: %s", assert.AnError))
 }
 
 func TestNewValidationErrorPrimitiveArray(t *testing.T) {
-	st := &SliceErrorTestDoc{
+	st := &sliceErrorTestDoc{
 		PrimitiveArray: [3]int{1, 2, 3},
 	}
 
@@ -215,12 +215,12 @@ func TestNewValidationErrorPrimitiveArray(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.primitiveArray[1]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating sliceErrorTestDoc.primitiveArray[1]: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructSlice(t *testing.T) {
-	st := &SliceErrorTestDoc{
-		StructSlice: []ErrorTestDoc{
+	st := &sliceErrorTestDoc{
+		StructSlice: []errorTestDoc{
 			{
 				ExportedField: "abc",
 				OtherField:    123,
@@ -236,12 +236,12 @@ func TestNewValidationErrorStructSlice(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structSlice[1].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating sliceErrorTestDoc.structSlice[1].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructArray(t *testing.T) {
-	st := &SliceErrorTestDoc{
-		StructArray: [3]ErrorTestDoc{
+	st := &sliceErrorTestDoc{
+		StructArray: [3]errorTestDoc{
 			{
 				ExportedField: "abc",
 				OtherField:    123,
@@ -257,12 +257,12 @@ func TestNewValidationErrorStructArray(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structArray[1].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating sliceErrorTestDoc.structArray[1].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructPointerSlice(t *testing.T) {
-	st := &SliceErrorTestDoc{
-		StructPointerSlice: []*ErrorTestDoc{
+	st := &sliceErrorTestDoc{
+		StructPointerSlice: []*errorTestDoc{
 			{
 				ExportedField: "abc",
 				OtherField:    123,
@@ -278,12 +278,12 @@ func TestNewValidationErrorStructPointerSlice(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structPointerSlice[1].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating sliceErrorTestDoc.structPointerSlice[1].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructPointerArray(t *testing.T) {
-	st := &SliceErrorTestDoc{
-		StructPointerArray: [3]*ErrorTestDoc{
+	st := &sliceErrorTestDoc{
+		StructPointerArray: [3]*errorTestDoc{
 			{
 				ExportedField: "abc",
 				OtherField:    123,
@@ -299,11 +299,11 @@ func TestNewValidationErrorStructPointerArray(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.structPointerArray[1].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating sliceErrorTestDoc.structPointerArray[1].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorPrimitiveSliceSlice(t *testing.T) {
-	st := &SliceErrorTestDoc{
+	st := &sliceErrorTestDoc{
 		PrimitiveSliceSlice: [][]string{
 			{"abc", "def"},
 			{"ghi", "jkl"},
@@ -314,13 +314,13 @@ func TestNewValidationErrorPrimitiveSliceSlice(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating SliceErrorTestDoc.primitiveSliceSlice[1][1]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating sliceErrorTestDoc.primitiveSliceSlice[1][1]: %s", assert.AnError))
 }
 
 // Tests for maps
 
 func TestNewValidationErrorPrimitiveMap(t *testing.T) {
-	st := &MapErrorTestDoc{
+	st := &mapErrorTestDoc{
 		PrimitiveMap: map[string]string{
 			"abc": "def",
 			"ghi": "jkl",
@@ -331,12 +331,12 @@ func TestNewValidationErrorPrimitiveMap(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating MapErrorTestDoc.primitiveMap[\"ghi\"]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating mapErrorTestDoc.primitiveMap[\"ghi\"]: %s", assert.AnError))
 }
 
 func TestNewValidationErrorStructPointerMap(t *testing.T) {
-	st := &MapErrorTestDoc{
-		StructPointerMap: map[string]*ErrorTestDoc{
+	st := &mapErrorTestDoc{
+		StructPointerMap: map[string]*errorTestDoc{
 			"abc": {
 				ExportedField: "abc",
 				OtherField:    123,
@@ -352,11 +352,11 @@ func TestNewValidationErrorStructPointerMap(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating MapErrorTestDoc.structPointerMap[\"ghi\"].otherField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating mapErrorTestDoc.structPointerMap[\"ghi\"].otherField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorNestedPrimitiveMap(t *testing.T) {
-	st := &MapErrorTestDoc{
+	st := &mapErrorTestDoc{
 		NestedPointerMap: map[string]*map[string]string{
 			"abc": {
 				"def": "ghi",
@@ -371,13 +371,13 @@ func TestNewValidationErrorNestedPrimitiveMap(t *testing.T) {
 	err := newError(doc, field, assert.AnError)
 	t.Log(err)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating MapErrorTestDoc.nestedPointerMap[\"jkl\"][\"mno\"]: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating mapErrorTestDoc.nestedPointerMap[\"jkl\"][\"mno\"]: %s", assert.AnError))
 }
 
 // Special cases
 
 func TestNewValidationErrorTopLevelIsNeedle(t *testing.T) {
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
 	}
@@ -385,11 +385,11 @@ func TestNewValidationErrorTopLevelIsNeedle(t *testing.T) {
 	doc, field := references(t, st, st, "")
 	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating errorTestDoc: %s", assert.AnError))
 }
 
 func TestNewValidationErrorUntaggedField(t *testing.T) {
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
 		NoTagField:    123,
@@ -398,11 +398,11 @@ func TestNewValidationErrorUntaggedField(t *testing.T) {
 	doc, field := references(t, st, &st.NoTagField, "")
 	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.NoTagField: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating errorTestDoc.NoTagField: %s", assert.AnError))
 }
 
 func TestNewValidationErrorOnlyYamlTaggedField(t *testing.T) {
-	st := &ErrorTestDoc{
+	st := &errorTestDoc{
 		ExportedField: "abc",
 		OtherField:    42,
 		NoTagField:    123,
@@ -412,47 +412,47 @@ func TestNewValidationErrorOnlyYamlTaggedField(t *testing.T) {
 	doc, field := references(t, st, &st.OnlyYamlKey, "")
 	err := newError(doc, field, assert.AnError)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("validating ErrorTestDoc.onlyYamlKey: %s", assert.AnError))
+	require.Contains(t, err.Error(), fmt.Sprintf("validating errorTestDoc.onlyYamlKey: %s", assert.AnError))
 }
 
-type ErrorTestDoc struct {
+type errorTestDoc struct {
 	ExportedField      string              `json:"exportedField" yaml:"exportedField"`
 	OtherField         int                 `json:"otherField" yaml:"otherField"`
 	PointerField       *int                `json:"pointerField" yaml:"pointerField"`
 	DoublePointerField **int               `json:"doublePointerField" yaml:"doublePointerField"`
-	NestedField        NestedErrorTestDoc  `json:"nestedField" yaml:"nestedField"`
-	NestedPointerField *NestedErrorTestDoc `json:"nestedPointerField" yaml:"nestedPointerField"`
+	NestedField        nestederrorTestDoc  `json:"nestedField" yaml:"nestedField"`
+	NestedPointerField *nestederrorTestDoc `json:"nestedPointerField" yaml:"nestedPointerField"`
 	NoTagField         int
 	OnlyYamlKey        string `yaml:"onlyYamlKey"`
 }
 
-type NestedErrorTestDoc struct {
+type nestederrorTestDoc struct {
 	ExportedField      string                    `json:"exportedField" yaml:"exportedField"`
 	OtherField         int                       `json:"otherField" yaml:"otherField"`
 	PointerField       *int                      `json:"pointerField" yaml:"pointerField"`
-	NestedField        NestedNestedErrorTestDoc  `json:"nestedField" yaml:"nestedField"`
-	NestedPointerField *NestedNestedErrorTestDoc `json:"nestedPointerField" yaml:"nestedPointerField"`
+	NestedField        nestedNestederrorTestDoc  `json:"nestedField" yaml:"nestedField"`
+	NestedPointerField *nestedNestederrorTestDoc `json:"nestedPointerField" yaml:"nestedPointerField"`
 }
 
-type NestedNestedErrorTestDoc struct {
+type nestedNestederrorTestDoc struct {
 	ExportedField string `json:"exportedField" yaml:"exportedField"`
 	OtherField    int    `json:"otherField" yaml:"otherField"`
 	PointerField  *int   `json:"pointerField" yaml:"pointerField"`
 }
 
-type SliceErrorTestDoc struct {
+type sliceErrorTestDoc struct {
 	PrimitiveSlice      []string         `json:"primitiveSlice" yaml:"primitiveSlice"`
 	PrimitiveArray      [3]int           `json:"primitiveArray" yaml:"primitiveArray"`
-	StructSlice         []ErrorTestDoc   `json:"structSlice" yaml:"structSlice"`
-	StructArray         [3]ErrorTestDoc  `json:"structArray" yaml:"structArray"`
-	StructPointerSlice  []*ErrorTestDoc  `json:"structPointerSlice" yaml:"structPointerSlice"`
-	StructPointerArray  [3]*ErrorTestDoc `json:"structPointerArray" yaml:"structPointerArray"`
+	StructSlice         []errorTestDoc   `json:"structSlice" yaml:"structSlice"`
+	StructArray         [3]errorTestDoc  `json:"structArray" yaml:"structArray"`
+	StructPointerSlice  []*errorTestDoc  `json:"structPointerSlice" yaml:"structPointerSlice"`
+	StructPointerArray  [3]*errorTestDoc `json:"structPointerArray" yaml:"structPointerArray"`
 	PrimitiveSliceSlice [][]string       `json:"primitiveSliceSlice" yaml:"primitiveSliceSlice"`
 }
 
-type MapErrorTestDoc struct {
+type mapErrorTestDoc struct {
 	PrimitiveMap     map[string]string             `json:"primitiveMap" yaml:"primitiveMap"`
-	StructPointerMap map[string]*ErrorTestDoc      `json:"structPointerMap" yaml:"structPointerMap"`
+	StructPointerMap map[string]*errorTestDoc      `json:"structPointerMap" yaml:"structPointerMap"`
 	NestedPointerMap map[string]*map[string]string `json:"nestedPointerMap" yaml:"nestedPointerMap"`
 }
 

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -31,7 +31,44 @@ func TestNewValidationErrorSingleFieldPtr(t *testing.T) {
 	require.Contains(t, err.Error(), fmt.Sprintf("validating pointerField: %s", assert.AnError))
 }
 
+func TestNewValidationErrorSingleFieldInexistent(t *testing.T) {
+	st := &ErrorTestDoc{
+		ExportedField: "abc",
+		OtherField:    42,
+		PointerField:  new(int),
+	}
+
+	inexistentField := 123
+
+	err := NewValidationError(st, &inexistentField, assert.AnError)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "cannot find path to field: cannot traverse anymore")
+}
+
+func TestNewValidationErrorNestedField(t *testing.T) {
+	st := &ErrorTestDoc{
+		ExportedField: "abc",
+		OtherField:    42,
+		NestedErrorTestDoc: NestedErrorTestDoc{
+			ExportedField: "nested",
+			OtherField:    123,
+		},
+	}
+
+	err := NewValidationError(st, &st.NestedErrorTestDoc.OtherField, assert.AnError)
+	t.Log(err)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), fmt.Sprintf("validating nestedErrorTestDoc.otherField: %s", assert.AnError))
+}
+
 type ErrorTestDoc struct {
+	ExportedField      string             `json:"exportedField" yaml:"exportedField"`
+	OtherField         int                `json:"otherField" yaml:"otherField"`
+	PointerField       *int               `json:"pointerField" yaml:"pointerField"`
+	NestedErrorTestDoc NestedErrorTestDoc `json:"nestedErrorTestDoc" yaml:"nestedErrorTestDoc"`
+}
+
+type NestedErrorTestDoc struct {
 	ExportedField string `json:"exportedField" yaml:"exportedField"`
 	OtherField    int    `json:"otherField" yaml:"otherField"`
 	PointerField  *int   `json:"pointerField" yaml:"pointerField"`

--- a/internal/validation/errors_test.go
+++ b/internal/validation/errors_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
 package validation
 
 import (

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -36,7 +36,7 @@ type ValidateOptions struct {
 func (v *Validator) Validate(doc Validatable, opts ValidateOptions) error {
 	var retErr error
 	for _, c := range doc.Constraints() {
-		if valid, err := c(); !valid {
+		if valid, err := c.Satisfied(); !valid {
 			if opts.FailFast {
 				return err
 			}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -22,6 +22,7 @@ func NewValidator() *Validator {
 type Validator struct{}
 
 // Validatable is implemented by documents that can be validated.
+// It returns a list of constraints that must be satisfied for the document to be valid.
 type Validatable interface {
 	Constraints() []Constraint
 }

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -1,0 +1,47 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+/*
+Package validation provides a unified document validation interface for use within the Constellation CLI.
+
+It validates documents that specify a set of constraints on their content.
+*/
+package validation
+
+import "errors"
+
+// NewValidator creates a new Validator.
+func NewValidator() *Validator {
+	return &Validator{}
+}
+
+// Validator validates documents.
+type Validator struct{}
+
+// Validatable is implemented by documents that can be validated.
+type Validatable interface {
+	Constraints() []Constraint
+}
+
+// ValidateOptions are the options to use when validating a document.
+type ValidateOptions struct {
+	// FailFast stops validation on the first error.
+	FailFast bool
+}
+
+// Validate validates a document using the given options.
+func (v *Validator) Validate(doc Validatable, opts ValidateOptions) error {
+	var retErr error
+	for _, c := range doc.Constraints() {
+		if valid, err := c(); !valid {
+			if opts.FailFast {
+				return err
+			}
+			retErr = errors.Join(retErr, err)
+		}
+	}
+	return retErr
+}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -37,7 +37,7 @@ type ValidateOptions struct {
 func (v *Validator) Validate(doc Validatable, opts ValidateOptions) error {
 	var retErr error
 	for _, c := range doc.Constraints() {
-		if valid, err := c.Satisfied(); !valid {
+		if err := c.Satisfied(); err != nil {
 			if opts.FailFast {
 				return err
 			}

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package validation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidate(t *testing.T) {
+	testCases := map[string]struct {
+		doc          Validatable
+		opts         ValidateOptions
+		wantErr      bool
+		errAssertion func(*assert.Assertions, error) bool
+	}{
+		"valid": {
+			doc: &exampleDoc{
+				strField: "abc",
+			},
+			opts: ValidateOptions{},
+		},
+		"invalid": {
+			doc: &exampleDoc{
+				strField: "def",
+			},
+			wantErr: true,
+			errAssertion: func(assert *assert.Assertions, err error) bool {
+				return assert.Contains(err.Error(), "strField must be abc")
+			},
+			opts: ValidateOptions{},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			assert := assert.New(t)
+			require := require.New(t)
+
+			err := NewValidator().Validate(tc.doc, tc.opts)
+			if tc.wantErr {
+				require.Error(err)
+				if !tc.errAssertion(assert, err) {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				require.NoError(err)
+			}
+		})
+	}
+
+}
+
+type exampleDoc struct {
+	strField  string
+	numField  int
+	nested    nestedExampleDoc
+	nestedPtr *nestedExampleDoc
+}
+
+type nestedExampleDoc struct {
+	strField string
+	numField int
+}
+
+func (d *exampleDoc) Constraints() []Constraint {
+	return []Constraint{
+		d.strFieldNeedsToBeAbc,
+		MatchRegex(d.strField, "^[a-z]+$"),
+		Equal(d.numField, 42),
+	}
+}
+
+// StrFieldNeedsToBeAbc is an example for a custom constraint.
+func (d *exampleDoc) strFieldNeedsToBeAbc() (bool, error) {
+	if d.strField != "abc" {
+		return false, fmt.Errorf("%s must be abc", d.strField)
+	}
+	return true, nil
+}

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -202,11 +202,11 @@ func (d *exampleDoc) Constraints() []Constraint {
 // StrFieldNeedsToBeAbc is an example for a custom constraint.
 func (d *exampleDoc) strFieldNeedsToBeAbc() *Constraint {
 	return &Constraint{
-		Satisfied: func() (bool, error) {
+		Satisfied: func() error {
 			if d.StrField != "abc" {
-				return false, fmt.Errorf("%s must be abc", d.StrField)
+				return fmt.Errorf("%s must be abc", d.StrField)
 			}
-			return true, nil
+			return nil
 		},
 	}
 }

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -171,7 +171,6 @@ func TestValidate(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 type exampleDoc struct {

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -182,6 +182,7 @@ type exampleDoc struct {
 	MatchRegexField string             `json:"matchRegexField"`
 }
 
+// Constraints implements the Validatable interface.
 func (d *exampleDoc) Constraints() []Constraint {
 	mapField := *(d.MapField)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We want to have a generic framework for document validation in Constellation, for use on the config and state file.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a framework for config validation. A usage example can be found in [`validation_test.go`](https://github.com/edgelesssys/constellation/blob/0ee82ee88c6b0d1ebb52915881c502be7034e45c/internal/validation/validation_test.go)  and in the Go doc comments of the exported functions. If more thorough documentation on this is required, I can also prepare a page in the dev-docs.
- This PR uses quite hacky reflection to implement JSONPath traces of fields that fail validation. This approach is quite prone to errors, but is verified to work for all types tested in the unit tests. In case any type that you might want to validate is not covered by this, please let me know.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3496](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3496)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
