### PR TITLE
terraform: always output node cidr

### DIFF
--- a/cli/internal/helm/loader_test.go
+++ b/cli/internal/helm/loader_test.go
@@ -70,9 +70,8 @@ func TestLoadReleases(t *testing.T) {
 		state.New().
 			SetInfrastructure(state.Infrastructure{
 				GCP: &state.GCP{
-					ProjectID:  "test-project-id",
-					IPCidrNode: "test-node-cidr",
-					IPCidrPod:  "test-pod-cidr",
+					ProjectID: "test-project-id",
+					IPCidrPod: "test-pod-cidr",
 				},
 			}).
 			SetClusterValues(state.ClusterValues{MeasurementSalt: []byte{0x41}}),

--- a/cli/internal/state/state.go
+++ b/cli/internal/state/state.go
@@ -106,6 +106,9 @@ type Infrastructure struct {
 	//   Name used in the cluster's named resources.
 	Name string `yaml:"name"`
 	// description: |
+	//   CIDR range of the cluster's nodes.
+	IPCidrNode string `yaml:"ipCidrNode"`
+	// description: |
 	//   Values specific to a Constellation cluster running on Azure.
 	Azure *Azure `yaml:"azure,omitempty"`
 	// description: |
@@ -118,9 +121,6 @@ type GCP struct {
 	// description: |
 	//   Project ID of the GCP project the cluster is running in.
 	ProjectID string `yaml:"projectID"`
-	// description: |
-	//   CIDR range of the cluster's nodes.
-	IPCidrNode string `yaml:"ipCidrNode"`
 	// description: |
 	//   CIDR range of the cluster's pods.
 	IPCidrPod string `yaml:"ipCidrPod"`

--- a/cli/internal/state/state_doc.go
+++ b/cli/internal/state/state_doc.go
@@ -74,7 +74,7 @@ func init() {
 			FieldName: "infrastructure",
 		},
 	}
-	InfrastructureDoc.Fields = make([]encoder.Doc, 8)
+	InfrastructureDoc.Fields = make([]encoder.Doc, 9)
 	InfrastructureDoc.Fields[0].Name = "uid"
 	InfrastructureDoc.Fields[0].Type = "string"
 	InfrastructureDoc.Fields[0].Note = ""
@@ -105,16 +105,21 @@ func init() {
 	InfrastructureDoc.Fields[5].Note = ""
 	InfrastructureDoc.Fields[5].Description = "Name used in the cluster's named resources."
 	InfrastructureDoc.Fields[5].Comments[encoder.LineComment] = "Name used in the cluster's named resources."
-	InfrastructureDoc.Fields[6].Name = "azure"
-	InfrastructureDoc.Fields[6].Type = "Azure"
+	InfrastructureDoc.Fields[6].Name = "ipCidrNode"
+	InfrastructureDoc.Fields[6].Type = "string"
 	InfrastructureDoc.Fields[6].Note = ""
-	InfrastructureDoc.Fields[6].Description = "Values specific to a Constellation cluster running on Azure."
-	InfrastructureDoc.Fields[6].Comments[encoder.LineComment] = "Values specific to a Constellation cluster running on Azure."
-	InfrastructureDoc.Fields[7].Name = "gcp"
-	InfrastructureDoc.Fields[7].Type = "GCP"
+	InfrastructureDoc.Fields[6].Description = "CIDR range of the cluster's nodes."
+	InfrastructureDoc.Fields[6].Comments[encoder.LineComment] = "CIDR range of the cluster's nodes."
+	InfrastructureDoc.Fields[7].Name = "azure"
+	InfrastructureDoc.Fields[7].Type = "Azure"
 	InfrastructureDoc.Fields[7].Note = ""
-	InfrastructureDoc.Fields[7].Description = "Values specific to a Constellation cluster running on GCP."
-	InfrastructureDoc.Fields[7].Comments[encoder.LineComment] = "Values specific to a Constellation cluster running on GCP."
+	InfrastructureDoc.Fields[7].Description = "Values specific to a Constellation cluster running on Azure."
+	InfrastructureDoc.Fields[7].Comments[encoder.LineComment] = "Values specific to a Constellation cluster running on Azure."
+	InfrastructureDoc.Fields[8].Name = "gcp"
+	InfrastructureDoc.Fields[8].Type = "GCP"
+	InfrastructureDoc.Fields[8].Note = ""
+	InfrastructureDoc.Fields[8].Description = "Values specific to a Constellation cluster running on GCP."
+	InfrastructureDoc.Fields[8].Comments[encoder.LineComment] = "Values specific to a Constellation cluster running on GCP."
 
 	GCPDoc.Type = "GCP"
 	GCPDoc.Comments[encoder.LineComment] = "GCP describes the infra state related to GCP."
@@ -125,22 +130,17 @@ func init() {
 			FieldName: "gcp",
 		},
 	}
-	GCPDoc.Fields = make([]encoder.Doc, 3)
+	GCPDoc.Fields = make([]encoder.Doc, 2)
 	GCPDoc.Fields[0].Name = "projectID"
 	GCPDoc.Fields[0].Type = "string"
 	GCPDoc.Fields[0].Note = ""
 	GCPDoc.Fields[0].Description = "Project ID of the GCP project the cluster is running in."
 	GCPDoc.Fields[0].Comments[encoder.LineComment] = "Project ID of the GCP project the cluster is running in."
-	GCPDoc.Fields[1].Name = "ipCidrNode"
+	GCPDoc.Fields[1].Name = "ipCidrPod"
 	GCPDoc.Fields[1].Type = "string"
 	GCPDoc.Fields[1].Note = ""
-	GCPDoc.Fields[1].Description = "CIDR range of the cluster's nodes."
-	GCPDoc.Fields[1].Comments[encoder.LineComment] = "CIDR range of the cluster's nodes."
-	GCPDoc.Fields[2].Name = "ipCidrPod"
-	GCPDoc.Fields[2].Type = "string"
-	GCPDoc.Fields[2].Note = ""
-	GCPDoc.Fields[2].Description = "CIDR range of the cluster's pods."
-	GCPDoc.Fields[2].Comments[encoder.LineComment] = "CIDR range of the cluster's pods."
+	GCPDoc.Fields[1].Description = "CIDR range of the cluster's pods."
+	GCPDoc.Fields[1].Comments[encoder.LineComment] = "CIDR range of the cluster's pods."
 
 	AzureDoc.Type = "Azure"
 	AzureDoc.Comments[encoder.LineComment] = "Azure describes the infra state related to Azure."

--- a/cli/internal/state/state_test.go
+++ b/cli/internal/state/state_test.go
@@ -29,6 +29,7 @@ func defaultState() *State {
 				"api-server-cert-san-test",
 				"api-server-cert-san-test-2",
 			},
+			IPCidrNode: "test-cidr-node",
 			Azure: &Azure{
 				ResourceGroup:            "test-rg",
 				SubscriptionID:           "test-sub",
@@ -38,9 +39,8 @@ func defaultState() *State {
 				AttestationURL:           "test-maaUrl",
 			},
 			GCP: &GCP{
-				ProjectID:  "test-project",
-				IPCidrNode: "test-cidr-node",
-				IPCidrPod:  "test-cidr-pod",
+				ProjectID: "test-project",
+				IPCidrPod: "test-cidr-pod",
 			},
 		},
 		ClusterValues: ClusterValues{

--- a/cli/internal/terraform/terraform.go
+++ b/cli/internal/terraform/terraform.go
@@ -239,6 +239,15 @@ func (c *Client) ShowInfrastructure(ctx context.Context, provider cloudprovider.
 		return state.Infrastructure{}, errors.New("invalid type in name output: not a string")
 	}
 
+	cidrNodesOutput, ok := tfState.Values.Outputs["ip_cidr_nodes"]
+	if !ok {
+		return state.Infrastructure{}, errors.New("no ip_cidr_nodes output found")
+	}
+	cidrNodes, ok := cidrNodesOutput.Value.(string)
+	if !ok {
+		return state.Infrastructure{}, errors.New("invalid type in ip_cidr_nodes output: not a string")
+	}
+
 	res := state.Infrastructure{
 		ClusterEndpoint:   outOfClusterEndpoint,
 		InClusterEndpoint: inClusterEndpoint,
@@ -246,6 +255,7 @@ func (c *Client) ShowInfrastructure(ctx context.Context, provider cloudprovider.
 		InitSecret:        []byte(secret),
 		UID:               uid,
 		Name:              name,
+		IPCidrNode:        cidrNodes,
 	}
 
 	switch provider {
@@ -259,15 +269,6 @@ func (c *Client) ShowInfrastructure(ctx context.Context, provider cloudprovider.
 			return state.Infrastructure{}, errors.New("invalid type in project output: not a string")
 		}
 
-		cidrNodesOutput, ok := tfState.Values.Outputs["ip_cidr_nodes"]
-		if !ok {
-			return state.Infrastructure{}, errors.New("no ip_cidr_nodes output found")
-		}
-		cidrNodes, ok := cidrNodesOutput.Value.(string)
-		if !ok {
-			return state.Infrastructure{}, errors.New("invalid type in ip_cidr_nodes output: not a string")
-		}
-
 		cidrPodsOutput, ok := tfState.Values.Outputs["ip_cidr_pods"]
 		if !ok {
 			return state.Infrastructure{}, errors.New("no ip_cidr_pods output found")
@@ -278,9 +279,8 @@ func (c *Client) ShowInfrastructure(ctx context.Context, provider cloudprovider.
 		}
 
 		res.GCP = &state.GCP{
-			ProjectID:  gcpProject,
-			IPCidrNode: cidrNodes,
-			IPCidrPod:  cidrPods,
+			ProjectID: gcpProject,
+			IPCidrPod: cidrPods,
 		}
 	case cloudprovider.Azure:
 		attestationURLOutput, ok := tfState.Values.Outputs["attestationURL"]

--- a/cli/internal/terraform/terraform/aws/main.tf
+++ b/cli/internal/terraform/terraform/aws/main.tf
@@ -17,10 +17,11 @@ provider "aws" {
 }
 
 locals {
-  uid              = random_id.uid.hex
-  name             = "${var.name}-${local.uid}"
-  initSecretHash   = random_password.initSecret.bcrypt_hash
-  ports_node_range = "30000-32767"
+  uid                   = random_id.uid.hex
+  name                  = "${var.name}-${local.uid}"
+  initSecretHash        = random_password.initSecret.bcrypt_hash
+  cidr_vpc_subnet_nodes = "192.168.176.0/20"
+  ports_node_range      = "30000-32767"
   load_balancer_ports = flatten([
     { name = "kubernetes", port = "6443", health_check = "HTTPS" },
     { name = "bootstrapper", port = "9000", health_check = "TCP" },
@@ -75,7 +76,7 @@ module "public_private_subnet" {
   source                   = "./modules/public_private_subnet"
   name                     = local.name
   vpc_id                   = aws_vpc.vpc.id
-  cidr_vpc_subnet_nodes    = "192.168.176.0/20"
+  cidr_vpc_subnet_nodes    = local.cidr_vpc_subnet_nodes
   cidr_vpc_subnet_internet = "192.168.0.0/20"
   zone                     = var.zone
   zones                    = local.zones

--- a/cli/internal/terraform/terraform/aws/outputs.tf
+++ b/cli/internal/terraform/terraform/aws/outputs.tf
@@ -31,3 +31,7 @@ output "initSecret" {
 output "name" {
   value = local.name
 }
+
+output "ip_cidr_nodes" {
+  value = local.cidr_vpc_subnet_nodes
+}

--- a/cli/internal/terraform/terraform/azure/main.tf
+++ b/cli/internal/terraform/terraform/azure/main.tf
@@ -28,7 +28,6 @@ locals {
   }
   ports_node_range      = "30000-32767"
   cidr_vpc_subnet_nodes = "192.168.178.0/24"
-  cidr_vpc_subnet_pods  = "10.10.0.0/16"
   ports = flatten([
     { name = "kubernetes", port = "6443", health_check_protocol = "Https", path = "/readyz", priority = 100 },
     { name = "bootstrapper", port = "9000", health_check_protocol = "Tcp", path = null, priority = 101 },

--- a/cli/internal/terraform/terraform/azure/outputs.tf
+++ b/cli/internal/terraform/terraform/azure/outputs.tf
@@ -58,3 +58,7 @@ output "subscription_id" {
 output "name" {
   value = local.name
 }
+
+output "ip_cidr_nodes" {
+  value = local.cidr_vpc_subnet_nodes
+}

--- a/cli/internal/terraform/terraform/openstack/outputs.tf
+++ b/cli/internal/terraform/terraform/openstack/outputs.tf
@@ -22,3 +22,7 @@ output "initSecret" {
 output "name" {
   value = local.name
 }
+
+output "ip_cidr_nodes" {
+  value = local.cidr_vpc_subnet_nodes
+}

--- a/cli/internal/terraform/terraform/qemu/main.tf
+++ b/cli/internal/terraform/terraform/qemu/main.tf
@@ -19,6 +19,12 @@ provider "docker" {
   host = "unix:///var/run/docker.sock"
 }
 
+locals {
+  cidr_vpc_subnet_nodes          = "10.42.0.0/22"
+  cidr_vpc_subnet_control_planes = "10.42.1.0/24"
+  cidr_vpc_subnet_worker         = "10.42.2.0/24"
+}
+
 resource "random_password" "initSecret" {
   length           = 32
   special          = true
@@ -61,7 +67,7 @@ module "node_group" {
   vcpus            = each.value.vcpus
   memory           = each.value.memory
   machine          = var.machine
-  cidr             = each.value.role == "control-plane" ? "10.42.1.0/24" : "10.42.2.0/24"
+  cidr             = each.value.role == "control-plane" ? local.cidr_vpc_subnet_control_planes : local.cidr_vpc_subnet_worker
   network_id       = libvirt_network.constellation.id
   pool             = libvirt_pool.cluster.name
   boot_mode        = var.constellation_boot_mode

--- a/cli/internal/terraform/terraform/qemu/outputs.tf
+++ b/cli/internal/terraform/terraform/qemu/outputs.tf
@@ -46,3 +46,7 @@ output "validate_constellation_cmdline" {
 output "name" {
   value = "${var.name}-qemu" // placeholder, as per "uid" output
 }
+
+output "ip_cidr_nodes" {
+  value = local.cidr_vpc_subnet_nodes
+}

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -230,6 +230,9 @@ func TestCreateCluster(t *testing.T) {
 					"name": {
 						Value: "constell-12345abc",
 					},
+					"ip_cidr_nodes": {
+						Value: "192.0.2.103/32",
+					},
 				},
 			},
 		}
@@ -274,6 +277,9 @@ func TestCreateCluster(t *testing.T) {
 					},
 					"name": {
 						Value: "constell-12345abc",
+					},
+					"ip_cidr_nodes": {
+						Value: "192.0.2.103/32",
 					},
 				},
 			},
@@ -487,6 +493,7 @@ func TestCreateCluster(t *testing.T) {
 			assert.Equal(state.HexBytes("initSecret"), infraState.InitSecret)
 			assert.Equal("12345abc", infraState.UID)
 			assert.Equal("192.0.2.101", infraState.InClusterEndpoint)
+			assert.Equal("192.0.2.103/32", infraState.IPCidrNode)
 			if tc.provider == cloudprovider.Azure {
 				assert.Equal(tc.expectedAttestationURL, infraState.Azure.AttestationURL)
 			}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We need to expose the node CIDR of the Constellation so that we can use the value later (in https://github.com/edgelesssys/constellation/pull/2462) as a strict CIDR in the Cilium helm values.


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Always output the node CIDR and write into our state file

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
Upgrade test gcp: https://github.com/edgelesssys/constellation/actions/runs/6576667618

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
