### PR TITLE
cli: add `constellation apply` command to replace `init` and `upgrade apply`

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -147,7 +147,11 @@ runs:
       id: constellation-init
       shell: bash
       run: |
-        constellation init --debug
+        cmd=apply
+        if constellation --help | grep -q init; then
+          cmd=init
+        fi
+        constellation $cmd --force --debug
         echo "KUBECONFIG=$(pwd)/constellation-admin.conf" | tee -a $GITHUB_OUTPUT
 
     - name: Wait for nodes to join and become ready

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -147,11 +147,12 @@ runs:
       id: constellation-init
       shell: bash
       run: |
+        # TODO(v2.14): Remove workaround for CLIs not supporting apply command
         cmd=apply
         if constellation --help | grep -q init; then
           cmd=init
         fi
-        constellation $cmd --force --debug
+        constellation $cmd --debug
         echo "KUBECONFIG=$(pwd)/constellation-admin.conf" | tee -a $GITHUB_OUTPUT
 
     - name: Wait for nodes to join and become ready

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Initialize cluster
         shell: pwsh
         run: |
-          .\constellation.exe init --debug
+          .\constellation.exe apply --debug
 
       - name: Liveness probe
         shell: pwsh

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -49,10 +49,9 @@ func NewRootCmd() *cobra.Command {
 
 	must(rootCmd.MarkPersistentFlagDirname("workspace"))
 
-	rootCmd.AddCommand(cmd.NewApplyCmd())
 	rootCmd.AddCommand(cmd.NewConfigCmd())
 	rootCmd.AddCommand(cmd.NewCreateCmd())
-	rootCmd.AddCommand(cmd.NewInitCmd())
+	rootCmd.AddCommand(cmd.NewApplyCmd())
 	rootCmd.AddCommand(cmd.NewMiniCmd())
 	rootCmd.AddCommand(cmd.NewStatusCmd())
 	rootCmd.AddCommand(cmd.NewVerifyCmd())
@@ -61,6 +60,7 @@ func NewRootCmd() *cobra.Command {
 	rootCmd.AddCommand(cmd.NewTerminateCmd())
 	rootCmd.AddCommand(cmd.NewIAMCmd())
 	rootCmd.AddCommand(cmd.NewVersionCmd())
+	rootCmd.AddCommand(cmd.NewInitCmd())
 
 	return rootCmd
 }

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -49,6 +49,7 @@ func NewRootCmd() *cobra.Command {
 
 	must(rootCmd.MarkPersistentFlagDirname("workspace"))
 
+	rootCmd.AddCommand(cmd.NewApplyCmd())
 	rootCmd.AddCommand(cmd.NewConfigCmd())
 	rootCmd.AddCommand(cmd.NewCreateCmd())
 	rootCmd.AddCommand(cmd.NewInitCmd())

--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -45,7 +45,7 @@ func NewApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "apply",
 		Short: "Apply a configuration to a Constellation cluster",
-		Long:  "Apply an upgrade to a Constellation cluster by applying the chosen configuration.",
+		Long:  "Apply a configuration to a Constellation cluster to initialize or upgrade the cluster.",
 		Args:  cobra.NoArgs,
 		RunE:  runApply,
 	}

--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -40,6 +40,32 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
+// NewApplyCmd creates the apply command.
+func NewApplyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "apply",
+		Short: "Apply a configuration to a Constellation cluster",
+		Long:  "Apply an upgrade to a Constellation cluster by applying the chosen configuration.",
+		Args:  cobra.NoArgs,
+		RunE:  runApply,
+	}
+
+	cmd.Flags().Bool("conformance", false, "enable conformance mode")
+	cmd.Flags().Bool("skip-helm-wait", false, "install helm charts without waiting for deployments to be ready")
+	cmd.Flags().Bool("merge-kubeconfig", false, "merge Constellation kubeconfig file with default kubeconfig file in $HOME/.kube/config")
+	cmd.Flags().BoolP("yes", "y", false, "run upgrades without further confirmation\n"+
+		"WARNING: might delete your resources in case you are using cert-manager in your cluster. Please read the docs.\n"+
+		"WARNING: might unintentionally overwrite measurements in the running cluster.")
+	cmd.Flags().Duration("timeout", 5*time.Minute, "change helm upgrade timeout\n"+
+		"Might be useful for slow connections or big clusters.")
+	cmd.Flags().StringSlice("skip-phases", nil, "comma-separated list of upgrade phases to skip\n"+
+		"one or multiple of { infrastructure | helm | image | k8s }")
+
+	must(cmd.Flags().MarkHidden("timeout"))
+
+	return cmd
+}
+
 // applyFlags defines the flags for the apply command.
 type applyFlags struct {
 	rootFlags

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/helm"
 	"github.com/edgelesssys/constellation/v2/internal/file"
@@ -22,19 +23,13 @@ import (
 
 func TestParseApplyFlags(t *testing.T) {
 	require := require.New(t)
-	// TODO: Use flags := applyCmd().Flags() once we have a separate apply command
 	defaultFlags := func() *pflag.FlagSet {
-		flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		flags := NewApplyCmd().Flags()
+		// Register persistent flags
 		flags.String("workspace", "", "")
 		flags.String("tf-log", "NONE", "")
 		flags.Bool("force", false, "")
 		flags.Bool("debug", false, "")
-		flags.Bool("merge-kubeconfig", false, "")
-		flags.Bool("conformance", false, "")
-		flags.Bool("skip-helm-wait", false, "")
-		flags.Bool("yes", false, "")
-		flags.StringSlice("skip-phases", []string{}, "")
-		flags.Duration("timeout", 0, "")
 		return flags
 	}
 
@@ -46,7 +41,8 @@ func TestParseApplyFlags(t *testing.T) {
 		"default flags": {
 			flags: defaultFlags(),
 			wantFlags: applyFlags{
-				helmWaitMode: helm.WaitModeAtomic,
+				helmWaitMode:   helm.WaitModeAtomic,
+				upgradeTimeout: 5 * time.Minute,
 			},
 		},
 		"skip phases": {
@@ -56,8 +52,9 @@ func TestParseApplyFlags(t *testing.T) {
 				return flags
 			}(),
 			wantFlags: applyFlags{
-				skipPhases:   skipPhases{skipHelmPhase: struct{}{}, skipK8sPhase: struct{}{}},
-				helmWaitMode: helm.WaitModeAtomic,
+				skipPhases:     skipPhases{skipHelmPhase: struct{}{}, skipK8sPhase: struct{}{}},
+				helmWaitMode:   helm.WaitModeAtomic,
+				upgradeTimeout: 5 * time.Minute,
 			},
 		},
 		"skip helm wait": {
@@ -67,7 +64,8 @@ func TestParseApplyFlags(t *testing.T) {
 				return flags
 			}(),
 			wantFlags: applyFlags{
-				helmWaitMode: helm.WaitModeNone,
+				helmWaitMode:   helm.WaitModeNone,
+				upgradeTimeout: 5 * time.Minute,
 			},
 		},
 	}

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -49,6 +49,7 @@ func NewInitCmd() *cobra.Command {
 			cmd.Flags().Duration("timeout", time.Hour, "")
 			return runApply(cmd, args)
 		},
+		Deprecated: "use 'constellation apply' instead.",
 	}
 	cmd.Flags().Bool("conformance", false, "enable conformance mode")
 	cmd.Flags().Bool("skip-helm-wait", false, "install helm charts without waiting for deployments to be ready")

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -51,6 +51,7 @@ func newUpgradeApplyCmd() *cobra.Command {
 			cmd.Flags().Bool("merge-kubeconfig", false, "")
 			return runApply(cmd, args)
 		},
+		Deprecated: "use 'constellation apply' instead.",
 	}
 
 	cmd.Flags().BoolP("yes", "y", false, "run upgrades without further confirmation\n"+

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"github.com/edgelesssys/constellation/v2/cli/internal/state"
@@ -23,22 +22,6 @@ import (
 	"gopkg.in/yaml.v3"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
-
-const (
-	// skipInitPhase skips the init RPC of the apply process.
-	skipInitPhase skipPhase = "init"
-	// skipInfrastructurePhase skips the terraform apply of the upgrade process.
-	skipInfrastructurePhase skipPhase = "infrastructure"
-	// skipHelmPhase skips the helm upgrade of the upgrade process.
-	skipHelmPhase skipPhase = "helm"
-	// skipImagePhase skips the image upgrade of the upgrade process.
-	skipImagePhase skipPhase = "image"
-	// skipK8sPhase skips the k8s upgrade of the upgrade process.
-	skipK8sPhase skipPhase = "k8s"
-)
-
-// skipPhase is a phase of the upgrade process that can be skipped.
-type skipPhase string
 
 func newUpgradeApplyCmd() *cobra.Command {
 	cmd := &cobra.Command{
@@ -80,25 +63,6 @@ func diffAttestationCfg(currentAttestationCfg config.AttestationCfg, newAttestat
 	}
 	diff := string(diff.Diff("current", currentYml, "new", newYml))
 	return diff, nil
-}
-
-// skipPhases is a list of phases that can be skipped during the upgrade process.
-type skipPhases map[skipPhase]struct{}
-
-// contains returns true if the list of phases contains the given phase.
-func (s skipPhases) contains(phase skipPhase) bool {
-	_, ok := s[skipPhase(strings.ToLower(string(phase)))]
-	return ok
-}
-
-// add a phase to the list of phases.
-func (s *skipPhases) add(phases ...skipPhase) {
-	if *s == nil {
-		*s = make(skipPhases)
-	}
-	for _, phase := range phases {
-		(*s)[skipPhase(strings.ToLower(string(phase)))] = struct{}{}
-	}
 }
 
 type kubernetesUpgrader interface {

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -11,6 +11,7 @@ constellation [command]
 ```
 Commands:
 
+* [apply](#constellation-apply): Apply a configuration to a Constellation cluster
 * [config](#constellation-config): Work with the Constellation configuration file
   * [generate](#constellation-config-generate): Generate a default configuration and state file
   * [fetch-measurements](#constellation-config-fetch-measurements): Fetch measurements for configured cloud provider and image
@@ -38,6 +39,41 @@ Commands:
   * [upgrade](#constellation-iam-upgrade): Find and apply upgrades to your IAM profile
     * [apply](#constellation-iam-upgrade-apply): Apply an upgrade to an IAM profile
 * [version](#constellation-version): Display version of this CLI
+
+## constellation apply
+
+Apply a configuration to a Constellation cluster
+
+### Synopsis
+
+Apply an upgrade to a Constellation cluster by applying the chosen configuration.
+
+```
+constellation apply [flags]
+```
+
+### Options
+
+```
+      --conformance           enable conformance mode
+  -h, --help                  help for apply
+      --merge-kubeconfig      merge Constellation kubeconfig file with default kubeconfig file in $HOME/.kube/config
+      --skip-helm-wait        install helm charts without waiting for deployments to be ready
+      --skip-phases strings   comma-separated list of upgrade phases to skip
+                              one or multiple of { infrastructure | helm | image | k8s }
+  -y, --yes                   run upgrades without further confirmation
+                              WARNING: might delete your resources in case you are using cert-manager in your cluster. Please read the docs.
+                              WARNING: might unintentionally overwrite measurements in the running cluster.
+```
+
+### Options inherited from parent commands
+
+```
+      --debug              enable debug logging
+      --force              disable version compatibility checks - might result in corrupted clusters
+      --tf-log string      Terraform log level (default "NONE")
+  -C, --workspace string   path to the Constellation workspace
+```
 
 ## constellation config
 

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -46,7 +46,7 @@ Apply a configuration to a Constellation cluster
 
 ### Synopsis
 
-Apply an upgrade to a Constellation cluster by applying the chosen configuration.
+Apply a configuration to a Constellation cluster to initialize or upgrade the cluster.
 
 ```
 constellation apply [flags]
@@ -60,10 +60,10 @@ constellation apply [flags]
       --merge-kubeconfig      merge Constellation kubeconfig file with default kubeconfig file in $HOME/.kube/config
       --skip-helm-wait        install helm charts without waiting for deployments to be ready
       --skip-phases strings   comma-separated list of upgrade phases to skip
-                              one or multiple of { infrastructure | helm | image | k8s }
-  -y, --yes                   run upgrades without further confirmation
-                              WARNING: might delete your resources in case you are using cert-manager in your cluster. Please read the docs.
-                              WARNING: might unintentionally overwrite measurements in the running cluster.
+                              one or multiple of { infrastructure | init | attestationconfig | certsans | helm | image | k8s }
+  -y, --yes                   run command without further confirmation
+                              WARNING: the command might delete or update existing resources without additional checks. Please read the docs.
+                              
 ```
 
 ### Options inherited from parent commands

--- a/docs/docs/reference/cli.md
+++ b/docs/docs/reference/cli.md
@@ -11,7 +11,6 @@ constellation [command]
 ```
 Commands:
 
-* [apply](#constellation-apply): Apply a configuration to a Constellation cluster
 * [config](#constellation-config): Work with the Constellation configuration file
   * [generate](#constellation-config-generate): Generate a default configuration and state file
   * [fetch-measurements](#constellation-config-fetch-measurements): Fetch measurements for configured cloud provider and image
@@ -19,7 +18,7 @@ Commands:
   * [kubernetes-versions](#constellation-config-kubernetes-versions): Print the Kubernetes versions supported by this CLI
   * [migrate](#constellation-config-migrate): Migrate a configuration file to a new version
 * [create](#constellation-create): Create instances on a cloud platform for your Constellation cluster
-* [init](#constellation-init): Initialize the Constellation cluster
+* [apply](#constellation-apply): Apply a configuration to a Constellation cluster
 * [mini](#constellation-mini): Manage MiniConstellation clusters
   * [up](#constellation-mini-up): Create and initialize a new MiniConstellation cluster
   * [down](#constellation-mini-down): Destroy a MiniConstellation cluster
@@ -39,41 +38,7 @@ Commands:
   * [upgrade](#constellation-iam-upgrade): Find and apply upgrades to your IAM profile
     * [apply](#constellation-iam-upgrade-apply): Apply an upgrade to an IAM profile
 * [version](#constellation-version): Display version of this CLI
-
-## constellation apply
-
-Apply a configuration to a Constellation cluster
-
-### Synopsis
-
-Apply a configuration to a Constellation cluster to initialize or upgrade the cluster.
-
-```
-constellation apply [flags]
-```
-
-### Options
-
-```
-      --conformance           enable conformance mode
-  -h, --help                  help for apply
-      --merge-kubeconfig      merge Constellation kubeconfig file with default kubeconfig file in $HOME/.kube/config
-      --skip-helm-wait        install helm charts without waiting for deployments to be ready
-      --skip-phases strings   comma-separated list of upgrade phases to skip
-                              one or multiple of { infrastructure | init | attestationconfig | certsans | helm | image | k8s }
-  -y, --yes                   run command without further confirmation
-                              WARNING: the command might delete or update existing resources without additional checks. Please read the docs.
-                              
-```
-
-### Options inherited from parent commands
-
-```
-      --debug              enable debug logging
-      --force              disable version compatibility checks - might result in corrupted clusters
-      --tf-log string      Terraform log level (default "NONE")
-  -C, --workspace string   path to the Constellation workspace
-```
+* [init](#constellation-init): Initialize the Constellation cluster
 
 ## constellation config
 
@@ -267,27 +232,30 @@ constellation create [flags]
   -C, --workspace string   path to the Constellation workspace
 ```
 
-## constellation init
+## constellation apply
 
-Initialize the Constellation cluster
+Apply a configuration to a Constellation cluster
 
 ### Synopsis
 
-Initialize the Constellation cluster.
-
-Start your confidential Kubernetes.
+Apply a configuration to a Constellation cluster to initialize or upgrade the cluster.
 
 ```
-constellation init [flags]
+constellation apply [flags]
 ```
 
 ### Options
 
 ```
-      --conformance        enable conformance mode
-  -h, --help               help for init
-      --merge-kubeconfig   merge Constellation kubeconfig file with default kubeconfig file in $HOME/.kube/config
-      --skip-helm-wait     install helm charts without waiting for deployments to be ready
+      --conformance           enable conformance mode
+  -h, --help                  help for apply
+      --merge-kubeconfig      merge Constellation kubeconfig file with default kubeconfig file in $HOME/.kube/config
+      --skip-helm-wait        install helm charts without waiting for deployments to be ready
+      --skip-phases strings   comma-separated list of upgrade phases to skip
+                              one or multiple of { infrastructure | init | attestationconfig | certsans | helm | image | k8s }
+  -y, --yes                   run command without further confirmation
+                              WARNING: the command might delete or update existing resources without additional checks. Please read the docs.
+                              
 ```
 
 ### Options inherited from parent commands
@@ -829,6 +797,38 @@ constellation version [flags]
 
 ```
   -h, --help   help for version
+```
+
+### Options inherited from parent commands
+
+```
+      --debug              enable debug logging
+      --force              disable version compatibility checks - might result in corrupted clusters
+      --tf-log string      Terraform log level (default "NONE")
+  -C, --workspace string   path to the Constellation workspace
+```
+
+## constellation init
+
+Initialize the Constellation cluster
+
+### Synopsis
+
+Initialize the Constellation cluster.
+
+Start your confidential Kubernetes.
+
+```
+constellation init [flags]
+```
+
+### Options
+
+```
+      --conformance        enable conformance mode
+  -h, --help               help for init
+      --merge-kubeconfig   merge Constellation kubeconfig file with default kubeconfig file in $HOME/.kube/config
+      --skip-helm-wait     install helm charts without waiting for deployments to be ready
 ```
 
 ### Options inherited from parent commands

--- a/e2e/internal/upgrade/upgrade_test.go
+++ b/e2e/internal/upgrade/upgrade_test.go
@@ -343,7 +343,7 @@ func runUpgradeApply(require *require.Assertions, cli string) {
 		tfLogFlag = "--tf-log=DEBUG"
 	}
 
-	cmd = exec.CommandContext(context.Background(), cli, "upgrade", "apply", "--debug", "--yes", tfLogFlag)
+	cmd = exec.CommandContext(context.Background(), cli, "apply", "--debug", "--yes", tfLogFlag)
 	stdout, stderr, err = runCommandWithSeparateOutputs(cmd)
 	require.NoError(err, "Stdout: %s\nStderr: %s", string(stdout), string(stderr))
 	require.NoError(containsUnexepectedMsg(string(stdout)))


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
https://github.com/edgelesssys/constellation/pull/2449 replaces the backend code for `init` and `upgrade apply` with one common implementation.
This PR adds a new command to replace both `init` and `upgrade apply` with a single command.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add `constellation apply` command
- Mark `constellation init` and `constellation upgrade apply` as deprecated
- Use `constellation apply` in CI

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3494](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3494)
- [GCP e2e test](https://github.com/edgelesssys/constellation/actions/runs/6584992230)
- [e2e upgrade test](https://github.com/edgelesssys/constellation/actions/runs/6585561665)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
  - See [AB#3499](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/3499)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
