### PR TITLE
cli: set image version in tests to stamped binary version

### DIFF
--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -577,7 +577,7 @@ func TestAttestation(t *testing.T) {
 	require.NoError(existingStateFile.WriteToFile(fileHandler, constants.StateFilename))
 
 	cfg := config.Default()
-	cfg.Image = "v0.0.0" // is the default version of the the CLI (before build injects the real version)
+	cfg.Image = constants.BinaryVersion().String()
 	cfg.RemoveProviderAndAttestationExcept(cloudprovider.QEMU)
 	cfg.Attestation.QEMUVTPM.Measurements[0] = measurements.WithAllBytes(0x00, measurements.Enforce, measurements.PCRMeasurementLength)
 	cfg.Attestation.QEMUVTPM.Measurements[1] = measurements.WithAllBytes(0x11, measurements.Enforce, measurements.PCRMeasurementLength)
@@ -611,6 +611,9 @@ func TestAttestation(t *testing.T) {
 	assert.Error(err)
 	// make sure the error is actually a TLS handshake error
 	assert.Contains(err.Error(), "transport: authentication handshake failed")
+	if validationErr, ok := err.(*config.ValidationError); ok {
+		t.Log(validationErr.LongMessage())
+	}
 }
 
 type testValidator struct {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

The image version is compared to the cli version. The cli version is set during link time (depending on build settings it is either "v0.0.0", a release version (like "v2.12.0") or a pseudo version (like "v2.13.0-pre.0.20231020081051-5cd70ac58aa1"). We just set the image version in this test to the same variable to ensure it is stamped to the same value to pass validation.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- cli: set image version in tests to stamped binary version

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
