### PR TITLE
nix: flake update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,17 +20,17 @@
     },
     "nixpkgsUnstable": {
       "locked": {
-        "lastModified": 1696261572,
-        "narHash": "sha256-s8TtSYJ1LBpuITXjbPLUPyxzAKw35LhETcajJjCS5f0=",
+        "lastModified": 1697808392,
+        "narHash": "sha256-hHIWoHctiLmH9al5mU58lw5tMuaGerei/rUyJjVc+3o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c7ffbc66e6d78c50c38e717ec91a2a14e0622fb",
+        "rev": "9ef2c8ddff172378496b118f709bfe81280a7e58",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
+        "rev": "9ef2c8ddff172378496b118f709bfe81280a7e58",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,8 @@
 
   inputs = {
     nixpkgsUnstable = {
-      url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+      # TODO(malt3): use github:NixOS/nixpkgs/nixpkgs-unstable after repart fix is upstreamed
+      url = "github:NixOS/nixpkgs/9ef2c8ddff172378496b118f709bfe81280a7e58";
     };
     flake-utils = {
       url = "github:numtide/flake-utils";


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Upstream (in systemd-repart) reproducibility issues were fixed[^1][^2].
We update nixpkgs to use a patched version of systemd-repart.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- nix: flake update

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info

On my test systems, images are now fully reproducible.
As a reviewer, you can test this using the following steps:

```
git pull
git checkout deps/nix/flake-update
git rev-parse HEAD # should return 9ca2bf574d5105b4c61015d6417d02df9cd62b0c
bazel build //image/system:qemu_qemu-vtpm_stable
sha256sum bazel-bin/image/system/qemu_qemu-vtpm_stable/constellation.raw
# should return the hash 6ffdc5043572f5ad3909b9feba913335cfe157c6bac747bac4445069a357db07
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone

[^1]: [systemd-repart hardlink store leaks into generated OS images](https://github.com/systemd/systemd/commit/6bbb893b90e2dcb05fb310ba4608f9c9dc587845)
[^2]: [systemd-repart vfat partitions use timestamps in local timezone of the host](https://github.com/systemd/systemd/commit/972bd5d18ae22cf392bb5a7c205af8ab2633a696)