### PR TITLE
cli: remove unnecessary check from QEMU rollbacker

### DIFF
--- a/cli/internal/cloudcmd/create.go
+++ b/cli/internal/cloudcmd/create.go
@@ -232,7 +232,7 @@ type qemuCreateOptions struct {
 }
 
 func (c *Creator) createQEMU(ctx context.Context, cl tfResourceClient, lv libvirtRunner, opts qemuCreateOptions) (tfOutput state.Infrastructure, retErr error) {
-	qemuRollbacker := &rollbackerQEMU{client: cl, libvirt: lv, createdWorkspace: false}
+	qemuRollbacker := &rollbackerQEMU{client: cl, libvirt: lv}
 	defer rollbackOnError(c.out, &retErr, qemuRollbacker, opts.TFLogLevel)
 
 	// TODO(malt3): render progress bar
@@ -287,9 +287,6 @@ func (c *Creator) createQEMU(ctx context.Context, cl tfResourceClient, lv libvir
 	if err := cl.PrepareWorkspace(path.Join("terraform", strings.ToLower(cloudprovider.QEMU.String())), vars); err != nil {
 		return state.Infrastructure{}, fmt.Errorf("prepare workspace: %w", err)
 	}
-
-	// Allow rollback of QEMU Terraform workspace from this point on
-	qemuRollbacker.createdWorkspace = true
 
 	tfOutput, err = cl.ApplyCluster(ctx, opts.Provider, opts.TFLogLevel)
 	if err != nil {

--- a/cli/internal/cloudcmd/rollback_test.go
+++ b/cli/internal/cloudcmd/rollback_test.go
@@ -70,16 +70,14 @@ func TestRollbackQEMU(t *testing.T) {
 	someErr := errors.New("failed")
 
 	testCases := map[string]struct {
-		libvirt          *stubLibvirtRunner
-		tfClient         *stubTerraformClient
-		createdWorkspace bool
-		wantDestroyErr   bool
-		wantErr          bool
+		libvirt        *stubLibvirtRunner
+		tfClient       *stubTerraformClient
+		wantDestroyErr bool
+		wantErr        bool
 	}{
 		"success": {
-			libvirt:          &stubLibvirtRunner{},
-			tfClient:         &stubTerraformClient{},
-			createdWorkspace: true,
+			libvirt:  &stubLibvirtRunner{},
+			tfClient: &stubTerraformClient{},
 		},
 		"stop libvirt error": {
 			libvirt:  &stubLibvirtRunner{stopErr: someErr},
@@ -103,9 +101,8 @@ func TestRollbackQEMU(t *testing.T) {
 			assert := assert.New(t)
 
 			rollbacker := &rollbackerQEMU{
-				libvirt:          tc.libvirt,
-				client:           tc.tfClient,
-				createdWorkspace: tc.createdWorkspace,
+				libvirt: tc.libvirt,
+				client:  tc.tfClient,
 			}
 
 			destroyClusterErrOutput := &bytes.Buffer{}
@@ -125,11 +122,7 @@ func TestRollbackQEMU(t *testing.T) {
 			}
 			assert.NoError(err)
 			assert.True(tc.libvirt.stopCalled)
-			if tc.createdWorkspace {
-				assert.True(tc.tfClient.destroyCalled)
-			} else {
-				assert.False(tc.tfClient.destroyCalled)
-			}
+			assert.True(tc.tfClient.destroyCalled)
 			assert.True(tc.tfClient.cleanUpWorkspaceCalled)
 		})
 	}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Terraform does not care if `destroy` is called on an empty directory.
In that case it simply returns `nil`, so we can skip the extra check during `cloudcmd.Create`.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove unnecessary rollback destroy guards form QEMU rollbacker

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- Setup work for [AB#3288](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3288)
