### PR TITLE
cli: increase kubecmd retry limit

### DIFF
--- a/cli/internal/kubecmd/kubecmd.go
+++ b/cli/internal/kubecmd/kubecmd.go
@@ -52,7 +52,7 @@ import (
 )
 
 const (
-	maxRetryAttempts = 5
+	maxRetryAttempts = 20
 )
 
 // ErrInProgress signals that an upgrade is in progress inside the cluster.
@@ -231,7 +231,7 @@ func (k *KubeCmd) ApplyJoinConfig(ctx context.Context, newAttestConfig config.At
 		}
 		retries++
 		k.log.Debugf("Getting join-config ConfigMap failed (attempt %d/%d): %s", retries, maxRetryAttempts, err)
-		return retries <= maxRetryAttempts
+		return retries < maxRetryAttempts
 	}
 
 	var joinConfig *corev1.ConfigMap
@@ -488,7 +488,7 @@ func retryAction(ctx context.Context, retryInterval time.Duration, maxRetries in
 	retrier := conretry.NewIntervalRetrier(&kubeDoer{action: action}, retryInterval, func(err error) bool {
 		ctr++
 		log.Debugf("Action failed (attempt %d/%d): %s", ctr, maxRetries, err)
-		return ctr <= maxRetries
+		return ctr < maxRetries
 	})
 	return retrier.Do(ctx)
 }

--- a/cli/internal/kubecmd/kubecmd_test.go
+++ b/cli/internal/kubecmd/kubecmd_test.go
@@ -484,7 +484,7 @@ func TestApplyJoinConfig(t *testing.T) {
 	// be updated here
 	repeatedErrors := func(err error) []error {
 		var errs []error
-		for i := 0; i < 20; i++ {
+		for i := 0; i < 30; i++ {
 			errs = append(errs, err)
 		}
 		return errs


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
When initializing or upgrading a cluster we check if an an attestation config already exists.
For that we try to fetch it from the Kubernetes API with a retry limit.
On AWS we sometimes hit that limit after just creating the cluster.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Increase retry limit from 5 to 20
- Fix range to display correct log message for retries

### Related issue
- [e2e failure ticket](https://github.com/orgs/edgelesssys/projects/3?pane=issue&itemId=42248164)

