### PR TITLE
Revert "ci: execute unit tests and tidy check against merge of PR branch and main"

### DIFF
--- a/.github/workflows/test-tidy.yml
+++ b/.github/workflows/test-tidy.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
-          # ref is unset here intentionally to ensure we test against a merge of PR and main branch
+          ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
           # No token available for forks, so we can't push changes
           token: ${{ !github.event.pull_request.head.repo.fork && secrets.CI_COMMIT_PUSH_PR || '' }}
 

--- a/.github/workflows/test-unittest.yml
+++ b/.github/workflows/test-unittest.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
-          # ref is unset here intentionally to ensure we test against a merge of PR and main branch
+          ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
           fetch-depth: 0
 
       - name: Install AWS cli


### PR DESCRIPTION
Reverts edgelesssys/constellation#2452

This caused problems with the fix commits on renovate PRs. Reverting for now, needs revisit.