### PR TITLE
cli: fix apply flag issues

### DIFF
--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -568,8 +568,8 @@ func (a *applyCmd) runK8sUpgrade(cmd *cobra.Command, conf *config.Config, kubeUp
 ) error {
 	err := kubeUpgrader.UpgradeNodeVersion(
 		cmd.Context(), conf, a.flags.force,
-		a.flags.skipPhases.contains(skipK8sPhase),
 		a.flags.skipPhases.contains(skipImagePhase),
+		a.flags.skipPhases.contains(skipK8sPhase),
 	)
 
 	var upgradeErr *compatibility.InvalidUpgradeError

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -283,26 +283,6 @@ func TestUpgradeApply(t *testing.T) {
 	}
 }
 
-func TestUpgradeApplyFlagsForSkipPhases(t *testing.T) {
-	require := require.New(t)
-	cmd := newUpgradeApplyCmd()
-	// register persistent flags manually
-	cmd.Flags().String("workspace", "", "")
-	cmd.Flags().Bool("force", true, "")
-	cmd.Flags().String("tf-log", "NONE", "")
-	cmd.Flags().Bool("debug", false, "")
-	cmd.Flags().Bool("merge-kubeconfig", false, "")
-
-	require.NoError(cmd.Flags().Set("skip-phases", "infrastructure,helm,k8s,image"))
-	wantPhases := skipPhases{}
-	wantPhases.add(skipInfrastructurePhase, skipHelmPhase, skipK8sPhase, skipImagePhase)
-
-	var flags applyFlags
-	err := flags.parse(cmd.Flags())
-	require.NoError(err)
-	assert.Equal(t, wantPhases, flags.skipPhases)
-}
-
 type stubKubernetesUpgrader struct {
 	nodeVersionErr                 error
 	currentConfig                  config.AttestationCfg


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
K8s and image skip flags were in the wrong order.
Init, certSANs, and AttestationConfig flags were not parsed by the command.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Put flags in the correct order
- Parse missing flags


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
