### PR TITLE
image: use all of cilium's sysctl overrides

### DIFF
--- a/image/base/mkosi.skeleton/usr/lib/sysctl.d/10-cilium.conf
+++ b/image/base/mkosi.skeleton/usr/lib/sysctl.d/10-cilium.conf
@@ -1,3 +1,0 @@
-# See https://github.com/cilium/cilium/issues/10645
-net.ipv4.conf.lxc*.rp_filter = 0
-net.ipv4.conf.cilium_*.rp_filter = 0

--- a/image/base/mkosi.skeleton/usr/lib/sysctl.d/99-zzz-override_cilium.conf
+++ b/image/base/mkosi.skeleton/usr/lib/sysctl.d/99-zzz-override_cilium.conf
@@ -1,0 +1,8 @@
+# See https://github.com/cilium/cilium/issues/10645
+# and https://github.com/cilium/cilium/blame/898a632e3c3b64eaa0f23ebde5a069e87373c59b/tools/sysctlfix/main.go#L41
+# Disable rp_filter on Cilium interfaces since it may cause mangled packets to be dropped
+-net.ipv4.conf.lxc*.rp_filter = 0
+-net.ipv4.conf.cilium_*.rp_filter = 0
+# The kernel uses max(conf.all, conf.{dev}) as its value, so we need to set .all. to 0 as well.
+# Otherwise it will overrule the device specific settings.
+net.ipv4.conf.all.rp_filter = 0


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Move the overrides to the place where cilium would write them (if we didn't have a read-only fs)
- Use all of ciliums sysctl overrides

Note that this moves the config from before the `50-default...` files in the directory to after it. 

Image build: https://github.com/edgelesssys/constellation/actions/runs/6667663251

This change is required for cilium's node-to-node encryption.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- Any additional information or context

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
