### PR TITLE
cli: spinner for planning Terraform migrations

### DIFF
--- a/cli/internal/cmd/applyterraform.go
+++ b/cli/internal/cmd/applyterraform.go
@@ -71,7 +71,9 @@ func (a *applyCmd) planTerraformMigration(cmd *cobra.Command, conf *config.Confi
 	// 	  u.upgrader.AddManualStateMigration(migration)
 	// }
 
-	return a.clusterUpgrader.PlanClusterUpgrade(cmd.Context(), cmd.OutOrStdout(), vars, conf.GetProvider())
+	a.spinner.Start("Checking for infrastructure changes", false)
+	defer a.spinner.Stop()
+	return a.clusterUpgrader.PlanClusterUpgrade(cmd.Context(), a.spinner, vars, conf.GetProvider())
 }
 
 // migrateTerraform migrates an existing Terraform state and the post-migration infrastructure state is returned.

--- a/cli/internal/cmd/applyterraform.go
+++ b/cli/internal/cmd/applyterraform.go
@@ -77,7 +77,7 @@ func (a *applyCmd) planTerraformMigration(cmd *cobra.Command, conf *config.Confi
 // migrateTerraform migrates an existing Terraform state and the post-migration infrastructure state is returned.
 func (a *applyCmd) migrateTerraform(cmd *cobra.Command, conf *config.Config, upgradeDir string) (state.Infrastructure, error) {
 	// Ask for confirmation first
-	fmt.Fprintln(cmd.OutOrStdout(), "The upgrade requires a migration of Constellation cloud resources by applying an updated Terraform template. Please manually review the suggested changes below.")
+	cmd.Println("The upgrade requires a migration of Constellation cloud resources by applying an updated Terraform template.")
 	if !a.flags.yes {
 		ok, err := askToConfirm(cmd, "Do you want to apply the Terraform migrations?")
 		if err != nil {

--- a/cli/internal/terraform/terraform/azure/main.tf
+++ b/cli/internal/terraform/terraform/azure/main.tf
@@ -288,4 +288,3 @@ data "azurerm_user_assigned_identity" "uaid" {
   name                = local.uai_name
   resource_group_name = local.uai_resource_group
 }
-


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Planning the Terraform migrations takes a decent amount of time, locking the terminal with no feedback to the user.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a spinner to the planning of Terraform changes
- Remove the mention of "changes below" that are actually printed above the message

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
