### PR TITLE
hack: don't limit memory in Metricbeat daemonset

### DIFF
--- a/hack/logcollector/internal/templates/metricbeat/values-all-nodes.yml
+++ b/hack/logcollector/internal/templates/metricbeat/values-all-nodes.yml
@@ -39,7 +39,12 @@ daemonset:
           hostPath:
             path: /var/run/dbus
             type: ""
-
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "100Mi"
+      limits: null
+      
 clusterRoleRules:
   - apiGroups: [""]
     resources:

--- a/hack/logcollector/internal/templates/metricbeat/values-control-plane.yml
+++ b/hack/logcollector/internal/templates/metricbeat/values-control-plane.yml
@@ -48,7 +48,12 @@ daemonset:
         hostPath:
           path: /etc/kubernetes/pki/etcd
           type: ""
-
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "100Mi"
+      limits: null
+      
 clusterRoleRules:
   - apiGroups: [""]
     resources:


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We recently ran into OOM kills on the metricbeat deployment (since metricbeat seems to be quite memory-hungry), causing issues when updating a cluster with metricbeat deployed.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove the 200MiB default limit on the daemonset.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3508](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3508)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
