### PR TITLE
cli: only create Terraform client when needed

### DIFF
--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -277,7 +277,7 @@ func TestInitialize(t *testing.T) {
 						getClusterAttestationConfigErr: k8serrors.NewNotFound(schema.GroupResource{}, ""),
 					}, nil
 				},
-				clusterUpgrader: stubTerraformUpgrader{},
+				newClusterApplier: func(ctx context.Context) (clusterUpgrader, error) { return stubTerraformUpgrader{}, nil },
 			}
 
 			err := i.apply(cmd, stubAttestationFetcher{}, "test")

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -265,7 +265,7 @@ func TestUpgradeApply(t *testing.T) {
 				newKubeUpgrader: func(_ io.Writer, _ string, _ debugLog) (kubernetesUpgrader, error) {
 					return tc.kubeUpgrader, nil
 				},
-				clusterUpgrader: tc.terraformUpgrader,
+				newClusterApplier: func(ctx context.Context) (clusterUpgrader, error) { return tc.terraformUpgrader, nil },
 			}
 			err := upgrader.apply(cmd, stubAttestationFetcher{}, "test")
 			if tc.wantErr {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The apply command checks if a Terraform state exists in the current working directory, and if not, skips the Terraform phase.
However, during set up of the command, the directory is automatically created by `cloudcmd.NewClusterUpgrader`, meaning this check is always false, and we never skip the phase.
This causes problems with th self-managed infrastructure deployment when the phase is not manually skipped.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Create the Terraform client on demand when the phase is not skipped.


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
