### PR TITLE
ci: force delete files on self-managed destroy

### DIFF
--- a/.github/actions/constellation_destroy/action.yml
+++ b/.github/actions/constellation_destroy/action.yml
@@ -54,6 +54,6 @@ runs:
       run: |
         terraform init
         terraform destroy -auto-approve
-        # Explicitly delete the state file
-        rm ${{ github.workspace }}/constellation-state.yaml
-        rm ${{ github.workspace }}/constellation-admin.conf
+
+        rm -f ${{ github.workspace }}/constellation-state.yaml
+        rm -f ${{ github.workspace }}/constellation-admin.conf


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Self-managed `constellation_destroy` action fails if the state or the config file don't exist in the working directory.
Since the action should just be a NOP if no resources were created, we want to fix that

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- use `rm -f` to ignore non existent files on destroy

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->
