### PR TITLE
logging: convert logger package from zap to slog

### DIFF
--- a/bootstrapper/cmd/bootstrapper/main.go
+++ b/bootstrapper/cmd/bootstrapper/main.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"flag"
 	"io"
+	"log/slog"
 	"os"
 	"strconv"
 
@@ -47,12 +48,11 @@ func main() {
 	verbosity := flag.Int("v", 0, logger.CmdLineVerbosityDescription)
 	flag.Parse()
 	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity)).Named("bootstrapper")
-	defer log.Sync()
 
 	if *gRPCDebug {
 		log.Named("gRPC").ReplaceGRPCLogger()
 	} else {
-		log.Named("gRPC").WithIncreasedLevel(zap.WarnLevel).ReplaceGRPCLogger()
+		log.Named("gRPC").WithIncreasedLevel(slog.LevelWarn).ReplaceGRPCLogger()
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/bootstrapper/cmd/bootstrapper/main.go
+++ b/bootstrapper/cmd/bootstrapper/main.go
@@ -47,12 +47,12 @@ func main() {
 	gRPCDebug := flag.Bool("debug", false, "Enable gRPC debug logging")
 	verbosity := flag.Int("v", 0, logger.CmdLineVerbosityDescription)
 	flag.Parse()
-	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity)).Named("bootstrapper")
+	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity)).Grouped("bootstrapper")
 
 	if *gRPCDebug {
-		log.Named("gRPC").ReplaceGRPCLogger()
+		log.Grouped("gRPC").ReplaceGRPCLogger()
 	} else {
-		log.Named("gRPC").WithIncreasedLevel(slog.LevelWarn).ReplaceGRPCLogger()
+		log.Grouped("gRPC").WithIncreasedLevel(slog.LevelWarn).ReplaceGRPCLogger()
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/bootstrapper/internal/initserver/initserver.go
+++ b/bootstrapper/internal/initserver/initserver.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"strings"
 	"sync"
@@ -43,7 +44,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/nodestate"
 	"github.com/edgelesssys/constellation/v2/internal/role"
 	"github.com/edgelesssys/constellation/v2/internal/versions/components"
-	"go.uber.org/zap"
 	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -132,7 +132,7 @@ func (s *Server) Init(req *initproto.InitRequest, stream initproto.API_InitServe
 	s.shutdownLock.RLock()
 	defer s.shutdownLock.RUnlock()
 
-	log := s.log.With(zap.String("peer", grpclog.PeerAddrFromContext(stream.Context())))
+	log := s.log.With(slog.String("peer", grpclog.PeerAddrFromContext(stream.Context())))
 	log.Infof("Init called")
 
 	s.kmsURI = req.KmsUri

--- a/bootstrapper/internal/initserver/initserver.go
+++ b/bootstrapper/internal/initserver/initserver.go
@@ -77,7 +77,7 @@ type Server struct {
 
 // New creates a new initialization server.
 func New(ctx context.Context, lock locker, kube ClusterInitializer, issuer atls.Issuer, fh file.Handler, metadata MetadataAPI, log *logger.Logger) (*Server, error) {
-	log = log.Named("initServer")
+	log = log.Grouped("initServer")
 
 	initSecretHash, err := metadata.InitSecretHash(ctx)
 	if err != nil {
@@ -106,7 +106,7 @@ func New(ctx context.Context, lock locker, kube ClusterInitializer, issuer atls.
 	grpcServer := grpc.NewServer(
 		grpc.Creds(atlscredentials.New(issuer, nil)),
 		grpc.KeepaliveParams(keepalive.ServerParameters{Time: 15 * time.Second}),
-		log.Named("gRPC").GetServerUnaryInterceptor(),
+		log.Grouped("gRPC").GetServerUnaryInterceptor(),
 	)
 	initproto.RegisterAPIServer(grpcServer, server)
 

--- a/bootstrapper/internal/joinclient/joinclient.go
+++ b/bootstrapper/internal/joinclient/joinclient.go
@@ -93,7 +93,7 @@ func New(lock locker, dial grpcDialer, joiner ClusterJoiner, meta MetadataAPI, l
 		dialer:      dial,
 		joiner:      joiner,
 		metadataAPI: meta,
-		log:         log.Named("join-client"),
+		log:         log.Grouped("join-client"),
 	}
 }
 

--- a/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/k8sutil.go
@@ -13,6 +13,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -36,7 +37,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/installer"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/afero"
-	"go.uber.org/zap"
 )
 
 const (
@@ -169,11 +169,11 @@ func (k *KubernetesUtil) InitCluster(
 		}
 		return nil, fmt.Errorf("kubeadm init: %w", err)
 	}
-	log.With(zap.String("output", string(out))).Infof("kubeadm init succeeded")
+	log.With(slog.String("output", string(out))).Infof("kubeadm init succeeded")
 
 	userName := clusterName + "-admin"
 
-	log.With(zap.String("userName", userName)).Infof("Creating admin kubeconfig file")
+	log.With(slog.String("userName", userName)).Infof("Creating admin kubeconfig file")
 	cmd = exec.CommandContext(
 		ctx, constants.KubeadmPath, "kubeconfig", "user",
 		"--client-name", userName, "--config", initConfigFile.Name(), "--org", user.SystemPrivilegedGroup,
@@ -266,7 +266,7 @@ func (k *KubernetesUtil) WaitForCilium(ctx context.Context, log *logger.Logger) 
 			}
 			resp, err := client.Do(req)
 			if err != nil {
-				log.With(zap.Error(err)).Infof("Waiting for local Cilium DaemonSet - Pod not healthy yet")
+				log.With(slog.Any("error", err)).Infof("Waiting for local Cilium DaemonSet - Pod not healthy yet")
 				continue
 			}
 			resp.Body.Close()
@@ -359,7 +359,7 @@ func (k *KubernetesUtil) JoinCluster(ctx context.Context, joinConfig []byte, pee
 		}
 		return fmt.Errorf("kubeadm join: %w", err)
 	}
-	log.With(zap.String("output", string(out))).Infof("kubeadm join succeeded")
+	log.With(slog.String("output", string(out))).Infof("kubeadm join succeeded")
 
 	return nil
 }

--- a/cli/internal/cloudcmd/validators.go
+++ b/cli/internal/cloudcmd/validators.go
@@ -121,5 +121,4 @@ func (wl warnLogger) Warnf(fmtStr string, args ...any) {
 
 type debugLog interface {
 	Debugf(format string, args ...any)
-	Sync()
 }

--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -194,7 +194,6 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("creating logger: %w", err)
 	}
-	defer log.Sync()
 	spinner, err := newSpinnerOrStderr(cmd)
 	if err != nil {
 		return err

--- a/cli/internal/cmd/configfetchmeasurements.go
+++ b/cli/internal/cmd/configfetchmeasurements.go
@@ -84,7 +84,6 @@ func runConfigFetchMeasurements(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("creating logger: %w", err)
 	}
-	defer log.Sync()
 	fileHandler := file.NewHandler(afero.NewOsFs())
 	rekor, err := sigstore.NewRekor()
 	if err != nil {

--- a/cli/internal/cmd/configgenerate.go
+++ b/cli/internal/cmd/configgenerate.go
@@ -77,7 +77,6 @@ func runConfigGenerate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("creating logger: %w", err)
 	}
-	defer log.Sync()
 
 	fileHandler := file.NewHandler(afero.NewOsFs())
 	provider := cloudprovider.FromString(args[0])

--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -68,7 +68,6 @@ func runCreate(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("creating logger: %w", err)
 	}
-	defer log.Sync()
 	spinner, err := newSpinnerOrStderr(cmd)
 	if err != nil {
 		return fmt.Errorf("creating spinner: %w", err)

--- a/cli/internal/cmd/iamcreate.go
+++ b/cli/internal/cmd/iamcreate.go
@@ -82,7 +82,6 @@ func runIAMCreate(cmd *cobra.Command, providerCreator providerIAMCreator, provid
 	if err != nil {
 		return fmt.Errorf("creating logger: %w", err)
 	}
-	defer log.Sync()
 
 	iamCreator := &iamCreator{
 		cmd:             cmd,

--- a/cli/internal/cmd/iamdestroy.go
+++ b/cli/internal/cmd/iamdestroy.go
@@ -58,7 +58,6 @@ func runIAMDestroy(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("creating logger: %w", err)
 	}
-	defer log.Sync()
 	spinner := newSpinner(cmd.ErrOrStderr())
 	destroyer := cloudcmd.NewIAMDestroyer()
 	fsHandler := file.NewHandler(afero.NewOsFs())

--- a/cli/internal/cmd/log.go
+++ b/cli/internal/cmd/log.go
@@ -7,24 +7,24 @@ SPDX-License-Identifier: AGPL-3.0-only
 package cmd
 
 import (
+	"log/slog"
+
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 )
 
 type debugLog interface {
 	Debugf(format string, args ...any)
-	Sync()
 }
 
 func newCLILogger(cmd *cobra.Command) (debugLog, error) {
-	logLvl := zapcore.InfoLevel
+	logLvl := slog.LevelInfo
 	debugLog, err := cmd.Flags().GetBool("debug")
 	if err != nil {
 		return nil, err
 	}
 	if debugLog {
-		logLvl = zapcore.DebugLevel
+		logLvl = slog.LevelDebug
 	}
 
 	return logger.New(logger.PlainLog, logLvl), nil

--- a/cli/internal/cmd/miniup.go
+++ b/cli/internal/cmd/miniup.go
@@ -52,7 +52,6 @@ func runUp(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("creating logger: %w", err)
 	}
-	defer log.Sync()
 	spinner, err := newSpinnerOrStderr(cmd)
 	if err != nil {
 		return err

--- a/cli/internal/cmd/recover.go
+++ b/cli/internal/cmd/recover.go
@@ -76,7 +76,6 @@ func runRecover(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("creating logger: %w", err)
 	}
-	defer log.Sync()
 	fileHandler := file.NewHandler(afero.NewOsFs())
 	newDialer := func(validator atls.Validator) *dialer.Dialer {
 		return dialer.New(nil, validator, &net.Dialer{})

--- a/cli/internal/cmd/status.go
+++ b/cli/internal/cmd/status.go
@@ -43,7 +43,6 @@ func runStatus(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("creating logger: %w", err)
 	}
-	defer log.Sync()
 
 	fileHandler := file.NewHandler(afero.NewOsFs())
 

--- a/cli/internal/cmd/upgradecheck.go
+++ b/cli/internal/cmd/upgradecheck.go
@@ -93,7 +93,6 @@ func runUpgradeCheck(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("creating logger: %w", err)
 	}
-	defer log.Sync()
 
 	var flags upgradeCheckFlags
 	if err := flags.parse(cmd.Flags()); err != nil {

--- a/cli/internal/cmd/verify.go
+++ b/cli/internal/cmd/verify.go
@@ -104,7 +104,6 @@ func runVerify(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("creating logger: %w", err)
 	}
-	defer log.Sync()
 
 	fileHandler := file.NewHandler(afero.NewOsFs())
 	verifyClient := &constellationVerifier{

--- a/debugd/cmd/debugd/debugd.go
+++ b/debugd/cmd/debugd/debugd.go
@@ -49,8 +49,8 @@ func main() {
 	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity))
 	fs := afero.NewOsFs()
 	streamer := streamer.New(fs)
-	filetransferer := filetransfer.New(log.Named("filetransfer"), streamer, filetransfer.DontShowProgress)
-	serviceManager := deploy.NewServiceManager(log.Named("serviceManager"))
+	filetransferer := filetransfer.New(log.Grouped("filetransfer"), streamer, filetransfer.DontShowProgress)
+	serviceManager := deploy.NewServiceManager(log.Grouped("serviceManager"))
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -99,13 +99,13 @@ func main() {
 
 	infoMap := info.NewMap()
 	infoMap.RegisterOnReceiveTrigger(
-		logcollector.NewStartTrigger(ctx, wg, platform.FromString(csp), fetcher, log.Named("logcollector")),
+		logcollector.NewStartTrigger(ctx, wg, platform.FromString(csp), fetcher, log.Grouped("logcollector")),
 	)
 
-	download := deploy.New(log.Named("download"), &net.Dialer{}, serviceManager, filetransferer, infoMap)
+	download := deploy.New(log.Grouped("download"), &net.Dialer{}, serviceManager, filetransferer, infoMap)
 
-	sched := metadata.NewScheduler(log.Named("scheduler"), fetcher, download)
-	serv := server.New(log.Named("server"), serviceManager, filetransferer, infoMap)
+	sched := metadata.NewScheduler(log.Grouped("scheduler"), fetcher, download)
+	serv := server.New(log.Grouped("server"), serviceManager, filetransferer, infoMap)
 
 	writeDebugBanner(log)
 

--- a/debugd/cmd/debugd/debugd.go
+++ b/debugd/cmd/debugd/debugd.go
@@ -10,12 +10,12 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
 	"net"
 	"os"
 	"sync"
 
 	"github.com/spf13/afero"
-	"go.uber.org/zap"
 
 	"github.com/edgelesssys/constellation/v2/debugd/internal/debugd/deploy"
 	"github.com/edgelesssys/constellation/v2/debugd/internal/debugd/info"
@@ -64,21 +64,21 @@ func main() {
 	case platform.AWS:
 		meta, err := awscloud.New(ctx)
 		if err != nil {
-			log.With(zap.Error(err)).Fatalf("Failed to initialize AWS metadata")
+			log.With(slog.Any("error", err)).Fatalf("Failed to initialize AWS metadata")
 		}
 		fetcher = cloudprovider.New(meta)
 
 	case platform.Azure:
 		meta, err := azurecloud.New(ctx)
 		if err != nil {
-			log.With(zap.Error(err)).Fatalf("Failed to initialize Azure metadata")
+			log.With(slog.Any("error", err)).Fatalf("Failed to initialize Azure metadata")
 		}
 		fetcher = cloudprovider.New(meta)
 
 	case platform.GCP:
 		meta, err := gcpcloud.New(ctx)
 		if err != nil {
-			log.With(zap.Error(err)).Fatalf("Failed to initialize GCP metadata")
+			log.With(slog.Any("error", err)).Fatalf("Failed to initialize GCP metadata")
 		}
 		defer meta.Close()
 		fetcher = cloudprovider.New(meta)
@@ -86,7 +86,7 @@ func main() {
 	case platform.OpenStack:
 		meta, err := openstackcloud.New(ctx)
 		if err != nil {
-			log.With(zap.Error(err)).Fatalf("Failed to initialize OpenStack metadata")
+			log.With(slog.Any("error", err)).Fatalf("Failed to initialize OpenStack metadata")
 		}
 		fetcher = cloudprovider.New(meta)
 	case platform.QEMU:
@@ -117,11 +117,11 @@ func main() {
 func writeDebugBanner(log *logger.Logger) {
 	tty, err := os.OpenFile("/dev/ttyS0", os.O_WRONLY, os.ModeAppend)
 	if err != nil {
-		log.With(zap.Error(err)).Errorf("Unable to open /dev/ttyS0 for printing banner")
+		log.With(slog.Any("error", err)).Errorf("Unable to open /dev/ttyS0 for printing banner")
 		return
 	}
 	defer tty.Close()
 	if _, err := fmt.Fprint(tty, debugBanner); err != nil {
-		log.With(zap.Error(err)).Errorf("Unable to print to /dev/ttyS0")
+		log.With(slog.Any("error", err)).Errorf("Unable to print to /dev/ttyS0")
 	}
 }

--- a/debugd/internal/debugd/deploy/download.go
+++ b/debugd/internal/debugd/deploy/download.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"strconv"
 
@@ -18,7 +19,6 @@ import (
 	pb "github.com/edgelesssys/constellation/v2/debugd/service"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -51,7 +51,7 @@ func (d *Download) DownloadInfo(ctx context.Context, ip string) error {
 		return nil
 	}
 
-	log := d.log.With(zap.String("ip", ip))
+	log := d.log.With(slog.String("ip", ip))
 	serverAddr := net.JoinHostPort(ip, strconv.Itoa(constants.DebugdPort))
 
 	client, closer, err := d.newClient(ctx, serverAddr, log)
@@ -72,7 +72,7 @@ func (d *Download) DownloadInfo(ctx context.Context, ip string) error {
 
 // DownloadDeployment will open a new grpc connection to another instance, attempting to download files from that instance.
 func (d *Download) DownloadDeployment(ctx context.Context, ip string) error {
-	log := d.log.With(zap.String("ip", ip))
+	log := d.log.With(slog.String("ip", ip))
 	serverAddr := net.JoinHostPort(ip, strconv.Itoa(constants.DebugdPort))
 
 	client, closer, err := d.newClient(ctx, serverAddr, log)
@@ -98,7 +98,7 @@ func (d *Download) DownloadDeployment(ctx context.Context, ip string) error {
 		d.log.Warnf("Download already finished")
 		return nil
 	default:
-		d.log.With(zap.Error(err)).Errorf("Downloading files failed")
+		d.log.With(slog.Any("error", err)).Errorf("Downloading files failed")
 		return err
 	}
 
@@ -111,7 +111,7 @@ func (d *Download) DownloadDeployment(ctx context.Context, ip string) error {
 			ctx, file.OverrideServiceUnit, file.TargetPath,
 		); err != nil {
 			// continue on error to allow other units to be overridden
-			d.log.With(zap.Error(err)).Errorf("Failed to override service unit %s", file.OverrideServiceUnit)
+			d.log.With(slog.Any("error", err)).Errorf("Failed to override service unit %s", file.OverrideServiceUnit)
 		}
 	}
 

--- a/debugd/internal/debugd/deploy/service.go
+++ b/debugd/internal/debugd/deploy/service.go
@@ -9,6 +9,7 @@ package deploy
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -17,7 +18,6 @@ import (
 
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/afero"
-	"go.uber.org/zap"
 )
 
 const (
@@ -102,7 +102,7 @@ type dbusConn interface {
 
 // SystemdAction will perform a systemd action on a service unit (start, stop, restart, reload).
 func (s *ServiceManager) SystemdAction(ctx context.Context, request ServiceManagerRequest) error {
-	log := s.log.With(zap.String("unit", request.Unit), zap.String("action", request.Action.String()))
+	log := s.log.With(slog.String("unit", request.Unit), slog.String("action", request.Action.String()))
 	conn, err := s.dbus.NewSystemConnectionContext(ctx)
 	if err != nil {
 		return fmt.Errorf("establishing systemd connection: %w", err)
@@ -146,7 +146,7 @@ func (s *ServiceManager) SystemdAction(ctx context.Context, request ServiceManag
 
 // WriteSystemdUnitFile will write a systemd unit to disk.
 func (s *ServiceManager) WriteSystemdUnitFile(ctx context.Context, unit SystemdUnit) error {
-	log := s.log.With(zap.String("unitFile", fmt.Sprintf("%s/%s", systemdUnitFolder, unit.Name)))
+	log := s.log.With(slog.String("unitFile", fmt.Sprintf("%s/%s", systemdUnitFolder, unit.Name)))
 	log.Infof("Writing systemd unit file")
 	s.systemdUnitFilewriteLock.Lock()
 	defer s.systemdUnitFilewriteLock.Unlock()
@@ -164,7 +164,7 @@ func (s *ServiceManager) WriteSystemdUnitFile(ctx context.Context, unit SystemdU
 
 // OverrideServiceUnitExecStart will override the ExecStart of a systemd unit.
 func (s *ServiceManager) OverrideServiceUnitExecStart(ctx context.Context, unitName, execStart string) error {
-	log := s.log.With(zap.String("unitFile", fmt.Sprintf("%s/%s", systemdUnitFolder, unitName)))
+	log := s.log.With(slog.String("unitFile", fmt.Sprintf("%s/%s", systemdUnitFolder, unitName)))
 	log.Infof("Overriding systemd unit file execStart")
 	if !systemdUnitNameRegexp.MatchString(unitName) {
 		return fmt.Errorf("unit name %q is invalid", unitName)

--- a/debugd/internal/debugd/logcollector/logcollector.go
+++ b/debugd/internal/debugd/logcollector/logcollector.go
@@ -201,7 +201,7 @@ func startPod(ctx context.Context, logger *logger.Logger) error {
 	}
 
 	// start logstash container
-	logstashLog := newCmdLogger(logger.Named("logstash"))
+	logstashLog := newCmdLogger(logger.Grouped("logstash"))
 	runLogstashArgs := []string{
 		"run",
 		"--rm",
@@ -220,7 +220,7 @@ func startPod(ctx context.Context, logger *logger.Logger) error {
 	}
 
 	// start filebeat container
-	filebeatLog := newCmdLogger(logger.Named("filebeat"))
+	filebeatLog := newCmdLogger(logger.Grouped("filebeat"))
 	runFilebeatArgs := []string{
 		"run",
 		"--rm",
@@ -245,7 +245,7 @@ func startPod(ctx context.Context, logger *logger.Logger) error {
 	}
 
 	// start metricbeat container
-	metricbeatLog := newCmdLogger(logger.Named("metricbeat"))
+	metricbeatLog := newCmdLogger(logger.Grouped("metricbeat"))
 	runMetricbeatArgs := []string{
 		"run",
 		"--rm",

--- a/debugd/internal/debugd/metadata/scheduler.go
+++ b/debugd/internal/debugd/metadata/scheduler.go
@@ -8,12 +8,12 @@ package metadata
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/edgelesssys/constellation/v2/debugd/internal/debugd"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
-	"go.uber.org/zap"
 )
 
 // Fetcher retrieves other debugd IPs from cloud provider metadata.
@@ -60,22 +60,22 @@ func (s *Scheduler) Start(ctx context.Context, wg *sync.WaitGroup) {
 
 			ips, err := s.fetcher.DiscoverDebugdIPs(ctx)
 			if err != nil {
-				s.log.With(zap.Error(err)).Warnf("Discovering debugd IPs failed")
+				s.log.With(slog.Any("error", err)).Warnf("Discovering debugd IPs failed")
 			}
 
 			lbip, err := s.fetcher.DiscoverLoadBalancerIP(ctx)
 			if err != nil {
-				s.log.With(zap.Error(err)).Warnf("Discovering load balancer IP failed")
+				s.log.With(slog.Any("error", err)).Warnf("Discovering load balancer IP failed")
 			} else {
 				ips = append(ips, lbip)
 			}
 
 			if len(ips) == 0 {
-				s.log.With(zap.Error(err)).Warnf("No debugd IPs discovered")
+				s.log.With(slog.Any("error", err)).Warnf("No debugd IPs discovered")
 				continue
 			}
 
-			s.log.With(zap.Strings("ips", ips)).Infof("Discovered instances")
+			s.log.With(slog.Any("ips", ips)).Infof("Discovered instances")
 			s.download(ctx, ips)
 			if s.deploymentDone && s.infoDone {
 				return
@@ -90,7 +90,7 @@ func (s *Scheduler) download(ctx context.Context, ips []string) {
 	for _, ip := range ips {
 		if !s.deploymentDone {
 			if err := s.downloader.DownloadDeployment(ctx, ip); err != nil {
-				s.log.With(zap.Error(err), zap.String("peer", ip)).
+				s.log.With(slog.Any("error", err), slog.String("peer", ip)).
 					Warnf("Downloading deployment from %s: %s", ip, err)
 			} else {
 				s.deploymentDone = true
@@ -99,7 +99,7 @@ func (s *Scheduler) download(ctx context.Context, ips []string) {
 
 		if !s.infoDone {
 			if err := s.downloader.DownloadInfo(ctx, ip); err != nil {
-				s.log.With(zap.Error(err), zap.String("peer", ip)).
+				s.log.With(slog.Any("error", err), slog.String("peer", ip)).
 					Warnf("Downloading info from %s: %s", ip, err)
 			} else {
 				s.infoDone = true

--- a/debugd/internal/debugd/server/server.go
+++ b/debugd/internal/debugd/server/server.go
@@ -155,7 +155,7 @@ func Start(log *logger.Logger, wg *sync.WaitGroup, serv pb.DebugdServer) {
 	go func() {
 		defer wg.Done()
 
-		grpcLog := log.Named("gRPC")
+		grpcLog := log.Grouped("gRPC")
 		grpcLog.WithIncreasedLevel(slog.LevelWarn).ReplaceGRPCLogger()
 
 		grpcServer := grpc.NewServer(

--- a/debugd/internal/debugd/server/server.go
+++ b/debugd/internal/debugd/server/server.go
@@ -10,6 +10,7 @@ package server
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net"
 	"strconv"
 	"sync"
@@ -155,7 +156,7 @@ func Start(log *logger.Logger, wg *sync.WaitGroup, serv pb.DebugdServer) {
 		defer wg.Done()
 
 		grpcLog := log.Named("gRPC")
-		grpcLog.WithIncreasedLevel(zap.WarnLevel).ReplaceGRPCLogger()
+		grpcLog.WithIncreasedLevel(slog.LevelWarn).ReplaceGRPCLogger()
 
 		grpcServer := grpc.NewServer(
 			grpcLog.GetServerStreamInterceptor(),

--- a/debugd/internal/debugd/server/server.go
+++ b/debugd/internal/debugd/server/server.go
@@ -22,7 +22,6 @@ import (
 	pb "github.com/edgelesssys/constellation/v2/debugd/service"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 )
@@ -63,7 +62,7 @@ func (s *debugdServer) SetInfo(_ context.Context, req *pb.SetInfoRequest) (*pb.S
 	}
 
 	if setProtoErr != nil {
-		s.log.With(zap.Error(setProtoErr)).Errorf("Setting info failed")
+		s.log.With(slog.Any("error", setProtoErr)).Errorf("Setting info failed")
 		return nil, setProtoErr
 	}
 	s.log.Infof("Info set")
@@ -103,7 +102,7 @@ func (s *debugdServer) UploadFiles(stream pb.Debugd_UploadFilesServer) error {
 			Status: pb.UploadFilesStatus_UPLOAD_FILES_ALREADY_FINISHED,
 		})
 	default:
-		s.log.With(zap.Error(err)).Errorf("Uploading files failed")
+		s.log.With(slog.Any("error", err)).Errorf("Uploading files failed")
 		return stream.SendAndClose(&pb.UploadFilesResponse{
 			Status: pb.UploadFilesStatus_UPLOAD_FILES_UPLOAD_FAILED,
 		})
@@ -121,7 +120,7 @@ func (s *debugdServer) UploadFiles(stream pb.Debugd_UploadFilesServer) error {
 	}
 
 	if overrideUnitErr != nil {
-		s.log.With(zap.Error(overrideUnitErr)).Errorf("Overriding service units failed")
+		s.log.With(slog.Any("error", overrideUnitErr)).Errorf("Overriding service units failed")
 		return stream.SendAndClose(&pb.UploadFilesResponse{
 			Status: pb.UploadFilesStatus_UPLOAD_FILES_START_FAILED,
 		})
@@ -166,7 +165,7 @@ func Start(log *logger.Logger, wg *sync.WaitGroup, serv pb.DebugdServer) {
 		pb.RegisterDebugdServer(grpcServer, serv)
 		lis, err := net.Listen("tcp", net.JoinHostPort("0.0.0.0", strconv.Itoa(constants.DebugdPort)))
 		if err != nil {
-			log.With(zap.Error(err)).Fatalf("Listening failed")
+			log.With(slog.Any("error", err)).Fatalf("Listening failed")
 		}
 		log.Infof("gRPC server is waiting for connections")
 		grpcServer.Serve(lis)

--- a/debugd/internal/filetransfer/filetransfer.go
+++ b/debugd/internal/filetransfer/filetransfer.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"io"
 	"io/fs"
+	"log/slog"
 	"sync"
 	"sync/atomic"
 
@@ -19,7 +20,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/debugd/internal/filetransfer/streamer"
 	pb "github.com/edgelesssys/constellation/v2/debugd/service"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
-	"go.uber.org/zap"
 )
 
 // RecvFilesStream is a stream that receives FileTransferMessages.
@@ -160,7 +160,7 @@ func (s *FileTransferer) handleFileRecv(stream RecvFilesStream) (bool, error) {
 	})
 	recvChunkStream := &recvChunkStream{stream: stream}
 	if err := s.streamer.WriteStream(header.TargetPath, recvChunkStream, s.showProgress); err != nil {
-		s.log.With(zap.Error(err)).Errorf("Receive of file %q failed", header.TargetPath)
+		s.log.With(slog.Any("error", err)).Errorf("Receive of file %q failed", header.TargetPath)
 		return false, err
 	}
 	s.log.Infof("Finished file receive of %q", header.TargetPath)

--- a/disk-mapper/cmd/main.go
+++ b/disk-mapper/cmd/main.go
@@ -133,7 +133,7 @@ func main() {
 		}
 	}
 	setupManger := setup.New(
-		log.Named("setupManager"),
+		log.Grouped("setupManager"),
 		*csp,
 		diskPath,
 		afero.Afero{Fs: afero.NewOsFs()},
@@ -158,15 +158,15 @@ func main() {
 			dialer.New(issuer, nil, &net.Dialer{}),
 			self,
 			metadataClient,
-			log.Named("rejoinClient"),
+			log.Grouped("rejoinClient"),
 		)
 
 		// set up recovery server if control-plane node
 		var recoveryServer setup.RecoveryServer
 		if self.Role == role.ControlPlane {
-			recoveryServer = recoveryserver.New(issuer, kmssetup.KMS, log.Named("recoveryServer"))
+			recoveryServer = recoveryserver.New(issuer, kmssetup.KMS, log.Grouped("recoveryServer"))
 		} else {
-			recoveryServer = recoveryserver.NewStub(log.Named("recoveryServer"))
+			recoveryServer = recoveryserver.NewStub(log.Grouped("recoveryServer"))
 		}
 
 		err = setupManger.PrepareExistingDisk(setup.NewNodeRecoverer(recoveryServer, rejoinClient))

--- a/disk-mapper/internal/diskencryption/diskencryption.go
+++ b/disk-mapper/internal/diskencryption/diskencryption.go
@@ -15,11 +15,11 @@ package diskencryption
 
 import (
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/edgelesssys/constellation/v2/internal/cryptsetup"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
-	"go.uber.org/zap"
 )
 
 // DiskEncryption handles actions for formatting and mapping crypt devices.
@@ -101,7 +101,7 @@ func (d *DiskEncryption) UnmapDisk(target string) error {
 func (d *DiskEncryption) Wipe(blockWipeSize int) error {
 	logProgress := func(size, offset uint64) {
 		prog := (float64(offset) / float64(size)) * 100
-		d.log.With(zap.String("progress", fmt.Sprintf("%.2f%%", prog))).Infof("Wiping disk")
+		d.log.With(slog.String("progress", fmt.Sprintf("%.2f%%", prog))).Infof("Wiping disk")
 	}
 
 	start := time.Now()
@@ -109,7 +109,7 @@ func (d *DiskEncryption) Wipe(blockWipeSize int) error {
 	if err := d.device.Wipe("integrity", blockWipeSize, 0, logProgress, 30*time.Second); err != nil {
 		return fmt.Errorf("wiping disk: %w", err)
 	}
-	d.log.With(zap.Duration("duration", time.Since(start))).Infof("Wiping disk successful")
+	d.log.With(slog.Duration("duration", time.Since(start))).Infof("Wiping disk successful")
 
 	return nil
 }

--- a/disk-mapper/internal/recoveryserver/recoveryserver.go
+++ b/disk-mapper/internal/recoveryserver/recoveryserver.go
@@ -59,7 +59,7 @@ func New(issuer atls.Issuer, factory kmsFactory, log *logger.Logger) *RecoverySe
 
 	grpcServer := grpc.NewServer(
 		grpc.Creds(atlscredentials.New(issuer, nil)),
-		log.Named("gRPC").GetServerStreamInterceptor(),
+		log.Grouped("gRPC").GetServerStreamInterceptor(),
 	)
 	recoverproto.RegisterAPIServer(grpcServer, server)
 

--- a/disk-mapper/internal/recoveryserver/recoveryserver.go
+++ b/disk-mapper/internal/recoveryserver/recoveryserver.go
@@ -17,6 +17,7 @@ package recoveryserver
 
 import (
 	"context"
+	"log/slog"
 	"net"
 	"sync"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/grpc/grpclog"
 	"github.com/edgelesssys/constellation/v2/internal/kms/kms"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -105,7 +105,7 @@ func (s *RecoveryServer) Serve(ctx context.Context, listener net.Listener, diskU
 func (s *RecoveryServer) Recover(ctx context.Context, req *recoverproto.RecoverMessage) (*recoverproto.RecoverResponse, error) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
-	log := s.log.With(zap.String("peer", grpclog.PeerAddrFromContext(ctx)))
+	log := s.log.With(slog.String("peer", grpclog.PeerAddrFromContext(ctx)))
 
 	log.Infof("Received recover call")
 

--- a/disk-mapper/internal/setup/setup.go
+++ b/disk-mapper/internal/setup/setup.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"net"
 	"os"
 	"path/filepath"
@@ -34,7 +35,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/internal/nodestate"
 	"github.com/spf13/afero"
-	"go.uber.org/zap"
 )
 
 const (
@@ -82,7 +82,7 @@ func (s *Manager) PrepareExistingDisk(recover RecoveryDoer) error {
 	if err != nil {
 		return err
 	}
-	s.log.With(zap.String("uuid", uuid)).Infof("Preparing existing state disk")
+	s.log.With(slog.String("uuid", uuid)).Infof("Preparing existing state disk")
 	endpoint := net.JoinHostPort("0.0.0.0", strconv.Itoa(constants.RecoveryPort))
 
 	passphrase, measurementSecret, err := recover.Do(uuid, endpoint)
@@ -128,7 +128,7 @@ func (s *Manager) PrepareExistingDisk(recover RecoveryDoer) error {
 // PrepareNewDisk prepares an instances state disk by formatting the disk as a LUKS device using a random passphrase.
 func (s *Manager) PrepareNewDisk() error {
 	uuid, _ := s.mapper.DiskUUID()
-	s.log.With(zap.String("uuid", uuid)).Infof("Preparing new state disk")
+	s.log.With(slog.String("uuid", uuid)).Infof("Preparing new state disk")
 
 	// generate and save temporary passphrase
 	passphrase := make([]byte, crypto.RNGLengthDefault)
@@ -197,7 +197,7 @@ func (s *Manager) LogDevices() error {
 		var stat syscall.Statfs_t
 		dev := "/dev/" + device.Name()
 		if err := syscall.Statfs(dev, &stat); err != nil {
-			s.log.With(zap.Error(err)).Errorf("failed to statfs %s", dev)
+			s.log.With(slog.Any("error", err)).Errorf("failed to statfs %s", dev)
 			continue
 		}
 

--- a/disk-mapper/internal/test/benchmark_test.go
+++ b/disk-mapper/internal/test/benchmark_test.go
@@ -10,13 +10,13 @@ package integration
 
 import (
 	"fmt"
+	"log/slog"
 	"math"
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/disk-mapper/internal/diskencryption"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/martinjungblut/go-cryptsetup"
-	"go.uber.org/zap/zapcore"
 )
 
 func BenchmarkMapper(b *testing.B) {
@@ -39,7 +39,7 @@ func BenchmarkMapper(b *testing.B) {
 	}
 
 	passphrase := "benchmark"
-	mapper, free, err := diskencryption.New(testPath, logger.New(logger.PlainLog, zapcore.InfoLevel))
+	mapper, free, err := diskencryption.New(testPath, logger.New(logger.PlainLog, slog.LevelInfo))
 	if err != nil {
 		b.Fatal("Failed to create mapper:", err)
 	}

--- a/e2e/malicious-join/malicious-join.go
+++ b/e2e/malicious-join/malicious-join.go
@@ -12,6 +12,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"log/slog"
 	"net"
 	"strings"
 
@@ -20,7 +21,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/grpc/dialer"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/joinservice/joinproto"
-	"go.uber.org/zap/zapcore"
 )
 
 func main() {
@@ -116,7 +116,7 @@ func formatFlags(attVariant, csp, jsEndpoint string) string {
 // JoinFromUnattestedNode simulates a join request from a Node that uses a stub issuer
 // and thus cannot be attested correctly.
 func JoinFromUnattestedNode(attVariant, csp, jsEndpoint string) error {
-	log := logger.New(logger.JSONLog, zapcore.DebugLevel)
+	log := logger.New(logger.JSONLog, slog.LevelDebug)
 	joiner, err := newMaliciousJoiner(attVariant, csp, jsEndpoint, log)
 	if err != nil {
 		return fmt.Errorf("creating malicious joiner: %w", err)

--- a/hack/bazel-deps-mirror/check.go
+++ b/hack/bazel-deps-mirror/check.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"github.com/edgelesssys/constellation/v2/hack/bazel-deps-mirror/internal/bazelfiles"
 	"github.com/edgelesssys/constellation/v2/hack/bazel-deps-mirror/internal/issues"
@@ -16,7 +17,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/hack/bazel-deps-mirror/internal/rules"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 )
 
 func newCheckCmd() *cobra.Command {
@@ -130,7 +130,7 @@ type checkFlags struct {
 	region                string
 	bucket                string
 	mirrorBaseURL         string
-	logLevel              zapcore.Level
+	logLevel              slog.Level
 }
 
 func parseCheckFlags(cmd *cobra.Command) (checkFlags, error) {
@@ -146,9 +146,9 @@ func parseCheckFlags(cmd *cobra.Command) (checkFlags, error) {
 	if err != nil {
 		return checkFlags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 	region, err := cmd.Flags().GetString("region")
 	if err != nil {

--- a/hack/bazel-deps-mirror/fix.go
+++ b/hack/bazel-deps-mirror/fix.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"github.com/bazelbuild/buildtools/build"
 	"github.com/edgelesssys/constellation/v2/hack/bazel-deps-mirror/internal/bazelfiles"
@@ -17,7 +18,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/hack/bazel-deps-mirror/internal/rules"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 )
 
 func newFixCmd() *cobra.Command {
@@ -211,7 +211,7 @@ type fixFlags struct {
 	region          string
 	bucket          string
 	mirrorBaseURL   string
-	logLevel        zapcore.Level
+	logLevel        slog.Level
 }
 
 func parseFixFlags(cmd *cobra.Command) (fixFlags, error) {
@@ -227,9 +227,9 @@ func parseFixFlags(cmd *cobra.Command) (fixFlags, error) {
 	if err != nil {
 		return fixFlags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 	region, err := cmd.Flags().GetString("region")
 	if err != nil {

--- a/hack/bazel-deps-mirror/upgrade.go
+++ b/hack/bazel-deps-mirror/upgrade.go
@@ -9,6 +9,7 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
 
 	"github.com/bazelbuild/buildtools/build"
 	"github.com/edgelesssys/constellation/v2/hack/bazel-deps-mirror/internal/bazelfiles"
@@ -17,7 +18,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/hack/bazel-deps-mirror/internal/rules"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 )
 
 func newUpgradeCmd() *cobra.Command {
@@ -177,7 +177,7 @@ type upgradeFlags struct {
 	region          string
 	bucket          string
 	mirrorBaseURL   string
-	logLevel        zapcore.Level
+	logLevel        slog.Level
 }
 
 func parseUpgradeFlags(cmd *cobra.Command) (upgradeFlags, error) {
@@ -193,9 +193,9 @@ func parseUpgradeFlags(cmd *cobra.Command) (upgradeFlags, error) {
 	if err != nil {
 		return upgradeFlags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 	region, err := cmd.Flags().GetString("region")
 	if err != nil {

--- a/hack/cli-k8s-compatibility/main.go
+++ b/hack/cli-k8s-compatibility/main.go
@@ -10,11 +10,11 @@ package main
 import (
 	"context"
 	"flag"
+	"log/slog"
 
 	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/internal/versions"
-	"go.uber.org/zap/zapcore"
 )
 
 var (
@@ -24,7 +24,7 @@ var (
 )
 
 func main() {
-	log := logger.New(logger.PlainLog, zapcore.DebugLevel)
+	log := logger.New(logger.PlainLog, slog.LevelDebug)
 	ctx := context.Background()
 
 	flag.Parse()

--- a/hack/oci-pin/codegen.go
+++ b/hack/oci-pin/codegen.go
@@ -8,6 +8,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,7 +17,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/hack/oci-pin/internal/inject"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 )
 
 func newCodegenCmd() *cobra.Command {
@@ -102,7 +102,7 @@ type codegenFlags struct {
 	pkg          string
 	identifier   string
 	imageRepoTag string
-	logLevel     zapcore.Level
+	logLevel     slog.Level
 }
 
 func parseCodegenFlags(cmd *cobra.Command) (codegenFlags, error) {
@@ -137,9 +137,9 @@ func parseCodegenFlags(cmd *cobra.Command) (codegenFlags, error) {
 	if err != nil {
 		return codegenFlags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 
 	return codegenFlags{

--- a/hack/oci-pin/merge.go
+++ b/hack/oci-pin/merge.go
@@ -8,12 +8,12 @@ package main
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 
 	"github.com/edgelesssys/constellation/v2/hack/oci-pin/internal/sums"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 )
 
 func newMergeCmd() *cobra.Command {
@@ -93,7 +93,7 @@ func parseInput(input string) ([]sums.PinnedImageReference, error) {
 type mergeFlags struct {
 	inputs   []string
 	output   string
-	logLevel zapcore.Level
+	logLevel slog.Level
 }
 
 func parseMergeFlags(cmd *cobra.Command) (mergeFlags, error) {
@@ -109,9 +109,9 @@ func parseMergeFlags(cmd *cobra.Command) (mergeFlags, error) {
 	if err != nil {
 		return mergeFlags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 
 	return mergeFlags{

--- a/hack/oci-pin/sum.go
+++ b/hack/oci-pin/sum.go
@@ -8,6 +8,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,7 +17,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/hack/oci-pin/internal/sums"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 )
 
 func newSumCmd() *cobra.Command {
@@ -99,7 +99,7 @@ type sumFlags struct {
 	ociPath      string
 	output       string
 	imageRepoTag string
-	logLevel     zapcore.Level
+	logLevel     slog.Level
 }
 
 func parseSumFlags(cmd *cobra.Command) (sumFlags, error) {
@@ -126,9 +126,9 @@ func parseSumFlags(cmd *cobra.Command) (sumFlags, error) {
 	if err != nil {
 		return sumFlags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 
 	return sumFlags{

--- a/hack/qemu-metadata-api/main.go
+++ b/hack/qemu-metadata-api/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/hack/qemu-metadata-api/server"
 	"github.com/edgelesssys/constellation/v2/hack/qemu-metadata-api/virtwrapper"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
-	"go.uber.org/zap"
 	"libvirt.org/go/libvirt"
 )
 
@@ -30,12 +29,12 @@ func main() {
 
 	conn, err := libvirt.NewConnect(*libvirtURI)
 	if err != nil {
-		log.With(zap.Error(err)).Fatalf("Failed to connect to libvirt")
+		log.With(slog.Any("error", err)).Fatalf("Failed to connect to libvirt")
 	}
 	defer conn.Close()
 
 	serv := server.New(log, *targetNetwork, *initSecretHash, &virtwrapper.Connect{Conn: conn})
 	if err := serv.ListenAndServe(*bindPort); err != nil {
-		log.With(zap.Error(err)).Fatalf("Failed to serve")
+		log.With(slog.Any("error", err)).Fatalf("Failed to serve")
 	}
 }

--- a/hack/qemu-metadata-api/main.go
+++ b/hack/qemu-metadata-api/main.go
@@ -10,12 +10,12 @@ package main
 
 import (
 	"flag"
+	"log/slog"
 
 	"github.com/edgelesssys/constellation/v2/hack/qemu-metadata-api/server"
 	"github.com/edgelesssys/constellation/v2/hack/qemu-metadata-api/virtwrapper"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"libvirt.org/go/libvirt"
 )
 
@@ -26,7 +26,7 @@ func main() {
 	initSecretHash := flag.String("initsecrethash", "", "brcypt hash of the init secret")
 	flag.Parse()
 
-	log := logger.New(logger.JSONLog, zapcore.InfoLevel)
+	log := logger.New(logger.JSONLog, slog.LevelInfo)
 
 	conn, err := libvirt.NewConnect(*libvirtURI)
 	if err != nil {

--- a/image/upload/internal/cmd/flags.go
+++ b/image/upload/internal/cmd/flags.go
@@ -8,6 +8,7 @@ package cmd
 
 import (
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -15,7 +16,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 )
 
 type commonFlags struct {
@@ -30,7 +30,7 @@ type commonFlags struct {
 	bucket             string
 	distributionID     string
 	out                string
-	logLevel           zapcore.Level
+	logLevel           slog.Level
 }
 
 func parseCommonFlags(cmd *cobra.Command) (commonFlags, error) {
@@ -93,9 +93,9 @@ func parseCommonFlags(cmd *cobra.Command) (commonFlags, error) {
 	if err != nil {
 		return commonFlags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 
 	return commonFlags{
@@ -216,7 +216,7 @@ type s3Flags struct {
 	region         string
 	bucket         string
 	distributionID string
-	logLevel       zapcore.Level
+	logLevel       slog.Level
 }
 
 func parseS3Flags(cmd *cobra.Command) (s3Flags, error) {
@@ -236,9 +236,9 @@ func parseS3Flags(cmd *cobra.Command) (s3Flags, error) {
 	if err != nil {
 		return s3Flags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 
 	return s3Flags{
@@ -279,7 +279,7 @@ func parseUploadMeasurementsFlags(cmd *cobra.Command) (measurementsFlags, error)
 
 type mergeMeasurementsFlags struct {
 	out      string
-	logLevel zapcore.Level
+	logLevel slog.Level
 }
 
 func parseMergeMeasurementsFlags(cmd *cobra.Command) (mergeMeasurementsFlags, error) {
@@ -291,9 +291,9 @@ func parseMergeMeasurementsFlags(cmd *cobra.Command) (mergeMeasurementsFlags, er
 	if err != nil {
 		return mergeMeasurementsFlags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 
 	return mergeMeasurementsFlags{
@@ -307,7 +307,7 @@ type envelopeMeasurementsFlags struct {
 	csp                cloudprovider.Provider
 	attestationVariant string
 	in, out            string
-	logLevel           zapcore.Level
+	logLevel           slog.Level
 }
 
 func parseEnvelopeMeasurementsFlags(cmd *cobra.Command) (envelopeMeasurementsFlags, error) {
@@ -343,9 +343,9 @@ func parseEnvelopeMeasurementsFlags(cmd *cobra.Command) (envelopeMeasurementsFla
 	if err != nil {
 		return envelopeMeasurementsFlags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 
 	return envelopeMeasurementsFlags{

--- a/internal/api/attestationconfigapi/cli/delete.go
+++ b/internal/api/attestationconfigapi/cli/delete.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -17,7 +18,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/internal/staticupload"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 // newDeleteCmd creates the delete command.
@@ -57,7 +57,7 @@ func (d deleteCmd) delete(cmd *cobra.Command) error {
 }
 
 func runDelete(cmd *cobra.Command, _ []string) (retErr error) {
-	log := logger.New(logger.PlainLog, zap.DebugLevel).Named("attestationconfigapi")
+	log := logger.New(logger.PlainLog, slog.LevelDebug).Named("attestationconfigapi")
 
 	region, err := cmd.Flags().GetString("region")
 	if err != nil {
@@ -115,7 +115,7 @@ func runRecursiveDelete(cmd *cobra.Command, _ []string) (retErr error) {
 	}
 	apiCfg := getAPIEnvironment(testing)
 
-	log := logger.New(logger.PlainLog, zap.DebugLevel).Named("attestationconfigapi")
+	log := logger.New(logger.PlainLog, slog.LevelDebug).Named("attestationconfigapi")
 	client, closeFn, err := staticupload.New(cmd.Context(), staticupload.Config{
 		Bucket:         bucket,
 		Region:         region,

--- a/internal/api/attestationconfigapi/cli/delete.go
+++ b/internal/api/attestationconfigapi/cli/delete.go
@@ -57,7 +57,7 @@ func (d deleteCmd) delete(cmd *cobra.Command) error {
 }
 
 func runDelete(cmd *cobra.Command, _ []string) (retErr error) {
-	log := logger.New(logger.PlainLog, slog.LevelDebug).Named("attestationconfigapi")
+	log := logger.New(logger.PlainLog, slog.LevelDebug).Grouped("attestationconfigapi")
 
 	region, err := cmd.Flags().GetString("region")
 	if err != nil {
@@ -115,7 +115,7 @@ func runRecursiveDelete(cmd *cobra.Command, _ []string) (retErr error) {
 	}
 	apiCfg := getAPIEnvironment(testing)
 
-	log := logger.New(logger.PlainLog, slog.LevelDebug).Named("attestationconfigapi")
+	log := logger.New(logger.PlainLog, slog.LevelDebug).Grouped("attestationconfigapi")
 	client, closeFn, err := staticupload.New(cmd.Context(), staticupload.Config{
 		Bucket:         bucket,
 		Region:         region,

--- a/internal/api/attestationconfigapi/cli/main.go
+++ b/internal/api/attestationconfigapi/cli/main.go
@@ -92,7 +92,7 @@ func envCheck(_ *cobra.Command, _ []string) error {
 
 func runCmd(cmd *cobra.Command, _ []string) (retErr error) {
 	ctx := cmd.Context()
-	log := logger.New(logger.PlainLog, slog.LevelDebug).Named("attestationconfigapi")
+	log := logger.New(logger.PlainLog, slog.LevelDebug).Grouped("attestationconfigapi")
 
 	flags, err := parseCliFlags(cmd)
 	if err != nil {

--- a/internal/api/attestationconfigapi/cli/main.go
+++ b/internal/api/attestationconfigapi/cli/main.go
@@ -17,6 +17,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"time"
 
@@ -28,7 +29,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/verify"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap"
 )
 
 const (
@@ -92,7 +92,7 @@ func envCheck(_ *cobra.Command, _ []string) error {
 
 func runCmd(cmd *cobra.Command, _ []string) (retErr error) {
 	ctx := cmd.Context()
-	log := logger.New(logger.PlainLog, zap.DebugLevel).Named("attestationconfigapi")
+	log := logger.New(logger.PlainLog, slog.LevelDebug).Named("attestationconfigapi")
 
 	flags, err := parseCliFlags(cmd)
 	if err != nil {

--- a/internal/api/client/client.go
+++ b/internal/api/client/client.go
@@ -33,6 +33,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -42,7 +43,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/internal/sigstore"
 	"github.com/edgelesssys/constellation/v2/internal/staticupload"
-	"go.uber.org/zap"
 )
 
 // Client is the a general client for all APIs.
@@ -232,7 +232,7 @@ func Update(ctx context.Context, c *Client, obj APIObject) error {
 	}
 
 	if c.DryRun {
-		c.Logger.With(zap.String("bucket", c.bucket), zap.String("key", obj.JSONPath()), zap.String("body", string(rawJSON))).Debugf("DryRun: s3 put object")
+		c.Logger.With(slog.String("bucket", c.bucket), slog.String("key", obj.JSONPath()), slog.String("body", string(rawJSON))).Debugf("DryRun: s3 put object")
 		return nil
 	}
 

--- a/internal/api/versionsapi/cli/add.go
+++ b/internal/api/versionsapi/cli/add.go
@@ -154,11 +154,11 @@ func updateLatest(ctx context.Context, client *versionsapi.Client, kind versions
 	}
 
 	if latest.Version == ver.Version() {
-		log.Infof("Version %q is already latest version", ver)
+		log.Infof("Version %q is already latest version", ver.Version())
 		return nil
 	}
 
-	log.Infof("Setting %q as latest version", ver)
+	log.Infof("Setting %q as latest version", ver.Version())
 	latest = versionsapi.Latest{
 		Ref:     ver.Ref(),
 		Stream:  ver.Stream(),

--- a/internal/api/versionsapi/cli/add.go
+++ b/internal/api/versionsapi/cli/add.go
@@ -10,12 +10,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	apiclient "github.com/edgelesssys/constellation/v2/internal/api/client"
 	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 	"golang.org/x/mod/semver"
 )
 
@@ -183,7 +183,7 @@ type addFlags struct {
 	bucket         string
 	distributionID string
 	kind           versionsapi.VersionKind
-	logLevel       zapcore.Level
+	logLevel       slog.Level
 }
 
 func (f *addFlags) validate(log *logger.Logger) error {
@@ -256,9 +256,9 @@ func parseAddFlags(cmd *cobra.Command) (addFlags, error) {
 	if err != nil {
 		return addFlags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 	region, err := cmd.Flags().GetString("region")
 	if err != nil {

--- a/internal/api/versionsapi/cli/latest.go
+++ b/internal/api/versionsapi/cli/latest.go
@@ -10,11 +10,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/edgelesssys/constellation/v2/internal/api/versionsapi"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 )
 
 func newLatestCmd() *cobra.Command {
@@ -89,7 +89,7 @@ type latestFlags struct {
 	region         string
 	bucket         string
 	distributionID string
-	logLevel       zapcore.Level
+	logLevel       slog.Level
 }
 
 func (l *latestFlags) validate() error {
@@ -133,9 +133,9 @@ func parseLatestFlags(cmd *cobra.Command) (latestFlags, error) {
 	if err != nil {
 		return latestFlags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 
 	return latestFlags{

--- a/internal/api/versionsapi/cli/list.go
+++ b/internal/api/versionsapi/cli/list.go
@@ -11,9 +11,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 	"golang.org/x/mod/semver"
 
 	apiclient "github.com/edgelesssys/constellation/v2/internal/api/client"
@@ -158,7 +158,7 @@ type listFlags struct {
 	bucket         string
 	distributionID string
 	json           bool
-	logLevel       zapcore.Level
+	logLevel       slog.Level
 }
 
 func (l *listFlags) validate() error {
@@ -211,9 +211,9 @@ func parseListFlags(cmd *cobra.Command) (listFlags, error) {
 	if err != nil {
 		return listFlags{}, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 
 	return listFlags{

--- a/internal/api/versionsapi/cli/rm.go
+++ b/internal/api/versionsapi/cli/rm.go
@@ -138,12 +138,12 @@ func runRemove(cmd *cobra.Command, _ []string) (retErr error) {
 func deleteSingleVersion(ctx context.Context, clients rmImageClients, ver versionsapi.Version, dryrun bool, log *logger.Logger) error {
 	var retErr error
 
-	log.Debugf("Deleting images for %s", ver.Version)
+	log.Debugf("Deleting images for %s", ver.Version())
 	if err := deleteImage(ctx, clients, ver, dryrun, log); err != nil {
 		retErr = errors.Join(retErr, fmt.Errorf("deleting images: %w", err))
 	}
 
-	log.Debugf("Deleting version %s from versions API", ver.Version)
+	log.Debugf("Deleting version %s from versions API", ver.Version())
 	if err := clients.version.DeleteVersion(ctx, ver); err != nil {
 		retErr = errors.Join(retErr, fmt.Errorf("deleting version from versions API: %w", err))
 	}
@@ -204,8 +204,8 @@ func deleteImage(ctx context.Context, clients rmImageClients, ver versionsapi.Ve
 	imageInfo, err := clients.version.FetchImageInfo(ctx, imageInfo)
 	var notFound *apiclient.NotFoundError
 	if errors.As(err, &notFound) {
-		log.Warnf("Image info for %s not found", ver.Version)
-		log.Warnf("Skipping image deletion")
+		log.Warnf("Image info for %s not found", ver.Version())
+		log.Warn("Skipping image deletion")
 		return nil
 	} else if err != nil {
 		return fmt.Errorf("fetching image info: %w", err)

--- a/internal/api/versionsapi/cli/rm.go
+++ b/internal/api/versionsapi/cli/rm.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"regexp"
 	"strings"
 	"time"
@@ -29,7 +30,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	gaxv2 "github.com/googleapis/gax-go/v2"
 	"github.com/spf13/cobra"
-	"go.uber.org/zap/zapcore"
 )
 
 func newRemoveCmd() *cobra.Command {
@@ -259,7 +259,7 @@ type rmFlags struct {
 	azSubscription  string
 	azLocation      string
 	azResourceGroup string
-	logLevel        zapcore.Level
+	logLevel        slog.Level
 
 	ver versionsapi.Version
 }
@@ -358,9 +358,9 @@ func parseRmFlags(cmd *cobra.Command) (*rmFlags, error) {
 	if err != nil {
 		return nil, err
 	}
-	logLevel := zapcore.InfoLevel
+	logLevel := slog.LevelInfo
 	if verbose {
-		logLevel = zapcore.DebugLevel
+		logLevel = slog.LevelDebug
 	}
 
 	return &rmFlags{

--- a/internal/cloud/azure/azure.go
+++ b/internal/cloud/azure/azure.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"path"
 	"strconv"
 
@@ -31,7 +32,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/internal/role"
-	"go.uber.org/zap"
 	"k8s.io/kubernetes/pkg/util/iptables"
 	"k8s.io/utils/exec"
 )
@@ -471,7 +471,7 @@ func (c *Cloud) PrepareControlPlaneNode(ctx context.Context, log *logger.Logger)
 	// for public LB architectures
 	loadbalancerIP, err := c.getLoadBalancerPrivateIP(ctx)
 	if err != nil {
-		log.With(zap.Error(err)).Warnf("skipping iptables setup, failed to get load balancer private IP")
+		log.With(slog.Any("error", err)).Warnf("skipping iptables setup, failed to get load balancer private IP")
 		return nil
 	}
 

--- a/internal/logger/cmdline.go
+++ b/internal/logger/cmdline.go
@@ -11,9 +11,9 @@ import (
 )
 
 // CmdLineVerbosityDescription explains numeric log levels.
-const CmdLineVerbosityDescription = "log verbosity in zap logging levels. Use -1 for debug information, 0 for info, 1 for warn, 2 for error"
+const CmdLineVerbosityDescription = "log verbosity in slog logging levels. Use -1 for debug information, 0 for info, 1 for warn, 2 for error"
 
-// VerbosityFromInt converts a verbosity level from an integer to a zapcore.Level.
+// VerbosityFromInt converts a verbosity level from an integer to a slog.Level.
 func VerbosityFromInt(verbosity int) slog.Level {
 	switch {
 	case verbosity <= -1:

--- a/internal/logger/cmdline.go
+++ b/internal/logger/cmdline.go
@@ -7,25 +7,24 @@ SPDX-License-Identifier: AGPL-3.0-only
 package logger
 
 import (
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
+	"log/slog"
 )
 
 // CmdLineVerbosityDescription explains numeric log levels.
 const CmdLineVerbosityDescription = "log verbosity in zap logging levels. Use -1 for debug information, 0 for info, 1 for warn, 2 for error"
 
 // VerbosityFromInt converts a verbosity level from an integer to a zapcore.Level.
-func VerbosityFromInt(verbosity int) zapcore.Level {
+func VerbosityFromInt(verbosity int) slog.Level {
 	switch {
 	case verbosity <= -1:
-		return zap.DebugLevel
+		return slog.LevelDebug
 	case verbosity == 0:
-		return zap.InfoLevel
+		return slog.LevelInfo
 	case verbosity == 1:
-		return zap.WarnLevel
+		return slog.LevelWarn
 	case verbosity >= 2:
-		return zap.ErrorLevel
+		return slog.LevelError
 	default:
-		return zap.InfoLevel
+		return slog.LevelInfo
 	}
 }

--- a/internal/logger/grpclogger.go
+++ b/internal/logger/grpclogger.go
@@ -12,19 +12,14 @@ import (
 	"log/slog"
 	"os"
 	"runtime"
+	"time"
 
 	"google.golang.org/grpc/grpclog"
 )
 
 func replaceGRPCLogger(log *slog.Logger) {
-	// get correct reference in callstack
-	// to log function that called the
-	// wrapper
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:])
-
 	gl := &grpcLogger{
-		logger:    log.With(slog.String("system", "grpc"), slog.Bool("grpc_log", true), pcs[0]),
+		logger:    log.With(slog.String("system", "grpc"), slog.Bool("grpc_log", true)),
 		verbosity: 0,
 	}
 	grpclog.SetLoggerV2(gl)
@@ -36,53 +31,125 @@ type grpcLogger struct {
 }
 
 func (l *grpcLogger) Info(args ...interface{}) {
-	l.logger.Info(fmt.Sprint(args...))
+	if !l.logger.Enabled(context.Background(), LevelInfo) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Info]
+	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprint(args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 func (l *grpcLogger) Infoln(args ...interface{}) {
-	l.logger.Info(fmt.Sprint(args...))
+	if !l.logger.Enabled(context.Background(), LevelInfo) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Infoln]
+	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprint(args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 func (l *grpcLogger) Infof(format string, args ...interface{}) {
-	l.logger.Info(fmt.Sprintf(format, args...))
+	if !l.logger.Enabled(context.Background(), LevelInfo) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Infof]
+	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprintf(format, args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 func (l *grpcLogger) Warning(args ...interface{}) {
-	l.logger.Warn(fmt.Sprint(args...))
+	if !l.logger.Enabled(context.Background(), LevelWarn) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Warning]
+	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprint(args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 func (l *grpcLogger) Warningln(args ...interface{}) {
-	l.logger.Warn(fmt.Sprint(args...))
+	if !l.logger.Enabled(context.Background(), LevelWarn) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Warningln]
+	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprint(args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 func (l *grpcLogger) Warningf(format string, args ...interface{}) {
-	l.logger.Warn(fmt.Sprintf(format, args...))
+	if !l.logger.Enabled(context.Background(), LevelWarn) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Warningf]
+	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprintf(format, args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 func (l *grpcLogger) Error(args ...interface{}) {
-	l.logger.Error(fmt.Sprint(args...))
+	if !l.logger.Enabled(context.Background(), LevelError) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Error]
+	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprint(args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 func (l *grpcLogger) Errorln(args ...interface{}) {
-	l.logger.Error(fmt.Sprint(args...))
+	if !l.logger.Enabled(context.Background(), LevelError) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Errorln]
+	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprint(args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 func (l *grpcLogger) Errorf(format string, args ...interface{}) {
-	l.logger.Error(fmt.Sprintf(format, args...))
+	if !l.logger.Enabled(context.Background(), LevelError) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Errorf]
+	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprintf(format, args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 func (l *grpcLogger) Fatal(args ...interface{}) {
-	l.logger.Log(context.Background(), LevelFatal, fmt.Sprint(args...))
+	if !l.logger.Enabled(context.Background(), LevelFatal) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Fatal]
+	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprint(args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 	os.Exit(1)
 }
 
 func (l *grpcLogger) Fatalln(args ...interface{}) {
-	l.logger.Log(context.Background(), LevelFatal, fmt.Sprint(args...))
+	if !l.logger.Enabled(context.Background(), LevelFatal) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Fatalln]
+	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprint(args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 	os.Exit(1)
 }
 
 func (l *grpcLogger) Fatalf(format string, args ...interface{}) {
-	l.logger.Log(context.Background(), LevelFatal, fmt.Sprint(args...))
+	if !l.logger.Enabled(context.Background(), LevelFatal) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Fatalf]
+	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprintf(format, args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 	os.Exit(1)
 }
 

--- a/internal/logger/grpclogger.go
+++ b/internal/logger/grpclogger.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"runtime"
 	"time"
 
 	"google.golang.org/grpc/grpclog"
@@ -34,9 +33,8 @@ func (l *grpcLogger) Info(args ...interface{}) {
 	if !l.logger.Enabled(context.Background(), LevelInfo) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Info]
-	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -44,9 +42,8 @@ func (l *grpcLogger) Infoln(args ...interface{}) {
 	if !l.logger.Enabled(context.Background(), LevelInfo) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Infoln]
-	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -54,9 +51,8 @@ func (l *grpcLogger) Infof(format string, args ...interface{}) {
 	if !l.logger.Enabled(context.Background(), LevelInfo) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Infof]
-	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprintf(format, args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprintf(format, args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -64,9 +60,8 @@ func (l *grpcLogger) Warning(args ...interface{}) {
 	if !l.logger.Enabled(context.Background(), LevelWarn) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Warning]
-	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -74,9 +69,8 @@ func (l *grpcLogger) Warningln(args ...interface{}) {
 	if !l.logger.Enabled(context.Background(), LevelWarn) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Warningln]
-	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -84,9 +78,8 @@ func (l *grpcLogger) Warningf(format string, args ...interface{}) {
 	if !l.logger.Enabled(context.Background(), LevelWarn) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Warningf]
-	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprintf(format, args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprintf(format, args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -94,9 +87,8 @@ func (l *grpcLogger) Error(args ...interface{}) {
 	if !l.logger.Enabled(context.Background(), LevelError) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Error]
-	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -104,9 +96,8 @@ func (l *grpcLogger) Errorln(args ...interface{}) {
 	if !l.logger.Enabled(context.Background(), LevelError) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Errorln]
-	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -114,9 +105,8 @@ func (l *grpcLogger) Errorf(format string, args ...interface{}) {
 	if !l.logger.Enabled(context.Background(), LevelError) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Errorf]
-	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprintf(format, args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprintf(format, args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -124,9 +114,8 @@ func (l *grpcLogger) Fatal(args ...interface{}) {
 	if !l.logger.Enabled(context.Background(), LevelFatal) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Fatal]
-	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 	os.Exit(1)
 }
@@ -135,9 +124,8 @@ func (l *grpcLogger) Fatalln(args ...interface{}) {
 	if !l.logger.Enabled(context.Background(), LevelFatal) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Fatalln]
-	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 	os.Exit(1)
 }
@@ -146,9 +134,8 @@ func (l *grpcLogger) Fatalf(format string, args ...interface{}) {
 	if !l.logger.Enabled(context.Background(), LevelFatal) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Fatalf]
-	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprintf(format, args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprintf(format, args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 	os.Exit(1)
 }

--- a/internal/logger/grpclogger.go
+++ b/internal/logger/grpclogger.go
@@ -8,10 +8,8 @@ package logger
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"os"
-	"time"
 
 	"google.golang.org/grpc/grpclog"
 )
@@ -34,8 +32,7 @@ func (l *grpcLogger) Info(args ...interface{}) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelInfo, originalFunction, args...)
 }
 
 func (l *grpcLogger) Infoln(args ...interface{}) {
@@ -43,8 +40,7 @@ func (l *grpcLogger) Infoln(args ...interface{}) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelInfo, originalFunction, args...)
 }
 
 func (l *grpcLogger) Infof(format string, args ...interface{}) {
@@ -52,8 +48,7 @@ func (l *grpcLogger) Infof(format string, args ...interface{}) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprintf(format, args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecordf(l.logger, LevelInfo, originalFunction, format, args...)
 }
 
 func (l *grpcLogger) Warning(args ...interface{}) {
@@ -61,8 +56,7 @@ func (l *grpcLogger) Warning(args ...interface{}) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelWarn, originalFunction, args...)
 }
 
 func (l *grpcLogger) Warningln(args ...interface{}) {
@@ -70,8 +64,7 @@ func (l *grpcLogger) Warningln(args ...interface{}) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelWarn, originalFunction, args...)
 }
 
 func (l *grpcLogger) Warningf(format string, args ...interface{}) {
@@ -79,8 +72,7 @@ func (l *grpcLogger) Warningf(format string, args ...interface{}) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprintf(format, args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecordf(l.logger, LevelWarn, originalFunction, format, args...)
 }
 
 func (l *grpcLogger) Error(args ...interface{}) {
@@ -88,8 +80,7 @@ func (l *grpcLogger) Error(args ...interface{}) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelError, originalFunction, args...)
 }
 
 func (l *grpcLogger) Errorln(args ...interface{}) {
@@ -97,8 +88,7 @@ func (l *grpcLogger) Errorln(args ...interface{}) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelError, originalFunction, args...)
 }
 
 func (l *grpcLogger) Errorf(format string, args ...interface{}) {
@@ -106,8 +96,7 @@ func (l *grpcLogger) Errorf(format string, args ...interface{}) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprintf(format, args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecordf(l.logger, LevelError, originalFunction, format, args...)
 }
 
 func (l *grpcLogger) Fatal(args ...interface{}) {
@@ -115,8 +104,7 @@ func (l *grpcLogger) Fatal(args ...interface{}) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelFatal, originalFunction, args...)
 	os.Exit(1)
 }
 
@@ -125,8 +113,7 @@ func (l *grpcLogger) Fatalln(args ...interface{}) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelFatal, originalFunction, args...)
 	os.Exit(1)
 }
 
@@ -135,8 +122,7 @@ func (l *grpcLogger) Fatalf(format string, args ...interface{}) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprintf(format, args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecordf(l.logger, LevelFatal, originalFunction, format, args...)
 	os.Exit(1)
 }
 

--- a/internal/logger/grpclogger.go
+++ b/internal/logger/grpclogger.go
@@ -7,8 +7,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 package logger
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"runtime"
 
 	"google.golang.org/grpc/grpclog"
@@ -70,15 +72,18 @@ func (l *grpcLogger) Errorf(format string, args ...interface{}) {
 }
 
 func (l *grpcLogger) Fatal(args ...interface{}) {
-	l.Fatal(fmt.Sprint(args...))
+	l.logger.Log(context.Background(), LevelFatal, fmt.Sprint(args...))
+	os.Exit(1)
 }
 
 func (l *grpcLogger) Fatalln(args ...interface{}) {
-	l.Fatal(fmt.Sprint(args...))
+	l.logger.Log(context.Background(), LevelFatal, fmt.Sprint(args...))
+	os.Exit(1)
 }
 
 func (l *grpcLogger) Fatalf(format string, args ...interface{}) {
-	l.Fatal(fmt.Sprintf(format, args...))
+	l.logger.Log(context.Background(), LevelFatal, fmt.Sprint(args...))
+	os.Exit(1)
 }
 
 func (l *grpcLogger) V(level int) bool {

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -216,7 +216,6 @@ func (l *Logger) With(fields ...any) *Logger {
 }
 
 // Grouped returns a named logger.
-// TODO: rename function to Grouped()
 func (l *Logger) Grouped(name string) *Logger {
 	return &Logger{logger: l.logger.WithGroup(name)}
 }

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -225,7 +225,7 @@ func (l *Logger) GetClientStreamInterceptor() grpc.DialOption {
 
 func (l *Logger) middlewareLogger() logging.Logger {
 	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
-		f := make([]slog.Attr, 0, len(fields)/2)
+		f := make([]interface{}, 0, len(fields)/2)
 
 		for i := 0; i < len(fields); i += 2 {
 			key := fields[i]
@@ -243,7 +243,7 @@ func (l *Logger) middlewareLogger() logging.Logger {
 			}
 		}
 
-		logger := l.logger.With(f)
+		logger := l.logger.With(f...)
 
 		switch lvl {
 		case logging.LevelDebug:

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -75,6 +75,16 @@ func getOriginalCaller() (original [1]uintptr) {
 	return pcs
 }
 
+func createAndLogRecord(logger *slog.Logger, level slog.Level, originalFunction [1]uintptr, args ...any) {
+	record := slog.NewRecord(time.Now(), level, fmt.Sprint(args...), originalFunction[0])
+	_ = logger.Handler().Handle(context.Background(), record)
+}
+
+func createAndLogRecordf(logger *slog.Logger, level slog.Level, originalFunction [1]uintptr, format string, args ...any) {
+	record := slog.NewRecord(time.Now(), level, fmt.Sprintf(format, args...), originalFunction[0])
+	_ = logger.Handler().Handle(context.Background(), record)
+}
+
 func replaceAttrFunction(groups []string, a slog.Attr) slog.Attr {
 	// change the time format to rfc 3339
 	if a.Key == slog.TimeKey {
@@ -151,8 +161,7 @@ func (l *Logger) Debugf(format string, args ...any) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelDebug, fmt.Sprintf(format, args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecordf(l.logger, LevelDebug, originalFunction, format, args...)
 }
 
 // Debug logs a message at Debug level.
@@ -162,8 +171,7 @@ func (l *Logger) Debug(args ...any) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelDebug, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelDebug, originalFunction, args...)
 }
 
 // Infof logs a message at Info level.
@@ -173,8 +181,7 @@ func (l *Logger) Infof(format string, args ...any) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprintf(format, args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecordf(l.logger, LevelInfo, originalFunction, format, args...)
 }
 
 // Info logs a message at Info level.
@@ -184,8 +191,7 @@ func (l *Logger) Info(args ...any) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelInfo, originalFunction, args...)
 }
 
 // Warnf logs a message at Warn level.
@@ -195,8 +201,7 @@ func (l *Logger) Warnf(format string, args ...any) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprintf(format, args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecordf(l.logger, LevelWarn, originalFunction, format, args...)
 }
 
 // Warn logs a message at Warn level.
@@ -206,8 +211,7 @@ func (l *Logger) Warn(args ...any) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelWarn, originalFunction, args...)
 }
 
 // Errorf logs a message at Error level.
@@ -217,8 +221,7 @@ func (l *Logger) Errorf(format string, args ...any) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprintf(format, args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecordf(l.logger, LevelError, originalFunction, format, args...)
 }
 
 // Error logs a message at Error level.
@@ -228,8 +231,7 @@ func (l *Logger) Error(args ...any) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelError, originalFunction, args...)
 }
 
 // Fatalf logs the message and then calls os.Exit(1).
@@ -239,8 +241,7 @@ func (l *Logger) Fatalf(format string, args ...any) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Errorf(format, args...).Error(), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecordf(l.logger, LevelFatal, originalFunction, format, args...)
 	os.Exit(1)
 }
 
@@ -251,8 +252,7 @@ func (l *Logger) Fatal(args ...any) {
 		return
 	}
 	originalFunction := getOriginalCaller()
-	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprint(args...), originalFunction[0])
-	_ = l.logger.Handler().Handle(context.Background(), r)
+	createAndLogRecord(l.logger, LevelFatal, originalFunction, args...)
 	os.Exit(1)
 }
 

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -150,6 +150,18 @@ func (l *Logger) Debugf(format string, args ...any) {
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
+// Debug logs a message at Debug level.
+// Debug logs are typically voluminous, and contain detailed information on the flow of execution.
+func (l *Logger) Debug(args ...any) {
+	if !l.logger.Enabled(context.Background(), LevelDebug) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Debugf]
+	r := slog.NewRecord(time.Now(), LevelDebug, fmt.Sprint(args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
+}
+
 // Infof logs a message at Info level.
 // This is the default logging priority and should be used for all normal messages.
 func (l *Logger) Infof(format string, args ...any) {
@@ -159,6 +171,18 @@ func (l *Logger) Infof(format string, args ...any) {
 	var pcs [1]uintptr
 	runtime.Callers(2, pcs[:]) // skip [Callers, Infof]
 	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprintf(format, args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
+}
+
+// Info logs a message at Info level.
+// This is the default logging priority and should be used for all normal messages.
+func (l *Logger) Info(args ...any) {
+	if !l.logger.Enabled(context.Background(), LevelInfo) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Infof]
+	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprint(args...), pcs[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -174,6 +198,18 @@ func (l *Logger) Warnf(format string, args ...any) {
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
+// Warn logs a message at Warn level.
+// Warn logs are more important than Info, but they don't need human review or necessarily indicate an error.
+func (l *Logger) Warn(args ...any) {
+	if !l.logger.Enabled(context.Background(), LevelWarn) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Warnf]
+	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprint(args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
+}
+
 // Errorf logs a message at Error level.
 // Error logs are high priority and indicate something has gone wrong.
 func (l *Logger) Errorf(format string, args ...any) {
@@ -186,6 +222,18 @@ func (l *Logger) Errorf(format string, args ...any) {
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
+// Error logs a message at Error level.
+// Error logs are high priority and indicate something has gone wrong.
+func (l *Logger) Error(args ...any) {
+	if !l.logger.Enabled(context.Background(), LevelError) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Errorf]
+	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprint(args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
+}
+
 // Fatalf logs the message and then calls os.Exit(1).
 // Use this to exit your program when a fatal error occurs.
 func (l *Logger) Fatalf(format string, args ...any) {
@@ -195,6 +243,19 @@ func (l *Logger) Fatalf(format string, args ...any) {
 	var pcs [1]uintptr
 	runtime.Callers(2, pcs[:]) // skip [Callers, Fatalf]
 	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprintf(format, args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
+	os.Exit(1)
+}
+
+// Fatal logs the message and then calls os.Exit(1).
+// Use this to exit your program when a fatal error occurs.
+func (l *Logger) Fatal(args ...any) {
+	if !l.logger.Enabled(context.Background(), LevelFatal) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Fatalf]
+	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprint(args...), pcs[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 	os.Exit(1)
 }

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -83,14 +83,22 @@ func New(logType LogType, logLevel slog.Level) *Logger {
 		// add the file and line number
 		AddSource: true,
 		Level:     logLevel,
-		// change the time format to rfc 3339
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
-			if a.Key != slog.TimeKey {
-				return a
+			// change the time format to rfc 3339
+			if a.Key == slog.TimeKey {
+				logTime := a.Value.Any().(time.Time)
+				a.Value = slog.StringValue(logTime.Format(time.RFC3339))
 			}
 
-			logTime := a.Value.Any().(time.Time)
-			a.Value = slog.StringValue(logTime.Format(time.RFC3339))
+			// include fatal log level
+			if a.Key == slog.LevelKey {
+				level := a.Value.Any().(slog.Level)
+				if level <= LevelError {
+					return a
+				}
+
+				a.Value = slog.StringValue("FATAL")
+			}
 
 			return a
 		},

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -22,7 +22,7 @@ Use this package to implement logging for your Constellation services.
 5. Use the With() method to create a child logger with structured context.
 This can also be used to add context to a single log message:
 
-	logger.With(zap.String("key", "value")).Infof("log message")
+	logger.With(slog.String("key", "value")).Infof("log message")
 
 # Log Levels
 

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -207,11 +207,6 @@ func (l *Logger) GetClientStreamInterceptor() grpc.DialOption {
 	)
 }
 
-// getZapLogger returns the underlying zap logger.
-func (l *Logger) getZapLogger() *zap.Logger {
-	return l.logger.Desugar()
-}
-
 func (l *Logger) middlewareLogger() logging.Logger {
 	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
 		f := make([]zap.Field, 0, len(fields)/2)
@@ -232,7 +227,7 @@ func (l *Logger) middlewareLogger() logging.Logger {
 			}
 		}
 
-		logger := l.getZapLogger().WithOptions(zap.AddCallerSkip(1)).With(f...)
+		logger := l.logger
 
 		switch lvl {
 		case logging.LevelDebug:

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -47,7 +47,6 @@ import (
 	"time"
 
 	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 )
 
@@ -226,7 +225,7 @@ func (l *Logger) GetClientStreamInterceptor() grpc.DialOption {
 
 func (l *Logger) middlewareLogger() logging.Logger {
 	return logging.LoggerFunc(func(ctx context.Context, lvl logging.Level, msg string, fields ...any) {
-		f := make([]zap.Field, 0, len(fields)/2)
+		f := make([]slog.Attr, 0, len(fields)/2)
 
 		for i := 0; i < len(fields); i += 2 {
 			key := fields[i]
@@ -234,17 +233,17 @@ func (l *Logger) middlewareLogger() logging.Logger {
 
 			switch v := value.(type) {
 			case string:
-				f = append(f, zap.String(key.(string), v))
+				f = append(f, slog.String(key.(string), v))
 			case int:
-				f = append(f, zap.Int(key.(string), v))
+				f = append(f, slog.Int(key.(string), v))
 			case bool:
-				f = append(f, zap.Bool(key.(string), v))
+				f = append(f, slog.Bool(key.(string), v))
 			default:
-				f = append(f, zap.Any(key.(string), v))
+				f = append(f, slog.Any(key.(string), v))
 			}
 		}
 
-		logger := l.logger
+		logger := l.logger.With(f)
 
 		switch lvl {
 		case logging.LevelDebug:

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -69,6 +69,12 @@ const (
 	LevelFatal = 12
 )
 
+func getOriginalCaller() (original [1]uintptr) {
+	var pcs [1]uintptr
+	runtime.Callers(3, pcs[:]) // skip Callers, getOriginalCaller and the function calling getOriginalCaller
+	return pcs
+}
+
 func replaceAttrFunction(groups []string, a slog.Attr) slog.Attr {
 	// change the time format to rfc 3339
 	if a.Key == slog.TimeKey {
@@ -144,9 +150,8 @@ func (l *Logger) Debugf(format string, args ...any) {
 	if !l.logger.Enabled(context.Background(), LevelDebug) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Debugf]
-	r := slog.NewRecord(time.Now(), LevelDebug, fmt.Sprintf(format, args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelDebug, fmt.Sprintf(format, args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -156,9 +161,8 @@ func (l *Logger) Debug(args ...any) {
 	if !l.logger.Enabled(context.Background(), LevelDebug) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Debugf]
-	r := slog.NewRecord(time.Now(), LevelDebug, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelDebug, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -168,9 +172,8 @@ func (l *Logger) Infof(format string, args ...any) {
 	if !l.logger.Enabled(context.Background(), LevelInfo) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Infof]
-	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprintf(format, args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprintf(format, args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -180,9 +183,8 @@ func (l *Logger) Info(args ...any) {
 	if !l.logger.Enabled(context.Background(), LevelInfo) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Infof]
-	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -192,9 +194,8 @@ func (l *Logger) Warnf(format string, args ...any) {
 	if !l.logger.Enabled(context.Background(), LevelWarn) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Warnf]
-	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprintf(format, args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprintf(format, args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -204,9 +205,8 @@ func (l *Logger) Warn(args ...any) {
 	if !l.logger.Enabled(context.Background(), LevelWarn) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Warnf]
-	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -216,9 +216,8 @@ func (l *Logger) Errorf(format string, args ...any) {
 	if !l.logger.Enabled(context.Background(), LevelError) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Errorf]
-	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprintf(format, args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprintf(format, args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -228,9 +227,8 @@ func (l *Logger) Error(args ...any) {
 	if !l.logger.Enabled(context.Background(), LevelError) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Errorf]
-	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
@@ -240,9 +238,8 @@ func (l *Logger) Fatalf(format string, args ...any) {
 	if !l.logger.Enabled(context.Background(), LevelFatal) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Fatalf]
-	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Errorf(format, args...).Error(), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Errorf(format, args...).Error(), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 	os.Exit(1)
 }
@@ -253,9 +250,8 @@ func (l *Logger) Fatal(args ...any) {
 	if !l.logger.Enabled(context.Background(), LevelFatal) {
 		return
 	}
-	var pcs [1]uintptr
-	runtime.Callers(2, pcs[:]) // skip [Callers, Fatalf]
-	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprint(args...), pcs[0])
+	originalFunction := getOriginalCaller()
+	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprint(args...), originalFunction[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 	os.Exit(1)
 }

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -176,7 +176,7 @@ func (l *Logger) Named(name string) *Logger {
 
 // ReplaceGRPCLogger replaces grpc's internal logger with the given logger.
 func (l *Logger) ReplaceGRPCLogger() {
-	replaceGRPCLogger(l.getZapLogger())
+	replaceGRPCLogger(l.logger)
 }
 
 // GetServerUnaryInterceptor returns a gRPC server option for intercepting unary gRPC logs.

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -43,6 +43,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"runtime"
 	"testing"
 	"time"
 
@@ -140,31 +141,61 @@ func NewTest(t *testing.T) *Logger {
 // Debugf logs a message at Debug level.
 // Debug logs are typically voluminous, and contain detailed information on the flow of execution.
 func (l *Logger) Debugf(format string, args ...any) {
-	l.logger.Debug(format, args...)
+	if !l.logger.Enabled(context.Background(), LevelDebug) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Debugf]
+	r := slog.NewRecord(time.Now(), LevelDebug, fmt.Sprintf(format, args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 // Infof logs a message at Info level.
 // This is the default logging priority and should be used for all normal messages.
 func (l *Logger) Infof(format string, args ...any) {
-	l.logger.Info(format, args...)
+	if !l.logger.Enabled(context.Background(), LevelInfo) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Infof]
+	r := slog.NewRecord(time.Now(), LevelInfo, fmt.Sprintf(format, args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 // Warnf logs a message at Warn level.
 // Warn logs are more important than Info, but they don't need human review or necessarily indicate an error.
 func (l *Logger) Warnf(format string, args ...any) {
-	l.logger.Warn(format, args...)
+	if !l.logger.Enabled(context.Background(), LevelWarn) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Warnf]
+	r := slog.NewRecord(time.Now(), LevelWarn, fmt.Sprintf(format, args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 // Errorf logs a message at Error level.
 // Error logs are high priority and indicate something has gone wrong.
 func (l *Logger) Errorf(format string, args ...any) {
-	l.logger.Error(format, args...)
+	if !l.logger.Enabled(context.Background(), LevelError) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Errorf]
+	r := slog.NewRecord(time.Now(), LevelError, fmt.Sprintf(format, args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 }
 
 // Fatalf logs the message and then calls os.Exit(1).
 // Use this to exit your program when a fatal error occurs.
 func (l *Logger) Fatalf(format string, args ...any) {
-	l.logger.Log(context.Background(), LevelFatal, format, args...)
+	if !l.logger.Enabled(context.Background(), LevelFatal) {
+		return
+	}
+	var pcs [1]uintptr
+	runtime.Callers(2, pcs[:]) // skip [Callers, Fatalf]
+	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprintf(format, args...), pcs[0])
+	_ = l.logger.Handler().Handle(context.Background(), r)
 	os.Exit(1)
 }
 

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -161,8 +161,9 @@ func (l *Logger) With(fields ...any) *Logger {
 }
 
 // Named returns a named logger.
+// TODO: rename function to Grouped()
 func (l *Logger) Named(name string) *Logger {
-	return &Logger{logger: l.logger.Named(name)}
+	return &Logger{logger: l.logger.WithGroup(name)}
 }
 
 // ReplaceGRPCLogger replaces grpc's internal logger with the given logger.

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -242,7 +242,7 @@ func (l *Logger) Fatalf(format string, args ...any) {
 	}
 	var pcs [1]uintptr
 	runtime.Callers(2, pcs[:]) // skip [Callers, Fatalf]
-	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Sprintf(format, args...), pcs[0])
+	r := slog.NewRecord(time.Now(), LevelFatal, fmt.Errorf(format, args...).Error(), pcs[0])
 	_ = l.logger.Handler().Handle(context.Background(), r)
 	os.Exit(1)
 }

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -144,12 +144,6 @@ func (l *Logger) Fatalf(format string, args ...any) {
 	os.Exit(1)
 }
 
-// Sync flushes any buffered log entries.
-// Applications should take care to call Sync before exiting.
-func (l *Logger) Sync() {
-	_ = l.logger.Sync()
-}
-
 // WithIncreasedLevel returns a logger with increased logging level.
 func (l *Logger) WithIncreasedLevel(level slog.Level) *Logger {
 	var logger Logger

--- a/internal/logger/log.go
+++ b/internal/logger/log.go
@@ -215,9 +215,9 @@ func (l *Logger) With(fields ...any) *Logger {
 	return &Logger{logger: l.logger.With(fields...)}
 }
 
-// Named returns a named logger.
+// Grouped returns a named logger.
 // TODO: rename function to Grouped()
-func (l *Logger) Named(name string) *Logger {
+func (l *Logger) Grouped(name string) *Logger {
 	return &Logger{logger: l.logger.WithGroup(name)}
 }
 

--- a/internal/osimage/aws/awsupload.go
+++ b/internal/osimage/aws/awsupload.go
@@ -19,7 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
 
@@ -103,7 +102,7 @@ func (u *Uploader) Upload(ctx context.Context, req *osimage.UploadRequest) ([]ve
 	}
 	defer func() {
 		if err := u.ensureBlobDeleted(ctx, blobName); err != nil {
-			u.log.Errorf("post-cleaning: deleting temporary blob from s3", err)
+			u.log.Error("post-cleaning: deleting temporary blob from s3", err)
 		}
 	}()
 	snapshotID, err := u.importSnapshot(ctx, blobName, imageName)
@@ -166,7 +165,7 @@ func (u *Uploader) ensureBucket(ctx context.Context) error {
 		u.log.Debugf("Bucket %s exists", u.bucketName)
 		return nil
 	}
-	var noSuchBucketErr *types.NoSuchBucket
+	var noSuchBucketErr *s3types.NoSuchBucket
 	if !errors.As(err, &noSuchBucketErr) {
 		return fmt.Errorf("determining if bucket %s exists: %w", u.bucketName, err)
 	}

--- a/joinservice/cmd/main.go
+++ b/joinservice/cmd/main.go
@@ -68,13 +68,13 @@ func main() {
 		log.With(zap.Error(err)).Fatalf("Failed to parse attestation variant")
 	}
 
-	certCacheClient := certcache.NewClient(log.Named("certcache"), kubeClient, attVariant)
+	certCacheClient := certcache.NewClient(log.Grouped("certcache"), kubeClient, attVariant)
 	cachedCerts, err := certCacheClient.CreateCertChainCache(context.Background())
 	if err != nil {
 		log.With(zap.Error(err)).Fatalf("Failed to create certificate chain cache")
 	}
 
-	validator, err := watcher.NewValidator(log.Named("validator"), attVariant, handler, cachedCerts)
+	validator, err := watcher.NewValidator(log.Grouped("validator"), attVariant, handler, cachedCerts)
 	if err != nil {
 		flag.Usage()
 		log.With(zap.Error(err)).Fatalf("Failed to create validator")
@@ -90,11 +90,11 @@ func main() {
 		log.With(zap.Error(err)).Fatalf("Failed to get IP in VPC")
 	}
 	apiServerEndpoint := net.JoinHostPort(vpcIP, strconv.Itoa(constants.KubernetesPort))
-	kubeadm, err := kubeadm.New(apiServerEndpoint, log.Named("kubeadm"))
+	kubeadm, err := kubeadm.New(apiServerEndpoint, log.Grouped("kubeadm"))
 	if err != nil {
 		log.With(zap.Error(err)).Fatalf("Failed to create kubeadm")
 	}
-	keyServiceClient := kms.New(log.Named("keyServiceClient"), *keyServiceEndpoint)
+	keyServiceClient := kms.New(log.Grouped("keyServiceClient"), *keyServiceEndpoint)
 
 	measurementSalt, err := handler.Read(filepath.Join(constants.ServiceBasePath, constants.MeasurementSaltFilename))
 	if err != nil {
@@ -103,17 +103,17 @@ func main() {
 
 	server, err := server.New(
 		measurementSalt,
-		kubernetesca.New(log.Named("certificateAuthority"), handler),
+		kubernetesca.New(log.Grouped("certificateAuthority"), handler),
 		kubeadm,
 		keyServiceClient,
 		kubeClient,
-		log.Named("server"),
+		log.Grouped("server"),
 	)
 	if err != nil {
 		log.With(zap.Error(err)).Fatalf("Failed to create server")
 	}
 
-	watcher, err := watcher.New(log.Named("fileWatcher"), validator)
+	watcher, err := watcher.New(log.Grouped("fileWatcher"), validator)
 	if err != nil {
 		log.With(zap.Error(err)).Fatalf("Failed to create watcher for measurements updates")
 	}

--- a/joinservice/internal/kms/kms.go
+++ b/joinservice/internal/kms/kms.go
@@ -10,10 +10,10 @@ package kms
 import (
 	"context"
 	"fmt"
+	"log/slog"
 
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/keyservice/keyserviceproto"
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
@@ -36,7 +36,7 @@ func New(log *logger.Logger, endpoint string) Client {
 
 // GetDataKey returns a data encryption key for the given UUID.
 func (c Client) GetDataKey(ctx context.Context, keyID string, length int) ([]byte, error) {
-	log := c.log.With(zap.String("keyID", keyID), zap.String("endpoint", c.endpoint))
+	log := c.log.With(slog.String("keyID", keyID), slog.String("endpoint", c.endpoint))
 	// the KMS does not use aTLS since traffic is only routed through the Constellation cluster
 	// cluster internal connections are considered trustworthy
 	log.Infof("Connecting to KMS at %s", c.endpoint)

--- a/joinservice/internal/server/server.go
+++ b/joinservice/internal/server/server.go
@@ -59,10 +59,10 @@ func New(
 
 // Run starts the gRPC server on the given port, using the provided tlsConfig.
 func (s *Server) Run(creds credentials.TransportCredentials, port string) error {
-	s.log.WithIncreasedLevel(slog.LevelWarn).Named("gRPC").ReplaceGRPCLogger()
+	s.log.WithIncreasedLevel(slog.LevelWarn).Grouped("gRPC").ReplaceGRPCLogger()
 	grpcServer := grpc.NewServer(
 		grpc.Creds(creds),
-		s.log.Named("gRPC").GetServerUnaryInterceptor(),
+		s.log.Grouped("gRPC").GetServerUnaryInterceptor(),
 	)
 
 	joinproto.RegisterAPIServer(grpcServer, s)

--- a/joinservice/internal/server/server.go
+++ b/joinservice/internal/server/server.go
@@ -10,6 +10,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 	"time"
 
@@ -58,7 +59,7 @@ func New(
 
 // Run starts the gRPC server on the given port, using the provided tlsConfig.
 func (s *Server) Run(creds credentials.TransportCredentials, port string) error {
-	s.log.WithIncreasedLevel(zap.WarnLevel).Named("gRPC").ReplaceGRPCLogger()
+	s.log.WithIncreasedLevel(slog.LevelWarn).Named("gRPC").ReplaceGRPCLogger()
 	grpcServer := grpc.NewServer(
 		grpc.Creds(creds),
 		s.log.Named("gRPC").GetServerUnaryInterceptor(),

--- a/joinservice/internal/watcher/watcher.go
+++ b/joinservice/internal/watcher/watcher.go
@@ -9,10 +9,10 @@ package watcher
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/fsnotify/fsnotify"
-	"go.uber.org/zap"
 )
 
 // FileWatcher watches for changes to the file and calls the waiter's Update method.
@@ -66,21 +66,21 @@ func (f *FileWatcher) Watch(file string) error {
 			// file changes may be indicated by either a WRITE, CHMOD, CREATE or RENAME event
 			if event.Op&(fsnotify.Write|fsnotify.Chmod|fsnotify.Create|fsnotify.Rename) != 0 {
 				if err := f.updater.Update(); err != nil {
-					log.With(zap.Error(err)).Errorf("Update failed")
+					log.With(slog.Any("error", err)).Errorf("Update failed")
 				}
 			}
 
 			// if a file gets removed, e.g. by a rename event, we need to re-add the file to the watcher
 			if event.Has(fsnotify.Remove) {
 				if err := f.watcher.Add(event.Name); err != nil {
-					log.With(zap.Error(err)).Errorf("Failed to re-add file to watcher")
+					log.With(slog.Any("error", err)).Errorf("Failed to re-add file to watcher")
 					return fmt.Errorf("failed to re-add file %q to watcher: %w", event.Name, err)
 				}
 			}
 
 		case err := <-f.watcher.Errors():
 			if err != nil {
-				log.With(zap.Error(err)).Errorf("Watching for measurements updates")
+				log.With(slog.Any("error", err)).Errorf("Watching for measurements updates")
 				return fmt.Errorf("watching for measurements updates: %w", err)
 			}
 		}

--- a/keyservice/cmd/main.go
+++ b/keyservice/cmd/main.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"flag"
+	"log/slog"
 	"path/filepath"
 	"strconv"
 	"time"
@@ -22,7 +23,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/keyservice/internal/server"
 	"github.com/spf13/afero"
-	"go.uber.org/zap"
 )
 
 func main() {
@@ -34,24 +34,24 @@ func main() {
 	flag.Parse()
 	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity))
 
-	log.With(zap.String("version", constants.BinaryVersion().String())).
+	log.With(slog.String("version", constants.BinaryVersion().String())).
 		Infof("Constellation Key Management Service")
 
 	// read master secret and salt
 	file := file.NewHandler(afero.NewOsFs())
 	masterKey, err := file.Read(*masterSecretPath)
 	if err != nil {
-		log.With(zap.Error(err)).Fatalf("Failed to read master secret")
+		log.With(slog.Any("error", err)).Fatalf("Failed to read master secret")
 	}
 	if len(masterKey) < crypto.MasterSecretLengthMin {
-		log.With(zap.Error(errors.New("invalid key length"))).Fatalf("Provided master secret is smaller than the required minimum of %d bytes", crypto.MasterSecretLengthMin)
+		log.With(slog.Any("error", errors.New("invalid key length"))).Fatalf("Provided master secret is smaller than the required minimum of %d bytes", crypto.MasterSecretLengthMin)
 	}
 	salt, err := file.Read(*saltPath)
 	if err != nil {
-		log.With(zap.Error(err)).Fatalf("Failed to read salt")
+		log.With(slog.Any("error", err)).Fatalf("Failed to read salt")
 	}
 	if len(salt) < crypto.RNGLengthDefault {
-		log.With(zap.Error(errors.New("invalid salt length"))).Fatalf("Expected salt to be %d bytes, but got %d", crypto.RNGLengthDefault, len(salt))
+		log.With(slog.Any("error", errors.New("invalid salt length"))).Fatalf("Expected salt to be %d bytes, but got %d", crypto.RNGLengthDefault, len(salt))
 	}
 	masterSecret := uri.MasterSecret{Key: masterKey, Salt: salt}
 
@@ -60,11 +60,11 @@ func main() {
 	defer cancel()
 	conKMS, err := setup.KMS(ctx, uri.NoStoreURI, masterSecret.EncodeToURI())
 	if err != nil {
-		log.With(zap.Error(err)).Fatalf("Failed to setup KMS")
+		log.With(slog.Any("error", err)).Fatalf("Failed to setup KMS")
 	}
 	defer conKMS.Close()
 
 	if err := server.New(log.Grouped("keyService"), conKMS).Run(*port); err != nil {
-		log.With(zap.Error(err)).Fatalf("Failed to run key-service server")
+		log.With(slog.Any("error", err)).Fatalf("Failed to run key-service server")
 	}
 }

--- a/keyservice/cmd/main.go
+++ b/keyservice/cmd/main.go
@@ -64,7 +64,7 @@ func main() {
 	}
 	defer conKMS.Close()
 
-	if err := server.New(log.Named("keyService"), conKMS).Run(*port); err != nil {
+	if err := server.New(log.Grouped("keyService"), conKMS).Run(*port); err != nil {
 		log.With(zap.Error(err)).Fatalf("Failed to run key-service server")
 	}
 }

--- a/keyservice/internal/server/server.go
+++ b/keyservice/internal/server/server.go
@@ -10,6 +10,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net"
 
 	"github.com/edgelesssys/constellation/v2/internal/crypto"
@@ -18,7 +19,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/keyservice/keyserviceproto"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -51,7 +51,7 @@ func (s *Server) Run(port string) error {
 
 	server := grpc.NewServer(s.log.Named("gRPC").GetServerUnaryInterceptor())
 	keyserviceproto.RegisterAPIServer(server, s)
-	s.log.Named("gRPC").WithIncreasedLevel(zapcore.WarnLevel).ReplaceGRPCLogger()
+	s.log.Named("gRPC").WithIncreasedLevel(slog.LevelWarn).ReplaceGRPCLogger()
 
 	// start the server
 	s.log.Infof("Starting Constellation key management service on %s", listener.Addr().String())

--- a/keyservice/internal/server/server.go
+++ b/keyservice/internal/server/server.go
@@ -49,9 +49,9 @@ func (s *Server) Run(port string) error {
 		return fmt.Errorf("failed to listen on port %s: %v", port, err)
 	}
 
-	server := grpc.NewServer(s.log.Named("gRPC").GetServerUnaryInterceptor())
+	server := grpc.NewServer(s.log.Grouped("gRPC").GetServerUnaryInterceptor())
 	keyserviceproto.RegisterAPIServer(server, s)
-	s.log.Named("gRPC").WithIncreasedLevel(slog.LevelWarn).ReplaceGRPCLogger()
+	s.log.Grouped("gRPC").WithIncreasedLevel(slog.LevelWarn).ReplaceGRPCLogger()
 
 	// start the server
 	s.log.Infof("Starting Constellation key management service on %s", listener.Addr().String())

--- a/keyservice/internal/server/server.go
+++ b/keyservice/internal/server/server.go
@@ -18,7 +18,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/kms/kms"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/keyservice/keyserviceproto"
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -76,7 +75,7 @@ func (s *Server) GetDataKey(ctx context.Context, in *keyserviceproto.GetDataKeyR
 
 	key, err := s.conKMS.GetDEK(ctx, crypto.DEKPrefix+in.DataKeyId, int(in.Length))
 	if err != nil {
-		log.With(zap.Error(err)).Errorf("Failed to get data key")
+		log.With(slog.Any("error", err)).Errorf("Failed to get data key")
 		return nil, status.Errorf(codes.Internal, "%v", err)
 	}
 	return &keyserviceproto.GetDataKeyResponse{DataKey: key}, nil

--- a/measurement-reader/cmd/main.go
+++ b/measurement-reader/cmd/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/measurement-reader/internal/sorted"
 	"github.com/edgelesssys/constellation/v2/measurement-reader/internal/tdx"
 	"github.com/edgelesssys/constellation/v2/measurement-reader/internal/tpm"
-	"go.uber.org/zap"
 )
 
 func main() {
@@ -25,7 +24,7 @@ func main() {
 	variantString := os.Getenv(constants.AttestationVariant)
 	attestationVariant, err := variant.FromString(variantString)
 	if err != nil {
-		log.With(zap.Error(err)).Fatalf("Failed to parse attestation variant")
+		log.With(slog.Any("error", err)).Fatalf("Failed to parse attestation variant")
 	}
 
 	var m []sorted.Measurement
@@ -33,15 +32,15 @@ func main() {
 	case variant.AWSNitroTPM{}, variant.AWSSEVSNP{}, variant.AzureSEVSNP{}, variant.AzureTrustedLaunch{}, variant.GCPSEVES{}, variant.QEMUVTPM{}:
 		m, err = tpm.Measurements()
 		if err != nil {
-			log.With(zap.Error(err)).Fatalf("Failed to read TPM measurements")
+			log.With(slog.Any("error", err)).Fatalf("Failed to read TPM measurements")
 		}
 	case variant.QEMUTDX{}:
 		m, err = tdx.Measurements()
 		if err != nil {
-			log.With(zap.Error(err)).Fatalf("Failed to read Intel TDX measurements")
+			log.With(slog.Any("error", err)).Fatalf("Failed to read Intel TDX measurements")
 		}
 	default:
-		log.With(zap.String("attestationVariant", variantString)).Fatalf("Unsupported attestation variant")
+		log.With(slog.String("attestationVariant", variantString)).Fatalf("Unsupported attestation variant")
 	}
 
 	fmt.Println("Measurements:")

--- a/measurement-reader/cmd/main.go
+++ b/measurement-reader/cmd/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/edgelesssys/constellation/v2/internal/attestation/variant"
@@ -17,11 +18,10 @@ import (
 	"github.com/edgelesssys/constellation/v2/measurement-reader/internal/tdx"
 	"github.com/edgelesssys/constellation/v2/measurement-reader/internal/tpm"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 func main() {
-	log := logger.New(logger.JSONLog, zapcore.InfoLevel)
+	log := logger.New(logger.JSONLog, slog.LevelInfo)
 	variantString := os.Getenv(constants.AttestationVariant)
 	attestationVariant, err := variant.FromString(variantString)
 	if err != nil {

--- a/s3proxy/cmd/main.go
+++ b/s3proxy/cmd/main.go
@@ -13,12 +13,12 @@ import (
 	"crypto/tls"
 	"flag"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/s3proxy/internal/router"
-	"go.uber.org/zap"
 )
 
 const (
@@ -59,7 +59,7 @@ func main() {
 }
 
 func runServer(flags cmdFlags, log *logger.Logger) error {
-	log.With(zap.String("ip", flags.ip), zap.Int("port", defaultPort), zap.String("region", flags.region)).Infof("listening")
+	log.With(slog.String("ip", flags.ip), slog.Int("port", defaultPort), slog.String("region", flags.region)).Infof("listening")
 
 	router, err := router.New(flags.region, flags.kmsEndpoint, flags.forwardMultipartReqs, log)
 	if err != nil {

--- a/s3proxy/internal/router/handler.go
+++ b/s3proxy/internal/router/handler.go
@@ -10,16 +10,16 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/s3proxy/internal/s3"
-	"go.uber.org/zap"
 )
 
 func handleGetObject(client *s3.Client, key string, bucket string, log *logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		log.With(zap.String("path", req.URL.Path), zap.String("method", req.Method), zap.String("host", req.Host)).Debugf("intercepting")
+		log.With(slog.String("path", req.URL.Path), slog.String("method", req.Method), slog.String("host", req.Host)).Debugf("intercepting")
 		if req.Header.Get("Range") != "" {
 			log.Errorf("GetObject Range header unsupported")
 			http.Error(w, "s3proxy currently does not support Range headers", http.StatusNotImplemented)
@@ -42,10 +42,10 @@ func handleGetObject(client *s3.Client, key string, bucket string, log *logger.L
 
 func handlePutObject(client *s3.Client, key string, bucket string, log *logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		log.With(zap.String("path", req.URL.Path), zap.String("method", req.Method), zap.String("host", req.Host)).Debugf("intercepting")
+		log.With(slog.String("path", req.URL.Path), slog.String("method", req.Method), slog.String("host", req.Host)).Debugf("intercepting")
 		body, err := io.ReadAll(req.Body)
 		if err != nil {
-			log.With(zap.Error(err)).Errorf("PutObject")
+			log.With(slog.Any("error", err)).Errorf("PutObject")
 			http.Error(w, fmt.Sprintf("reading body: %s", err.Error()), http.StatusInternalServerError)
 			return
 		}
@@ -65,7 +65,7 @@ func handlePutObject(client *s3.Client, key string, bucket string, log *logger.L
 			mismatchErr := NewContentSHA256MismatchError(clientDigest, serverDigest)
 			marshalled, err := xml.Marshal(mismatchErr)
 			if err != nil {
-				log.With(zap.Error(err)).Errorf("PutObject")
+				log.With(slog.Any("error", err)).Errorf("PutObject")
 				http.Error(w, fmt.Sprintf("marshalling error: %s", err.Error()), http.StatusInternalServerError)
 				return
 			}
@@ -79,14 +79,14 @@ func handlePutObject(client *s3.Client, key string, bucket string, log *logger.L
 		raw := req.Header.Get("x-amz-object-lock-retain-until-date")
 		retentionTime, err := parseRetentionTime(raw)
 		if err != nil {
-			log.With(zap.String("data", raw), zap.Error(err)).Errorf("parsing lock retention time")
+			log.With(slog.String("data", raw), slog.Any("error", err)).Errorf("parsing lock retention time")
 			http.Error(w, fmt.Sprintf("parsing x-amz-object-lock-retain-until-date: %s", err.Error()), http.StatusInternalServerError)
 			return
 		}
 
 		err = validateContentMD5(req.Header.Get("content-md5"), body)
 		if err != nil {
-			log.With(zap.Error(err)).Errorf("validating content md5")
+			log.With(slog.Any("error", err)).Errorf("validating content md5")
 			http.Error(w, fmt.Sprintf("validating content md5: %s", err.Error()), http.StatusBadRequest)
 			return
 		}
@@ -115,14 +115,14 @@ func handlePutObject(client *s3.Client, key string, bucket string, log *logger.L
 
 func handleForwards(log *logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		log.With(zap.String("path", req.URL.Path), zap.String("method", req.Method), zap.String("host", req.Host)).Debugf("forwarding")
+		log.With(slog.String("path", req.URL.Path), slog.String("method", req.Method), slog.String("host", req.Host)).Debugf("forwarding")
 
 		newReq := repackage(req)
 
 		httpClient := http.DefaultClient
 		resp, err := httpClient.Do(&newReq)
 		if err != nil {
-			log.With(zap.Error(err)).Errorf("do request")
+			log.With(slog.Any("error", err)).Errorf("do request")
 			http.Error(w, fmt.Sprintf("do request: %s", err.Error()), http.StatusInternalServerError)
 			return
 		}
@@ -133,7 +133,7 @@ func handleForwards(log *logger.Logger) http.HandlerFunc {
 		}
 		body, err := io.ReadAll(resp.Body)
 		if err != nil {
-			log.With(zap.Error(err)).Errorf("ReadAll")
+			log.With(slog.Any("error", err)).Errorf("ReadAll")
 			http.Error(w, fmt.Sprintf("reading body: %s", err.Error()), http.StatusInternalServerError)
 			return
 		}
@@ -143,7 +143,7 @@ func handleForwards(log *logger.Logger) http.HandlerFunc {
 		}
 
 		if _, err := w.Write(body); err != nil {
-			log.With(zap.Error(err)).Errorf("Write")
+			log.With(slog.Any("error", err)).Errorf("Write")
 			http.Error(w, fmt.Sprintf("writing body: %s", err.Error()), http.StatusInternalServerError)
 			return
 		}
@@ -153,7 +153,7 @@ func handleForwards(log *logger.Logger) http.HandlerFunc {
 // handleCreateMultipartUpload logs the request and blocks with an error message.
 func handleCreateMultipartUpload(log *logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		log.With(zap.String("path", req.URL.Path), zap.String("method", req.Method), zap.String("host", req.Host)).Debugf("intercepting CreateMultipartUpload")
+		log.With(slog.String("path", req.URL.Path), slog.String("method", req.Method), slog.String("host", req.Host)).Debugf("intercepting CreateMultipartUpload")
 
 		log.Errorf("Blocking CreateMultipartUpload request")
 		http.Error(w, "s3proxy is configured to block CreateMultipartUpload requests", http.StatusNotImplemented)
@@ -163,7 +163,7 @@ func handleCreateMultipartUpload(log *logger.Logger) http.HandlerFunc {
 // handleUploadPart logs the request and blocks with an error message.
 func handleUploadPart(log *logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		log.With(zap.String("path", req.URL.Path), zap.String("method", req.Method), zap.String("host", req.Host)).Debugf("intercepting UploadPart")
+		log.With(slog.String("path", req.URL.Path), slog.String("method", req.Method), slog.String("host", req.Host)).Debugf("intercepting UploadPart")
 
 		log.Errorf("Blocking UploadPart request")
 		http.Error(w, "s3proxy is configured to block UploadPart requests", http.StatusNotImplemented)
@@ -173,7 +173,7 @@ func handleUploadPart(log *logger.Logger) http.HandlerFunc {
 // handleCompleteMultipartUpload logs the request and blocks with an error message.
 func handleCompleteMultipartUpload(log *logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		log.With(zap.String("path", req.URL.Path), zap.String("method", req.Method), zap.String("host", req.Host)).Debugf("intercepting CompleteMultipartUpload")
+		log.With(slog.String("path", req.URL.Path), slog.String("method", req.Method), slog.String("host", req.Host)).Debugf("intercepting CompleteMultipartUpload")
 
 		log.Errorf("Blocking CompleteMultipartUpload request")
 		http.Error(w, "s3proxy is configured to block CompleteMultipartUpload requests", http.StatusNotImplemented)
@@ -183,7 +183,7 @@ func handleCompleteMultipartUpload(log *logger.Logger) http.HandlerFunc {
 // handleAbortMultipartUpload logs the request and blocks with an error message.
 func handleAbortMultipartUpload(log *logger.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		log.With(zap.String("path", req.URL.Path), zap.String("method", req.Method), zap.String("host", req.Host)).Debugf("intercepting AbortMultipartUpload")
+		log.With(slog.String("path", req.URL.Path), slog.String("method", req.Method), slog.String("host", req.Host)).Debugf("intercepting AbortMultipartUpload")
 
 		log.Errorf("Blocking AbortMultipartUpload request")
 		http.Error(w, "s3proxy is configured to block AbortMultipartUpload requests", http.StatusNotImplemented)

--- a/s3proxy/internal/router/handler.go
+++ b/s3proxy/internal/router/handler.go
@@ -60,7 +60,7 @@ func handlePutObject(client *s3.Client, key string, bucket string, log *logger.L
 		// Thus we have to check incoming requets for matching content digests.
 		// UNSIGNED-PAYLOAD can be used to disabled payload signing. In that case we don't check the content digest.
 		if clientDigest != "" && clientDigest != "UNSIGNED-PAYLOAD" && clientDigest != serverDigest {
-			log.Debugf("PutObject", "error", "x-amz-content-sha256 mismatch")
+			log.Debug("PutObject", "error", "x-amz-content-sha256 mismatch")
 			// The S3 API responds with an XML formatted error message.
 			mismatchErr := NewContentSHA256MismatchError(clientDigest, serverDigest)
 			marshalled, err := xml.Marshal(mismatchErr)

--- a/s3proxy/internal/router/object.go
+++ b/s3proxy/internal/router/object.go
@@ -117,7 +117,7 @@ func (o object) get(w http.ResponseWriter, r *http.Request) {
 	if ok {
 		encryptedDEK, err := hex.DecodeString(rawEncryptedDEK)
 		if err != nil {
-			o.log.Errorf("GetObject decoding DEK", "error", err)
+			o.log.Error("GetObject decoding DEK", "error", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/upgrade-agent/cmd/main.go
+++ b/upgrade-agent/cmd/main.go
@@ -27,12 +27,12 @@ func main() {
 	verbosity := flag.Int("v", 0, logger.CmdLineVerbosityDescription)
 	flag.Parse()
 
-	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity)).Named("bootstrapper")
+	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity)).Grouped("bootstrapper")
 
 	if *gRPCDebug {
-		log.Named("gRPC").ReplaceGRPCLogger()
+		log.Grouped("gRPC").ReplaceGRPCLogger()
 	} else {
-		log.Named("gRPC").WithIncreasedLevel(slog.LevelWarn).ReplaceGRPCLogger()
+		log.Grouped("gRPC").WithIncreasedLevel(slog.LevelWarn).ReplaceGRPCLogger()
 	}
 
 	handler := file.NewHandler(afero.NewOsFs())

--- a/upgrade-agent/cmd/main.go
+++ b/upgrade-agent/cmd/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"flag"
+	"log/slog"
 
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
@@ -27,12 +28,11 @@ func main() {
 	flag.Parse()
 
 	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity)).Named("bootstrapper")
-	defer log.Sync()
 
 	if *gRPCDebug {
 		log.Named("gRPC").ReplaceGRPCLogger()
 	} else {
-		log.Named("gRPC").WithIncreasedLevel(zap.WarnLevel).ReplaceGRPCLogger()
+		log.Named("gRPC").WithIncreasedLevel(slog.LevelWarn).ReplaceGRPCLogger()
 	}
 
 	handler := file.NewHandler(afero.NewOsFs())

--- a/upgrade-agent/cmd/main.go
+++ b/upgrade-agent/cmd/main.go
@@ -15,7 +15,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/upgrade-agent/internal/server"
 	"github.com/spf13/afero"
-	"go.uber.org/zap"
 )
 
 const (
@@ -38,11 +37,11 @@ func main() {
 	handler := file.NewHandler(afero.NewOsFs())
 	server, err := server.New(log, handler)
 	if err != nil {
-		log.With(zap.Error(err)).Fatalf("Failed to create update server")
+		log.With(slog.Any("error", err)).Fatalf("Failed to create update server")
 	}
 
 	err = server.Run(protocol, constants.UpgradeAgentSocketPath)
 	if err != nil {
-		log.With(zap.Error(err)).Fatalf("Failed to start update server")
+		log.With(slog.Any("error", err)).Fatalf("Failed to start update server")
 	}
 }

--- a/upgrade-agent/internal/server/server.go
+++ b/upgrade-agent/internal/server/server.go
@@ -45,7 +45,7 @@ type Server struct {
 
 // New creates a new upgrade-agent server.
 func New(log *logger.Logger, fileHandler file.Handler) (*Server, error) {
-	log = log.Named("upgradeServer")
+	log = log.Grouped("upgradeServer")
 
 	server := &Server{
 		log:  log,
@@ -53,7 +53,7 @@ func New(log *logger.Logger, fileHandler file.Handler) (*Server, error) {
 	}
 
 	grpcServer := grpc.NewServer(
-		log.Named("gRPC").GetServerUnaryInterceptor(),
+		log.Grouped("gRPC").GetServerUnaryInterceptor(),
 	)
 	upgradeproto.RegisterUpdateServer(grpcServer, server)
 

--- a/verify/cmd/main.go
+++ b/verify/cmd/main.go
@@ -33,12 +33,12 @@ func main() {
 	if err != nil {
 		log.With(zap.Error(err)).Fatalf("Failed to parse attestation variant")
 	}
-	issuer, err := choose.Issuer(variant, log.Named("issuer"))
+	issuer, err := choose.Issuer(variant, log.Grouped("issuer"))
 	if err != nil {
 		log.With(zap.Error(err)).Fatalf("Failed to create issuer")
 	}
 
-	server := server.New(log.Named("server"), issuer)
+	server := server.New(log.Grouped("server"), issuer)
 	httpListener, err := net.Listen("tcp", net.JoinHostPort("", strconv.Itoa(constants.VerifyServicePortHTTP)))
 	if err != nil {
 		log.With(zap.Error(err), zap.Int("port", constants.VerifyServicePortHTTP)).

--- a/verify/cmd/main.go
+++ b/verify/cmd/main.go
@@ -8,6 +8,7 @@ package main
 
 import (
 	"flag"
+	"log/slog"
 	"net"
 	"strconv"
 
@@ -16,7 +17,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/verify/server"
-	"go.uber.org/zap"
 )
 
 func main() {
@@ -26,31 +26,31 @@ func main() {
 	flag.Parse()
 	log := logger.New(logger.JSONLog, logger.VerbosityFromInt(*verbosity))
 
-	log.With(zap.String("version", constants.BinaryVersion().String()), zap.String("attestationVariant", *attestationVariant)).
+	log.With(slog.String("version", constants.BinaryVersion().String()), slog.String("attestationVariant", *attestationVariant)).
 		Infof("Constellation Verification Service")
 
 	variant, err := variant.FromString(*attestationVariant)
 	if err != nil {
-		log.With(zap.Error(err)).Fatalf("Failed to parse attestation variant")
+		log.With(slog.Any("error", err)).Fatalf("Failed to parse attestation variant")
 	}
 	issuer, err := choose.Issuer(variant, log.Grouped("issuer"))
 	if err != nil {
-		log.With(zap.Error(err)).Fatalf("Failed to create issuer")
+		log.With(slog.Any("error", err)).Fatalf("Failed to create issuer")
 	}
 
 	server := server.New(log.Grouped("server"), issuer)
 	httpListener, err := net.Listen("tcp", net.JoinHostPort("", strconv.Itoa(constants.VerifyServicePortHTTP)))
 	if err != nil {
-		log.With(zap.Error(err), zap.Int("port", constants.VerifyServicePortHTTP)).
+		log.With(slog.Any("error", err), slog.Int("port", constants.VerifyServicePortHTTP)).
 			Fatalf("Failed to listen")
 	}
 	grpcListener, err := net.Listen("tcp", net.JoinHostPort("", strconv.Itoa(constants.VerifyServicePortGRPC)))
 	if err != nil {
-		log.With(zap.Error(err), zap.Int("port", constants.VerifyServicePortGRPC)).
+		log.With(slog.Any("error", err), slog.Int("port", constants.VerifyServicePortGRPC)).
 			Fatalf("Failed to listen")
 	}
 
 	if err := server.Run(httpListener, grpcListener); err != nil {
-		log.With(zap.Error(err)).Fatalf("Failed to run server")
+		log.With(slog.Any("error", err)).Fatalf("Failed to run server")
 	}
 }

--- a/verify/server/server.go
+++ b/verify/server/server.go
@@ -57,9 +57,9 @@ func (s *Server) Run(httpListener, grpcListener net.Listener) error {
 	var wg sync.WaitGroup
 	var once sync.Once
 
-	s.log.WithIncreasedLevel(slog.LevelWarn).Named("grpc").ReplaceGRPCLogger()
+	s.log.WithIncreasedLevel(slog.LevelWarn).Grouped("grpc").ReplaceGRPCLogger()
 	grpcServer := grpc.NewServer(
-		s.log.Named("gRPC").GetServerUnaryInterceptor(),
+		s.log.Grouped("gRPC").GetServerUnaryInterceptor(),
 		grpc.KeepaliveParams(keepalive.ServerParameters{Time: 15 * time.Second}),
 	)
 	verifyproto.RegisterAPIServer(grpcServer, s)
@@ -103,7 +103,7 @@ func (s *Server) GetAttestation(ctx context.Context, req *verifyproto.GetAttesta
 		peerAddr = peer.Addr.String()
 	}
 
-	log := s.log.With(zap.String("peerAddress", peerAddr)).Named("gRPC")
+	log := s.log.With(zap.String("peerAddress", peerAddr)).Grouped("gRPC")
 	s.log.Infof("Received attestation request")
 	if len(req.Nonce) == 0 {
 		log.Errorf("Received attestation request with empty nonce")
@@ -122,7 +122,7 @@ func (s *Server) GetAttestation(ctx context.Context, req *verifyproto.GetAttesta
 
 // getAttestationHTTP implements the HTTP endpoint for retrieving attestation statements.
 func (s *Server) getAttestationHTTP(w http.ResponseWriter, r *http.Request) {
-	log := s.log.With(zap.String("peerAddress", r.RemoteAddr)).Named("http")
+	log := s.log.With(zap.String("peerAddress", r.RemoteAddr)).Grouped("http")
 
 	nonceB64 := r.URL.Query()["nonce"]
 	if len(nonceB64) != 1 || nonceB64[0] == "" {

--- a/verify/server/server.go
+++ b/verify/server/server.go
@@ -21,7 +21,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/verify/verifyproto"
-	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/keepalive"
@@ -103,7 +102,7 @@ func (s *Server) GetAttestation(ctx context.Context, req *verifyproto.GetAttesta
 		peerAddr = peer.Addr.String()
 	}
 
-	log := s.log.With(zap.String("peerAddress", peerAddr)).Grouped("gRPC")
+	log := s.log.With(slog.String("peerAddress", peerAddr)).Grouped("gRPC")
 	s.log.Infof("Received attestation request")
 	if len(req.Nonce) == 0 {
 		log.Errorf("Received attestation request with empty nonce")
@@ -122,7 +121,7 @@ func (s *Server) GetAttestation(ctx context.Context, req *verifyproto.GetAttesta
 
 // getAttestationHTTP implements the HTTP endpoint for retrieving attestation statements.
 func (s *Server) getAttestationHTTP(w http.ResponseWriter, r *http.Request) {
-	log := s.log.With(zap.String("peerAddress", r.RemoteAddr)).Grouped("http")
+	log := s.log.With(slog.String("peerAddress", r.RemoteAddr)).Grouped("http")
 
 	nonceB64 := r.URL.Query()["nonce"]
 	if len(nonceB64) != 1 || nonceB64[0] == "" {
@@ -133,7 +132,7 @@ func (s *Server) getAttestationHTTP(w http.ResponseWriter, r *http.Request) {
 
 	nonce, err := base64.URLEncoding.DecodeString(nonceB64[0])
 	if err != nil {
-		log.With(zap.Error(err)).Errorf("Received attestation request with invalid nonce")
+		log.With(slog.Any("error", err)).Errorf("Received attestation request with invalid nonce")
 		http.Error(w, fmt.Sprintf("invalid base64 encoding for nonce: %v", err), http.StatusBadRequest)
 		return
 	}

--- a/verify/server/server.go
+++ b/verify/server/server.go
@@ -12,6 +12,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net"
 	"net/http"
 	"sync"
@@ -21,7 +22,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/logger"
 	"github.com/edgelesssys/constellation/v2/verify/verifyproto"
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/keepalive"
@@ -57,7 +57,7 @@ func (s *Server) Run(httpListener, grpcListener net.Listener) error {
 	var wg sync.WaitGroup
 	var once sync.Once
 
-	s.log.WithIncreasedLevel(zapcore.WarnLevel).Named("grpc").ReplaceGRPCLogger()
+	s.log.WithIncreasedLevel(slog.LevelWarn).Named("grpc").ReplaceGRPCLogger()
 	grpcServer := grpc.NewServer(
 		s.log.Named("gRPC").GetServerUnaryInterceptor(),
 		grpc.KeepaliveParams(keepalive.ServerParameters{Time: 15 * time.Second}),


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- rewrite the `logger` package in `internal/logger` to use slog instead of zap
- rewrite references to the logger package to be compatible with slog
- add non-formatting functions for similar usage to `fmt.Print(a, b)`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- code in `operators/` was not changed and still uses zap since it didn't depend on the `logger` package

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [X] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [X] Add labels (e.g., for changelog category)
- [X] Is PR title adequate for changelog?
- [X] Link to Milestone
