### PR TITLE
ci: increase collection period for Metricbeat

### DIFF
--- a/debugd/metricbeat/templates/metricbeat.yml
+++ b/debugd/metricbeat/templates/metricbeat.yml
@@ -37,7 +37,7 @@ metricbeat.modules:
       #- socket         # Sockets and connection info (linux only)
       #- service        # systemd service information
     cpu.metrics:  ["percentages","normalized_percentages"]
-    period: 10s
+    period: 60s
     processes: ['.*']
     # To monitor host metrics from within a container. As per:
     # https://www.elastic.co/guide/en/beats/metricbeat/current/metricbeat-module-system.html#_example_configuration_59
@@ -47,7 +47,7 @@ metricbeat.modules:
   - module: etcd
     enabled: true
     metricsets: ["metrics"]
-    period: 30s
+    period: 60s
     hosts: ["https://localhost:2379"]
     ssl:
       certificate_authorities: ["/etc/kubernetes/pki/etcd/ca.crt"]


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
To decrease Memory demands in our OpenSearch, we want to decrease the overall document count in our indices. Therefore, we can increase the period in which metrics are sent to OpenSearch by Metricbeat to sent documents less regularly.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Decrease the period for OpenSearch collection to 60 seconds.



### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
