### PR TITLE
ci: temporarily disable Metricbeat deployment

### DIFF
--- a/.github/actions/deploy_logcollection/action.yml
+++ b/.github/actions/deploy_logcollection/action.yml
@@ -91,16 +91,17 @@ runs:
         helm install filebeat elastic/filebeat \
           --wait --timeout=1200s --values values.yml
 
-    - name: Deploy Metricbeat
-      id: deploy-metricbeat
-      shell: bash
-      working-directory: ./metricbeat
-      env:
-        KUBECONFIG: ${{ inputs.kubeconfig }}
-      run: |
-        helm repo add elastic https://helm.elastic.co
-        helm repo update
-        helm install metricbeat-k8s elastic/metricbeat \
-          --wait --timeout=1200s --values values-control-plane.yml
-        helm install metricbeat-system elastic/metricbeat \
-          --wait --timeout=1200s --values values-all-nodes.yml
+    # TODO(msanft): Re-enable Metricbeat deployment once OpenSearch instance health issues are resolved.
+    # - name: Deploy Metricbeat
+    #   id: deploy-metricbeat
+    #   shell: bash
+    #   working-directory: ./metricbeat
+    #   env:
+    #     KUBECONFIG: ${{ inputs.kubeconfig }}
+    #   run: |
+    #     helm repo add elastic https://helm.elastic.co
+    #     helm repo update
+    #     helm install metricbeat-k8s elastic/metricbeat \
+    #       --wait --timeout=1200s --values values-control-plane.yml
+    #     helm install metricbeat-system elastic/metricbeat \
+    #       --wait --timeout=1200s --values values-all-nodes.yml


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The OpenSearch cluster is under heavy load, which can be reduced by disabling metric collection until further optimizations are done.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Temporarily disable Metricbeat deployment.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
