### PR TITLE
ci: separate logs and metrics indices

### DIFF
--- a/debugd/internal/debugd/logcollector/logcollector.go
+++ b/debugd/internal/debugd/logcollector/logcollector.go
@@ -93,7 +93,6 @@ func NewStartTrigger(ctx context.Context, wg *sync.WaitGroup, provider cloudprov
 			pipelineConf := logstashConfInput{
 				Port:        5044,
 				Host:        openSearchHost,
-				IndexPrefix: "systemd-logs",
 				InfoMap:     infoMapM,
 				Credentials: creds,
 			}
@@ -272,7 +271,6 @@ func startPod(ctx context.Context, logger *logger.Logger) error {
 type logstashConfInput struct {
 	Port        int
 	Host        string
-	IndexPrefix string
 	InfoMap     map[string]string
 	Credentials credentials
 }

--- a/debugd/logstash/templates/pipeline.conf
+++ b/debugd/logstash/templates/pipeline.conf
@@ -55,12 +55,28 @@ filter {
 }
 
 output {
-    opensearch {
-        hosts => "{{ .Host }}"
-        index => "{{ .IndexPrefix }}-%{+YYYY.MM.dd}"
-        user => "{{ .Credentials.Username }}"
-        password => "{{ .Credentials.Password }}"
-        ssl => true
-        ssl_certificate_verification => true
+    if ([@metadata][beat] == "filebeat") {
+        # Logs, which are output by filebeat, go to the logs-index.
+        opensearch {
+            hosts => "{{ .Host }}"
+            # YYYY doesn't handle rolling over the year, so we use xxxx instead.
+            # See https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/541#issuecomment-270923437.
+            index => "logs-%{+xxxx.ww}"
+            user => "{{ .Credentials.Username }}"
+            password => "{{ .Credentials.Password }}"
+            ssl => true
+            ssl_certificate_verification => true
+        }
+    } else {
+        opensearch {
+            hosts => "{{ .Host }}"
+            # YYYY doesn't handle rolling over the year, so we use xxxx instead.
+            # See https://github.com/logstash-plugins/logstash-output-elasticsearch/issues/541#issuecomment-270923437.
+            index => "metrics-%{+xxxx.ww}"
+            user => "{{ .Credentials.Username }}"
+            password => "{{ .Credentials.Password }}"
+            ssl => true
+            ssl_certificate_verification => true
+        }
     }
 }

--- a/hack/logcollector/cmd/template.go
+++ b/hack/logcollector/cmd/template.go
@@ -28,7 +28,6 @@ func newTemplateCmd() *cobra.Command {
 	must(templateCmd.MarkFlagRequired("username"))
 	templateCmd.Flags().String("password", "", "OpenSearch password (required)")
 	must(templateCmd.MarkFlagRequired("password"))
-	templateCmd.Flags().String("index-prefix", "systemd-logs", "Prefix for logging index (e.g. systemd-logs)")
 	templateCmd.Flags().Int("port", 5045, "Logstash port")
 	templateCmd.Flags().StringToString("fields", nil, "Additional fields for the Logstash pipeline")
 
@@ -49,7 +48,6 @@ func runTemplate(cmd *cobra.Command, _ []string) error {
 		flags.extraFields,
 		flags.username,
 		flags.password,
-		flags.indexPrefix,
 		flags.port,
 	)
 	if err := logstashPreparer.Prepare(flags.dir); err != nil {
@@ -89,11 +87,6 @@ func parseTemplateFlags(cmd *cobra.Command) (templateFlags, error) {
 		return templateFlags{}, fmt.Errorf("parse password string: %w", err)
 	}
 
-	indexPrefix, err := cmd.Flags().GetString("index-prefix")
-	if err != nil {
-		return templateFlags{}, fmt.Errorf("parse index-prefix string: %w", err)
-	}
-
 	extraFields, err := cmd.Flags().GetStringToString("fields")
 	if err != nil {
 		return templateFlags{}, fmt.Errorf("parse fields map: %w", err)
@@ -108,7 +101,6 @@ func parseTemplateFlags(cmd *cobra.Command) (templateFlags, error) {
 		dir:         dir,
 		username:    username,
 		password:    password,
-		indexPrefix: indexPrefix,
 		extraFields: extraFields,
 		port:        port,
 	}, nil
@@ -118,7 +110,6 @@ type templateFlags struct {
 	dir         string
 	username    string
 	password    string
-	indexPrefix string
 	extraFields fields.Fields
 	port        int
 }

--- a/hack/logcollector/internal/logstash.go
+++ b/hack/logcollector/internal/logstash.go
@@ -31,7 +31,6 @@ const (
 type LogstashPreparer struct {
 	fh          file.Handler
 	fields      map[string]string
-	indexPrefix string
 	username    string
 	password    string
 	port        int
@@ -39,11 +38,10 @@ type LogstashPreparer struct {
 }
 
 // NewLogstashPreparer returns a new LogstashPreparer.
-func NewLogstashPreparer(fields map[string]string, username, password, indexPrefix string, port int) *LogstashPreparer {
+func NewLogstashPreparer(fields map[string]string, username, password string, port int) *LogstashPreparer {
 	return &LogstashPreparer{
 		username:    username,
 		password:    password,
-		indexPrefix: indexPrefix,
 		fields:      fields,
 		fh:          file.NewHandler(afero.NewOsFs()),
 		port:        port,
@@ -55,7 +53,6 @@ func (p *LogstashPreparer) Prepare(dir string) error {
 	templatedPipelineConf, err := p.template(logstashAssets, "templates/pipeline.conf", pipelineConfTemplate{
 		InfoMap:     p.fields,
 		Host:        openSearchHost,
-		IndexPrefix: p.indexPrefix,
 		Credentials: Credentials{
 			Username: p.username,
 			Password: p.password,
@@ -134,7 +131,6 @@ type LogstashHelmValues struct {
 type pipelineConfTemplate struct {
 	InfoMap     map[string]string
 	Host        string
-	IndexPrefix string
 	Credentials Credentials
 	Port        int
 }

--- a/hack/logcollector/internal/logstash.go
+++ b/hack/logcollector/internal/logstash.go
@@ -29,30 +29,30 @@ const (
 
 // LogstashPreparer prepares the Logstash Helm chart.
 type LogstashPreparer struct {
-	fh          file.Handler
-	fields      map[string]string
-	username    string
-	password    string
-	port        int
+	fh       file.Handler
+	fields   map[string]string
+	username string
+	password string
+	port     int
 	templatePreparer
 }
 
 // NewLogstashPreparer returns a new LogstashPreparer.
 func NewLogstashPreparer(fields map[string]string, username, password string, port int) *LogstashPreparer {
 	return &LogstashPreparer{
-		username:    username,
-		password:    password,
-		fields:      fields,
-		fh:          file.NewHandler(afero.NewOsFs()),
-		port:        port,
+		username: username,
+		password: password,
+		fields:   fields,
+		fh:       file.NewHandler(afero.NewOsFs()),
+		port:     port,
 	}
 }
 
 // Prepare prepares the Logstash Helm chart by templating the required files and placing them in the specified directory.
 func (p *LogstashPreparer) Prepare(dir string) error {
 	templatedPipelineConf, err := p.template(logstashAssets, "templates/pipeline.conf", pipelineConfTemplate{
-		InfoMap:     p.fields,
-		Host:        openSearchHost,
+		InfoMap: p.fields,
+		Host:    openSearchHost,
 		Credentials: Credentials{
 			Username: p.username,
 			Password: p.password,


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
OpenSearch cluster health was in a bad state previously, hence some improvements and optimizations are necessary. One of this is using bigger indices, which can impact search performance, but should drastically reduce needed JVM heap size.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Seperate the Metrics and Logs indices, but only rotate them on a weekly basis. Ideally, we want to get between [10-30GB index size](https://opensearch.org/blog/optimize-opensearch-index-shard-size/). Possibly, follow-up adjustments to reach that will be necessary after an initial testing period. 
- Re-enable the Metricbeat deployment.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3511](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3511)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
