### PR TITLE
cli: fix invalid upper case name on AWS

### DIFF
--- a/cli/internal/terraform/terraform/aws/variables.tf
+++ b/cli/internal/terraform/terraform/aws/variables.tf
@@ -5,6 +5,10 @@ variable "name" {
     condition     = length(var.name) <= 10
     error_message = "The length of the name of the Constellation must be <= 10 characters"
   }
+  validation {
+    condition     = var.name == lower(var.name)
+    error_message = "The name of the Constellation must be in lowercase"
+  }
 }
 
 variable "node_groups" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -728,7 +728,7 @@ func (c *Config) Validate(force bool) error {
 		return err
 	}
 
-	if err := validate.RegisterTranslation("valid_name", trans, registerValidateNameError, c.translateValidateNameError); err != nil {
+	if err := validate.RegisterTranslation("valid_name", trans, c.registerValidateNameError, c.translateValidateNameError); err != nil {
 		return err
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -421,6 +421,16 @@ func TestValidate(t *testing.T) {
 			wantErr:      true,
 			wantErrCount: awsErrCount,
 		},
+		"AWS config with upper case name": {
+			cnf: func() *Config {
+				cnf := Default()
+				cnf.RemoveProviderAndAttestationExcept(cloudprovider.AWS)
+				cnf.Name = "testAWS"
+				return cnf
+			}(),
+			wantErr:      true,
+			wantErrCount: awsErrCount + 1,
+		},
 		"AWS config with correct region and zone format": {
 			cnf: func() *Config {
 				cnf := Default()

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -711,8 +711,11 @@ func returnsTrue(_ validator.FieldLevel) bool {
 	return true
 }
 
-func registerValidateNameError(ut ut.Translator) error {
-	return ut.Add("validate_name", "{0} must be no more than {1} characters long / contain only lowercase letters on AWS", true)
+func (c *Config) registerValidateNameError(ut ut.Translator) error {
+	if c.Provider.AWS != nil {
+		return ut.Add("validate_name", "{0} must be no more than {1} characters long and contain only lowercase letters", true)
+	}
+	return ut.Add("validate_name", "{0} must be no more than {1} characters long", true)
 }
 
 func (c *Config) translateValidateNameError(ut ut.Translator, fe validator.FieldError) string {

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -712,7 +712,7 @@ func returnsTrue(_ validator.FieldLevel) bool {
 }
 
 func registerValidateNameError(ut ut.Translator) error {
-	return ut.Add("validate_name", "{0} must be no more than {1} characters long", true)
+	return ut.Add("validate_name", "{0} must be no more than {1} characters long / contain only lowercase letters on AWS", true)
 }
 
 func (c *Config) translateValidateNameError(ut ut.Translator, fe validator.FieldError) string {
@@ -731,7 +731,8 @@ func (c *Config) translateValidateNameError(ut ut.Translator, fe validator.Field
 // This also allows us to eventually add more validation rules for constellation names if necessary.
 func (c *Config) validateName(fl validator.FieldLevel) bool {
 	if c.Provider.AWS != nil {
-		return len(fl.Field().String()) <= constants.AWSConstellationNameLength
+		name := fl.Field().String()
+		return strings.ToLower(name) == name && len(name) <= constants.AWSConstellationNameLength
 	}
 	return len(fl.Field().String()) <= constants.ConstellationNameLength
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
On AWS, the bootstrapper crashes when the cluster name has an upper case name due to recent changes related to DNS cluster reference instead of IP.
This only happens on nightly images and not on v2.12.0.

```
Failed to collect logs from bootstrapper: rpc error: code = Unknown desc = kubeadm init: kubeadm init phase preflight failed (code 1) with: I1031 15:15:11.139446    5161
│ initconfiguration.go:255] loading configuration from "/tmp/kubeadm-init.546194692.yaml"
│ I1031 15:15:11.154487    5161 interface.go:432] Looking for default routes with IPv4 addresses
│ I1031 15:15:11.154503    5161 interface.go:437] Default route transits interface "ens5"
│ I1031 15:15:11.155331    5161 interface.go:209] Interface ens5 is up
│ I1031 15:15:11.155385    5161 interface.go:257] Interface "ens5" has 2 addresses :[192.168.180.13/24 fe80::8c4:aeff:fee9:c65f/64].
│ I1031 15:15:11.155398    5161 interface.go:224] Checking addr  192.168.180.13/24.
│ I1031 15:15:11.155405    5161 interface.go:231] IP found 192.168.180.13
│ I1031 15:15:11.155413    5161 interface.go:263] Found valid IPv4 address 192.168.180.13 for interface "ens5".
│ I1031 15:15:11.155420    5161 interface.go:443] Found active IP 192.168.180.13
│ I1031 15:15:11.155445    5161 kubelet.go:196] the value of KubeletConfiguration.cgroupDriver is empty; setting it to "systemd"
│ hostport adrianTFm-4040ed6a-loadbalancer-18c7cc6d66eb52c4.elb.eu-west-1.amazonaws.com: host 'adrianTFm-4040ed6a-loadbalancer-18c7cc6d66eb52c4.elb.eu-west-1.amazonaws.com' must be a
│ valid IP address or a valid RFC-1123 DNS subdomain
│ k8s.io/kubernetes/cmd/kubeadm/app/util.ParseHostPort
│ 	cmd/kubeadm/app/util/endpoint.go:112
│ k8s.io/kubernetes/cmd/kubeadm/app/util/config.SetClusterDynamicDefaults
│ 	cmd/kubeadm/app/util/config/initconfiguration.go:178
│ k8s.io/kubernetes/cmd/kubeadm/app/util/config.SetInitDynamicDefaults
│ 	cmd/kubeadm/app/util/config/initconfiguration.go:70
│ k8s.io/kubernetes/cmd/kubeadm/app/util/config.documentMapToInitConfiguration
│ 	cmd/kubeadm/app/util/config/initconfiguration.go:369
│ k8s.io/kubernetes/cmd/kubeadm/app/util/config.BytesToInitConfiguration
│ 	cmd/kubeadm/app/util/config/initconfiguration.go:290
│ k8s.io/kubernetes/cmd/kubeadm/app/util/config.LoadInitConfigurationFromFile
│ 	cmd/kubeadm/app/util/config/initconfiguration.go:262
│ k8s.io/kubernetes/cmd/kubeadm/app/util/config.LoadOrDefaultInitConfiguration
│ 	cmd/kubeadm/app/util/config/initconfiguration.go:274
│ k8s.io/kubernetes/cmd/kubeadm/app/cmd.newInitData
│ 	cmd/kubeadm/app/cmd/init.go:304
│ k8s.io/kubernetes/cmd/kubeadm/app/cmd.newCmdInit.func3
│ 	cmd/kubeadm/app/cmd/init.go:157
│ k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).InitData
│ 	cmd/kubeadm/app/cmd/phases/workflow/runner.go:183
│ k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).Run
│ 	cmd/kubeadm/app/cmd/phases/workflow/runner.go:227
│ k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow.(*Runner).BindToCommand.func1.1
│ 	cmd/kubeadm/app/cmd/phases/workflow/runner.go:372
│ github.com/spf13/cobra.(*Command).execute
│ 	vendor/github.com/spf13/cobra/command.go:916
│ github.com/spf13/cobra.(*Command).ExecuteC
│ 	vendor/github.com/spf13/cobra/command.go:1040
│ github.com/spf13/cobra.(*Command).Execute
│ 	vendor/github.com/spf13/cobra/command.go:968
│ k8s.io/kubernetes/cmd/kubeadm/app.Run
│ 	cmd/kubeadm/app/kubeadm.go:50
│ main.main
│ 	cmd/kubeadm/kubeadm.go:25
│ runtime.main
│ 	/usr/local/go/src/runtime/proc.go:250
│ runtime.goexit
│ 	/usr/local/go/src/runtime/asm_amd64.s:1598
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- only allow lower case names on AWS

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#1234](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/1234)
- Any additional information or context

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
