### PR TITLE
cli: use apply command to start mini cluster

### DIFF
--- a/cli/internal/cmd/minidown.go
+++ b/cli/internal/cmd/minidown.go
@@ -48,7 +48,7 @@ func checkForMiniCluster(fileHandler file.Handler) error {
 		return fmt.Errorf("reading state file: %w", err)
 	}
 
-	if stateFile.Infrastructure.UID != constants.MiniConstellationUID {
+	if stateFile.Infrastructure.Name != constants.MiniConstellationName {
 		return errors.New("cluster is not a MiniConstellation cluster")
 	}
 

--- a/cli/internal/libvirt/libvirt.go
+++ b/cli/internal/libvirt/libvirt.go
@@ -16,7 +16,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
@@ -76,9 +75,8 @@ func (r *Runner) Start(ctx context.Context, name, imageName string) error {
 		// check if it is using the correct image and if it is running
 		if len(containers) == 1 {
 			// make sure the container we listed is using the correct image
-			imageBase := strings.Split(imageName, ":")[0]
-			if containers[0].Image != imageBase {
-				return fmt.Errorf("existing libvirt container %q is using a different image: expected %q, got %q", containerName, imageBase, containers[0].Image)
+			if containers[0].Image != imageName {
+				return fmt.Errorf("existing libvirt container %q is using a different image: expected %q, got %q", containerName, imageName, containers[0].Image)
 			}
 
 			// container already exists, check if its running

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -159,6 +159,8 @@ const (
 	EnvVarNoSpinner = EnvVarPrefix + "NO_SPINNER"
 	// MiniConstellationUID is a sentinel value for the UID of a mini constellation.
 	MiniConstellationUID = "mini"
+	// MiniConstellationName is a sentinel value for the name of a mini constellation.
+	MiniConstellationName = MiniConstellationUID + "-qemu"
 	// TerraformLogFile is the file name of the Terraform log file.
 	TerraformLogFile = "terraform.log"
 	// TerraformUpgradeWorkingDir is the directory name for the Terraform workspace being used in an upgrade.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
`mini up` was still using separate code to create and initialize the cluster.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use `constellation apply` to set up and initialize miniConstellation clusters

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- We could think about deprecating `mini up` and `mini down` as a whole, and simply add a miniConstellation target for `config generate`, since `apply` now takes care of creating and initializing a cluster in one command.
- [x] [e2e test MiniConstellation](https://github.com/edgelesssys/constellation/actions/runs/6734000175)

