### PR TITLE
cli: don't validate unused ownerID field

### DIFF
--- a/cli/internal/state/state.go
+++ b/cli/internal/state/state.go
@@ -268,8 +268,10 @@ func (s *State) preCreateConstraints() []*validation.Constraint {
 		// each field individually.
 		validation.Empty(s.ClusterValues.ClusterID).
 			WithFieldTrace(s, &s.ClusterValues.ClusterID),
-		validation.Empty(s.ClusterValues.OwnerID).
-			WithFieldTrace(s, &s.ClusterValues.OwnerID),
+		// ownerID is currently unused as functionality is not implemented
+		// Therefore, we don't want to validate it
+		// validation.Empty(s.ClusterValues.OwnerID).
+		//	WithFieldTrace(s, &s.ClusterValues.OwnerID),
 		validation.EmptySlice(s.ClusterValues.MeasurementSalt).
 			WithFieldTrace(s, &s.ClusterValues.MeasurementSalt),
 	}
@@ -396,8 +398,10 @@ func (s *State) preInitConstraints() []*validation.Constraint {
 		// each field individually.
 		validation.Empty(s.ClusterValues.ClusterID).
 			WithFieldTrace(s, &s.ClusterValues.ClusterID),
-		validation.Empty(s.ClusterValues.OwnerID).
-			WithFieldTrace(s, &s.ClusterValues.OwnerID),
+		// ownerID is currently unused as functionality is not implemented
+		// Therefore, we don't want to validate it
+		// validation.Empty(s.ClusterValues.OwnerID).
+		//	WithFieldTrace(s, &s.ClusterValues.OwnerID),
 		validation.EmptySlice(s.ClusterValues.MeasurementSalt).
 			WithFieldTrace(s, &s.ClusterValues.MeasurementSalt),
 	}
@@ -442,9 +446,10 @@ func (s *State) postInitConstraints(csp cloudprovider.Provider) func() []*valida
 			// ClusterID needs to be filled.
 			validation.NotEmpty(s.ClusterValues.ClusterID).
 				WithFieldTrace(s, &s.ClusterValues.ClusterID),
-			// OwnerID needs to be filled.
-			validation.NotEmpty(s.ClusterValues.OwnerID).
-				WithFieldTrace(s, &s.ClusterValues.OwnerID),
+			// ownerID is currently unused as functionality is not implemented
+			// Therefore, we don't want to validate it
+			// validation.NotEmpty(s.ClusterValues.OwnerID).
+			//	WithFieldTrace(s, &s.ClusterValues.OwnerID),
 			// MeasurementSalt needs to be filled.
 			validation.NotEmptySlice(s.ClusterValues.MeasurementSalt).
 				WithFieldTrace(s, &s.ClusterValues.MeasurementSalt),


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
`ownerID` is currently unused as functionality for it are not implemented

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- don't run validation on the `ownerID` field of the state file

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
