### PR TITLE
ci: use structured logging for all parts of the malicious-join test

### DIFF
--- a/.github/actions/e2e_malicious_join/action.yml
+++ b/.github/actions/e2e_malicious_join/action.yml
@@ -34,9 +34,10 @@ runs:
           [ \"/malicious-join_bin\", \
           \"--js-endpoint=join-service.kube-system:9090\", \
           \"--csp=${{ inputs.cloudProvider }}\", \
-          \"--variant=default\" ]" job.yaml
+          \"--variant=default\" ]" stamped_job.yaml
+
         kubectl create ns malicious-join
-        kubectl apply -n malicious-join -f job.yaml
+        kubectl apply -n malicious-join -f stamped_job.yaml
         kubectl wait -n malicious-join --for=condition=complete --timeout=10m job/malicious-join
         kubectl logs -n malicious-join job/malicious-join | tail -n 1 | jq '.'
         ALL_TESTS_PASSED=$(kubectl logs -n malicious-join job/malicious-join | tail -n 1 | jq -r '.result.allPassed')

--- a/.github/actions/e2e_malicious_join/action.yml
+++ b/.github/actions/e2e_malicious_join/action.yml
@@ -39,7 +39,7 @@ runs:
         kubectl apply -n malicious-join -f job.yaml
         kubectl wait -n malicious-join --for=condition=complete --timeout=10m job/malicious-join
         kubectl logs -n malicious-join job/malicious-join | tail -n 1 | jq '.'
-        ALL_TESTS_PASSED=$(kubectl logs -n malicious-join job/malicious-join | tail -n 1 | jq -r '.allPassed')
+        ALL_TESTS_PASSED=$(kubectl logs -n malicious-join job/malicious-join | tail -n 1 | jq -r '.result.allPassed')
         if [[ "$ALL_TESTS_PASSED" != "true" ]]; then
           kubectl logs -n malicious-join job/malicious-join
           kubectl logs -n kube-system svc/join-service

--- a/e2e/malicious-join/BUILD.bazel
+++ b/e2e/malicious-join/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//internal/grpc/dialer",
         "//internal/logger",
         "//joinservice/joinproto",
+        "@org_uber_go_zap//:zap",
         "@org_uber_go_zap//zapcore",
     ],
 )

--- a/e2e/malicious-join/BUILD.bazel
+++ b/e2e/malicious-join/BUILD.bazel
@@ -2,6 +2,7 @@ load("@com_github_ash2k_bazel_tools//multirun:def.bzl", "multirun")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_push")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//bazel/oci:containers.bzl", "container_reponame")
 load("//bazel/sh:def.bzl", "sh_template")
 
 go_library(
@@ -47,13 +48,19 @@ oci_image(
     visibility = ["//visibility:public"],
 )
 
+container_reponame(
+    name = "container_name",
+    container_name = "malicious-join-test",
+)
+
 genrule(
     name = "malicious-join-test_repotag",
     srcs = [
+        ":container_name",
         "//bazel/settings:tag",
     ],
     outs = ["repotag.txt"],
-    cmd = "echo -n 'ghcr.io/edgelesssys/malicious-join-test:' | cat - $(location //bazel/settings:tag) > $@",
+    cmd = "cat $(location :container_name) <(echo -n :) $(location //bazel/settings:tag) > $@",
     visibility = ["//visibility:public"],
 )
 

--- a/e2e/malicious-join/job.yaml
+++ b/e2e/malicious-join/job.yaml
@@ -7,6 +7,6 @@ spec:
     spec:
       containers:
         - name: malicious-join
-          image: ghcr.io/edgelesssys/malicious-join-test:latest@sha256:f36fe306d50a6731ecdae3920682606967eb339fdd1a1e978b0ce39c2ab744bd
+          image: placeholder
       restartPolicy: Never
   backoffLimit: 0 # Do not retry

--- a/e2e/malicious-join/job_template.sh.in
+++ b/e2e/malicious-join/job_template.sh.in
@@ -22,5 +22,5 @@ else
   workdir="$1"
 fi
 
-echo "Stamping job deployment with $REPO_TAG"
-$yq eval '.spec.template.spec.containers[0].image |= "ghcr.io/edgelesssys/malicious-join-test:" + load_str(strenv(REPO_TAG))' "$template" > "$workdir/stamped_job.yaml"
+echo "Stamping job deployment with $(cat "${REPO_TAG}")"
+$yq eval ".spec.template.spec.containers[0].image = \"$(cat "${REPO_TAG}")\"" "$template" > "$workdir/stamped_job.yaml"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The malicious join test was using structured logging for some parts, and relied on structured output to parse the final result.
However, large parts of the test used simple `fmt.Print` style logging.
This could result in some inconsistencies depending when the logs are flushed.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use structured logging for all output
- Correctly build, tag, upload and use malicious-join images from the branch the test is run on

### Related issue
- [e2e failure](https://github.com/orgs/edgelesssys/projects/3/views/1?pane=issue&itemId=43626559)
- [e2e test](https://github.com/edgelesssys/constellation/actions/runs/6772885265)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
