### PR TITLE
image: use dissect from nix

### DIFF
--- a/image/measured-boot/cmd/BUILD.bazel
+++ b/image/measured-boot/cmd/BUILD.bazel
@@ -21,13 +21,8 @@ go_binary(
     ],
     embed = [":cmd_lib"],
     # keep
-    # TODO(malt3): The commented out env variable
-    # means we are using `systemd-dissect` from the host.
-    # `systemd-dissect` from nixpkgs breaks GitHub actions runners
-    # for unknown reasons.
-    # Fix this.
-    # env = {
-    #     "DISSECT_TOOLCHAIN": "$(rootpath @systemd//:bin/systemd-dissect)",
-    # },
+    env = {
+        "DISSECT_TOOLCHAIN": "$(rootpath @systemd//:bin/systemd-dissect)",
+    },
     visibility = ["//visibility:public"],
 )

--- a/image/measured-boot/cmd/main.go
+++ b/image/measured-boot/cmd/main.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	ukiPath = "/efi/EFI/BOOT/BOOTX64.EFI"
+	ukiPath = "/boot/EFI/BOOT/BOOTX64.EFI"
 )
 
 func precalculatePCRs(fs afero.Fs, dissectToolchain, imageFile string) (*measure.Simulator, error) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Since systemd 254, the efi partition is expected to be mounted under `/boot` (if both mount points `/boot` and `/efi` exist in the image).
After accounting for this new behavior, we can use `systemd-dissect` from nixpkgs.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- image: use dissect from nix

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#1234](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/1234)
- Any additional information or context

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
