### PR TITLE
[Windows] cli: fix incorrect filepath separator causing upgrades to fail

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -18,7 +18,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -88,7 +87,7 @@ func (h *Handler) Read(name string) ([]byte, error) {
 // Write writes the data bytes into the file with the given name.
 func (h *Handler) Write(name string, data []byte, options ...Option) error {
 	if hasOption(options, OptMkdirAll) {
-		if err := h.fs.MkdirAll(path.Dir(name), os.ModePerm); err != nil {
+		if err := h.fs.MkdirAll(filepath.Dir(name), os.ModePerm); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix incorrect usage of `path.Dir()` (instead of `filepath.Dir()`) that breaks directory backups for the Constellation CLI on Windows.
  - This effectively made the CLI unable to run `constellation upgrade apply` on Windows systems
  - Detected because we run the Terraform state backup as part of `constellation apply`, which is called during the initialization process

### Additional info
- [e2e test Windows](https://github.com/edgelesssys/constellation/actions/runs/6786682549)
