### PR TITLE
attestation: clear certificate cache in azure snp unittest

### DIFF
--- a/internal/attestation/azure/snp/BUILD.bazel
+++ b/internal/attestation/azure/snp/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "@com_github_google_go_sev_guest//proto/sevsnp",
         "@com_github_google_go_sev_guest//validate",
         "@com_github_google_go_sev_guest//verify",
+        "@com_github_google_go_sev_guest//verify/trust",
         "@com_github_google_go_tpm//legacy/tpm2",
         "@com_github_google_go_tpm_tools//client",
         "@com_github_google_go_tpm_tools//proto/attest",


### PR DESCRIPTION
### Context
<!-- Please add background information on why this PR is opened. -->
The unittest was flacky as testcases with valid certs in the getter property lead to those certs being cached inside the go-sev-guest/trust pkg. Other testcases however, want to explicitly use invalid certs. The cache interferes with this by serving the valid certs from other testcases.

The fact that current main is broken can be seen by running: `bazel test --runs_per_test=100 //internal/attestation/azure/snp:snp_test`
Running the same command on this PR should succeed.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Clear certificate cache during each test
- Move shared required object into test body

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
