### PR TITLE
validation: use regex instead of dns lookup for DNSName validation

### DIFF
--- a/internal/validation/constraints.go
+++ b/internal/validation/constraints.go
@@ -13,6 +13,9 @@ import (
 	"regexp"
 )
 
+// Used to validate DNS names.
+var domainRegex = regexp.MustCompile(`^(?i)[a-z0-9-]+(\.[a-z0-9-]+)+\.?$`)
+
 // Constraint is a constraint on a document or a field of a document.
 type Constraint struct {
 	// Satisfied returns no error if the constraint is satisfied.
@@ -208,7 +211,7 @@ func CIDR(s string) *Constraint {
 func DNSName(s string) *Constraint {
 	return &Constraint{
 		Satisfied: func() *TreeError {
-			if _, err := net.LookupHost(s); err != nil {
+			if !domainRegex.MatchString(s) {
 				return NewErrorTree(fmt.Errorf("%s must be a valid DNS name", s))
 			}
 			return nil


### PR DESCRIPTION
### Context
Doing a DNS lookup may fail for domain names that are valid but currently not assigned.
The old test also breaks inside the bazel sandbox.
Investigation for why this did not break the pipeline is underway ([AB#3530](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3530)).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use a regex instead of doing a DNS lookup to validate DNS names.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)

