### PR TITLE
ci: fix failure issue creation for Windows e2e test

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -157,7 +157,7 @@ runs:
         refStream: ${{ inputs.refStream }}
         kubernetesVersion: ${{ inputs.kubernetesVersion }}
         selfManagedInfra: ${{ inputs.selfManagedInfra }}
-        
+
     - name: Constellation init
       id: constellation-init
       shell: bash

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -284,7 +284,7 @@ runs:
         kubernetesVersion: ${{ inputs.kubernetesVersion }}
         refStream: ${{ inputs.refStream }}
         selfManagedInfra: ${{ inputs.selfManagedInfra }}
-        
+
     #
     # Test payloads
     #

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -136,7 +136,8 @@ jobs:
 
       - uses: ./.github/actions/setup_bazel_nix
         with:
-          useCache: "false"
+          useCache: "true"
+          buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
 
       - name: Login to AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -163,6 +163,12 @@ jobs:
         with:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
+      - name: Setup bazel
+        uses: ./.github/actions/setup_bazel_nix
+        with:
+          useCache: "true"
+          buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+
       - name: Notify about failure
         continue-on-error: true
         uses: ./.github/actions/notify_failure


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Windows e2e test was missing a bazel set-up action in the notify-failure job, causing a failure when creating an issue for a failed test.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a "set up bazel" action to the job
- Enable buildbuddy cache for upgrade e2e-test
- Remove whitespace

### Additional info
- [Windows e2e test failure](https://github.com/edgelesssys/constellation/actions/runs/6797084954)
- [failure issue](https://github.com/orgs/edgelesssys/projects/3?pane=issue&itemId=44005076)


