### PR TITLE
ci: dont run SNP version upload on v2.12.0 CLI tests

### DIFF
--- a/.github/actions/e2e_verify/action.yml
+++ b/.github/actions/e2e_verify/action.yml
@@ -90,6 +90,11 @@ runs:
         COSIGN_PASSWORD: ${{ inputs.cosignPassword }}
         COSIGN_PRIVATE_KEY: ${{ inputs.cosignPrivateKey }}
       run: |
+        if constellation version | head -n 1 | grep "v2.12.0" > /dev/null
+        then
+          exit 0
+        fi
+
         for file in $(ls snp-report-*.json); do
           path=$(realpath "${file}")
           cat "${path}"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The sev-guest library used in v2.12.0 of Constellation included a debug `fmt.Println` statement in the verification code for SNP values. This breaks the SNP version upload since the stdout output of `constellation verify -o json` is no longer valid json.
Since v2.12.0 also didn't properly marshal all certificates, I opted to not fix the output file in case we are running a test with a v2.12 CLI, but simply not run the version upload

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Don't upload TCB versions from Azure e2e verify tests for CLI versions v2.12

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [Here](https://github.com/edgelesssys/constellation/actions/runs/6799481770/job/18486776613#step:6:4825) is the error in a run on main using `v2.12.0` CLI
- [Here](https://github.com/edgelesssys/constellation/actions/runs/6752370284/job/18357662122#step:3:5102) we can see the error occurring in our weekly e2e tests
- [e2e test v2.12.0 CLI with fix](https://github.com/edgelesssys/constellation/actions/runs/6800371931)
- [e2e test v2.13.0-pre with fix](https://github.com/edgelesssys/constellation/actions/runs/6800374308)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
