### PR TITLE
state: add migration for `IPCidrNode` and `InClusterEndpoint`

### DIFF
--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -337,6 +337,18 @@ The control flow is as follows:
 	                        └────────────────────┘
 */
 func (a *applyCmd) apply(cmd *cobra.Command, configFetcher attestationconfigapi.Fetcher, upgradeDir string) error {
+	// Migrate state file
+	stateFile, err := state.ReadFromFile(a.fileHandler, constants.StateFilename)
+	if err != nil {
+		return fmt.Errorf("reading state file: %w", err)
+	}
+	if err := stateFile.Migrate(); err != nil {
+		return fmt.Errorf("migrating state file: %w", err)
+	}
+	if err := stateFile.WriteToFile(a.fileHandler, constants.StateFilename); err != nil {
+		return fmt.Errorf("writing state file: %w", err)
+	}
+
 	// Validate inputs
 	conf, stateFile, err := a.validateInputs(cmd, configFetcher)
 	if err != nil {

--- a/cli/internal/state/BUILD.bazel
+++ b/cli/internal/state/BUILD.bazel
@@ -11,7 +11,9 @@ go_library(
     visibility = ["//cli:__subpackages__"],
     deps = [
         "//internal/cloud/cloudprovider",
+        "//internal/constants",
         "//internal/file",
+        "//internal/semver",
         "//internal/validation",
         "@cat_dario_mergo//:mergo",
         "@com_github_siderolabs_talos_pkg_machinery//config/encoder",

--- a/cli/internal/state/state.go
+++ b/cli/internal/state/state.go
@@ -20,7 +20,9 @@ import (
 
 	"dario.cat/mergo"
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
+	"github.com/edgelesssys/constellation/v2/internal/constants"
 	"github.com/edgelesssys/constellation/v2/internal/file"
+	"github.com/edgelesssys/constellation/v2/internal/semver"
 	"github.com/edgelesssys/constellation/v2/internal/validation"
 )
 
@@ -553,6 +555,24 @@ func (s *State) postInitConstraints(csp cloudprovider.Provider) func() []*valida
 // Constraints is a no-op implementation to fulfill the "Validatable" interface.
 func (s *State) Constraints() []*validation.Constraint {
 	return []*validation.Constraint{}
+}
+
+// Migrate migrates the state to the current version.
+// This is mostly done to pass the validation of the current version.
+// The infrastructure will be overwritten by the terraform outputs after the validation.
+func (s *State) Migrate() error {
+	// In v2.13.0 the ClusterEndpoint and InClusterEndpoint fields were added.
+	// So they are expected to be empty when upgrading to this version.
+	// TODO(3u13r): Remove on main after v2.13.0 is released.
+	if constants.BinaryVersion().MajorMinorEqual(semver.NewFromInt(2, 13, 0, "")) {
+		if s.Infrastructure.InClusterEndpoint == "" {
+			s.Infrastructure.InClusterEndpoint = s.Infrastructure.ClusterEndpoint
+		}
+		if s.Infrastructure.IPCidrNode == "" {
+			s.Infrastructure.IPCidrNode = "192.168.2.1/32"
+		}
+	}
+	return nil
 }
 
 // HexBytes is a byte slice that is marshalled to and from a hex string.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We added validation for the statefile after I implemented changes which depended on there being no validation (at least before the state is updated/re-crated from the new terrafom).


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a `Migrate` function to the state file to implement all future migrations.
- Add migrations to pass the validation for the new fields.
- We need to also revert https://github.com/edgelesssys/constellation/pull/2545. Otherwise we schedule 30+ nodes during the upgrade of a 1:1 cluster.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
