### PR TITLE
terraform: allow image to be empty

### DIFF
--- a/.github/actions/upload_terraform_module/action.yml
+++ b/.github/actions/upload_terraform_module/action.yml
@@ -18,7 +18,11 @@ runs:
     - name: Stamp version
       shell: bash
       run: |
-        sed -i "s/@@CONSTELLATION_VERSION@@/${{ inputs.version }}/g" terraform-module/constellation-cluster/variables.tf
+        sed -i "s/@@CONSTELLATION_VERSION@@/${{ inputs.version }}/g" \
+          terraform-module/constellation-cluster/variables.tf \
+          terraform-module/aws-constellation/variables.tf \
+          terraform-module/azure-constellation/variables.tf \
+          terraform-module/gcp-constellation/variables.tf
 
     - name: Zip terraform dir
       shell: bash

--- a/terraform/aws-constellation/variables.tf
+++ b/terraform/aws-constellation/variables.tf
@@ -5,7 +5,8 @@ variable "name" {
 
 variable "image" {
   type        = string
-  description = "Node image reference or semantic release version."
+  description = "Node image reference or semantic release version. When not set, the latest default version will be used."
+  default     = ""
 }
 
 variable "microservice_version" {

--- a/terraform/aws-constellation/variables.tf
+++ b/terraform/aws-constellation/variables.tf
@@ -6,7 +6,7 @@ variable "name" {
 variable "image" {
   type        = string
   description = "Node image reference or semantic release version. When not set, the latest default version will be used."
-  default     = ""
+  default     = "@@CONSTELLATION_VERSION@@"
 }
 
 variable "microservice_version" {

--- a/terraform/azure-constellation/variables.tf
+++ b/terraform/azure-constellation/variables.tf
@@ -5,7 +5,8 @@ variable "name" {
 
 variable "image" {
   type        = string
-  description = "Node image reference or semantical release version."
+  description = "Node image reference or semantical release version. When not set, the latest default version will be used."
+  default     = ""
 }
 
 variable "microservice_version" {

--- a/terraform/azure-constellation/variables.tf
+++ b/terraform/azure-constellation/variables.tf
@@ -5,7 +5,7 @@ variable "name" {
 
 variable "image" {
   type        = string
-  description = "Node image reference or semantical release version. When not set, the latest default version will be used."
+  description = "Node image reference or semantic release version. When not set, the latest default version will be used."
   default     = ""
 }
 

--- a/terraform/azure-constellation/variables.tf
+++ b/terraform/azure-constellation/variables.tf
@@ -6,7 +6,7 @@ variable "name" {
 variable "image" {
   type        = string
   description = "Node image reference or semantic release version. When not set, the latest default version will be used."
-  default     = ""
+  default     = "@@CONSTELLATION_VERSION@@"
 }
 
 variable "microservice_version" {

--- a/terraform/constellation-cluster/variables.tf
+++ b/terraform/constellation-cluster/variables.tf
@@ -7,7 +7,6 @@ variable "constellation_version" {
 variable "image" {
   type        = string
   description = "The node image reference or semantic release version."
-  default     = "@@CONSTELLATION_VERSION@@"
 }
 
 variable "csp" {

--- a/terraform/gcp-constellation/variables.tf
+++ b/terraform/gcp-constellation/variables.tf
@@ -16,7 +16,7 @@ variable "service_account_id" {
 variable "image" {
   type        = string
   description = "Node image reference or semantic release version. When not set, the latest default version will be used."
-  default     = ""
+  default     = "@@CONSTELLATION_VERSION@@"
 }
 
 variable "microservice_version" {

--- a/terraform/gcp-constellation/variables.tf
+++ b/terraform/gcp-constellation/variables.tf
@@ -15,7 +15,8 @@ variable "service_account_id" {
 
 variable "image" {
   type        = string
-  description = "Node image reference or semantic release version."
+  description = "Node image reference or semantic release version. When not set, the latest default version will be used."
+  default     = ""
 }
 
 variable "microservice_version" {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
#2566 added stamping for the image version as a default for the Terraform variable when the Terraform module is packaged to be released.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add default values to the image variables in the convenience modules, making them optional inputs. Leaving them empty will then cause the stamped image version to be selected.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
