### PR TITLE
Revert "operator: always delete terminated pending nodes (#2545)"

### DIFF
--- a/operators/constellation-node-operator/controllers/pendingnode_controller.go
+++ b/operators/constellation-node-operator/controllers/pendingnode_controller.go
@@ -93,7 +93,7 @@ func (r *PendingNodeReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 
 	if done {
 		logr.Info("Reached goal", "pendingNodeGoal", pendingNode.Spec.Goal, "cspNodeState", nodeState)
-		if pendingNode.Spec.Goal == updatev1alpha1.NodeGoalLeave || nodeState == updatev1alpha1.NodeStateTerminated {
+		if pendingNode.Spec.Goal == updatev1alpha1.NodeGoalLeave {
 			// delete self after pending node has been terminated successfully
 			if err := r.deletePendingNode(ctx, req.NamespacedName); err != nil {
 				return ctrl.Result{}, err
@@ -213,17 +213,13 @@ func (r *PendingNodeReconciler) findObjectsForNode(ctx context.Context, rawNode 
 // - joining node: CSP reports the node instance as running and node has joined kubernetes cluster.
 // - leaving node: CSP reports node instance as terminated.
 func (r *PendingNodeReconciler) reachedGoal(ctx context.Context, pendingNode updatev1alpha1.PendingNode, nodeState updatev1alpha1.CSPNodeState) (bool, error) {
-	// Always return if the node is terminated so the resource can be cleaned up.
-	if nodeState == updatev1alpha1.NodeStateTerminated {
-		return true, nil
-	}
 	if pendingNode.Spec.Goal == updatev1alpha1.NodeGoalJoin {
 		if err := r.Get(ctx, types.NamespacedName{Name: pendingNode.Spec.NodeName}, &corev1.Node{}); err != nil {
 			return false, client.IgnoreNotFound(err)
 		}
 		return nodeState == updatev1alpha1.NodeStateReady, nil
 	}
-	return false, nil
+	return nodeState == updatev1alpha1.NodeStateTerminated, nil
 }
 
 // deletePendingNode deletes a PendingNode resource.


### PR DESCRIPTION
This reverts commit 5267ad0f08de57e67c2713d8ec45ad2f8041ee3e.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- We need to revert this. With this patch we've observed 30+ nodes being scheduled during the upgrade of a 1:1 cluster on GCP. This presumably happens because if a node is not found then it's state within the operator is "Terminated". This likely happens in the first seconds of the new node being created. With is patch the "Terminated" node already has reached its goal. It's true goal was joining the cluster though. 

The idea before (and after) this patch is that the joiningNode has a deadline set until it must join the cluster. Otherwise it's goal is set to "Leaving" which is reached if the node never joined the cluster because it was shut down. This should've already handled the AWS case.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
