### PR TITLE
ci: refactor teams notification action

### DIFF
--- a/.github/actions/notify_e2e_failure/action.yml
+++ b/.github/actions/notify_e2e_failure/action.yml
@@ -1,4 +1,4 @@
-name: notify failure
+name: notify e2e failure
 description: "Post a failure message to project board and teams"
 
 inputs:
@@ -82,32 +82,43 @@ runs:
         echo "opensearchURL=${opensearchURL}" | tee -a "$GITHUB_OUTPUT"
         echo "issueURL=${issueURL}" | tee -a "$GITHUB_OUTPUT"
 
-    - name: Notify teams channel
+    - name: Create notification fields
+      id: create-fields
       continue-on-error: true
       shell: bash
       run: |
-        cp .github/teams_payload_template.json teams_payload.json
-        yq -iP '.attachments[0].content.body[0].columns[1].items[1].text = "${{ github.workflow }}"' teams_payload.json
-        yq -iP '.attachments[0].content.body[0].columns[1].items[2].facts += [ { "title": "CloudProvider", "value": "${{ inputs.provider }}" } ]' teams_payload.json
-        yq -iP '.attachments[0].content.body[0].columns[1].items[2].facts += [ { "title": "Test", "value": "${{ inputs.test }}" } ]' teams_payload.json
+        echo '[ { "title": "CloudProvider", "value": "${{ inputs.provider }}" }, { "title": "Test", "value": "${{ inputs.test }}" } ]' > facts.json
         if [[ -n "${{ inputs.kubernetesVersion }}" ]]; then
-          yq -iP '.attachments[0].content.body[0].columns[1].items[2].facts += [ { "title": "KubernetesVersion", "value": "${{ inputs.kubernetesVersion }}" } ]' teams_payload.json
+          yq -oj -iP '. += [ { "title": "KubernetesVersion", "value": "${{ inputs.kubernetesVersion }}" } ]' facts.json
         fi
         if [[ -n "${{ inputs.refStream }}" ]]; then
-          yq -iP '.attachments[0].content.body[0].columns[1].items[2].facts += [ { "title": "RefStream", "value": "${{ inputs.refStream }}" } ]' teams_payload.json
+          yq -oj -iP '. += [ { "title": "RefStream", "value": "${{ inputs.refStream }}" } ]' facts.json
         fi
-        text_value="<at>${{ steps.pick-assignee.outputs.assignee }}</at>"
-        entities=$(jq -c '.attachments[0].content.msteams.entities[]' teams_payload.json)
-        # need to filter entities to only have entry of mentioned person
-        filtered_entity=$(echo $entities | jq --arg text_value "$text_value" 'select(.text == $text_value)')
-        yq -iP '.attachments[0].content.msteams.entities = [ '"$filtered_entity"' ]' teams_payload.json
 
-        yq -iP '.attachments[0].content.body[0].columns[1].items[2].facts += [ { "title": "Assignee", "value": "<at>${{ steps.pick-assignee.outputs.assignee }}</at>" } ]' teams_payload.json
-        yq -iP '.attachments[0].content.actions[0].url = "${{ steps.create-project-card.outputs.jobURL }}"' teams_payload.json
-        yq -iP '.attachments[0].content.actions[1].url = "${{ steps.create-project-card.outputs.issueURL }}"' teams_payload.json
-        yq -iP ".attachments[0].content.actions[2].url = \"${{ steps.create-project-card.outputs.opensearchURL }}\"" teams_payload.json
-        cat teams_payload.json
-        curl \
-          -H "Content-Type: application/json" \
-          -d @teams_payload.json \
-          "${{ inputs.teamsWebhookUri }}"
+        buttons='[
+          {
+            "type": "Action.OpenUrl",
+            "title": "Project board issue",
+            "url": "${{ steps.create-project-card.outputs.issueURL }}",
+            "style": "positive"
+          },
+          {
+            "type": "Action.OpenUrl",
+            "title": "OpenSearch logs",
+            "url": "${{ steps.create-project-card.outputs.opensearchURL }}",
+            "style": "positive"
+          }
+        ]'
+
+        echo "additionalFields=$(cat facts.json)" | tee -a "$GITHUB_OUTPUT"
+        echo "additionalButtons=$buttons" | tee -a "$GITHUB_OUTPUT"
+
+    - name: Notify teams channel
+      continue-on-error: true
+      uses: ./.github/actions/notify_teams
+      with:
+        teamsWebhookURI: ${{ inputs.teamsWebhookUri }}
+        title: "Constellation E2E test failed"
+        assignee: ${{ steps.pick-assignee.outputs.assignee }}
+        additionalFields: ${{ steps.create-fields.outputs.additionalFields }}
+        additionalButtons: ${{ steps.create-fields.outputs.additionalButtons }}

--- a/.github/actions/notify_teams/action.yml
+++ b/.github/actions/notify_teams/action.yml
@@ -1,0 +1,52 @@
+name: notify teams
+description: "Post a message to Teams"
+
+inputs:
+  teamsWebhookURI:
+    description: "URI to send a message to the Teams channel"
+    required: true
+  title:
+    description: "Title of the Teams notification"
+    required: true
+  assignee:
+    description: "Assignee of the message"
+    required: true
+  additionalFields:
+    description: "Additional fields to add to the Teams message (JSON formatted)"
+    default: "[]"
+  additionalButtons:
+    description: "Additional Buttons to add to the Teams message (JSON formatted)"
+    default: "[]"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Notify Teams channel
+      continue-on-error: true
+      shell: bash
+      run: |
+        cp .github/teams_payload_template.json teams_payload.json
+
+        # Add workflow name to the notification
+        yq -oj -iP '.attachments[0].content.body[0].columns[1].items[0].text = "${{ inputs.title }}"' teams_payload.json
+        yq -oj -iP '.attachments[0].content.body[0].columns[1].items[1].text = "${{ github.workflow }}"' teams_payload.json
+
+        # Add additional fields
+        yq -oj -iP '.attachments[0].content.body[0].columns[1].items[2].facts += ${{ inputs.additionalFields }} ' teams_payload.json
+
+        # Remove everyone but the assignee from the JSON payload so the final message only contains the assignee
+        filtered_entity=$(yq -oj '.attachments[0].content.msteams.entities[] | select(.text == "<at>${{ inputs.assignee }}</at>")' teams_payload.json)
+        yq -oj -iP '.attachments[0].content.msteams.entities = [ '"$filtered_entity"' ]' teams_payload.json
+        yq -oj -iP '.attachments[0].content.body[0].columns[1].items[2].facts += [ { "title": "Assignee", "value": "<at>${{ inputs.assignee }}</at>" } ]' teams_payload.json
+
+        # Add clickable button which links to the workflow triggering this notification
+        yq -oj -iP '.attachments[0].content.actions[0].url = "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"' teams_payload.json
+
+        # Add additional buttons
+        yq -oj -iP '.attachments[0].content.actions += ${{ inputs.additionalButtons }}' teams_payload.json
+
+        cat teams_payload.json
+        curl \
+          -H "Content-Type: application/json" \
+          -d @teams_payload.json \
+          "${{ inputs.teamsWebhookURI }}"

--- a/.github/teams_payload_template.json
+++ b/.github/teams_payload_template.json
@@ -93,7 +93,7 @@
                                 "items": [
                                     {
                                         "type": "TextBlock",
-                                        "text": "Constellation E2E test failed",
+                                        "text": "Title",
                                         "wrap": true,
                                         "fontType": "Default",
                                         "size": "large",
@@ -121,18 +121,6 @@
                     {
                         "type": "Action.OpenUrl",
                         "title": "GitHub workflow run",
-                        "url": "",
-                        "style": "positive"
-                    },
-                    {
-                        "type": "Action.OpenUrl",
-                        "title": "Project board issue",
-                        "url": "",
-                        "style": "positive"
-                    },
-                    {
-                        "type": "Action.OpenUrl",
-                        "title": "OpenSearch logs",
                         "url": "",
                         "style": "positive"
                     }

--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -114,3 +114,26 @@ jobs:
           labels: no changelog
           # We need to push changes using a token, otherwise triggers like on:push and on:pull_request won't work.
           token: ${{ !github.event.pull_request.head.repo.fork && secrets.CI_COMMIT_PUSH_PR || '' }}
+
+  notify-failure:
+    if: failure()
+    needs: [ "stream", "build-image", "update-code" ]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Pick assignee
+        id: pick-assignee
+        continue-on-error: true
+        uses: ./.github/actions/pick_assignee
+
+      - name: Notify failure
+        continue-on-error: true
+        uses: ./.github/actions/notify_teams
+        with:
+          teamsWebhookURI: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
+          title: "Constellation image build failed"
+          assignee: ${{ steps.pick-assignee.outputs.assignee }}

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -114,7 +114,7 @@ jobs:
           github.ref == 'refs/heads/main' &&
           github.event_name == 'schedule'
         continue-on-error: true
-        uses: ./.github/actions/notify_failure
+        uses: ./.github/actions/notify_e2e_failure
         with:
           projectWriteToken: ${{ secrets.PROJECT_WRITE_TOKEN }}
           teamsWebhookUri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
@@ -162,7 +162,7 @@ jobs:
           github.ref == 'refs/heads/main' &&
           github.event_name == 'schedule'
         continue-on-error: true
-        uses: ./.github/actions/notify_failure
+        uses: ./.github/actions/notify_e2e_failure
         with:
           projectWriteToken: ${{ secrets.PROJECT_WRITE_TOKEN }}
           teamsWebhookUri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -282,7 +282,7 @@ jobs:
           github.ref == 'refs/heads/main' &&
           github.event_name == 'schedule'
         continue-on-error: true
-        uses: ./.github/actions/notify_failure
+        uses: ./.github/actions/notify_e2e_failure
         with:
           projectWriteToken: ${{ secrets.PROJECT_WRITE_TOKEN }}
           teamsWebhookUri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}
@@ -351,7 +351,7 @@ jobs:
           github.ref == 'refs/heads/main' &&
           github.event_name == 'schedule'
         continue-on-error: true
-        uses: ./.github/actions/notify_failure
+        uses: ./.github/actions/notify_e2e_failure
         with:
           projectWriteToken: ${{ secrets.PROJECT_WRITE_TOKEN }}
           teamsWebhookUri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -305,7 +305,7 @@ jobs:
           github.ref == 'refs/heads/main' &&
           inputs.scheduled
         continue-on-error: true
-        uses: ./.github/actions/notify_failure
+        uses: ./.github/actions/notify_e2e_failure
         with:
           projectWriteToken: ${{ secrets.PROJECT_WRITE_TOKEN }}
           teamsWebhookUri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -171,7 +171,7 @@ jobs:
 
       - name: Notify about failure
         continue-on-error: true
-        uses: ./.github/actions/notify_failure
+        uses: ./.github/actions/notify_e2e_failure
         with:
           projectWriteToken: ${{ secrets.PROJECT_WRITE_TOKEN }}
           teamsWebhookUri: ${{ secrets.MS_TEAMS_WEBHOOK_URI }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
- Scheduled image build failures require manual actions to be noticed
- Teams notifications should be a bit more modular

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Separate the teams notification into its own action
  - By itself, the action send a notification with some very structure
    - Title
    - Subtitle
    - Name of the assignee and ping in Teams. (Assignee should be chosen by the caller)
    - Clickable button that links to the workflow run triggering the notification
  - Additional fields may be set by the caller
  - Additional buttons may be added by the caller
- Call teams notification action if scheduled image build fails

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3329](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3329)
- [AB#3362](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3362)
- Looks like [this](https://github.com/edgelesssys/constellation/actions/runs/6863620861) on failure

