### PR TITLE
ci: add missing `runner` value to s3proxy test

### DIFF
--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -174,6 +174,7 @@ jobs:
             refStream: "ref/main/stream/debug/?"
             provider: "gcp"
             kubernetes-version: "v1.28"
+            runner: "ubuntu-22.04"
 
           #
           # Tests on macOS runner


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The release pipeline failed due to a missing `runner` value, which left the matrix at "waiting for pending jobs" even though it should be started in parallel. Once all other jobs were finished, the error `Error when evaluating 'runs-on' for job 'e2e-tests'. edgelesssys/constellation/.github/workflows/e2e-test-release.yml@246b9ce069acb0933ea8d2c786383b3e46d26936 (Line: 191, Col: 14): Unexpected value ''` was thrown.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add the missing `runner` value to the matrix.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [E2E Test (Pre-Fix)](https://github.com/edgelesssys/constellation/actions/runs/6874144304)
- [E2E Test (Post-Fix)](https://github.com/edgelesssys/constellation/actions/runs/6874179262)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
