### PR TITLE
ci: allow jobs to install tools from pinned nixpkgs

### DIFF
--- a/.github/actions/setup_bazel_nix/action.yml
+++ b/.github/actions/setup_bazel_nix/action.yml
@@ -12,6 +12,10 @@ inputs:
   rbePlatform:
     description: "RBE platform to use. If empty, RBE will not be used."
     required: false
+  nixTools:
+    description: "Nix tools to install as list of strings separated by newlines. If empty, no tools will be installed."
+    default: ""
+    required: false
 
 runs:
   using: "composite"
@@ -266,4 +270,48 @@ runs:
         echo "::group::Configure Bazel (disk cache)"
         echo "common --disk_cache=" >> "${WORKSPACE}/.bazeloverwriterc"
         echo "common --repository_cache=" >> "${WORKSPACE}/.bazeloverwriterc"
+        echo "::endgroup::"
+
+    - name: Install nix tools
+      if: inputs.nixTools != ''
+      shell: bash
+      env:
+        tools: ${{ inputs.nixTools }}
+        repository: ${{ github.repository }}
+        gitSha: ${{ github.sha }}
+      run: |
+        echo "::group::Install nix tools"
+        toolsNixList=$(printf ' "%s"' ${tools[@]})
+        toolsNixList="[ ${toolsNixList} ]"
+        expressionFile=$(mktemp)
+        cat << "EOF" > "${expressionFile}"
+        { tools, repository, rev }:
+        let
+          repoFlake = builtins.getFlake ("github:" + repository + "/" + rev);
+          nixpkgs = repoFlake.inputs.nixpkgsUnstable;
+          pkgs = import nixpkgs { system = builtins.currentSystem; };
+          toolPkgs = map (p: pkgs.${p}) tools;
+        in
+        {
+          tools = pkgs.symlinkJoin { name = "tools"; paths = [ toolPkgs ]; };
+          pathVar = pkgs.lib.makeBinPath toolPkgs;
+        }
+        EOF
+        # ensure the store paths are created
+        nix-build \
+          --no-out-link \
+          --arg tools "${toolsNixList}" \
+          --argstr repository "${repository}" \
+          --argstr rev "${gitSha}" \
+          --attr tools \
+          "${expressionFile}"
+        # evaluate the path expression
+        # EXTRA_PATH=/nix/store/...:/nix/store/...:/nix/store/...
+        EXTRA_PATH=$(nix eval --raw --file "${expressionFile}" \
+          --arg tools "${toolsNixList}" \
+          --argstr repository "${repository}" \
+          --argstr rev "${gitSha}" \
+          pathVar)
+        echo "EXTRA_PATH=${EXTRA_PATH}"
+        echo "${EXTRA_PATH}" >> "${GITHUB_PATH}"
         echo "::endgroup::"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

We often need additional tools in GitHub Actions Workflow jobs. This extension to the `setup_bazel_nix` action adds a new parameter `nixTools` which (if provided) will install a list of tools for the duration of the job and add their store paths to the `GITHUB_PATH` env.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: allow jobs to install tools from pinned nixpkgs

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [test run](https://github.com/edgelesssys/constellation/actions/runs/6891198755/job/18745750123) (prints cowsay and ponysay output)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [ ] Link to Milestone
