### PR TITLE
Revert "deps: update rules_oci to 1.4.2"

### DIFF
--- a/bazel/release/BUILD.bazel
+++ b/bazel/release/BUILD.bazel
@@ -62,8 +62,7 @@ oci_sum_merge(
     oci_push(
         name = container["name"] + "_push",
         image = container["oci"],
-        remote_tags = "//bazel/settings:tag",
-        repository_file = "//bazel/release:" + container["name"] + "_reponame",
+        repotags = container["repotag_file"],
     )
     for container in containers()
 ]

--- a/bazel/toolchains/oci_deps.bzl
+++ b/bazel/toolchains/oci_deps.bzl
@@ -5,11 +5,11 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def oci_deps():
     http_archive(
         name = "rules_oci",
-        strip_prefix = "rules_oci-1.4.2",
+        strip_prefix = "rules_oci-0.4.0",
         type = "tar.gz",
         urls = [
-            "https://cdn.confidential.cloud/constellation/cas/sha256/be1fce88d05dd0b946f3c874f8af1a473468ea4daba0b69b459a5866416e10d5",
-            "https://github.com/bazel-contrib/rules_oci/releases/download/v1.4.2/rules_oci-v1.4.2.tar.gz",
+            "https://cdn.confidential.cloud/constellation/cas/sha256/d7b0760ba28554b71941ea0bbfd0a9f089bf250fd4448f9c116e1cb7a63b3933",
+            "https://github.com/bazel-contrib/rules_oci/releases/download/v0.4.0/rules_oci-v0.4.0.tar.gz",
         ],
-        sha256 = "be1fce88d05dd0b946f3c874f8af1a473468ea4daba0b69b459a5866416e10d5",
+        sha256 = "d7b0760ba28554b71941ea0bbfd0a9f089bf250fd4448f9c116e1cb7a63b3933",
     )

--- a/e2e/malicious-join/BUILD.bazel
+++ b/e2e/malicious-join/BUILD.bazel
@@ -67,8 +67,7 @@ genrule(
 oci_push(
     name = "malicious-join_push",
     image = ":malicious-join_image",
-    remote_tags = "//bazel/settings:tag",
-    repository_file = ":container_name",
+    repotags = ":repotag.txt",
 )
 
 sh_template(


### PR DESCRIPTION
Reverts edgelesssys/constellation#2616

The change breaks building the CLI for windows.
See https://github.com/bazel-contrib/rules_oci/issues/420 for the upstream issue.