### PR TITLE
cli: fix panic in status cmd without conf file

### DIFF
--- a/cli/internal/cmd/status.go
+++ b/cli/internal/cmd/status.go
@@ -84,6 +84,9 @@ func (s *statusCmd) status(
 	if errors.As(err, &configValidationErr) {
 		cmd.PrintErrln(configValidationErr.LongMessage())
 	}
+	if err != nil {
+		return fmt.Errorf("loading config file: %w", err)
+	}
 
 	nodeVersion, err := kubeClient.GetConstellationVersion(cmd.Context())
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -397,17 +397,6 @@ func TestValidate(t *testing.T) {
 				cnf := Default()
 				cnf.RemoveProviderAndAttestationExcept(cloudprovider.Azure)
 				cnf.Image = constants.BinaryVersion().String()
-				az := cnf.Provider.Azure
-				az.SubscriptionID = "01234567-0123-0123-0123-0123456789ab"
-				az.TenantID = "01234567-0123-0123-0123-0123456789ab"
-				az.Location = "test-location"
-				az.UserAssignedIdentity = "test-identity"
-				az.ResourceGroup = "test-resource-group"
-				cnf.Provider = ProviderConfig{}
-				cnf.Provider.Azure = az
-				cnf.Attestation.AzureSEVSNP.Measurements = measurements.M{
-					0: measurements.WithAllBytes(0x00, measurements.Enforce, measurements.PCRMeasurementLength),
-				}
 				modifyConfigForAzureToPassValidate(cnf)
 				return cnf
 			}(),


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
When executing `constellation status` without a present config file, the command panics because the config reading error is not caught.
This issue occurs on 2.13 and also 2.12.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- return config read error

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
