### PR TITLE
ci: fix unsupported qemu in tests on mac

### DIFF
--- a/cli/internal/cloudcmd/apply_test.go
+++ b/cli/internal/cloudcmd/apply_test.go
@@ -301,7 +301,7 @@ func TestPlan(t *testing.T) {
 			}
 
 			cfg := config.Default()
-			cfg.RemoveProviderAndAttestationExcept(cloudprovider.QEMU)
+			cfg.RemoveProviderAndAttestationExcept(cloudprovider.Azure)
 
 			diff, err := u.Plan(context.Background(), cfg)
 			if tc.wantErr {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Executing the unit tests on Mac fails because of 
```
creating terraform variables: creation of a QEMU based Constellation is not supported for darwin/arm64
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- change provider to Azure

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#1234](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/1234)
- Any additional information or context

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
