### PR TITLE
ci: prepare Bazel for integration testing

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,6 +27,13 @@ build --flag_alias=container_prefix=//bazel/settings:container_prefix
 # set cli edition flag alias
 build --flag_alias=cli_edition=//bazel/settings:cli_edition
 
+# disable integration tests by default
+test --test_tag_filters=-integration
+# enable all tests (including integration)
+test:integration --test_tag_filters= --@io_bazel_rules_go//go/config:tags=integration
+# enable only integration tests
+test:integration-only --test_tag_filters=+integration --@io_bazel_rules_go//go/config:tags=integration
+
 # bazel configs to explicitly target a platform
 common:host --platforms @local_config_platform//:host
 common:linux_amd64 --platforms @zig_sdk//libc_aware/platform:linux_amd64_gnu.2.23

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -42,6 +42,17 @@ jobs:
         run: mkdir build && cd build && cmake ..
 
       # Runs all test targets starting with "integration-"
-      - name: Integration Tests
+      - name: CMake-based Integration Tests
         working-directory: build
         run: ctest -R integration-
+
+      - name: Setup bazel
+        uses: ./.github/actions/setup_bazel_nix
+        with:
+          useCache: "true"
+          buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
+
+      - name: Integration Tests
+        env:
+          TMPDIR: ${{ runner.temp }}
+        run: bazel test //... --test_output=errors --config=nostamp --config=integration-only --remote_download_minimal

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,3 @@ enable_testing()
 # TODO(malt3): Remove this once every integration test is migrated to Bazel
 add_test(NAME integration-csi COMMAND bash -c "go test -tags integration -c ./test/ && sudo ./test.test -test.v" WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/csi)
 add_test(NAME integration-dm COMMAND bash -c "go test -tags integration -c ./test/ && sudo ./test.test -test.v" WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/disk-mapper/internal)
-add_test(NAME integration-license COMMAND bash -c "go test -tags integration" WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/internal/license)

--- a/internal/license/BUILD.bazel
+++ b/internal/license/BUILD.bazel
@@ -26,7 +26,6 @@ go_test(
     name = "license_test",
     srcs = [
         "file_test.go",
-        "license_integration_test.go",
         "license_test.go",
     ],
     embed = [":license"],

--- a/internal/license/integration/BUILD.bazel
+++ b/internal/license/integration/BUILD.bazel
@@ -4,6 +4,7 @@ go_test(
     name = "integration_test",
     srcs = ["license_integration_test.go"],
     tags = [
+        "integration",
         "requires-network",
     ],
     deps = [

--- a/internal/license/integration/BUILD.bazel
+++ b/internal/license/integration/BUILD.bazel
@@ -1,0 +1,13 @@
+load("//bazel/go:go_test.bzl", "go_test")
+
+go_test(
+    name = "integration_test",
+    srcs = ["license_integration_test.go"],
+    tags = [
+        "requires-network",
+    ],
+    deps = [
+        "//internal/license",
+        "@com_github_stretchr_testify//assert",
+    ],
+)

--- a/internal/license/integration/license_integration_test.go
+++ b/internal/license/integration/license_integration_test.go
@@ -6,12 +6,13 @@ Copyright (c) Edgeless Systems GmbH
 SPDX-License-Identifier: AGPL-3.0-only
 */
 
-package license
+package integration
 
 import (
 	"context"
 	"testing"
 
+	"github.com/edgelesssys/constellation/v2/internal/license"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,7 +23,7 @@ func TestQuotaCheckIntegration(t *testing.T) {
 		wantError bool
 	}{
 		"OSS license has quota 8": {
-			license:   CommunityLicense,
+			license:   license.CommunityLicense,
 			wantQuota: 8,
 		},
 		"Empty license assumes community": {
@@ -35,10 +36,10 @@ func TestQuotaCheckIntegration(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			client := NewClient()
+			client := license.NewClient()
 
-			req := QuotaCheckRequest{
-				Action:  test,
+			req := license.QuotaCheckRequest{
+				Action:  license.Action("test"),
 				License: tc.license,
 			}
 			resp, err := client.QuotaCheck(context.Background(), req)


### PR DESCRIPTION
### Context

Our integration tests are currently executed with CMake, but we would like to consolidate everything to Bazel.

### Proposed change(s)

Integration test Bazel targets are tagged with `integration`. Tests tagged with `intregration` are not run in the standard configuration, but we introduce a new Bazel config (`integration`) which also includes these tests. For compatibility with legacy `go test`, the new config also applies the `integration` gotag. A second config (`integration-only`) can be used if only integration tests should be run.

This PR also migrates a first integration test, `//internal/license:license_integration_test`, to the new format.

### Additional info

- [AB#3067](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3067)

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
