### PR TITLE
Fix Konnectivity migration

### DIFF
--- a/internal/helm/actionfactory.go
+++ b/internal/helm/actionfactory.go
@@ -115,7 +115,11 @@ func (a actionFactory) appendNewAction(release Release, configTargetVersion semv
 		} else {
 			// This may break for external chart dependencies if we decide to upgrade more than one minor version at a time.
 			if err := newVersion.IsUpgradeTo(currentVersion); err != nil {
-				return fmt.Errorf("invalid upgrade for %s: %w", release.ReleaseName, err)
+				// TODO(3u13r): Remove when Constellation v2.14 is released.
+				// We need to ignore that we jump from Cilium v1.12 to v1.15-pre. We have verified that this works.
+				if !(errors.Is(err, compatibility.ErrMinorDrift) && release.ReleaseName == "cilium") {
+					return fmt.Errorf("invalid upgrade for %s: %w", release.ReleaseName, err)
+				}
 			}
 		}
 	}

--- a/internal/helm/helm_test.go
+++ b/internal/helm/helm_test.go
@@ -198,7 +198,7 @@ func TestHelmApply(t *testing.T) {
 			if tc.clusterCertManagerVersion != nil {
 				certManagerVersion = *tc.clusterCertManagerVersion
 			}
-			helmListVersion(lister, "cilium", "v1.12.1")
+			helmListVersion(lister, "cilium", "v1.15.0-pre.2")
 			helmListVersion(lister, "cert-manager", certManagerVersion)
 			helmListVersion(lister, "constellation-services", tc.clusterMicroServiceVersion)
 			helmListVersion(lister, "constellation-operators", tc.clusterMicroServiceVersion)

--- a/internal/kubecmd/BUILD.bazel
+++ b/internal/kubecmd/BUILD.bazel
@@ -69,6 +69,7 @@ go_test(
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured",
         "@io_k8s_apimachinery//pkg/runtime",
         "@io_k8s_apimachinery//pkg/runtime/schema",
+        "@io_k8s_kubernetes//cmd/kubeadm/app/apis/kubeadm/v1beta3",
         "@io_k8s_sigs_yaml//:yaml",
     ],
 )


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Allow Cilium to jump minor versions from v1.12 to v1.15
- If a nodeversion upgrade takes place (from v2.13.x) then remove all the konnectivity setting from the kubeadm config map. Otherwise the KubeAPI pods try to mount e.g. the Konnectivity UDS which we no longer provider through the bootstrapper

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
