### PR TITLE
api: respect `HTTP(S)_PROXY` environment variable

### DIFF
--- a/internal/api/fetcher/fetcher.go
+++ b/internal/api/fetcher/fetcher.go
@@ -31,7 +31,10 @@ import (
 
 // NewHTTPClient returns a new http client.
 func NewHTTPClient() HTTPClient {
-	return &http.Client{Transport: &http.Transport{DisableKeepAlives: true}} // DisableKeepAlives fixes concurrency issue see https://stackoverflow.com/a/75816347
+	return &http.Client{Transport: &http.Transport{
+		DisableKeepAlives: true, // DisableKeepAlives fixes concurrency issue see https://stackoverflow.com/a/75816347
+		Proxy:             http.ProxyFromEnvironment,
+	}}
 }
 
 // Fetch fetches the given apiObject from the public Constellation CDN.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We create a custom `*http.Transport`, which, per default, uses a `nil` proxy (i.e. no proxy). In contrast to the `http.DefaultClient`, which uses the `http.ProxyFromEnvironment` proxy. Therefore, it does not respect the `HTTP_PROXY` and `HTTPS_PROXY` environment variables, as seen in #2634.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Set the proxy to `http.ProxyFromEnvironment`.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional Information
The fix can be verified by setting `HTTPS_PROXY=http://8.8.8.8` or something else which does not proxy. Then, navigate to a directory with a Constellation workspace, and executing `bazel run //hack/image-fetch`. Prior to this change, this would run normally as the traffic is not routed through the proxy. With the change, it will timeout as `8.8.8.8` does not proxy.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
