### PR TITLE
ci: correctly clean up resource in self-managed infra tests

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -245,7 +245,7 @@ jobs:
         uses: ./.github/actions/constellation_destroy
         with:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
-          selfManagedInfra: "false"
+          selfManagedInfra: ${{ inputs.selfManagedInfra }}
 
       - name: Always delete IAM configuration
         if: always()


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Resources were not cleaned up correctly since the destroy action was not configured for self-managed infrastructure

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Correctly clean up resources

### Related issue
- closes https://github.com/edgelesssys/issues/issues/79


### Additional info
<!-- Remove items that do not apply -->
- [e2e test](https://github.com/edgelesssys/constellation/actions/runs/6968930299)
