### PR TITLE
rfc: add numeric ids to existing RFCs

### DIFF
--- a/rfc/001-key-derivation.md
+++ b/rfc/001-key-derivation.md
@@ -1,4 +1,4 @@
-# Key derivation
+# RFC 001: Key derivation
 
 To derive disk-encryption keys and other secret material in a Constellation Kubernetes cluster, we use [HKDF](https://datatracker.ietf.org/doc/html/rfc5869).
 

--- a/rfc/002-proof-of-ownership.md
+++ b/rfc/002-proof-of-ownership.md
@@ -1,4 +1,4 @@
-# Proof of Ownership
+# RFC 002: Proof of Ownership
 
 A cluster owner needs a way to prove a cluster belongs to them, while a third-party needs to be able to verify the owner's claims.
 For that, the owner generates a private/public key pair.

--- a/rfc/003-secure-software-distribution.md
+++ b/rfc/003-secure-software-distribution.md
@@ -104,7 +104,7 @@ measurements and keep them in a file (`measurements.yaml`) compatible with our c
 
 Comments should be omitted in final file. They show why certain values might be missing.
 
-Those measurements are signed and uploaded to AWS S3. Stored at a path matching the configured image (see [image API](image-api.md)).
+Those measurements are signed and uploaded to AWS S3. Stored at a path matching the configured image (see [image API](009-image-api.md)).
 
 ```yaml
 csp: azure

--- a/rfc/003-secure-software-distribution.md
+++ b/rfc/003-secure-software-distribution.md
@@ -1,4 +1,4 @@
-# Secure Distribution of CLI & Measurements
+# RFC 003: Secure Distribution of CLI & Measurements
 
 ## Goal / Motivation
 

--- a/rfc/004-updates.md
+++ b/rfc/004-updates.md
@@ -292,5 +292,5 @@ If users decide to change specific versions by changing the Kubernetes resources
 
 The compatibility information should be separated from the enforcement code.
 This way a minimal implementation can be created where the compatibility information is embedded into the CLI.
-As a next step the information can be served through the [Constellation API](./apis.md).
+As a next step the information can be served through the [Constellation API](./008-apis.md).
 By serving the compatibility information dynamically, faulty versions can be excluded from upgrade paths even after they have been released.

--- a/rfc/004-updates.md
+++ b/rfc/004-updates.md
@@ -1,4 +1,4 @@
-# Constellation updates
+# RFC 004: Constellation updates
 
 Things we manage for the user:
 

--- a/rfc/005-external-kms.md
+++ b/rfc/005-external-kms.md
@@ -1,4 +1,4 @@
-# External KMS
+# RFC 005: External KMS
 
 Currently, Constellation only supports [Constellation-managed key management](https://docs.edgeless.systems/constellation/2.0/architecture/keys#constellation-managed-key-management).
 The owner provides a master secret to the cluster on initialization.

--- a/rfc/006-reproducible-builds.md
+++ b/rfc/006-reproducible-builds.md
@@ -1,4 +1,4 @@
-# Reproducible Builds
+# RFC 006: Reproducible Builds
 
 To ensure the security of constellation's supply chain, we need to make our software builds reproducible.
 This is the only way to ensure a verifiable path from source code to binary.

--- a/rfc/007-version-api.md
+++ b/rfc/007-version-api.md
@@ -1,4 +1,4 @@
-# Version API
+# RFC 007: Version API
 
 The version API should expose easy, straightforward, extensible and forward compatible version information to the Constellation CLI (and possibly more consumers).
 

--- a/rfc/008-apis.md
+++ b/rfc/008-apis.md
@@ -1,4 +1,4 @@
-# Constellation APIs (v1)
+# RFC 008: Constellation APIs (v1)
 
 ## Base
 

--- a/rfc/008-apis.md
+++ b/rfc/008-apis.md
@@ -13,8 +13,8 @@ At this moment, the only valid API version is `v1`:
 
 The API version is followed by the API group. Possible values are:
 
-- [`versions`: version information for Constellation components](version-api.md)
-- [`image`: metadata for individual Constellation OS images](image-api.md)
+- [`versions`: version information for Constellation components](007-version-api.md)
+- [`image`: metadata for individual Constellation OS images](009-image-api.md)
   - `info`: image reference lookup for each cloud provider and additional metadata
   - `measurements`: TPM measurements for Constellation OS images
   - `raw`: raw OS images
@@ -24,15 +24,15 @@ There may be more API groups in the future (e.g. `cli`)
 
 ## API paths overview
 
-- [`/constellation/v1/ref/<ref>/stream/<stream>/versions/latest/<kind>.json`](version-api.md#latest)
-- [`/constellation/v1/ref/<ref>/stream/<stream>/versions/major/<base>/<kind>.json`](version-api.md#major-to-minor-version-list)
-- [`/constellation/v1/ref/<ref>/stream/<stream>/versions/minor/<base>/<kind>.json`](version-api.md#minor-to-patch-version-list)
-- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/info.json`](image-api.md#image-lookup-table)
-- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/sbom.<format>.json`](image-api.md)
-- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/csp/<csp>/measurements.json`](image-api.md)
-- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/csp/<csp>/measurements.json.sig`](image-api.md)
-- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/csp/<csp>/image.raw`](image-api.md)
-- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/cli/info.json`](cli-api.md#cli-lookup-table)
+- [`/constellation/v1/ref/<ref>/stream/<stream>/versions/latest/<kind>.json`](007-version-api.md#latest)
+- [`/constellation/v1/ref/<ref>/stream/<stream>/versions/major/<base>/<kind>.json`](007-version-api.md#major-to-minor-version-list)
+- [`/constellation/v1/ref/<ref>/stream/<stream>/versions/minor/<base>/<kind>.json`](007-version-api.md#minor-to-patch-version-list)
+- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/info.json`](009-image-api.md#image-lookup-table)
+- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/sbom.<format>.json`](009-image-api.md)
+- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/csp/<csp>/measurements.json`](009-image-api.md)
+- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/csp/<csp>/measurements.json.sig`](009-image-api.md)
+- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/image/csp/<csp>/image.raw`](009-image-api.md)
+- [`/constellation/v1/ref/<ref>/stream/<stream>/<version>/cli/info.json`](010-cli-api.md#cli-lookup-table)
 
 ## API path identifiers  `ref`, `stream` and `version`
 

--- a/rfc/009-image-api.md
+++ b/rfc/009-image-api.md
@@ -1,4 +1,4 @@
-# OS image & measurement discovery
+# RFC 009: OS image & measurement discovery
 
 The Constellation OS image build pipeline generates a set of images using a chosen commit of the Constellation monorepo and a desired release version number.
 

--- a/rfc/010-cli-api.md
+++ b/rfc/010-cli-api.md
@@ -1,4 +1,4 @@
-# CLI compatibility information
+# RFC 010: CLI compatibility information
 
 The CLI API provides information about the compatibility of the Constellation CLI and other components of the Constellation ecosystem such as Kubernetes versions.
 

--- a/rfc/011-attestation-config.md
+++ b/rfc/011-attestation-config.md
@@ -116,7 +116,7 @@ The value substitution is part of the unmarshalling logic.
 
 Config values are uploaded to S3 and can be accessed via HTTP.
 
-The attestation config API uses the same CSP names as [the image API](./image-api.md#image-api-endpoints).
+The attestation config API uses the same CSP names as [the image API](./009-image-api.md#image-api-endpoints).
 
 The following HTTP endpoint is available:
 

--- a/rfc/011-attestation-config.md
+++ b/rfc/011-attestation-config.md
@@ -1,4 +1,4 @@
-# Attestation configuration options
+# RFC 011: Attestation configuration options
 
 To allow users more in-depth control over validating attestation statements, a separate, attestation-specific entry in the user's Constellation config file needs to be added.
 

--- a/rfc/012-canonical-endpoint-dns.md
+++ b/rfc/012-canonical-endpoint-dns.md
@@ -1,4 +1,4 @@
-# Canonical endpoint / Constellation with custom DNS name
+# RFC 012: Canonical endpoint / Constellation with custom DNS name
 
 Customers may want to use a DNS name for the cluster endpoint instead of the public ip address.
 The public ip may be bound to a zonal loadbalancer (AWS), limiting the availability of the cluster to a single zone.

--- a/rfc/013-state-file.md
+++ b/rfc/013-state-file.md
@@ -1,4 +1,4 @@
-# Constellation state file
+# RFC 013: Constellation state file
 
 During a cluster's lifecycle, Constellation needs to keep track of multiple different values and state information of the cluster,
 like loadbalancer IPs or UID of the cluster.

--- a/rfc/014-terraform-provider.md
+++ b/rfc/014-terraform-provider.md
@@ -1,4 +1,4 @@
-# Constellation Terraform Provider
+# RFC 014: Constellation Terraform Provider
 
 The Constellation Terraform Provider allows its user to manage the full lifecycle of a Constellation cluster -- namely initialization and updates (`constellation apply`) -- via Terraform.
 


### PR DESCRIPTION
### Context

Now that we have a growing number of RFCs, having numeric identifiers for them makes it easier to refer to them and allows an intuitive understanding of the history of changes, without resorting to `git blame`.

### Proposed change(s)

Assign a numeric ID to all existing RFCs. IDs are handed out incrementally, starting from 001, to the RFCs sorted by first appearance in the repo. 999 RFC IDs should be enough for anybody.

This change was generated by the following script:

```bash
cd rfc

birthday() {
    git log --reverse --format=%at -- "$1" | head -n1
}

order() {
  while read -r line
  do
      echo "$(birthday $line) $line"
  done | sort -n | cut -f 2 -d' '
}

n=1
find . -type f | order | \
    while read -r line
    do
        file="$(basename "$line")"
        sed -i "1s/# /# RFC $(printf "%03d" $n): /" "$file"
        git mv "$file" "$(printf "%03d" $n)-$file"
        n=$((n+1))
    done
```

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
