### PR TITLE
ci: only run verify with JSON on v2.14 or newer

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -167,12 +167,7 @@ runs:
       id: constellation-init
       shell: bash
       run: |
-        # TODO(v2.14): Remove workaround for CLIs not supporting apply command
-        cmd="apply --skip-phases=infrastructure"
-        if constellation --help | grep -q init; then
-          cmd=init
-        fi
-        constellation $cmd --debug
+        constellation apply --skip-phases=infrastructure --debug
         echo "KUBECONFIG=$(pwd)/constellation-admin.conf" | tee -a $GITHUB_OUTPUT
 
     - name: Wait for nodes to join and become ready

--- a/.github/actions/e2e_verify/action.yml
+++ b/.github/actions/e2e_verify/action.yml
@@ -91,6 +91,11 @@ runs:
         COSIGN_PASSWORD: ${{ inputs.cosignPassword }}
         COSIGN_PRIVATE_KEY: ${{ inputs.cosignPrivateKey }}
       run: |
+        if [[ ${{ inputs.cloudProvider }} == "aws" ]] && constellation version | grep -q "v2.13."; then
+          echo "Skipping TCB upload for AWS on CLI v2.13"
+          exit 0
+        fi
+
         reports=(snp-report-*.json)
         if [ -z ${#reports[@]} ]; then
             exit 1

--- a/.github/actions/e2e_verify/action.yml
+++ b/.github/actions/e2e_verify/action.yml
@@ -66,7 +66,8 @@ runs:
           forwarderPID=$!
           sleep 5
 
-          if [[ ${{ inputs.cloudProvider }} == "azure" || ${{ inputs.cloudProvider }} == "aws" ]]; then
+          # TODO(v2.15): Remove workaround since we don't need to support v2.13 anymore
+          if [[ ${{ inputs.cloudProvider }} == "azure" ]] || { [[ ${{ inputs.cloudProvider }} == "aws" ]] && ! constellation version | grep -q "v2.13."; }; then
             echo "Extracting TCB versions for API update"
             constellation verify --cluster-id "${clusterID}" --node-endpoint localhost:9090 -o json > "snp-report-${node}.json"
           else


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
v2.13 doesnt support JSON flag for `constellation verify` on AWS yet.
So we shouldnt run the e2e verify test with that flag set.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Don't use JSON output if CLI version == v2.13

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
- [e2e verify AWS with v2.13 CLI/image](https://github.com/edgelesssys/constellation/actions/runs/7005955389)

