### PR TITLE
ci: fix serivce accounts introduced by merge

### DIFF
--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -100,7 +100,7 @@ jobs:
           selfManagedInfra: "false"
           cloudProvider: ${{ matrix.provider }}
           azureClusterDeleteCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
-          gcpClusterDeleteServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpClusterDeleteServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"
 
       - name: Always delete IAM configuration
         if: always()

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -74,7 +74,7 @@ jobs:
           isDebugImage: ${{ matrix.refStream == 'ref/main/stream/debug/?' }}
           cliVersion: ${{ matrix.refStream == 'ref/release/stream/stable/?' && needs.find-latest-image.outputs.image-release-stable || '' }}
           refStream: ${{ matrix.refStream }}
-          gcpProject: constellation-e2e # ${{ secrets.GCP_E2E_PROJECT }}
+          gcpProject: constellation-e2e
           gcpClusterCreateServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"
           gcpIAMCreateServiceAccount: "iam-e2e@constellation-e2e.iam.gserviceaccount.com"
           kubernetesVersion: ${{ matrix.kubernetesVersion }}

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -226,7 +226,7 @@ jobs:
           awsOpenSearchDomain: ${{ secrets.AWS_OPENSEARCH_DOMAIN }}
           awsOpenSearchUsers: ${{ secrets.AWS_OPENSEARCH_USER }}
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
-          gcpProject: constellation-e2e # ${{ secrets.GCP_E2E_PROJECT }}
+          gcpProject: constellation-e2e
           gcpClusterCreateServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"
           gcpIAMCreateServiceAccount: "iam-e2e@constellation-e2e.iam.gserviceaccount.com"
           test: ${{ matrix.test }}

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -249,7 +249,7 @@ jobs:
           selfManagedInfra: ${{ matrix.selfManagedInfra == 'true' }}
           cloudProvider: ${{ matrix.provider }}
           azureClusterDeleteCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
-          gcpClusterDeleteServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpClusterDeleteServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"
 
       - name: Always delete IAM configuration
         if: always()

--- a/.github/workflows/e2e-test-tf-module.yml
+++ b/.github/workflows/e2e-test-tf-module.yml
@@ -159,7 +159,6 @@ jobs:
         run: |
           cat > terraform.tfvars <<EOF
           name = "${{ steps.create-prefix.outputs.prefix }}"
-          # project = "${{ secrets.GCP_E2E_PROJECT }}"
           project = "constellation-e2e"
           service_account_id = "${{ steps.create-prefix.outputs.prefix }}-sa"
           image = "${{ steps.find-latest-image.outputs.image }}"

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -268,7 +268,7 @@ jobs:
           selfManagedInfra: ${{ matrix.selfManagedInfra == 'true' }}
           cloudProvider: ${{ matrix.provider }}
           azureClusterDeleteCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
-          gcpClusterDeleteServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpClusterDeleteServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"
 
       - name: Always delete IAM configuration
         if: always()

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -243,7 +243,7 @@ jobs:
           awsOpenSearchDomain: ${{ secrets.AWS_OPENSEARCH_DOMAIN }}
           awsOpenSearchUsers: ${{ secrets.AWS_OPENSEARCH_USER }}
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
-          gcpProject: constellation-e2e # ${{ secrets.GCP_E2E_PROJECT }}
+          gcpProject: constellation-e2e
           gcpClusterCreateServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"
           gcpIAMCreateServiceAccount: "iam-e2e@constellation-e2e.iam.gserviceaccount.com"
           test: ${{ matrix.test }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -215,7 +215,7 @@ jobs:
           cloudProvider: ${{ inputs.cloudProvider }}
           machineType: ${{ inputs.machineType }}
           regionZone: ${{ inputs.regionZone }}
-          gcpProject: constellation-e2e # ${{ secrets.GCP_E2E_PROJECT }}
+          gcpProject: constellation-e2e
           gcpClusterCreateServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"
           gcpIAMCreateServiceAccount: "iam-e2e@constellation-e2e.iam.gserviceaccount.com"
           test: ${{ inputs.test }}

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -247,7 +247,7 @@ jobs:
           selfManagedInfra: ${{ inputs.selfManagedInfra }}
           cloudProvider: ${{ inputs.cloudProvider }}
           azureClusterDeleteCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
-          gcpClusterDeleteServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpClusterDeleteServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"
 
       - name: Always delete IAM configuration
         if: always()

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -170,7 +170,7 @@ jobs:
           isDebugImage: "false"
           cliVersion: ${{ inputs.fromVersion }}
           regionZone: ${{ inputs.regionZone }}
-          gcpProject: constellation-e2e # ${{ secrets.GCP_E2E_PROJECT }}
+          gcpProject: constellation-e2e
           gcpClusterCreateServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"
           gcpIAMCreateServiceAccount: "iam-e2e@constellation-e2e.iam.gserviceaccount.com"
           test: "upgrade"

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -291,7 +291,7 @@ jobs:
           selfManagedInfra: "false"
           cloudProvider: ${{ inputs.cloudProvider }}
           azureClusterDeleteCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
-          gcpClusterDeleteServiceAccount: "constellation-e2e-cluster@constellation-331613.iam.gserviceaccount.com"
+          gcpClusterDeleteServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"
 
       - name: Always delete IAM configuration
         if: always()


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
https://github.com/edgelesssys/constellation/pull/2601 moved around some service accounts.
https://github.com/edgelesssys/constellation/pull/2629 was not rebased on these changes.
This caused now deleted service accounts to still be used by the CI

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Swap outdated service accounts for new ones
- Remove placeholders for the `GCP_E2E_PROJECT` secret. We decided to not use a hardcoded secret for this in the future as it makes updating the CI difficult

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->
