### PR TITLE
ci: add notify hook to Terraform module test

### DIFF
--- a/.github/actions/gh_create_issue/create_issue.sh
+++ b/.github/actions/gh_create_issue/create_issue.sh
@@ -175,6 +175,12 @@ function editItem() {
   local itemID="${2}"
   local id="${3}"
   local value="${4}"
+
+  if [[ -z ${value} ]]; then
+    debug skipping empty value
+    return
+  fi
+
   flags=(
     "--project-id=${projectID}"
     "--id=${itemID}"

--- a/.github/workflows/e2e-test-tf-module.yml
+++ b/.github/workflows/e2e-test-tf-module.yml
@@ -273,3 +273,15 @@ jobs:
             echo "Files  constellation-mastersecret.json or constellation-conf.yaml still exist"
             exit 1
           fi
+
+      - name: Notify about failure
+        if: |
+          failure() &&
+          github.ref == 'refs/heads/main' &&
+          github.event_name == 'schedule'
+        continue-on-error: true
+        uses: ./.github/actions/notify_e2e_failure
+        with:
+          projectWriteToken: ${{ secrets.PROJECT_WRITE_TOKEN }}
+          test: "terraform-module"
+          provider: ${{ inputs.cloudProvider }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Terraform module e2e test was missing a notification on failure

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add notification to Terraform module e2e test
- Fix an issue with the gh issue creation that would stop the script on empty values for project ticket tags
  - Empty values are now ignored

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [Failing workflow run](https://github.com/edgelesssys/constellation/actions/runs/7017785595/job/19091809291#step:23:1)
  - [The issue that was created by the workflow](https://github.com/edgelesssys/issues/issues/98)
- [project ticket tagging problem in a workflow](https://github.com/edgelesssys/constellation/actions/runs/7017244480/job/19090140725#step:23:170)

