### PR TITLE
ci: use given image if set

### DIFF
--- a/.github/actions/find_latest_image/action.yml
+++ b/.github/actions/find_latest_image/action.yml
@@ -16,7 +16,7 @@ inputs:
 outputs:
   image:
     description: "Image reference to be used in the cluster."
-    value: ${{ steps.find-latest-image.outputs.output }}${{ steps.check-input.outputs.image }}
+    value: ${{ steps.find-latest-image.outputs.output }}${{ steps.use-given-image.outputs.output }}
   isDebugImage:
     description: "Whether the image is a debug image."
     value: ${{ steps.isDebugImage.outputs.isDebugImage }}
@@ -51,6 +51,13 @@ runs:
         command: latest
         ref: ${{ inputs.ref }}
         stream: ${{ inputs.stream }}
+
+    - name: Use given image
+      id: use-given-image
+      if: inputs.imageVersion != ''
+      shell: bash
+      run: |
+        echo "output=${{ inputs.imageVersion }}" | tee -a "$GITHUB_OUTPUT"
 
     - name: Is debug image?
       id: isDebugImage


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
If an image reference is specified in the E2E test, we want to use it instead of finding an image through the versionsapi. This was intended, but not correctly implemented previously.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use the given image reference if set.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
