### PR TITLE
helm: re-enable timeout flag

### DIFF
--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -126,12 +126,12 @@ func NewApplyCmd() *cobra.Command {
 	cmd.Flags().Bool("merge-kubeconfig", false, "merge Constellation kubeconfig file with default kubeconfig file in $HOME/.kube/config")
 	cmd.Flags().BoolP("yes", "y", false, "run command without further confirmation\n"+
 		"WARNING: the command might delete or update existing resources without additional checks. Please read the docs.\n")
-	cmd.Flags().Duration("timeout", 5*time.Minute, "change helm upgrade timeout\n"+
+	cmd.Flags().Duration("helm-timeout", 10*time.Minute, "change helm install/upgrade timeout\n"+
 		"Might be useful for slow connections or big clusters.")
 	cmd.Flags().StringSlice("skip-phases", nil, "comma-separated list of upgrade phases to skip\n"+
 		fmt.Sprintf("one or multiple of %s", formatSkipPhases()))
 
-	must(cmd.Flags().MarkHidden("timeout"))
+	must(cmd.Flags().MarkHidden("helm-timeout"))
 
 	must(cmd.RegisterFlagCompletionFunc("skip-phases", skipPhasesCompletion))
 	return cmd
@@ -140,12 +140,12 @@ func NewApplyCmd() *cobra.Command {
 // applyFlags defines the flags for the apply command.
 type applyFlags struct {
 	rootFlags
-	yes            bool
-	conformance    bool
-	mergeConfigs   bool
-	upgradeTimeout time.Duration
-	helmWaitMode   helm.WaitMode
-	skipPhases     skipPhases
+	yes          bool
+	conformance  bool
+	mergeConfigs bool
+	helmTimeout  time.Duration
+	helmWaitMode helm.WaitMode
+	skipPhases   skipPhases
 }
 
 // parse the apply command flags.
@@ -174,9 +174,9 @@ func (f *applyFlags) parse(flags *pflag.FlagSet) error {
 		return fmt.Errorf("getting 'yes' flag: %w", err)
 	}
 
-	f.upgradeTimeout, err = flags.GetDuration("timeout")
+	f.helmTimeout, err = flags.GetDuration("helm-timeout")
 	if err != nil {
-		return fmt.Errorf("getting 'timeout' flag: %w", err)
+		return fmt.Errorf("getting 'helm-timeout' flag: %w", err)
 	}
 
 	f.conformance, err = flags.GetBool("conformance")

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -97,8 +97,8 @@ func TestParseApplyFlags(t *testing.T) {
 		"default flags": {
 			flags: defaultFlags(),
 			wantFlags: applyFlags{
-				helmWaitMode:   helm.WaitModeAtomic,
-				upgradeTimeout: 5 * time.Minute,
+				helmWaitMode: helm.WaitModeAtomic,
+				helmTimeout:  10 * time.Minute,
 			},
 		},
 		"skip phases": {
@@ -108,9 +108,9 @@ func TestParseApplyFlags(t *testing.T) {
 				return flags
 			}(),
 			wantFlags: applyFlags{
-				skipPhases:     newPhases(skipHelmPhase, skipK8sPhase),
-				helmWaitMode:   helm.WaitModeAtomic,
-				upgradeTimeout: 5 * time.Minute,
+				skipPhases:   newPhases(skipHelmPhase, skipK8sPhase),
+				helmWaitMode: helm.WaitModeAtomic,
+				helmTimeout:  10 * time.Minute,
 			},
 		},
 		"skip helm wait": {
@@ -120,8 +120,8 @@ func TestParseApplyFlags(t *testing.T) {
 				return flags
 			}(),
 			wantFlags: applyFlags{
-				helmWaitMode:   helm.WaitModeNone,
-				upgradeTimeout: 5 * time.Minute,
+				helmWaitMode: helm.WaitModeNone,
+				helmTimeout:  10 * time.Minute,
 			},
 		},
 	}

--- a/cli/internal/cmd/applyhelm.go
+++ b/cli/internal/cmd/applyhelm.go
@@ -37,6 +37,7 @@ func (a *applyCmd) runHelmApply(
 		Force:            a.flags.force,
 		Conformance:      a.flags.conformance,
 		HelmWaitMode:     a.flags.helmWaitMode,
+		ApplyTimeout:     a.flags.helmTimeout,
 		AllowDestructive: helm.DenyDestructive,
 	}
 	helmApplier, err := a.newHelmClient(constants.AdminConfFilename, a.log)

--- a/internal/helm/action.go
+++ b/internal/helm/action.go
@@ -19,11 +19,7 @@ import (
 	"helm.sh/helm/v3/pkg/cli"
 )
 
-const (
-	// timeout is the maximum time given per helm action.
-	timeout            = 10 * time.Minute
-	applyRetryInterval = 30 * time.Second
-)
+const applyRetryInterval = 30 * time.Second
 
 type applyAction interface {
 	Apply(context.Context) error
@@ -45,7 +41,7 @@ func newActionConfig(kubeconfig string, logger debugLog) (*action.Configuration,
 	return actionConfig, nil
 }
 
-func newHelmInstallAction(config *action.Configuration, release Release) *action.Install {
+func newHelmInstallAction(config *action.Configuration, release Release, timeout time.Duration) *action.Install {
 	action := action.NewInstall(config)
 	action.Namespace = constants.HelmNamespace
 	action.Timeout = timeout
@@ -118,7 +114,7 @@ func (a *installAction) IsAtomic() bool {
 	return a.helmAction.Atomic
 }
 
-func newHelmUpgradeAction(config *action.Configuration) *action.Upgrade {
+func newHelmUpgradeAction(config *action.Configuration, timeout time.Duration) *action.Upgrade {
 	action := action.NewUpgrade(config)
 	action.Namespace = constants.HelmNamespace
 	action.Timeout = timeout

--- a/internal/helm/action.go
+++ b/internal/helm/action.go
@@ -41,12 +41,12 @@ func newActionConfig(kubeconfig string, logger debugLog) (*action.Configuration,
 	return actionConfig, nil
 }
 
-func newHelmInstallAction(config *action.Configuration, release Release, timeout time.Duration) *action.Install {
+func newHelmInstallAction(config *action.Configuration, release release, timeout time.Duration) *action.Install {
 	action := action.NewInstall(config)
 	action.Namespace = constants.HelmNamespace
 	action.Timeout = timeout
-	action.ReleaseName = release.ReleaseName
-	setWaitMode(action, release.WaitMode)
+	action.ReleaseName = release.releaseName
+	setWaitMode(action, release.waitMode)
 	return action
 }
 
@@ -69,7 +69,7 @@ func setWaitMode(a *action.Install, waitMode WaitMode) {
 // installAction is an action that installs a helm chart.
 type installAction struct {
 	preInstall  func(context.Context) error
-	release     Release
+	release     release
 	helmAction  *action.Install
 	postInstall func(context.Context) error
 	log         debugLog
@@ -100,13 +100,13 @@ func (a *installAction) SaveChart(chartsDir string, fileHandler file.Handler) er
 }
 
 func (a *installAction) apply(ctx context.Context) error {
-	_, err := a.helmAction.RunWithContext(ctx, a.release.Chart, a.release.Values)
+	_, err := a.helmAction.RunWithContext(ctx, a.release.chart, a.release.values)
 	return err
 }
 
 // ReleaseName returns the release name.
 func (a *installAction) ReleaseName() string {
-	return a.release.ReleaseName
+	return a.release.releaseName
 }
 
 // IsAtomic returns true if the action is atomic.
@@ -127,7 +127,7 @@ func newHelmUpgradeAction(config *action.Configuration, timeout time.Duration) *
 type upgradeAction struct {
 	preUpgrade  func(context.Context) error
 	postUpgrade func(context.Context) error
-	release     Release
+	release     release
 	helmAction  *action.Upgrade
 	log         debugLog
 }
@@ -156,13 +156,13 @@ func (a *upgradeAction) SaveChart(chartsDir string, fileHandler file.Handler) er
 }
 
 func (a *upgradeAction) apply(ctx context.Context) error {
-	_, err := a.helmAction.RunWithContext(ctx, a.release.ReleaseName, a.release.Chart, a.release.Values)
+	_, err := a.helmAction.RunWithContext(ctx, a.release.releaseName, a.release.chart, a.release.values)
 	return err
 }
 
 // ReleaseName returns the release name.
 func (a *upgradeAction) ReleaseName() string {
-	return a.release.ReleaseName
+	return a.release.releaseName
 }
 
 // IsAtomic returns true if the action is atomic.
@@ -170,12 +170,12 @@ func (a *upgradeAction) IsAtomic() bool {
 	return a.helmAction.Atomic
 }
 
-func saveChart(release Release, chartsDir string, fileHandler file.Handler) error {
-	if err := saveChartToDisk(release.Chart, chartsDir, fileHandler); err != nil {
-		return fmt.Errorf("saving chart %s to %q: %w", release.ReleaseName, chartsDir, err)
+func saveChart(release release, chartsDir string, fileHandler file.Handler) error {
+	if err := saveChartToDisk(release.chart, chartsDir, fileHandler); err != nil {
+		return fmt.Errorf("saving chart %s to %q: %w", release.releaseName, chartsDir, err)
 	}
-	if err := fileHandler.WriteYAML(filepath.Join(chartsDir, release.Chart.Metadata.Name, "overrides.yaml"), release.Values); err != nil {
-		return fmt.Errorf("saving override values for chart %s to %q: %w", release.ReleaseName, filepath.Join(chartsDir, release.Chart.Metadata.Name), err)
+	if err := fileHandler.WriteYAML(filepath.Join(chartsDir, release.chart.Metadata.Name, "overrides.yaml"), release.values); err != nil {
+		return fmt.Errorf("saving override values for chart %s to %q: %w", release.releaseName, filepath.Join(chartsDir, release.chart.Metadata.Name), err)
 	}
 
 	return nil

--- a/internal/helm/actionfactory_test.go
+++ b/internal/helm/actionfactory_test.go
@@ -27,7 +27,7 @@ func TestAppendNewAction(t *testing.T) {
 
 	testCases := map[string]struct {
 		lister              stubLister
-		release             Release
+		release             release
 		configTargetVersion semver.Semver
 		force               bool
 		allowDestructive    bool
@@ -36,9 +36,9 @@ func TestAppendNewAction(t *testing.T) {
 	}{
 		"upgrade release": {
 			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
-			release: Release{
-				ReleaseName: "test",
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: "test",
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.1.0",
 					},
@@ -48,9 +48,9 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"upgrade to same version": {
 			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
-			release: Release{
-				ReleaseName: "test",
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: "test",
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.0.0",
 					},
@@ -62,9 +62,9 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"upgrade to older version": {
 			lister: stubLister{version: semver.NewFromInt(1, 1, 0, "")},
-			release: Release{
-				ReleaseName: "test",
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: "test",
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.0.0",
 					},
@@ -76,9 +76,9 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"upgrade to older version can be forced": {
 			lister: stubLister{version: semver.NewFromInt(1, 1, 0, "")},
-			release: Release{
-				ReleaseName: "test",
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: "test",
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.0.0",
 					},
@@ -89,9 +89,9 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"non semver in chart metadata": {
 			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
-			release: Release{
-				ReleaseName: "test",
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: "test",
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "some-version",
 					},
@@ -101,9 +101,9 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"listing release fails": {
 			lister: stubLister{err: assert.AnError},
-			release: Release{
-				ReleaseName: "test",
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: "test",
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.1.0",
 					},
@@ -114,9 +114,9 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"release not installed": {
 			lister: stubLister{err: errReleaseNotFound},
-			release: Release{
-				ReleaseName: "test",
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: "test",
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.1.0",
 					},
@@ -126,13 +126,13 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"destructive release upgrade requires confirmation": {
 			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
-			release: Release{
-				Chart: &chart.Chart{
+			release: release{
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.1.0",
 					},
 				},
-				ReleaseName: certManagerInfo.releaseName,
+				releaseName: certManagerInfo.releaseName,
 			},
 			configTargetVersion: semver.NewFromInt(1, 1, 0, ""),
 			wantErr:             true,
@@ -142,22 +142,22 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"destructive release upgrade can be accepted": {
 			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
-			release: Release{
-				Chart: &chart.Chart{
+			release: release{
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.1.0",
 					},
 				},
-				ReleaseName: certManagerInfo.releaseName,
+				releaseName: certManagerInfo.releaseName,
 			},
 			configTargetVersion: semver.NewFromInt(1, 1, 0, ""),
 			allowDestructive:    true,
 		},
 		"config version takes precedence over CLI version": {
 			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
-			release: Release{
-				ReleaseName: constellationServicesInfo.releaseName,
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: constellationServicesInfo.releaseName,
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.1.0",
 					},
@@ -169,9 +169,9 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"error if CLI version does not match config version on upgrade": {
 			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
-			release: Release{
-				ReleaseName: constellationServicesInfo.releaseName,
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: constellationServicesInfo.releaseName,
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.1.5",
 					},
@@ -183,9 +183,9 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"config version matches CLI version on upgrade": {
 			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
-			release: Release{
-				ReleaseName: constellationServicesInfo.releaseName,
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: constellationServicesInfo.releaseName,
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.1.5",
 					},
@@ -195,9 +195,9 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"config - CLI version mismatch can be forced through": {
 			lister: stubLister{version: semver.NewFromInt(1, 0, 0, "")},
-			release: Release{
-				ReleaseName: constellationServicesInfo.releaseName,
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: constellationServicesInfo.releaseName,
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.1.5",
 					},
@@ -208,9 +208,9 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"installing new release requires matching config and CLI version": {
 			lister: stubLister{err: errReleaseNotFound},
-			release: Release{
-				ReleaseName: constellationServicesInfo.releaseName,
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: constellationServicesInfo.releaseName,
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.1.0",
 					},
@@ -222,9 +222,9 @@ func TestAppendNewAction(t *testing.T) {
 		},
 		"config - CLI version mismatch for new releases can be forced through": {
 			lister: stubLister{err: errReleaseNotFound},
-			release: Release{
-				ReleaseName: constellationServicesInfo.releaseName,
-				Chart: &chart.Chart{
+			release: release{
+				releaseName: constellationServicesInfo.releaseName,
+				chart: &chart.Chart{
 					Metadata: &chart.Metadata{
 						Version: "1.1.0",
 					},

--- a/internal/helm/actionfactory_test.go
+++ b/internal/helm/actionfactory_test.go
@@ -9,6 +9,7 @@ package helm
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/edgelesssys/constellation/v2/internal/compatibility"
 	"github.com/edgelesssys/constellation/v2/internal/logger"
@@ -241,7 +242,7 @@ func TestAppendNewAction(t *testing.T) {
 			actions := []applyAction{}
 			actionFactory := newActionFactory(nil, tc.lister, &action.Configuration{}, logger.NewTest(t))
 
-			err := actionFactory.appendNewAction(tc.release, tc.configTargetVersion, tc.force, tc.allowDestructive, &actions)
+			err := actionFactory.appendNewAction(tc.release, tc.configTargetVersion, tc.force, tc.allowDestructive, time.Second, &actions)
 			if tc.wantErr {
 				assert.Error(err)
 				if tc.assertErr != nil {

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -31,6 +31,7 @@ package helm
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/edgelesssys/constellation/v2/internal/config"
 	"github.com/edgelesssys/constellation/v2/internal/constants"
@@ -81,6 +82,7 @@ type Options struct {
 	HelmWaitMode     WaitMode
 	AllowDestructive bool
 	Force            bool
+	ApplyTimeout     time.Duration
 }
 
 // PrepareApply loads the charts and returns the executor to apply them.
@@ -93,8 +95,11 @@ func (h Client) PrepareApply(
 	if err != nil {
 		return nil, false, fmt.Errorf("loading Helm releases: %w", err)
 	}
+
 	h.log.Debugf("Loaded Helm releases")
-	actions, includesUpgrades, err := h.factory.GetActions(releases, conf.MicroserviceVersion, flags.Force, flags.AllowDestructive)
+	actions, includesUpgrades, err := h.factory.GetActions(
+		releases, conf.MicroserviceVersion, flags.Force, flags.AllowDestructive, flags.ApplyTimeout,
+	)
 	return &ChartApplyExecutor{actions: actions, log: h.log}, includesUpgrades, err
 }
 

--- a/internal/helm/helm.go
+++ b/internal/helm/helm.go
@@ -106,7 +106,7 @@ func (h Client) PrepareApply(
 func (h Client) loadReleases(
 	conf *config.Config, secret uri.MasterSecret,
 	stateFile *state.State, flags Options, serviceAccURI string,
-) ([]Release, error) {
+) ([]release, error) {
 	helmLoader := newLoader(conf, stateFile, h.cliVersion)
 	h.log.Debugf("Created new Helm loader")
 	return helmLoader.loadReleases(flags.Conformance, flags.HelmWaitMode, secret, serviceAccURI)

--- a/internal/helm/loader_test.go
+++ b/internal/helm/loader_test.go
@@ -84,8 +84,8 @@ func TestLoadReleases(t *testing.T) {
 	)
 	require.NoError(err)
 	for _, release := range helmReleases {
-		if release.ReleaseName == constellationServicesInfo.releaseName {
-			assert.NotNil(release.Chart.Dependencies())
+		if release.releaseName == constellationServicesInfo.releaseName {
+			assert.NotNil(release.chart.Dependencies())
 		}
 	}
 }

--- a/internal/helm/release.go
+++ b/internal/helm/release.go
@@ -10,11 +10,11 @@ package helm
 import "helm.sh/helm/v3/pkg/chart"
 
 // Release bundles all information necessary to create a helm release.
-type Release struct {
-	Chart       *chart.Chart
-	Values      map[string]any
-	ReleaseName string
-	WaitMode    WaitMode
+type release struct {
+	chart       *chart.Chart
+	values      map[string]any
+	releaseName string
+	waitMode    WaitMode
 }
 
 // WaitMode specifies the wait mode for a helm release.

--- a/internal/helm/versionlister.go
+++ b/internal/helm/versionlister.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/edgelesssys/constellation/v2/internal/semver"
 	"helm.sh/helm/v3/pkg/action"
-	"helm.sh/helm/v3/pkg/release"
+	helmrelease "helm.sh/helm/v3/pkg/release"
 	"k8s.io/client-go/util/retry"
 )
 
@@ -34,7 +34,7 @@ func NewReleaseVersionClient(kubeConfigPath string, log debugLog) (*ReleaseVersi
 
 // listAction execute a List action by wrapping helm's action package.
 // It creates the action, runs it at returns results and errors.
-func (c ReleaseVersionClient) listAction(release string) (res []*release.Release, err error) {
+func (c ReleaseVersionClient) listAction(release string) (res []*helmrelease.Release, err error) {
 	action := action.NewList(c.config)
 	action.Filter = release
 	// during init, the kube API might not yet be reachable, so we retry


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The CLI, more specifically the `apply` command, has a (hidden) "--timeout" flag which was originally used to configure the timeout when upgrading helm charts.
This flag has been nonfunctional for some time now.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- re-enable the "--timeout" flag for `constellation apply`
- rename "--timeout" to "--helm-timeout" to more accurately indicate what it is used for
- Set the only internally used `Release` struct to private

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3357](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3357)
- Not sure if we want to add this to the changelog as the flag was, and still is, hidden by default

