### PR TITLE
docs: add Kubernetes version support list

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,7 @@
 /hack/remove-tf-providers @katexochen
 /hack/terraform @3u13r
 /hack/tools @katexochen
+/hack/versioninfogen @daniel-weisse
 /image @malt3
 /internal/api @derpsteb
 /internal/atls @thomasten

--- a/bazel/ci/BUILD.bazel
+++ b/bazel/ci/BUILD.bazel
@@ -454,6 +454,17 @@ sh_template(
     template = "terraform_docgen.sh.in",
 )
 
+sh_template(
+    name = "version_info_gen",
+    data = [
+        "//hack/versioninfogen",
+    ],
+    substitutions = {
+        "@@VERSIONINFOGEN@@": "$(rootpath //hack/versioninfogen:versioninfogen)",
+    },
+    template = "version_info_gen.sh.in",
+)
+
 alias(
     name = "com_github_katexochen_ghh",
     actual = select({
@@ -553,6 +564,7 @@ multirun(
         ":proto_generate",
         ":cli_docgen",
         ":terraform_docgen",
+        ":version_info_gen",
     ],
     jobs = 0,  # execute concurrently
     visibility = ["//visibility:public"],

--- a/bazel/ci/version_info_gen.sh.in
+++ b/bazel/ci/version_info_gen.sh.in
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+###### script header ######
+
+lib=$(realpath @@BASE_LIB@@) || exit 1
+stat "${lib}" >> /dev/null || exit 1
+
+# shellcheck source=../sh/lib.bash
+if ! source "${lib}"; then
+  echo "Error: could not find import"
+  exit 1
+fi
+
+versioninfogen=$(realpath @@VERSIONINFOGEN@@)
+stat "${versioninfogen}" >> /dev/null
+
+cd "${BUILD_WORKSPACE_DIRECTORY}"
+
+###### script body ######
+
+cd hack/versioninfogen
+${versioninfogen}

--- a/docs/docs/architecture/versions.md
+++ b/docs/docs/architecture/versions.md
@@ -12,3 +12,10 @@ New releases are published on [GitHub](https://github.com/edgelesssys/constellat
 Constellation is aligned to the [version support policy of Kubernetes](https://kubernetes.io/releases/version-skew-policy/#supported-versions), and therefore usually supports the most recent three minor versions.
 When a new minor version of Kubernetes is released, support is added to the next Constellation release, and that version then supports four Kubernetes versions.
 Subsequent Constellation releases drop support for the oldest (and deprecated) Kubernetes version.
+
+The following Kubernetes versions are currently supported:
+<!--AUTO_GENERATED_BY_BAZEL-->
+<!--DO_NOT_EDIT-->
+* v1.26.10
+* v1.27.7
+* v1.28.3

--- a/hack/versioninfogen/BUILD.bazel
+++ b/hack/versioninfogen/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "versioninfogen_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/edgelesssys/constellation/v2/hack/versioninfogen",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//internal/semver",
+        "//internal/versions",
+    ],
+)
+
+go_binary(
+    name = "versioninfogen",
+    embed = [":versioninfogen_lib"],
+    visibility = ["//visibility:public"],
+)

--- a/hack/versioninfogen/main.go
+++ b/hack/versioninfogen/main.go
@@ -1,0 +1,74 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/edgelesssys/constellation/v2/internal/semver"
+	"github.com/edgelesssys/constellation/v2/internal/versions"
+)
+
+const fileSeparator = "<!--AUTO_GENERATED_BY_BAZEL-->\n<!--DO_NOT_EDIT-->\n"
+
+func main() {
+	filePath := flag.String("file-path", "../../docs/docs/architecture/versions.md", "path to the version file to update")
+	flag.Parse()
+
+	k8sVersionStrings := versions.SupportedK8sVersions()
+	var k8sVersions []semver.Semver
+	for _, k8sVersionString := range k8sVersionStrings {
+		k8sVersion, err := semver.New(k8sVersionString)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "invalid kubernetes version %q: %s", k8sVersionString, err)
+			os.Exit(1)
+		}
+		k8sVersions = append(k8sVersions, k8sVersion)
+	}
+
+	if err := updateMatrix(*filePath, k8sVersions); err != nil {
+		fmt.Fprintf(os.Stderr, "error updating versions file: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+func updateMatrix(filePath string, supportedVersions []semver.Semver) error {
+	fileHeader, err := readVersionsFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	var versionList strings.Builder
+	for _, version := range supportedVersions {
+		if _, err := versionList.WriteString(
+			fmt.Sprintf("* %s\n", version.String()),
+		); err != nil {
+			return fmt.Errorf("writing matrix doc file: %w", err)
+		}
+	}
+
+	return os.WriteFile(filePath, []byte(fileHeader+fileSeparator+versionList.String()), 0o644)
+}
+
+func readVersionsFile(filePath string) (string, error) {
+	f, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("opening version info file: %w", err)
+	}
+	defer f.Close()
+
+	fileContentRaw, err := io.ReadAll(f)
+	if err != nil {
+		return "", fmt.Errorf("reading version info file: %w", err)
+	}
+	fileContent := strings.Split(string(fileContentRaw), fileSeparator)
+	return fileContent[0], nil
+}

--- a/hack/versioninfogen/main.go
+++ b/hack/versioninfogen/main.go
@@ -34,13 +34,13 @@ func main() {
 		k8sVersions = append(k8sVersions, k8sVersion)
 	}
 
-	if err := updateMatrix(*filePath, k8sVersions); err != nil {
+	if err := updateDocFile(*filePath, k8sVersions); err != nil {
 		fmt.Fprintf(os.Stderr, "error updating versions file: %s\n", err)
 		os.Exit(1)
 	}
 }
 
-func updateMatrix(filePath string, supportedVersions []semver.Semver) error {
+func updateDocFile(filePath string, supportedVersions []semver.Semver) error {
 	fileHeader, err := readVersionsFile(filePath)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
We would like to offer a table displaying which versions of Kubernetes are supported in any given Constellation release.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a new section to `/architecture/versions.md`  which contains a list of supported Kubernetes versions for a given Constellation release
- Automatically update the supported version list on `bazel run //:generate`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3198](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3198)
- [AB#3199](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3199)
