### PR TITLE
cli: fix renamed flag for mini-constellation

### DIFF
--- a/cli/internal/cmd/miniup.go
+++ b/cli/internal/cmd/miniup.go
@@ -103,7 +103,7 @@ func (m *miniUpCmd) up(cmd *cobra.Command) (retErr error) {
 	cmd.Flags().Bool("yes", true, "")
 	cmd.Flags().Bool("skip-helm-wait", false, "")
 	cmd.Flags().Bool("conformance", false, "")
-	cmd.Flags().Duration("timeout", time.Hour, "")
+	cmd.Flags().Duration("helm-timeout", time.Hour, "")
 
 	// create and initialize the cluster
 	if err := runApply(cmd, nil); err != nil {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The (hidden) `--timeout` flag for `constellation apply` was renamed to `--helm-timeout` in https://github.com/edgelesssys/constellation/pull/2658
This was not reflected for `constellation mini up`

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix flag naming for `constellation mini up`



### Additional info
- [e2e test](https://github.com/edgelesssys/constellation/actions/runs/7043956979)
- Fixes https://github.com/edgelesssys/issues/issues/102

