### PR TITLE
helm: deprioritize Cilium tc filters

### DIFF
--- a/internal/helm/values.go
+++ b/internal/helm/values.go
@@ -14,7 +14,7 @@ var ciliumVals = map[string]map[string]any{
 		"endpointRoutes": map[string]any{
 			"enabled": true,
 		},
-		"extraArgs": []string{"--node-encryption-opt-out-labels=invalid.label"},
+		"extraArgs": []string{"--node-encryption-opt-out-labels=invalid.label", "--bpf-filter-priority=50"},
 		"encryption": map[string]any{
 			"enabled":        true,
 			"type":           "wireguard",
@@ -57,7 +57,7 @@ var ciliumVals = map[string]map[string]any{
 		"endpointRoutes": map[string]any{
 			"enabled": true,
 		},
-		"extraArgs": []string{"--node-encryption-opt-out-labels=invalid.label"},
+		"extraArgs": []string{"--node-encryption-opt-out-labels=invalid.label", "--bpf-filter-priority=50"},
 		"encryption": map[string]any{
 			"enabled":        true,
 			"type":           "wireguard",
@@ -102,7 +102,7 @@ var ciliumVals = map[string]map[string]any{
 		"endpointRoutes": map[string]any{
 			"enabled": true,
 		},
-		"extraArgs": []string{"--node-encryption-opt-out-labels=invalid.label"},
+		"extraArgs": []string{"--node-encryption-opt-out-labels=invalid.label", "--bpf-filter-priority=50"},
 		"tunnel":    "disabled",
 		"encryption": map[string]any{
 			"enabled":        true,


### PR DESCRIPTION


### Context

By default, Cilium's tc filters are added add the highest priority, which makes it impossible to add any tc filters of our own (because the Cilium eBPF programs don't return to the filter chain).

Two near-future use cases would benefit from changing this:

* Network testing could add counting filters to interfaces and observe e.g. violations of encryption policy.
* The VPN Helm chart could add a filter policy that drops packets on the "physical" interface before they can leak to the CSP.

### Proposed change(s)

- Drop the priority of Cilium tc programs to 50.

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
