### PR TITLE
ci: fix constellation cli path

### DIFF
--- a/.github/actions/build_cli/action.yml
+++ b/.github/actions/build_cli/action.yml
@@ -66,8 +66,8 @@ runs:
         out_loc="$(realpath "${repository_root}/${out_rel}")"
         cp "${out_loc}" "${OUTPUT_PATH}"
         chmod +w "${OUTPUT_PATH}"
-        echo "$(dirname "${OUTPUT_PATH}")" >> $GITHUB_PATH
-        export PATH="$PATH:$(dirname "${OUTPUT_PATH}")"
+        export PATH="$PATH:$(realpath $(dirname "${OUTPUT_PATH}"))"
+        echo "$(realpath $(dirname "${OUTPUT_PATH}"))" >> $GITHUB_PATH
         echo "::endgroup::"
 
     - name: Upload container images

--- a/.github/actions/self_managed_create/action.yml
+++ b/.github/actions/self_managed_create/action.yml
@@ -84,7 +84,7 @@ runs:
       working-directory: ${{ github.workspace }}/e2e-infra
       if: inputs.cloudProvider == 'azure'
       run: |
-        ./constellation maa-patch $(terraform output attestationURL | jq -r)
+        constellation maa-patch $(terraform output attestationURL | jq -r)
 
     - name: Write outputs to state file
       shell: bash


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

After https://github.com/edgelesssys/constellation/blob/eea36d2669527ef3a4ca5a5a34695cdfe0db9901/.github/actions/e2e_test/action.yml#L151 the CLI should be in the PATH. Either via downloading or by building it.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Don't call local constellation `./constellation` but global `constellation`.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- Failed test on main: https://github.com/edgelesssys/constellation/actions/runs/7082838671/job/19274233541
- (Hopefully) successful test on this branch: https://github.com/edgelesssys/constellation/actions/runs/7085412241

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
