### PR TITLE
cli: fix helm-timeout flags for deprecated commands

### DIFF
--- a/cli/internal/cmd/create.go
+++ b/cli/internal/cmd/create.go
@@ -26,7 +26,7 @@ func NewCreateCmd() *cobra.Command {
 			cmd.Flags().Bool("conformance", false, "")
 			cmd.Flags().Bool("skip-helm-wait", false, "")
 			cmd.Flags().Bool("merge-kubeconfig", false, "")
-			cmd.Flags().Duration("timeout", 5*time.Minute, "")
+			cmd.Flags().Duration("helm-timeout", 10*time.Minute, "")
 			// Skip all phases but the infrastructure phase.
 			cmd.Flags().StringSlice("skip-phases", allPhases(skipInfrastructurePhase), "")
 			return runApply(cmd, args)

--- a/cli/internal/cmd/init.go
+++ b/cli/internal/cmd/init.go
@@ -50,7 +50,7 @@ func NewInitCmd() *cobra.Command {
 			// We always want to skip the infrastructure phase here, to be aligned with the
 			// functionality of the old init command.
 			cmd.Flags().StringSlice("skip-phases", []string{string(skipInfrastructurePhase)}, "")
-			cmd.Flags().Duration("timeout", time.Hour, "")
+			cmd.Flags().Duration("helm-timeout", 10*time.Minute, "")
 			return runApply(cmd, args)
 		},
 		Deprecated: "use 'constellation apply' instead.",

--- a/cli/internal/cmd/upgradeapply.go
+++ b/cli/internal/cmd/upgradeapply.go
@@ -36,13 +36,13 @@ func newUpgradeApplyCmd() *cobra.Command {
 	cmd.Flags().BoolP("yes", "y", false, "run upgrades without further confirmation\n"+
 		"WARNING: might delete your resources in case you are using cert-manager in your cluster. Please read the docs.\n"+
 		"WARNING: might unintentionally overwrite measurements in the running cluster.")
-	cmd.Flags().Duration("timeout", 5*time.Minute, "change helm upgrade timeout\n"+
+	cmd.Flags().Duration("helm-timeout", 10*time.Minute, "change helm upgrade timeout\n"+
 		"Might be useful for slow connections or big clusters.")
 	cmd.Flags().Bool("conformance", false, "enable conformance mode")
 	cmd.Flags().Bool("skip-helm-wait", false, "install helm charts without waiting for deployments to be ready")
 	cmd.Flags().StringSlice("skip-phases", nil, "comma-separated list of upgrade phases to skip\n"+
 		"one or multiple of { infrastructure | helm | image | k8s }")
-	must(cmd.Flags().MarkHidden("timeout"))
+	must(cmd.Flags().MarkHidden("helm-timeout"))
 
 	return cmd
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add `helm-timeout` flag to the cmd wrappers for `create`, `init`, and `upgrade apply`

### Related issue
- fixes https://github.com/edgelesssys/issues/issues/106

