### PR TITLE
terraform-provider: sync provider docs to Terraform provider repository

### DIFF
--- a/.github/workflows/sync-terraform-docs.yml
+++ b/.github/workflows/sync-terraform-docs.yml
@@ -57,10 +57,10 @@ jobs:
           token: ${{ !github.event.pull_request.head.repo.fork && secrets.CI_GITHUB_REPOSITORY || '' }}
           delete-branch: true
 
-      #- name: Merge pull request
-      #  uses: peter-evans/enable-pull-request-automerge@v3
-      #  with:
-      #    pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
-      #    merge-method: squash
-      #    repository: edgelesssys/terraform-provider-constellation
-      #    token: ${{ !github.event.pull_request.head.repo.fork && secrets.CI_GITHUB_REPOSITORY || '' }}
+      - name: Merge pull request
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
+          merge-method: squash
+          repository: edgelesssys/terraform-provider-constellation
+          token: ${{ !github.event.pull_request.head.repo.fork && secrets.CI_GITHUB_REPOSITORY || '' }}

--- a/.github/workflows/sync-terraform-docs.yml
+++ b/.github/workflows/sync-terraform-docs.yml
@@ -1,0 +1,66 @@
+name: Sync Terraform provider docs
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - "terraform-provider-constellation/docs/**"
+      - ".github/workflows/sync-terraform-provider-docs.yml"
+
+jobs:
+  sync-docs:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout constellation repo
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
+          fetch-depth: 0
+          path: constellation
+
+      - name: Checkout terraform-provider-constellation repo
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          repository: edgelesssys/terraform-provider-constellation
+          ref: main
+          path: terraform-provider-constellation
+          token: ${{ !github.event.pull_request.head.repo.fork && secrets.CI_GITHUB_REPOSITORY || '' }}
+
+      - name: Update docs
+        shell: bash
+        run: |
+          rm -rf terraform-provider-constellation/docs
+          cp -r constellation/terraform-provider-constellation/docs terraform-provider-constellation/docs
+
+      - name: Create pull request
+        id: create-pull-request
+        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
+        with:
+          path: terraform-provider-constellation
+          branch: "feat/docs/update"
+          base: main
+          title: "Update provider documentation"
+          body: |
+            :robot: *This is an automated PR.* :robot:
+
+            This PR is triggered as part of the [Constellation CI](https://github.com/edgelesssys/constellation/actions/runs/${{ github.run_id }}).
+            It updates the documentation for Constellation's Terraform provider docs.
+          commit-message: "Update provider documentation"
+          committer: edgelessci <edgelessci@users.noreply.github.com>
+          # We need to push changes using a token, otherwise triggers like on:push and on:pull_request won't work.
+          token: ${{ !github.event.pull_request.head.repo.fork && secrets.CI_GITHUB_REPOSITORY || '' }}
+          delete-branch: true
+
+      #- name: Merge pull request
+      #  uses: peter-evans/enable-pull-request-automerge@v3
+      #  with:
+      #    pull-request-number: ${{ steps.create-pull-request.outputs.pull-request-number }}
+      #    merge-method: squash
+      #    repository: edgelesssys/terraform-provider-constellation
+      #    token: ${{ !github.event.pull_request.head.repo.fork && secrets.CI_GITHUB_REPOSITORY || '' }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Publishing a Terraform provider in the hashicorp Terraform registry requires a specially set up GitHub repo containing docs and releases of the provider binaries.
Since we want to keep our source code in the mono-repo, we want to only sync the docs to the provider repo, and publish release binaries whenever we create new releases for Constellation.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Automatically keep docs in the provider repo in sync with the provider docs in the mono-repo

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3593](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3593)
- [Pull request created by this action](https://github.com/edgelesssys/terraform-provider-constellation/pull/1)

