### PR TITLE
bazel: migrate all integration tests (and retire CMakeLists.txt)

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -29,23 +29,6 @@ jobs:
         with:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
-      - name: Setup Go environment
-        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
-        with:
-          go-version: "1.21.5"
-          cache: true
-
-      - name: Install Dependencies
-        run: sudo apt-get update && sudo apt-get install -y libcryptsetup12 libcryptsetup-dev
-
-      - name: Create and populate build folder
-        run: mkdir build && cd build && cmake ..
-
-      # Runs all test targets starting with "integration-"
-      - name: CMake-based Integration Tests
-        working-directory: build
-        run: ctest -R integration-
-
       - name: Setup bazel
         uses: ./.github/actions/setup_bazel_nix
         with:
@@ -55,4 +38,4 @@ jobs:
       - name: Integration Tests
         env:
           TMPDIR: ${{ runner.temp }}
-        run: bazel test //... --test_output=errors --config=nostamp --config=integration-only --remote_download_minimal
+        run: sudo -E "PATH=$PATH" bazel test //... --config=nostamp --remote_download_minimal --config=integration  --spawn_strategy=standalone

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,0 @@
-cmake_minimum_required(VERSION 3.11)
-project(constellation LANGUAGES C)
-
-enable_testing()
-
-# TODO(malt3): Remove this once every integration test is migrated to Bazel
-add_test(NAME integration-csi COMMAND bash -c "go test -tags integration -c ./test/ && sudo ./test.test -test.v" WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/csi)
-add_test(NAME integration-dm COMMAND bash -c "go test -tags integration -c ./test/ && sudo ./test.test -test.v" WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/disk-mapper/internal)

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -76,6 +76,21 @@ nixpkgs_package(
     repository = "@nixpkgs",
 )
 
+nixpkgs_package(
+    name = "util-linux",
+    repository = "@nixpkgs",
+)
+
+nixpkgs_package(
+    name = "coreutils",
+    repository = "@nixpkgs",
+)
+
+nixpkgs_package(
+    name = "e2fsprogs",
+    repository = "@nixpkgs",
+)
+
 load("//nix/cc:nixpkgs_cc_libraries.bzl", "nixpkgs_cc_library_deps")
 
 nixpkgs_cc_library_deps()

--- a/csi/test/BUILD.bazel
+++ b/csi/test/BUILD.bazel
@@ -3,19 +3,51 @@ load("//bazel/go:go_test.bzl", "go_test")
 go_test(
     name = "test_test",
     srcs = ["mount_integration_test.go"],
+    count = 1,
+    # tool dependencies come from the test code itself (dd, rm, cp)
+    # and from github.com/kubernetes/mount-utils/mount_linux.go
+    data = [
+        "@coreutils//:bin/cp",
+        "@coreutils//:bin/dd",
+        "@coreutils//:bin/rm",
+        "@e2fsprogs//:bin/fsck.ext4",
+        "@e2fsprogs//:bin/mkfs.ext4",
+        "@util-linux//:bin/blkid",
+        "@util-linux//:bin/fsck",
+        "@util-linux//:bin/mount",
+        "@util-linux//:bin/umount",
+    ],
+    env = {
+        "BLKID": "$(rlocationpath @util-linux//:bin/blkid)",
+        "CP": "$(rlocationpath @coreutils//:bin/cp)",
+        "DD": "$(rlocationpath @coreutils//:bin/dd)",
+        "FSCK": "$(rlocationpath @util-linux//:bin/fsck)",
+        "FSCK_EXT4": "$(rlocationpath @e2fsprogs//:bin/fsck.ext4)",
+        "MKFS_EXT4": "$(rlocationpath @e2fsprogs//:bin/mkfs.ext4)",
+        "MOUNT": "$(rlocationpath @util-linux//:bin/mount)",
+        "RM": "$(rlocationpath @coreutils//:bin/rm)",
+        "UMOUNT": "$(rlocationpath @util-linux//:bin/umount)",
+    },
     # keep
-    tags = ["manual"],
+    tags = [
+        "integration",
+        "local",
+        "no-sandbox",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
     deps = select({
         "@io_bazel_rules_go//go/platform:android": [
             "//csi/cryptmapper",
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
+            "@io_bazel_rules_go//go/runfiles:go_default_library",
             "@org_uber_go_goleak//:goleak",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//csi/cryptmapper",
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
+            "@io_bazel_rules_go//go/runfiles:go_default_library",
             "@org_uber_go_goleak//:goleak",
         ],
         "//conditions:default": [],

--- a/disk-mapper/internal/test/BUILD.bazel
+++ b/disk-mapper/internal/test/BUILD.bazel
@@ -6,8 +6,21 @@ go_test(
         "benchmark_test.go",
         "integration_test.go",
     ],
+    data = [
+        "@coreutils//:bin/dd",
+        "@coreutils//:bin/rm",
+    ],
+    env = {
+        "DD": "$(rlocationpath @coreutils//:bin/dd)",
+        "RM": "$(rlocationpath @coreutils//:bin/rm)",
+    },
     # keep
-    tags = ["manual"],
+    tags = [
+        "integration",
+        "local",
+        "no-sandbox",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
     deps = select({
         "@io_bazel_rules_go//go/platform:android": [
             "//disk-mapper/internal/diskencryption",
@@ -16,6 +29,7 @@ go_test(
             "@com_github_martinjungblut_go_cryptsetup//:go-cryptsetup",
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
+            "@io_bazel_rules_go//go/runfiles:go_default_library",
             "@org_uber_go_goleak//:goleak",
             "@org_uber_go_zap//zapcore",
         ],
@@ -26,6 +40,7 @@ go_test(
             "@com_github_martinjungblut_go_cryptsetup//:go-cryptsetup",
             "@com_github_stretchr_testify//assert",
             "@com_github_stretchr_testify//require",
+            "@io_bazel_rules_go//go/runfiles:go_default_library",
             "@org_uber_go_goleak//:goleak",
             "@org_uber_go_zap//zapcore",
         ],


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
This is a follow-up for #2631. Now, we can finally retire CMake completely.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bazel: migrate all integration tests (and retire CMakeLists.txt)

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3067](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3067)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
