### PR TITLE
docs: replace reference to CMakeList on main branch with versioned link or Bazel

### DIFF
--- a/docs/docs/reference/slsa.md
+++ b/docs/docs/reference/slsa.md
@@ -10,7 +10,7 @@ SLSA is still in alpha status. The presented levels and their requirements might
 
 **[Build - Scripted](https://slsa.dev/spec/v0.1/requirements#scripted-build)**
 
-All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/main/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
+All build steps are automated via [Bazel](https://github.com/edgelesssys/constellation/tree/main/bazel/ci) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
 
 **[Provenance - Available](https://slsa.dev/spec/v0.1/requirements#available)**
 

--- a/docs/styles/Vocab/constellation/accept.txt
+++ b/docs/styles/Vocab/constellation/accept.txt
@@ -8,6 +8,7 @@ autoscaler
 AWS
 aws
 backend
+Bazel
 benchmarked
 [Bb]ootloader
 Bootstrapper

--- a/docs/versioned_docs/version-2.10/reference/slsa.md
+++ b/docs/versioned_docs/version-2.10/reference/slsa.md
@@ -10,7 +10,7 @@ SLSA is still in alpha status. The presented levels and their requirements might
 
 **[Build - Scripted](https://slsa.dev/spec/v0.1/requirements#scripted-build)**
 
-All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/main/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
+All build steps are automated via [Bazel](https://github.com/edgelesssys/constellation/tree/v2.10.0/bazel) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
 
 **[Provenance - Available](https://slsa.dev/spec/v0.1/requirements#available)**
 

--- a/docs/versioned_docs/version-2.11/reference/slsa.md
+++ b/docs/versioned_docs/version-2.11/reference/slsa.md
@@ -10,7 +10,7 @@ SLSA is still in alpha status. The presented levels and their requirements might
 
 **[Build - Scripted](https://slsa.dev/spec/v0.1/requirements#scripted-build)**
 
-All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/main/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
+All build steps are automated via [Bazel](https://github.com/edgelesssys/constellation/tree/v2.11.0/bazel) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
 
 **[Provenance - Available](https://slsa.dev/spec/v0.1/requirements#available)**
 

--- a/docs/versioned_docs/version-2.12/reference/slsa.md
+++ b/docs/versioned_docs/version-2.12/reference/slsa.md
@@ -10,7 +10,7 @@ SLSA is still in alpha status. The presented levels and their requirements might
 
 **[Build - Scripted](https://slsa.dev/spec/v0.1/requirements#scripted-build)**
 
-All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/main/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
+All build steps are automated via [Bazel](https://github.com/edgelesssys/constellation/tree/v2.12.0/bazel) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
 
 **[Provenance - Available](https://slsa.dev/spec/v0.1/requirements#available)**
 

--- a/docs/versioned_docs/version-2.13/reference/slsa.md
+++ b/docs/versioned_docs/version-2.13/reference/slsa.md
@@ -10,7 +10,7 @@ SLSA is still in alpha status. The presented levels and their requirements might
 
 **[Build - Scripted](https://slsa.dev/spec/v0.1/requirements#scripted-build)**
 
-All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/main/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
+All build steps are automated via [Bazel](https://github.com/edgelesssys/constellation/tree/v2.13.0/bazel) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
 
 **[Provenance - Available](https://slsa.dev/spec/v0.1/requirements#available)**
 

--- a/docs/versioned_docs/version-2.3/reference/slsa.md
+++ b/docs/versioned_docs/version-2.3/reference/slsa.md
@@ -10,7 +10,7 @@ SLSA is still in alpha status. The presented levels and their requirements might
 
 **[Build - Scripted](https://slsa.dev/spec/v0.1/requirements#scripted-build)**
 
-All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/main/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
+All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/v2.3.0/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
 
 **[Provenance - Available](https://slsa.dev/spec/v0.1/requirements#available)**
 

--- a/docs/versioned_docs/version-2.4/reference/slsa.md
+++ b/docs/versioned_docs/version-2.4/reference/slsa.md
@@ -10,7 +10,7 @@ SLSA is still in alpha status. The presented levels and their requirements might
 
 **[Build - Scripted](https://slsa.dev/spec/v0.1/requirements#scripted-build)**
 
-All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/main/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
+All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/v2.4.0/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
 
 **[Provenance - Available](https://slsa.dev/spec/v0.1/requirements#available)**
 

--- a/docs/versioned_docs/version-2.5/reference/slsa.md
+++ b/docs/versioned_docs/version-2.5/reference/slsa.md
@@ -10,7 +10,7 @@ SLSA is still in alpha status. The presented levels and their requirements might
 
 **[Build - Scripted](https://slsa.dev/spec/v0.1/requirements#scripted-build)**
 
-All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/main/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
+All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/v2.5.0/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
 
 **[Provenance - Available](https://slsa.dev/spec/v0.1/requirements#available)**
 

--- a/docs/versioned_docs/version-2.6/reference/slsa.md
+++ b/docs/versioned_docs/version-2.6/reference/slsa.md
@@ -10,7 +10,7 @@ SLSA is still in alpha status. The presented levels and their requirements might
 
 **[Build - Scripted](https://slsa.dev/spec/v0.1/requirements#scripted-build)**
 
-All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/main/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
+All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/v2.6.0/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
 
 **[Provenance - Available](https://slsa.dev/spec/v0.1/requirements#available)**
 

--- a/docs/versioned_docs/version-2.7/reference/slsa.md
+++ b/docs/versioned_docs/version-2.7/reference/slsa.md
@@ -10,7 +10,7 @@ SLSA is still in alpha status. The presented levels and their requirements might
 
 **[Build - Scripted](https://slsa.dev/spec/v0.1/requirements#scripted-build)**
 
-All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/main/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
+All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/v2.7.0/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
 
 **[Provenance - Available](https://slsa.dev/spec/v0.1/requirements#available)**
 

--- a/docs/versioned_docs/version-2.8/reference/slsa.md
+++ b/docs/versioned_docs/version-2.8/reference/slsa.md
@@ -10,7 +10,7 @@ SLSA is still in alpha status. The presented levels and their requirements might
 
 **[Build - Scripted](https://slsa.dev/spec/v0.1/requirements#scripted-build)**
 
-All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/main/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
+All build steps are automated via [Bazel](https://github.com/edgelesssys/constellation/tree/v2.8.0/bazel) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
 
 **[Provenance - Available](https://slsa.dev/spec/v0.1/requirements#available)**
 

--- a/docs/versioned_docs/version-2.9/reference/slsa.md
+++ b/docs/versioned_docs/version-2.9/reference/slsa.md
@@ -10,7 +10,7 @@ SLSA is still in alpha status. The presented levels and their requirements might
 
 **[Build - Scripted](https://slsa.dev/spec/v0.1/requirements#scripted-build)**
 
-All build steps are automated via [CMake](https://github.com/edgelesssys/constellation/blob/main/CMakeLists.txt) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
+All build steps are automated via [Bazel](https://github.com/edgelesssys/constellation/tree/v2.9.0/bazel) and [GitHub Actions](https://github.com/edgelesssys/constellation/tree/main/.github).
 
 **[Provenance - Available](https://slsa.dev/spec/v0.1/requirements#available)**
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
We removed our CMakeLists.txt file on main, yet our docs still had a link to said file on our main branch.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Replace the link to CMakeLists.txt on main with either a versioned link (v2.7 or older), or a reference to our bazel CI folder

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->
