### PR TITLE
terraform: fix Azure marketplace image defaults

### DIFF
--- a/cli/internal/cloudcmd/tfvars.go
+++ b/cli/internal/cloudcmd/tfvars.go
@@ -156,6 +156,7 @@ func azureTerraformVars(conf *config.Config, imageRef string) (*terraform.AzureC
 		ResourceGroup:        conf.Provider.Azure.ResourceGroup,
 		CustomEndpoint:       conf.CustomEndpoint,
 		InternalLoadBalancer: conf.InternalLoadBalancer,
+		MarketplaceImage:     nil,
 	}
 
 	if conf.UseMarketplaceImage() {
@@ -170,7 +171,7 @@ func azureTerraformVars(conf *config.Config, imageRef string) (*terraform.AzureC
 		}
 
 		// If a marketplace image is used, only the marketplace reference is required.
-		vars.MarketplaceImage = terraform.AzureMarketplaceImageVariables{
+		vars.MarketplaceImage = &terraform.AzureMarketplaceImageVariables{
 			Publisher: azureImage.Publisher,
 			Product:   azureImage.Offer,
 			Name:      azureImage.SKU,

--- a/cli/internal/terraform/variables.go
+++ b/cli/internal/terraform/variables.go
@@ -210,7 +210,7 @@ type AzureClusterVariables struct {
 	// InternalLoadBalancer is true if an internal load balancer should be created.
 	InternalLoadBalancer bool `hcl:"internal_load_balancer" cty:"internal_load_balancer"`
 	// MarketplaceImage is the (optional) Azure Marketplace image to use.
-	MarketplaceImage AzureMarketplaceImageVariables `hcl:"marketplace_image" cty:"marketplace_image"`
+	MarketplaceImage *AzureMarketplaceImageVariables `hcl:"marketplace_image" cty:"marketplace_image"`
 }
 
 // GetCreateMAA gets the CreateMAA variable.

--- a/cli/internal/terraform/variables_test.go
+++ b/cli/internal/terraform/variables_test.go
@@ -193,7 +193,7 @@ func TestAzureClusterVariables(t *testing.T) {
 		Debug:                to.Ptr(true),
 		Location:             "eu-central-1",
 		CustomEndpoint:       "example.com",
-		MarketplaceImage: AzureMarketplaceImageVariables{
+		MarketplaceImage: &AzureMarketplaceImageVariables{
 			Publisher: "edgelesssys",
 			Product:   "constellation",
 			Name:      "constellation",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -341,6 +341,7 @@ func Default() *Config {
 				ResourceGroup:        "",
 				DeployCSIDriver:      toPtr(true),
 				SecureBoot:           toPtr(false),
+				UseMarketplaceImage:  toPtr(false),
 			},
 			GCP: &GCPConfig{
 				Project:               "",


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Multiple of the weekly e2e tests failed due to the Azure marketplace image being set to an object with empty fields, but not an null object, which breaks the assumptions of the Terraform infrastructure module.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- (Unrelated) Make the Config default to `false` instead of `null` for `useMarketplaceImage`, which makes more sense for the user.
- Use a pointer for the marketplace image variable, making it default to `nil` / `null` in Terraform, which satisfies:
https://github.com/edgelesssys/constellation/blob/0247f4f6baa57b19e51bcffd62a26577b7e21a8e/terraform/infrastructure/azure/modules/scale_set/main.tf#L76-L93

### Additional Information
- [Post-fix E2E Test](https://github.com/edgelesssys/constellation/actions/runs/7153418937)

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
