### PR TITLE
ci: remove invalid input for recover action

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -356,7 +356,6 @@ runs:
       with:
         controlNodesCount: ${{ inputs.controlNodesCount }}
         kubeconfig: ${{ steps.constellation-create.outputs.kubeconfig }}
-        masterSecret: ${{ steps.constellation-create.outputs.masterSecret }}
 
     - name: Run malicious join test
       if: inputs.test == 'malicious join'


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove invalid input (masterSecret) when calling e2e recover test

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- See [any e2e recover test](https://github.com/edgelesssys/constellation/actions/runs/7148627410/job/19469856168#step:3:9638). Note that this doesnt cause a failure, just prints a warning
