### PR TITLE
installer: make hash checking optional

### DIFF
--- a/internal/installer/installer.go
+++ b/internal/installer/installer.go
@@ -70,7 +70,7 @@ func (i *OsInstaller) Install(ctx context.Context, kubernetesComponent component
 		return fmt.Errorf("reading file %q: %w", tempPath, err)
 	}
 	calculatedHash := fmt.Sprintf("sha256:%x", sha.Sum(nil))
-	if calculatedHash != kubernetesComponent.Hash {
+	if len(kubernetesComponent.Hash) > 0 && calculatedHash != kubernetesComponent.Hash {
 		return fmt.Errorf("hash of file %q %s does not match expected hash %s", tempPath, calculatedHash, kubernetesComponent.Hash)
 	}
 

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -70,6 +70,15 @@ func TestInstall(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		"hash is not mandatory": {
+			server: newHTTPBufconnServerWithBody([]byte("file-contents")),
+			component: components.Component{
+				URL:         serverURL,
+				Hash:        "",
+				InstallPath: "/destination",
+			},
+			wantFiles: map[string][]byte{"/destination": []byte("file-contents")},
+		},
 		"download fails": {
 			server: newHTTPBufconnServer(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(500) }),
 			component: components.Component{


### PR DESCRIPTION
### Context

RFC 015 proposes adding a new type of KubernetesComponent in the form of data URLs. As the content of these is deterministic, it does not make sense to also generate a hash for them and then check it in the installer.

### Proposed change(s)

- Omit the file hash check if the expected hash is empty. This does not change existing behaviour, but will be used by data URLs (to be introduced).

### Additional info

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
