### PR TITLE
upgrade-agent: set explicit k8s version for kubeadm

### DIFF
--- a/upgrade-agent/internal/server/server.go
+++ b/upgrade-agent/internal/server/server.go
@@ -110,9 +110,9 @@ func (s *Server) ExecuteUpdate(ctx context.Context, updateRequest *upgradeproto.
 		return nil, status.Errorf(codes.Internal, "unable to install the kubeadm binary: %s", err)
 	}
 
-	upgradeCmd := exec.CommandContext(ctx, "kubeadm", "upgrade", "plan")
+	upgradeCmd := exec.CommandContext(ctx, "kubeadm", "upgrade", "plan", updateRequest.WantedKubernetesVersion)
 	if out, err := upgradeCmd.CombinedOutput(); err != nil {
-		return nil, status.Errorf(codes.Internal, "unable to execute kubeadm upgrade plan: %s: %s", err, string(out))
+		return nil, status.Errorf(codes.Internal, "unable to execute kubeadm upgrade plan %s: %s: %s", updateRequest.WantedKubernetesVersion, err, string(out))
 	}
 
 	applyCmd := exec.CommandContext(ctx, "kubeadm", "upgrade", "apply", "--yes", updateRequest.WantedKubernetesVersion)


### PR DESCRIPTION
`kubeadm upgrade plan` takes an optional positional argument for the target Kubernetes version [1], which is documented as

> To skip the internet check, pass in the optional [version] parameter

In light of RFC 015, we should not do an "internet check" for latest versions, but stick to the version we're actually targeting with the upgrade. Thus, we explicitly pass the version as an argument.

[1]: https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm-upgrade/#cmd-upgrade-plan

### Context

RFC 015

### Proposed change(s)

- explicitly pass target version to `kubeadm upgrade plan`

### Additional info

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
