### PR TITLE
installer: add support for data URLs

### DIFF
--- a/bazel/toolchains/go_module_deps.bzl
+++ b/bazel/toolchains/go_module_deps.bzl
@@ -4877,6 +4877,14 @@ def go_dependencies():
         version = "v1.1.0",
     )
     go_repository(
+        name = "com_github_vincent_petithory_dataurl",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/vincent-petithory/dataurl",
+        sum = "h1:cXw+kPto8NLuJtlMsI152irrVw9fRDX8AbShPRpg2CI=",
+        version = "v1.0.0",
+    )
+    go_repository(
         name = "com_github_vishvananda_netlink",
         build_file_generation = "on",
         build_file_proto_mode = "disable_global",

--- a/go.mod
+++ b/go.mod
@@ -113,6 +113,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/theupdateframework/go-tuf v0.5.2
 	github.com/tink-crypto/tink-go/v2 v2.0.0
+	github.com/vincent-petithory/dataurl v1.0.0
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.26.0
 	golang.org/x/crypto v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -916,6 +916,8 @@ github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399 h1:e/5i7d4oYZ+C
 github.com/titanous/rocacheck v0.0.0-20171023193734-afe73141d399/go.mod h1:LdwHTNJT99C5fTAzDz0ud328OgXz+gierycbcIx2fRs=
 github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG81+twTK4=
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
+github.com/vincent-petithory/dataurl v1.0.0 h1:cXw+kPto8NLuJtlMsI152irrVw9fRDX8AbShPRpg2CI=
+github.com/vincent-petithory/dataurl v1.0.0/go.mod h1:FHafX5vmDzyP+1CQATJn7WFKc9CvnvxyvZy6I1MrG/U=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/internal/installer/BUILD.bazel
+++ b/internal/installer/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//internal/retry",
         "//internal/versions/components",
         "@com_github_spf13_afero//:afero",
+        "@com_github_vincent_petithory_dataurl//:dataurl",
         "@io_k8s_utils//clock",
     ],
 )

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -88,6 +88,24 @@ func TestInstall(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		"dataurl works": {
+			server: newHTTPBufconnServer(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(500) }),
+			component: &components.Component{
+				Url:         "data:text/plain,file-contents",
+				Hash:        "",
+				InstallPath: "/destination",
+			},
+			wantFiles: map[string][]byte{"/destination": []byte("file-contents")},
+		},
+		"broken dataurl fails": {
+			server: newHTTPBufconnServer(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(500) }),
+			component: &components.Component{
+				Url:         "data:file-contents",
+				Hash:        "",
+				InstallPath: "/destination",
+			},
+			wantErr: true,
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
RFC 015 proposes the introduction of data URLs to materialize static content to files on disk. This commit adds support for data URLs to the installer. The corresponding content will be added to versions.go in a subsequent commit.

### Context

RFC 015

### Proposed change(s)

- handle `data:` and `http(s):` URLs separately

### Additional info

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
