### PR TITLE
ci: disable curses support

### DIFF
--- a/bazel/bazelrc/ci.bazelrc
+++ b/bazel/bazelrc/ci.bazelrc
@@ -22,9 +22,10 @@ build --show_timestamps
 # https://bazel.build/reference/command-line-reference#flag--show_progress_rate_limit
 common --show_progress_rate_limit=15
 
-# Use cursor controls in screen output.
+# Github Action logs don't support curses, so we disable curses to prevent the logs from filling up
+# with garbage. 
 # Docs: https://bazel.build/docs/user-manual#curses
-common --curses=yes
+common --curses=no
 
 # Use colors to highlight output on the screen. Set to `no` if your CI does not display colors.
 # Docs: https://bazel.build/docs/user-manual#color


### PR DESCRIPTION
Comparison of output for a failed build. Old setup produces >3k lines of unhelpful messages:

https://github.com/edgelesssys/constellation/actions/runs/7165242775/job/19506817413

Without curses support, we get <400 lines with relevant details:

https://github.com/edgelesssys/constellation/actions/runs/7166031624/job/19509201790

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
