### PR TITLE
terraform-provider: support importing Constellation clusters

### DIFF
--- a/bazel/ci/shellcheck.sh.in
+++ b/bazel/ci/shellcheck.sh.in
@@ -28,6 +28,7 @@ excludeDirs=(
   "internal/constellation/helm/charts/cilium"
   "build"
   "docs/node_modules"
+  "terraform-provider-constellation/examples"
 )
 
 excludeFiles=(

--- a/bazel/ci/shfmt.sh.in
+++ b/bazel/ci/shfmt.sh.in
@@ -26,6 +26,7 @@ excludeDirs=(
   "internal/constellation/helm/charts/cilium"
   "build"
   "docs/node_modules"
+  "terraform-provider-constellation/examples"
 )
 
 echo "The following scripts are excluded and won't be formatted with shfmt:"

--- a/bazel/ci/terraform.sh.in
+++ b/bazel/ci/terraform.sh.in
@@ -46,9 +46,7 @@ excludeDirs=(
 excludeLockDirs=(
   "build"
   "terraform-provider-constellation"
-  "terraform/aws-constellation"
-  "terraform/azure-constellation"
-  "terraform/gcp-constellation"
+  "terraform/legacy-module"
 )
 
 excludeCheckDirs=(

--- a/dev-docs/workflows/terraform-provider.md
+++ b/dev-docs/workflows/terraform-provider.md
@@ -43,7 +43,7 @@ TF_CLI_CONFIG_FILE=config.tfrc terraform apply
 Terraform acceptance tests can be run hermetically through Bazel (recommended):
 
 ```bash
-bazel test --test_tag_filters=integration //terraform-provider-constellation/internal/provider:provider_acc_test
+bazel test --test_tag_filters=integration //terraform-provider-constellation/internal/provider:provider_test
 ```
 
 The tests can also be run through Go, but the `TF_ACC` environment variable needs to be set to `1`, and the host's Terraform binary is used, which may produce inaccurate test results.

--- a/dev-docs/workflows/terraform-provider.md
+++ b/dev-docs/workflows/terraform-provider.md
@@ -43,7 +43,7 @@ TF_CLI_CONFIG_FILE=config.tfrc terraform apply
 Terraform acceptance tests can be run hermetically through Bazel (recommended):
 
 ```bash
-bazel test --test_tag_filters=integration //terraform-provider-constellation/internal/provider:provider_test
+bazel test --config=integration-only //terraform-provider-constellation/internal/provider:provider_test
 ```
 
 The tests can also be run through Go, but the `TF_ACC` environment variable needs to be set to `1`, and the host's Terraform binary is used, which may produce inaccurate test results.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -268,6 +268,21 @@ MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELcPl4Ik+qZuH4K049wksoXK/Os3Z
 b92PDCpM7FZAINQF88s1TZS/HmRXYk62UJ4eqPduvUnJmXhNikhLbMi6fw==
 -----END PUBLIC KEY-----
 `
+
+	//
+	// Terraform Provider
+	//
+
+	// ConstellationClusterURIScheme is the scheme used in Terraform Constellation cluster import URIs.
+	ConstellationClusterURIScheme = "constellation-cluster"
+	// KubeConfigURIKey is the key used for the KubeConfig in Terraform Constellation cluster import URIs.
+	KubeConfigURIKey = "kubeConfig"
+	// ClusterEndpointURIKey is the key used for the cluster endpoint in Terraform Constellation cluster import URIs.
+	ClusterEndpointURIKey = "clusterEndpoint"
+	// MasterSecretURIKey is the key used for the master secret in Terraform Constellation cluster import URIs.
+	MasterSecretURIKey = "masterSecret"
+	// MasterSecretSaltURIKey is the key used for the master secret salt in Terraform Constellation cluster import URIs.
+	MasterSecretSaltURIKey = "masterSecretSalt"
 )
 
 // BinaryVersion returns the version of this Binary.

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -270,7 +270,7 @@ b92PDCpM7FZAINQF88s1TZS/HmRXYk62UJ4eqPduvUnJmXhNikhLbMi6fw==
 `
 
 	//
-	// Terraform Provider
+	// Terraform Provider.
 	//
 
 	// ConstellationClusterURIScheme is the scheme used in Terraform Constellation cluster import URIs.

--- a/terraform-provider-constellation/docs/resources/cluster.md
+++ b/terraform-provider-constellation/docs/resources/cluster.md
@@ -155,3 +155,11 @@ Required:
 
 - `project_id` (String) ID of the GCP project the cluster resides in.
 - `service_account_key` (String) Base64-encoded private key JSON object of the service account used within the cluster.
+
+## Import
+
+Import is supported using the following syntax:
+
+```shell
+terraform import constellation_cluster.constellation_cluster constellation-cluster://?kubeConfig=<base64-encoded-kubeconfig>&clusterEndpoint=<cluster-endpoint>&masterSecret=<hex-encoded-mastersecret>&masterSecretSalt=<hex-encoded-mastersecret-salt>
+```

--- a/terraform-provider-constellation/examples/resources/constellation_cluster/import.sh
+++ b/terraform-provider-constellation/examples/resources/constellation_cluster/import.sh
@@ -1,0 +1,1 @@
+terraform import constellation_cluster.constellation_cluster constellation-cluster://?kubeConfig=<base64-encoded-kubeconfig>&clusterEndpoint=<cluster-endpoint>&masterSecret=<hex-encoded-mastersecret>&masterSecretSalt=<hex-encoded-mastersecret-salt>

--- a/terraform-provider-constellation/internal/provider/BUILD.bazel
+++ b/terraform-provider-constellation/internal/provider/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//internal/cloud/azureshared",
         "//internal/cloud/cloudprovider",
         "//internal/config",
+        "//internal/constants",
         "//internal/constellation",
         "//internal/constellation/helm",
         "//internal/constellation/state",
@@ -53,33 +54,14 @@ go_test(
     name = "provider_test",
     srcs = [
         "attestation_data_source_test.go",
+        "cluster_resource_test.go",
         "convert_test.go",
-        "image_data_source_test.go",
-        "provider_test.go",
-    ],
-    embed = [":provider"],
-    deps = [
-        "//internal/attestation/idkeydigest",
-        "//internal/attestation/measurements",
-        "//internal/attestation/variant",
-        "//internal/config",
-        "@com_github_hashicorp_terraform_plugin_framework//providerserver",
-        "@com_github_hashicorp_terraform_plugin_go//tfprotov6",
-        "@com_github_hashicorp_terraform_plugin_testing//helper/resource",
-        "@com_github_stretchr_testify//assert",
-        "@com_github_stretchr_testify//require",
-        "@io_bazel_rules_go//go/runfiles:go_default_library",
-    ],
-)
-
-go_test(
-    name = "provider_acc_test",
-    srcs = [
         "image_data_source_test.go",
         "provider_test.go",
     ],
     # keep
     count = 1,
+    # keep
     data = [
         "//bazel/ci:com_github_hashicorp_terraform",
     ],
@@ -98,9 +80,16 @@ go_test(
     # keep
     x_defs = {"runsUnder": "bazel"},
     deps = [
+        "//internal/attestation/idkeydigest",
+        "//internal/attestation/measurements",
+        "//internal/attestation/variant",
+        "//internal/config",
         "@com_github_hashicorp_terraform_plugin_framework//providerserver",
         "@com_github_hashicorp_terraform_plugin_go//tfprotov6",
         "@com_github_hashicorp_terraform_plugin_testing//helper/resource",
+        "@com_github_hashicorp_terraform_plugin_testing//terraform",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
         "@io_bazel_rules_go//go/runfiles:go_default_library",
     ],
 )

--- a/terraform-provider-constellation/internal/provider/cluster_resource_test.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package provider
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAccClusteResourceImports(t *testing.T) {
+	// Set the path to the Terraform binary for acceptance testing when running under Bazel.
+	bazelPreCheck := func() { bazelSetTerraformBinaryPath(t) }
+
+	testCases := map[string]resource.TestCase{
+		"import success": {
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			PreCheck:                 bazelPreCheck,
+			Steps: []resource.TestStep{
+				{
+					Config: testingConfig + `
+					resource "constellation_cluster" "test" {}
+				`,
+					ResourceName: "constellation_cluster.test",
+					ImportState:  true,
+					ImportStateId: "constellation-cluster://?kubeConfig=YWJjZGU=&" + // valid base64 of "abcde"
+						"clusterEndpoint=b&" +
+						"masterSecret=de&" +
+						"masterSecretSalt=ad",
+					ImportStateCheck: func(states []*terraform.InstanceState) error {
+						state := states[0]
+						assert := assert.New(t)
+						assert.Equal("abcde", state.Attributes["kubeconfig"])
+						assert.Equal("b", state.Attributes["out_of_cluster_endpoint"])
+						assert.Equal("de", state.Attributes["master_secret"])
+						assert.Equal("ad", state.Attributes["master_secret_salt"])
+						return nil
+					},
+				},
+			},
+		},
+		"kubeconfig not base64": {
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			PreCheck:                 bazelPreCheck,
+			Steps: []resource.TestStep{
+				{
+					Config: testingConfig + `
+					resource "constellation_cluster" "test" {}
+				`,
+					ResourceName: "constellation_cluster.test",
+					ImportState:  true,
+					ImportStateId: "constellation-cluster://?kubeConfig=a&" +
+						"clusterEndpoint=b&" +
+						"masterSecret=de&" +
+						"masterSecretSalt=ad",
+					ExpectError: regexp.MustCompile(".*illegal base64 data.*"),
+				},
+			},
+		},
+		"mastersecret not hex": {
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			PreCheck:                 bazelPreCheck,
+			Steps: []resource.TestStep{
+				{
+					Config: testingConfig + `
+					resource "constellation_cluster" "test" {}
+				`,
+					ResourceName: "constellation_cluster.test",
+					ImportState:  true,
+					ImportStateId: "constellation-cluster://?kubeConfig=test&" +
+						"clusterEndpoint=b&" +
+						"masterSecret=xx&" +
+						"masterSecretSalt=ad",
+					ExpectError: regexp.MustCompile(".*Decoding hex-encoded master secret.*"),
+				},
+			},
+		},
+		"parameter missing": {
+			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+			PreCheck:                 bazelPreCheck,
+			Steps: []resource.TestStep{
+				{
+					Config: testingConfig + `
+					resource "constellation_cluster" "test" {}
+				`,
+					ResourceName: "constellation_cluster.test",
+					ImportState:  true,
+					ImportStateId: "constellation-cluster://?kubeConfig=test&" +
+						"clusterEndpoint=b&" +
+						"masterSecret=xx&",
+					ExpectError: regexp.MustCompile(".*Missing query parameter.*"),
+				},
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			resource.Test(t, tc)
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We want to be able to import legacy, possibly non-Terraform clusters into Terraform by specifying KubeConfig, Master Secret (& Salt), as well as the cluster endpoint, so that their future lifecycle can be managed with Terraform.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Implement state importing for the `constellation_cluster` resource.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3605](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3605)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
