### PR TITLE
ci: add v prefix to packaged Terraform provider binary

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -458,9 +458,9 @@ jobs:
 
             mkdir -p "${folder_name}"
             if [[ "${ext}" = "exe" ]]; then
-              cp "${file}" "${folder_name}/terraform-provider-constellation_${version}.exe"
+              cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}.exe"
             else
-              cp "${file}" "${folder_name}/terraform-provider-constellation_${version}"
+              cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}"
             fi
             zip -r "${folder_name}.zip" "${folder_name}"
             rm -r "${folder_name}"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Terraform expects the provider **binaries** to have a `v` prefix in their version. The packaged file must only have the version number.
The format is the following:
```
terraform-provider-${name}_${version}_${os}_${arch}.zip
│
└─ terraform-provider-${name}_v${version}[.exe]
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix binaries not being created with version number including v prefix in their name
