### PR TITLE
ci: use `sed` from GNU Coreutils

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -91,6 +91,11 @@ nixpkgs_package(
     repository = "@nixpkgs",
 )
 
+nixpkgs_package(
+    name = "gnused",
+    repository = "@nixpkgs",
+)
+
 load("//nix/cc:nixpkgs_cc_libraries.bzl", "nixpkgs_cc_library_deps")
 
 nixpkgs_cc_library_deps()

--- a/bazel/devbuild/BUILD.bazel
+++ b/bazel/devbuild/BUILD.bazel
@@ -12,6 +12,7 @@ sh_template(
         "//terraform-provider-constellation:terraform_rc",
         "//terraform-provider-constellation:tf_provider",
         "//upgrade-agent/cmd:upgrade_agent_linux_amd64",
+        "@gnused//:bin/sed",
         "@yq_toolchains//:resolved_toolchain",
     ],
     substitutions = {
@@ -20,6 +21,7 @@ sh_template(
         "@@CLI@@": "$(rootpath //cli:cli_edition_host)",
         "@@CONTAINER_SUMS@@": "$(rootpath //bazel/release:container_sums)",
         "@@EDITION@@": "$(rootpath :devbuild_cli_edition)",
+        "@@SED@@": "$(rootpath @gnused//:bin/sed)",
         "@@TERRAFORM_PROVIDER@@": "$(rootpath //terraform-provider-constellation:tf_provider)",
         "@@TERRAFORM_RC@@": "$(rootpath //terraform-provider-constellation:terraform_rc)",
         "@@UPGRADE_AGENT@@": "$(rootpath //upgrade-agent/cmd:upgrade_agent_linux_amd64)",

--- a/bazel/devbuild/prepare_developer_workspace.sh.in
+++ b/bazel/devbuild/prepare_developer_workspace.sh.in
@@ -16,6 +16,8 @@ fi
 
 yq=$(realpath @@YQ@@)
 stat "${yq}" >> /dev/null
+sed=$(realpath @@SED@@)
+stat "${sed}" >> /dev/null
 bootstrapper=$(realpath @@BOOTSTRAPPER@@)
 stat "${bootstrapper}" >> /dev/null
 upgrade_agent=$(realpath @@UPGRADE_AGENT@@)
@@ -70,7 +72,7 @@ TF_PROVIDER_DIR="${workdir}/terraform"
 mkdir -p "${TF_PROVIDER_DIR}"
 ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${terraform_provider}")" "${TF_PROVIDER_DIR}/terraform-provider-constellation"
 cp "$(replace_prefix "${host_cache}" "${builder_cache}" "${terraform_rc}")" "${TF_PROVIDER_DIR}/config.tfrc"
-sed -i "s|@@TERRAFORM_PROVIDER_PATH@@|$(dirname "${terraform_provider}")|g" "${TF_PROVIDER_DIR}/config.tfrc"
+${sed} -i "s|@@TERRAFORM_PROVIDER_PATH@@|$(dirname "${terraform_provider}")|g" "${TF_PROVIDER_DIR}/config.tfrc"
 
 build_version=$("${cli}" version | grep ^Version: | awk '{print $2}')
 if [[ ! -f "${workdir}/constellation-conf.yaml" ]]; then


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Fixed `devbuild` error on MacOS:
```
sed: 1: "./terraform/config.tfrc": invalid command code .
ERROR: bazel/devbuild/devbuild: 'sed -i "s|@@TERRAFORM_PROVIDER_PATH@@|$(dirname "${terraform_provider}")|g" "${TF_PROVIDER_DIR}/config.tfrc"' failed at line 73
ERROR: bazel/devbuild/devbuild: exit status 1
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use `sed` from GNU Coreutils, which ensures purity and thus common behaviour on all platforms.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
