### PR TITLE
constellation-lib: fix incorrect encoding and ordering of Init response

### DIFF
--- a/internal/constellation/applyinit.go
+++ b/internal/constellation/applyinit.go
@@ -8,6 +8,7 @@ package constellation
 
 import (
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -121,17 +122,17 @@ func (a *Applier) Init(
 	}
 
 	return InitOutput{
-		ClusterID:  string(doer.resp.OwnerId),
-		OwnerID:    string(doer.resp.ClusterId),
+		ClusterID:  hex.EncodeToString(doer.resp.ClusterId),
+		OwnerID:    hex.EncodeToString(doer.resp.OwnerId),
 		Kubeconfig: kubeconfigBytes,
 	}, nil
 }
 
 // InitOutput contains the output of the init RPC.
 type InitOutput struct {
-	// ClusterID is the ID of the cluster.
+	// ClusterID is the hex encoded ID of the cluster.
 	ClusterID string
-	// OwnerID is the ID of the owner of the cluster.
+	// OwnerID is the hex encoded ID of the owner of the cluster.
 	OwnerID string
 	// Kubeconfig is the kubeconfig for the cluster.
 	Kubeconfig []byte


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
`ClusterID` and `OwnerID` were swapped and not correctly hex encoded when returned from the Constellation-lib's Init method.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Correctly set `ClusterID` and `OwnerID` in the Init response
- Correctly hex encode both IDs

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->
