### PR TITLE
ci: Terraform provider e2e tests

### DIFF
--- a/.github/actions/cdbg_deploy/action.yml
+++ b/.github/actions/cdbg_deploy/action.yml
@@ -20,9 +20,9 @@ inputs:
   refStream:
     description: "The refStream of the image the test runs on."
     required: true
-  selfManagedInfra:
-    description: "Use self-managed infrastructure instead of infrastructure created by the Constellation CLI."
-    default: "false"
+  clusterCreation:
+    description: "How the infrastructure for the e2e test was created. One of [cli, self-managed, terraform]."
+    default: "cli"
 
 runs:
   using: "composite"
@@ -97,7 +97,7 @@ runs:
           --info logcollect.github.is-debug-cluster=false \
           --info logcollect.github.ref-stream="${{ inputs.refStream }}" \
           --info logcollect.github.kubernetes-version="${{ inputs.kubernetesVersion }}" \
-          --info logcollect.github.self-managed-infra="${{ inputs.selfManagedInfra }}" \
+          --info logcollect.github.cluster-creation="${{ inputs.clusterCreation }}" \
           --info logcollect.deployment-type="debugd" \
           --verbosity=-1 \
           --force

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -63,7 +63,7 @@ inputs:
 outputs:
   kubeconfig:
     description: "The kubeconfig for the cluster."
-    value: ${{ steps.constellation-init.outputs.KUBECONFIG }}
+    value: ${{ steps.get-kubeconfig.outputs.KUBECONFIG }}
   osImageUsed:
     description: "The OS image used in the cluster."
     value: ${{ steps.setImage.outputs.image }}
@@ -186,20 +186,27 @@ runs:
     - name: Constellation apply (Terraform)
       id: constellation-apply-terraform
       if: inputs.clusterCreation == 'terraform'
-      shell: bash
       uses: ./.github/actions/terraform_apply
+      with:
+        cloudProvider: ${{ inputs.cloudProvider }}
 
     - name: Constellation apply
       id: constellation-apply-cli
+      if: inputs.clusterCreation != 'terraform'
       shell: bash
       run: |
         constellation apply --skip-phases=infrastructure --debug ${{ steps.set-force-flag.outputs.flag }}
+
+    - name: Get kubeconfig
+      id: get-kubeconfig
+      shell: bash
+      run: |
         echo "KUBECONFIG=$(pwd)/constellation-admin.conf" | tee -a $GITHUB_OUTPUT
 
     - name: Wait for nodes to join and become ready
       shell: bash
       env:
-        KUBECONFIG: "${{ steps.constellation-init.outputs.KUBECONFIG }}"
+        KUBECONFIG: "${{ steps.get-kubeconfig.outputs.KUBECONFIG }}"
         JOINTIMEOUT: "1200" # 20 minutes timeout for all nodes to join
       run: |
         echo "::group::Wait for nodes"

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -50,9 +50,9 @@ inputs:
   internalLoadBalancer:
     description: "Whether to use an internal load balancer for the control plane"
     required: false
-  selfManagedInfra:
-    description: "Use self-managed infrastructure instead of infrastructure created by the Constellation CLI."
-    required: true
+  clusterCreation:
+    description: "How to create infrastructure for the e2e test. One of [cli, self-managed, terraform]."
+    default: "cli"
   marketplaceImageVersion:
     description: "Marketplace OS image version. Used instead of osImage."
     required: false
@@ -148,7 +148,7 @@ runs:
         sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts' || true
 
     - name: Constellation create (CLI)
-      if : inputs.selfManagedInfra != 'true'
+      if : inputs.clusterCreation != 'self-managed'
       shell: bash
       run: |
         # TODO(v2.14): Remove workaround for CLIs not supporting apply command
@@ -159,7 +159,7 @@ runs:
         constellation $cmd -y --debug --tf-log=DEBUG
 
     - name: Constellation create (self-managed)
-      if : inputs.selfManagedInfra == 'true'
+      if : inputs.clusterCreation == 'self-managed'
       uses: ./.github/actions/self_managed_create
       with:
         cloudProvider: ${{ inputs.cloudProvider }}
@@ -174,7 +174,7 @@ runs:
         azureIAMCreateCredentials: ${{ inputs.azureIAMCreateCredentials }}
         refStream: ${{ inputs.refStream }}
         kubernetesVersion: ${{ inputs.kubernetesVersion }}
-        selfManagedInfra: ${{ inputs.selfManagedInfra }}
+        clusterCreation: ${{ inputs.clusterCreation }}
 
     - name: Set force flag
       id: set-force-flag
@@ -183,8 +183,14 @@ runs:
       run: |
         echo "flag=--force" | tee -a $GITHUB_OUTPUT
 
-    - name: Constellation init
-      id: constellation-init
+    - name: Constellation apply (Terraform)
+      id: constellation-apply-terraform
+      if: inputs.clusterCreation == 'terraform'
+      shell: bash
+      uses: ./.github/actions/terraform_apply
+
+    - name: Constellation apply
+      id: constellation-apply-cli
       shell: bash
       run: |
         constellation apply --skip-phases=infrastructure --debug ${{ steps.set-force-flag.outputs.flag }}

--- a/.github/actions/constellation_destroy/action.yml
+++ b/.github/actions/constellation_destroy/action.yml
@@ -5,9 +5,9 @@ inputs:
   kubeconfig:
     description: "The kubeconfig for the cluster."
     required: true
-  selfManagedInfra:
-    description: "Use self-managed infrastructure instead of infrastructure created by the Constellation CLI."
-    required: true
+  clusterCreation:
+    description: "How the infrastructure for the e2e test was created. One of [cli, self-managed, terraform]."
+    default: "cli"
   gcpClusterDeleteServiceAccount:
     description: "Service account with permissions to delete a Constellation cluster on GCP."
     required: true
@@ -72,13 +72,13 @@ runs:
         azure_credentials: ${{ inputs.azureClusterDeleteCredentials }}
 
     - name: Constellation terminate
-      if: inputs.selfManagedInfra != 'true'
+      if: inputs.clusterCreation != 'self-managed'
       shell: bash
       run: |
         constellation terminate --yes --tf-log=DEBUG
 
     - name: Constellation terminate (self-managed)
-      if: inputs.selfManagedInfra == 'true'
+      if: inputs.clusterCreation == 'self-managed'
       shell: bash
       working-directory: ${{ github.workspace }}/e2e-infra
       run: |

--- a/.github/actions/deploy_logcollection/action.yml
+++ b/.github/actions/deploy_logcollection/action.yml
@@ -29,9 +29,9 @@ inputs:
   kubernetesVersion:
     description: "Kubernetes version of the cluster"
     required: false
-  selfManagedInfra:
-    description: "Use self-managed infrastructure instead of infrastructure created by the Constellation CLI."
-    default: "false"
+  clusterCreation:
+    description: "How the infrastructure for the e2e test was created. One of [cli, self-managed, terraform]."
+    default: "cli"
 
 runs:
   using: "composite"
@@ -57,7 +57,7 @@ runs:
          --fields github.e2e-test-provider="${{ inputs.provider }}" \
          --fields github.ref-stream="${{ inputs.refStream }}" \
          --fields github.kubernetes-version="${{ inputs.kubernetesVersion }}" \
-         --fields github.self-managed-infra="${{ inputs.selfManagedInfra }}" \
+         --fields github.cluster-creation="${{ inputs.clusterCreation }}" \
          --fields deployment-type="k8s"
 
     # Make sure that helm is installed

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -73,9 +73,9 @@ inputs:
     description: "Enable security policy for the cluster."
   internalLoadBalancer:
     description: "Enable internal load balancer for the cluster."
-  selfManagedInfra:
-    description: "Use self-managed infrastructure instead of infrastructure created by the Constellation CLI."
-    default: "false"
+  clusterCreation:
+    description: "How to create infrastructure for the e2e test. One of [cli, self-managed, terraform]."
+    default: "cli"
   s3AccessKey:
     description: "Access key for s3proxy"
   s3SecretKey:
@@ -165,6 +165,28 @@ runs:
         constellation version
         # Do not spam license server from pipeline
         sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts'
+
+    - name: Build Terraform provider binary
+      if: inputs.clusterCreation == 'terraform' && inputs.cliVersion == ''
+      uses: ./.github/actions/build_tf_provider
+      with:
+        targetOS: ${{ steps.determine-build-target.outputs.hostOS }}
+        targetArch: ${{ steps.determine-build-target.outputs.hostArch }}
+        outputPath: "build/terraform-provider-constellation"
+
+    - name: Move Terraform provider binary
+      if: inputs.clusterCreation == 'terraform' && inputs.cliVersion == ''
+      shell: bash
+      run: |
+        bazel build //bazel/settings:tag
+
+        repository_root=$(git rev-parse --show-toplevel)
+        out_rel=$(bazel cquery --output=files //bazel/settings:tag)
+        build_version=$(cat "$(realpath "${repository_root}/${out_rel}")")
+
+        terraform_provider_dir="~/.terraform.d/plugins/registry.terraform.io/edgelesssys/constellation/${build_version#v}/${{ steps.determine-build-target.outputs.hostOS }}_${{ steps.determine-build-target.outputs.hostArch }}/"
+        mkdir -p "${terraform_provider_dir}"
+        mv build/terraform-provider-constellation "${terraform_provider_dir}/terraform-provider-constellation_${build_version}"
 
     - name: Build the bootstrapper
       id: build-bootstrapper
@@ -271,7 +293,7 @@ runs:
         refStream: ${{ inputs.refStream }}
         internalLoadBalancer: ${{ inputs.internalLoadBalancer }}
         test: ${{ inputs.test }}
-        selfManagedInfra: ${{ inputs.selfManagedInfra }}
+        clusterCreation: ${{ inputs.clusterCreation }}
         marketplaceImageVersion: ${{ inputs.marketplaceImageVersion }}
         force: ${{ inputs.force }}
 
@@ -288,7 +310,7 @@ runs:
         isDebugImage: ${{ inputs.isDebugImage }}
         kubernetesVersion: ${{ inputs.kubernetesVersion }}
         refStream: ${{ inputs.refStream }}
-        selfManagedInfra: ${{ inputs.selfManagedInfra }}
+        clusterCreation: ${{ inputs.clusterCreation }}
 
     #
     # Test payloads

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -184,7 +184,7 @@ runs:
         out_rel=$(bazel cquery --output=files //bazel/settings:tag)
         build_version=$(cat "$(realpath "${repository_root}/${out_rel}")")
 
-        terraform_provider_dir="~/.terraform.d/plugins/registry.terraform.io/edgelesssys/constellation/${build_version#v}/${{ steps.determine-build-target.outputs.hostOS }}_${{ steps.determine-build-target.outputs.hostArch }}/"
+        terraform_provider_dir="${HOME}/.terraform.d/plugins/registry.terraform.io/edgelesssys/constellation/${build_version#v}/${{ steps.determine-build-target.outputs.hostOS }}_${{ steps.determine-build-target.outputs.hostArch }}/"
         mkdir -p "${terraform_provider_dir}"
         mv build/terraform-provider-constellation "${terraform_provider_dir}/terraform-provider-constellation_${build_version}"
 

--- a/.github/actions/notify_e2e_failure/action.yml
+++ b/.github/actions/notify_e2e_failure/action.yml
@@ -17,8 +17,8 @@ inputs:
   kubernetesVersion:
     description: "Kubernetes version"
     required: false
-  selfManagedInfra:
-    description: "Use self-managed infrastructure instead of infrastructure created by the Constellation CLI."
+  clusterCreation:
+    description: "How the infrastructure for the e2e test was created. One of [cli, self-managed, terraform]."
     default: "false"
 
 runs:
@@ -66,6 +66,7 @@ runs:
           workflow: ${{ github.workflow }}
           kubernetesVersion: ${{ inputs.kubernetesVersion }}
           cloudProvider: ${{ inputs.provider }}
+          clusterCreation: ${{ inputs.clusterCreation }}
           test: ${{ inputs.test }}
           refStream: ${{ inputs.refStream }}
         token: ${{ inputs.projectWriteToken }}

--- a/.github/actions/terraform_apply/action.yml
+++ b/.github/actions/terraform_apply/action.yml
@@ -60,6 +60,7 @@ runs:
           attestation_variant = "${attestationVariant}"
           image_version       = "$(yq '.image' constellation-conf.yaml)"
           maa_url             = "$(yq '.infrastructure.azure.attestationURL' constellation-state.yaml)"
+          insecure            = true
         }
 
         data "constellation_image" "con_image" {
@@ -97,7 +98,7 @@ runs:
           gcp = {
             count = "$(yq '.provider | keys | .[0]' constellation-conf.yaml)" == "gcp" ? 1 : 0
             project_id          = "$(yq '.infrastructure.gcp.projectID' constellation-state.yaml)"
-            service_account_key = "$(cat $(yq '.provider.gcp.serviceAccountKeyPath' constellation-conf.yaml) | base64 -w0)"
+            service_account_key = sensitive("$(cat $(yq '.provider.gcp.serviceAccountKeyPath' constellation-conf.yaml) | base64 -w0)")
           }
           network_config = {
             ip_cidr_node    = "$(yq '.infrastructure.ipCidrNode' constellation-state.yaml)"

--- a/.github/actions/terraform_apply/action.yml
+++ b/.github/actions/terraform_apply/action.yml
@@ -1,0 +1,156 @@
+name: Terraform provider apply
+description: "Create/Apply a Constellation cluster using the Terraform provider."
+
+inputs:
+  cloudProvider:
+    description: "The cloud provider the test runs on."
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Create Terraform file
+      shell: bash
+      run: |
+        attestationVariant=""
+        case "$(yq '.attestation | keys | .[0]' constellation-conf.yaml)" in
+          "awsSEVSNP")
+            attestationVariant="aws-sev-snp"
+            ;;
+          "azureSEVSNP")
+            attestationVariant="azure-sev-snp"
+            ;;
+          "gcpSEVES")
+            attestationVariant="gcp-sev-es"
+            ;;
+          *)
+            echo "Unknown attestation variant: $(yq '.attestation | keys | .[0]' constellation-conf.yaml)"
+            exit 1
+            ;;
+        esac
+
+        cat << EOF > main.tf
+        terraform {
+          required_providers {
+            constellation = {
+              source  = "edgelesssys/constellation"
+              version = "$(yq '.microserviceVersion' constellation-conf.yaml | sed 's/^v//')"
+            }
+            random = {
+              source  = "hashicorp/random"
+              version = "3.6.0"
+            }
+          }
+        }
+
+        resource "random_bytes" "master_secret" {
+          length = 32
+        }
+
+        resource "random_bytes" "master_secret_salt" {
+          length = 32
+        }
+
+        resource "random_bytes" "measurement_salt" {
+          length = 32
+        }
+
+        data "constellation_attestation" "con_attestation" {
+          csp                 = "${{ inputs.cloudProvider }}"
+          attestation_variant = "${attestationVariant}"
+          image_version       = "$(yq '.image' constellation-conf.yaml)"
+          maa_url             = "$(yq '.infrastructure.azure.attestationURL' constellation-state.yaml)"
+        }
+
+        data "constellation_image" "con_image" {
+          image_version       = "$(yq '.image' constellation-conf.yaml)"
+          attestation_variant = "${attestationVariant}"
+          csp                 = "${{ inputs.cloudProvider }}"
+          region              = "$(yq '.provider.aws.region' constellation-conf.yaml)"
+        }
+
+        resource "constellation_cluster" "cluster" {
+          csp                                = "${{ inputs.cloudProvider }}"
+          constellation_microservice_version = "$(yq '.microserviceVersion' constellation-conf.yaml)"
+          name                               = "$(yq '.name' constellation-conf.yaml)"
+          uid                                = "$(yq '.infrastructure.uid' constellation-state.yaml)"
+          image_reference                    = data.constellation_image.con_image.reference
+          image_version                      = "$(yq '.microserviceVersion' constellation-conf.yaml)"
+          attestation                        = data.constellation_attestation.con_attestation.attestation
+          init_secret                        = "$(yq '.infrastructure.initSecret' constellation-state.yaml | xxd -r -p)"
+          master_secret                      = random_bytes.master_secret.hex
+          master_secret_salt                 = random_bytes.master_secret_salt.hex
+          measurement_salt                   = random_bytes.measurement_salt.hex
+          out_of_cluster_endpoint            = "$(yq '.infrastructure.clusterEndpoint' constellation-state.yaml)"
+          in_cluster_endpoint                = "$(yq '.infrastructure.inClusterEndpoint' constellation-state.yaml)"
+          azure = {
+            count = "$(yq '.provider | keys | .[0]' constellation-conf.yaml)" == "azure" ? 1 : 0
+            tenant_id                   = "$(yq '.provider.azure.tenant' constellation-conf.yaml)"
+            subscription_id             = "$(yq '.infrastructure.azure.subscriptionID' constellation-state.yaml)"
+            uami_client_id              = "$(yq '.infrastructure.azure.userAssignedIdentity' constellation-state.yaml)"
+            uami_resource_id            = "$(yq '.provider.azure.userAssignedIdentity' constellation-conf.yaml)"
+            location                    = "$(yq '.provider.azure.location' constellation-conf.yaml)"
+            resource_group              = "$(yq '.infrastructure.azure.resourceGroup' constellation-state.yaml)"
+            load_balancer_name          = "$(yq '.infrastructure.azure.loadBalancerName' constellation-state.yaml)"
+            network_security_group_name = "$(yq '.infrastructure.azure.networkSecurityGroupName' constellation-state.yaml)"
+          }
+          gcp = {
+            count = "$(yq '.provider | keys | .[0]' constellation-conf.yaml)" == "gcp" ? 1 : 0
+            project_id          = "$(yq '.infrastructure.gcp.projectID' constellation-state.yaml)"
+            service_account_key = "$(cat $(yq '.provider.gcp.serviceAccountKeyPath' constellation-conf.yaml) | base64 -w0)"
+          }
+          network_config = {
+            ip_cidr_node    = "$(yq '.infrastructure.ipCidrNode' constellation-state.yaml)"
+            ip_cidr_service = "$(yq '.serviceCIDR' constellation-conf.yaml)"
+            ip_cidr_pod     = "$(yq '.infrastructure.gcp.ipCidrPod' constellation-state.yaml)" # This is null for everything but GCP
+          }
+        }
+
+        output "master_secret" {
+          value = random_bytes.master_secret.base64
+          sensitive = true
+        }
+
+        output "master_secret_salt" {
+          value = random_bytes.master_secret_salt.base64
+          sensitive = true
+        }
+
+        output "measurement_salt" {
+          value = random_bytes.measurement_salt.hex
+          sensitive = true
+        }
+
+        output "cluster_id" {
+          value = constellation_cluster.cluster.cluster_id
+        }
+
+        output "owner_id" {
+          value = constellation_cluster.cluster.owner_id
+        }
+
+        output "kubeconfig" {
+          value = constellation_cluster.cluster.kubeconfig
+          sensitive = true
+        }
+        EOF
+
+    - name: Apply Terraform configuration
+      shell: bash
+      run: |
+        terraform init
+        terraform apply -auto-approve
+
+    - name: Write output
+      shell: bash
+      run: |
+        terraform output -raw kubeconfig > "$(pwd)/constellation-admin.conf"
+        yq -i ".clusterValues.measurementSalt = $(terraform output measurement_salt)" constellation-state.yaml
+        yq -i ".clusterValues.clusterID = $(terraform output cluster_id)" constellation-state.yaml
+        yq -i ".clusterValues.ownerID = $(terraform output owner_id)" constellation-state.yaml
+        cat << EOF > constellation-mastersecret.json
+        {
+          "key": "$(terraform output -raw master_secret)",
+          "salt": "$(terraform output -raw master_secret_salt)"
+        }
+        EOF

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -90,14 +90,14 @@ jobs:
           awsOpenSearchDomain: ${{ secrets.AWS_OPENSEARCH_DOMAIN }}
           awsOpenSearchUsers: ${{ secrets.AWS_OPENSEARCH_USER }}
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
-          selfManagedInfra: "false"
+          clusterCreation: "cli"
 
       - name: Always terminate cluster
         if: always()
         uses: ./.github/actions/constellation_destroy
         with:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
-          selfManagedInfra: "false"
+          clusterCreation: "cli"
           cloudProvider: ${{ matrix.provider }}
           azureClusterDeleteCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
           gcpClusterDeleteServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"
@@ -123,7 +123,7 @@ jobs:
           test: ${{ matrix.test }}
           kubernetesVersion: ${{ matrix.kubernetesVersion }}
           provider: ${{ matrix.provider }}
-          selfManagedInfra: "false"
+          clusterCreation: "cli"
 
   e2e-mini:
     name: Run miniconstellation E2E test

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -49,107 +49,130 @@ jobs:
             provider: "gcp"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "sonobuoy full"
             provider: "azure"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "sonobuoy full"
             provider: "aws"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
 
 
           - test: "sonobuoy full"
             provider: "gcp"
             kubernetes-version: "v1.27"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "sonobuoy full"
             provider: "azure"
             kubernetes-version: "v1.27"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "sonobuoy full"
             provider: "aws"
             kubernetes-version: "v1.27"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
 
           - test: "sonobuoy full"
             provider: "gcp"
             kubernetes-version: "v1.26"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "sonobuoy full"
             provider: "azure"
             kubernetes-version: "v1.26"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "sonobuoy full"
             provider: "aws"
             kubernetes-version: "v1.26"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
 
           # verify test on latest k8s version
           - test: "verify"
             provider: "gcp"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "verify"
             provider: "azure"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "verify"
             provider: "aws"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
 
           # recover test on latest k8s version
           - test: "recover"
             provider: "gcp"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "recover"
             provider: "azure"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "recover"
             provider: "aws"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
 
           # lb test on latest k8s version
           - test: "lb"
             provider: "gcp"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "lb"
             provider: "azure"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "lb"
             provider: "aws"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
 
           # autoscaling test on latest k8s version
           - test: "autoscaling"
             provider: "gcp"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "autoscaling"
             provider: "azure"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "autoscaling"
             provider: "aws"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
 
           # perf-bench test on latest k8s version, not supported on AWS
           - test: "perf-bench"
             provider: "gcp"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
           - test: "perf-bench"
             provider: "azure"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
 
           # self-managed infra test on latest k8s version
           # runs Sonobuoy full test
@@ -157,17 +180,17 @@ jobs:
             provider: "gcp"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
-            selfManagedInfra: "true"
+            clusterCreation: "self-managed"
           - test: "sonobuoy full"
             provider: "azure"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
-            selfManagedInfra: "true"
+            clusterCreation: "self-managed"
           - test: "sonobuoy full"
             provider: "aws"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
-            selfManagedInfra: "true"
+            clusterCreation: "self-managed"
 
           # s3proxy test on latest k8s version
           - test: "s3proxy"
@@ -175,6 +198,7 @@ jobs:
             provider: "gcp"
             kubernetes-version: "v1.28"
             runner: "ubuntu-22.04"
+            clusterCreation: "cli"
 
           #
           # Tests on macOS runner
@@ -189,6 +213,7 @@ jobs:
             provider: "gcp"
             kubernetes-version: "v1.28"
             runner: "macos-12"
+            clusterCreation: "cli"
     runs-on: ${{ matrix.runner }}
     permissions:
       id-token: write
@@ -237,7 +262,7 @@ jobs:
           cosignPassword: ${{ secrets.COSIGN_PASSWORD }}
           cosignPrivateKey: ${{ secrets.COSIGN_PRIVATE_KEY }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
-          selfManagedInfra: ${{ matrix.selfManagedInfra == 'true' }}
+          clusterCreation: ${{ matrix.clusterCreation }}
           s3AccessKey: ${{ secrets.AWS_ACCESS_KEY_ID_S3PROXY }}
           s3SecretKey: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3PROXY }}
 
@@ -246,7 +271,7 @@ jobs:
         uses: ./.github/actions/constellation_destroy
         with:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
-          selfManagedInfra: ${{ matrix.selfManagedInfra == 'true' }}
+          clusterCreation: ${{ matrix.clusterCreation }}
           cloudProvider: ${{ matrix.provider }}
           azureClusterDeleteCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
           gcpClusterDeleteServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"

--- a/.github/workflows/e2e-test-terraform-provider.yml
+++ b/.github/workflows/e2e-test-terraform-provider.yml
@@ -1,4 +1,4 @@
-name: e2e test self managed infrastructure
+name: e2e test Terraform provider
 
 on:
   workflow_dispatch:
@@ -41,8 +41,8 @@ on:
         description: "Kubernetes version to create the cluster from."
         default: "1.27"
         required: true
-      cliVersion:
-        description: "Version of a released CLI to download. Leave empty to build the CLI from the checked out ref."
+      releaseVersion:
+        description: "Version of a released provider to download. Leave empty to build the provider from the checked out ref."
         type: string
         default: ""
         required: false
@@ -80,9 +80,9 @@ jobs:
       runner: ${{ inputs.runner }}
       test: ${{ inputs.test }}
       kubernetesVersion: ${{ inputs.kubernetesVersion }}
-      cliVersion: ${{ inputs.cliVersion }}
+      cliVersion: ${{ inputs.releaseVersion }}
       imageVersion: ${{ inputs.imageVersion }}
       machineType: ${{ inputs.machineType }}
       regionZone: ${{ inputs.regionZone }}
       git-ref: ${{ inputs.git-ref }}
-      clusterCreation: "self-managed"
+      clusterCreation: "terraform"

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -56,121 +56,147 @@ jobs:
             refStream: "ref/main/stream/debug/?"
             provider: "gcp"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
           - test: "sonobuoy full"
             refStream: "ref/main/stream/debug/?"
             provider: "azure"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
           - test: "sonobuoy full"
             refStream: "ref/main/stream/debug/?"
             provider: "aws"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
 
           - test: "sonobuoy full"
             refStream: "ref/main/stream/debug/?"
             provider: "gcp"
             kubernetes-version: "v1.27"
+            clusterCreation: "cli"
           - test: "sonobuoy full"
             refStream: "ref/main/stream/debug/?"
             provider: "azure"
             kubernetes-version: "v1.27"
+            clusterCreation: "cli"
           - test: "sonobuoy full"
             refStream: "ref/main/stream/debug/?"
             provider: "aws"
             kubernetes-version: "v1.27"
+            clusterCreation: "cli"
 
           - test: "sonobuoy full"
             refStream: "ref/main/stream/debug/?"
             provider: "gcp"
             kubernetes-version: "v1.26"
+            clusterCreation: "cli"
           - test: "sonobuoy full"
             refStream: "ref/main/stream/debug/?"
             provider: "azure"
             kubernetes-version: "v1.26"
+            clusterCreation: "cli"
           - test: "sonobuoy full"
             refStream: "ref/main/stream/debug/?"
             provider: "aws"
             kubernetes-version: "v1.26"
+            clusterCreation: "cli"
 
           # verify test on latest k8s version
           - test: "verify"
             refStream: "ref/main/stream/debug/?"
             provider: "gcp"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
           - test: "verify"
             refStream: "ref/main/stream/debug/?"
             provider: "azure"
             kubernetes-version: "v1.28"
             azureSNPEnforcementPolicy: "equal" # This run checks for unknown ID Key disgests.
+            clusterCreation: "cli"
           - test: "verify"
             provider: "aws"
             refStream: "ref/main/stream/debug/?"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
 
           # recover test on latest k8s version
           - test: "recover"
             refStream: "ref/main/stream/debug/?"
             provider: "gcp"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
           - test: "recover"
             refStream: "ref/main/stream/debug/?"
             provider: "azure"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
           - test: "recover"
             refStream: "ref/main/stream/debug/?"
             provider: "aws"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
 
           # lb test on latest k8s version
           - test: "lb"
             refStream: "ref/main/stream/debug/?"
             provider: "gcp"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
           - test: "lb"
             refStream: "ref/main/stream/debug/?"
             provider: "azure"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
           - test: "lb"
             refStream: "ref/main/stream/debug/?"
             provider: "aws"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
 
           # autoscaling test on latest k8s version
           - test: "autoscaling"
             refStream: "ref/main/stream/debug/?"
             provider: "gcp"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
           - test: "autoscaling"
             refStream: "ref/main/stream/debug/?"
             provider: "azure"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
           - test: "autoscaling"
             refStream: "ref/main/stream/debug/?"
             provider: "aws"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
 
           # perf-bench test on latest k8s version, not supported on AWS
           - test: "perf-bench"
             refStream: "ref/main/stream/debug/?"
             provider: "gcp"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
           - test: "perf-bench"
             refStream: "ref/main/stream/debug/?"
             provider: "azure"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
 
           # malicious join test on latest k8s version
           - test: "malicious join"
             refStream: "ref/main/stream/debug/?"
             provider: "gcp"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
           - test: "malicious join"
             refStream: "ref/main/stream/debug/?"
             provider: "azure"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
           - test: "malicious join"
             refStream: "ref/main/stream/debug/?"
             provider: "aws"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
 
           # self-managed infra test on latest k8s version
           # with Sonobuoy full
@@ -178,23 +204,24 @@ jobs:
             refStream: "ref/main/stream/debug/?"
             provider: "gcp"
             kubernetes-version: "v1.28"
-            selfManagedInfra: "true"
+            clusterCreation: "self-managed"
           - test: "sonobuoy full"
             refStream: "ref/main/stream/debug/?"
             provider: "azure"
             kubernetes-version: "v1.28"
-            selfManagedInfra: "true"
+            clusterCreation: "self-managed"
           - test: "sonobuoy full"
             provider: "aws"
             refStream: "ref/main/stream/debug/?"
             kubernetes-version: "v1.28"
-            selfManagedInfra: "true"
+            clusterCreation: "self-managed"
 
           # s3proxy test on latest k8s version
           - test: "s3proxy"
             refStream: "ref/main/stream/debug/?"
             provider: "gcp"
             kubernetes-version: "v1.28"
+            clusterCreation: "cli"
 
           #
           # Tests on release-stable refStream
@@ -205,14 +232,17 @@ jobs:
             refStream: "ref/release/stream/stable/?"
             provider: "gcp"
             kubernetes-version: "v1.27"
+            clusterCreation: "cli"
           - test: "verify"
             refStream: "ref/release/stream/stable/?"
             provider: "azure"
             kubernetes-version: "v1.27"
+            clusterCreation: "cli"
           - test: "verify"
             refStream: "ref/release/stream/stable/?"
             provider: "aws"
             kubernetes-version: "v1.27"
+            clusterCreation: "cli"
 
     runs-on: ubuntu-22.04
     permissions:
@@ -256,7 +286,7 @@ jobs:
           cosignPrivateKey: ${{ secrets.COSIGN_PRIVATE_KEY }}
           fetchMeasurements: ${{ matrix.refStream != 'ref/release/stream/stable/?' }}
           azureSNPEnforcementPolicy: ${{ matrix.azureSNPEnforcementPolicy }}
-          selfManagedInfra: ${{ matrix.selfManagedInfra == 'true' }}
+          clusterCreation: ${{ matrix.clusterCreation }}
           s3AccessKey: ${{ secrets.AWS_ACCESS_KEY_ID_S3PROXY }}
           s3SecretKey: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3PROXY }}
 
@@ -265,7 +295,7 @@ jobs:
         uses: ./.github/actions/constellation_destroy
         with:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
-          selfManagedInfra: ${{ matrix.selfManagedInfra == 'true' }}
+          clusterCreation: ${{ matrix.clusterCreation }}
           cloudProvider: ${{ matrix.provider }}
           azureClusterDeleteCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
           gcpClusterDeleteServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"
@@ -291,7 +321,7 @@ jobs:
           test: ${{ matrix.test }}
           kubernetesVersion: ${{ matrix.kubernetes-version }}
           provider: ${{ matrix.provider }}
-          selfManagedInfra: ${{ matrix.selfManagedInfra == 'true' }}
+          clusterCreation: ${{ matrix.clusterCreation }}
 
   e2e-upgrade:
     strategy:

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -216,6 +216,22 @@ jobs:
             kubernetes-version: "v1.28"
             clusterCreation: "self-managed"
 
+          - test: "sonobuoy full"
+            refStream: "ref/main/stream/debug/?"
+            provider: "gcp"
+            kubernetes-version: "v1.28"
+            clusterCreation: "terraform"
+          - test: "sonobuoy full"
+            refStream: "ref/main/stream/debug/?"
+            provider: "azure"
+            kubernetes-version: "v1.28"
+            clusterCreation: "terraform"
+          - test: "sonobuoy full"
+            refStream: "ref/main/stream/debug/?"
+            provider: "aws"
+            kubernetes-version: "v1.28"
+            clusterCreation: "terraform"
+
           # s3proxy test on latest k8s version
           - test: "s3proxy"
             refStream: "ref/main/stream/debug/?"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -112,10 +112,10 @@ on:
         description: "Enable internal load balancer for the cluster."
         type: boolean
         default: false
-      selfManagedInfra:
-        description: "Use self-managed infrastructure."
-        type: boolean
-        default: false
+      clusterCreation:
+        description: "How to create infrastructure for the e2e test. One of [cli, self-managed, terraform]."
+        type: string
+        default: "cli"
       marketplaceImageVersion:
         description: "Marketplace image version to use."
         type: string
@@ -241,7 +241,7 @@ jobs:
           cosignPrivateKey: ${{ secrets.COSIGN_PRIVATE_KEY }}
           fetchMeasurements: ${{ contains(needs.find-latest-image.outputs.image, '/stream/stable/') }}
           internalLoadBalancer: ${{ inputs.internalLoadBalancer }}
-          selfManagedInfra: ${{ inputs.selfManagedInfra }}
+          clusterCreation: ${{ inputs.clusterCreation }}
           s3AccessKey: ${{ secrets.AWS_ACCESS_KEY_ID_S3PROXY }}
           s3SecretKey: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3PROXY }}
           marketplaceImageVersion: ${{ inputs.marketplaceImageVersion }}
@@ -252,7 +252,7 @@ jobs:
         uses: ./.github/actions/constellation_destroy
         with:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
-          selfManagedInfra: ${{ inputs.selfManagedInfra }}
+          clusterCreation: ${{ inputs.clusterCreation }}
           cloudProvider: ${{ inputs.cloudProvider }}
           azureClusterDeleteCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
           gcpClusterDeleteServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -182,7 +182,7 @@ jobs:
           awsOpenSearchDomain: ${{ secrets.AWS_OPENSEARCH_DOMAIN }}
           awsOpenSearchUsers: ${{ secrets.AWS_OPENSEARCH_USER }}
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
-          selfManagedInfra: "false"
+          clusterCreation: "cli"
 
       - name: Build CLI
         uses: ./.github/actions/build_cli
@@ -288,7 +288,7 @@ jobs:
         uses: ./.github/actions/constellation_destroy
         with:
           kubeconfig: ${{ steps.e2e_test.outputs.kubeconfig }}
-          selfManagedInfra: "false"
+          clusterCreation: "cli"
           cloudProvider: ${{ inputs.cloudProvider }}
           azureClusterDeleteCredentials: ${{ secrets.AZURE_E2E_CLUSTER_CREDENTIALS }}
           gcpClusterDeleteServiceAccount: "infrastructure-e2e@constellation-e2e.iam.gserviceaccount.com"

--- a/debugd/internal/debugd/logcollector/fields.go
+++ b/debugd/internal/debugd/logcollector/fields.go
@@ -35,7 +35,7 @@ var (
 		"github.e2e-test-provider":  {},
 		"github.ref-stream":         {},
 		"github.kubernetes-version": {},
-		"github.self-managed-infra": {},
+		"github.cluster-creation":   {},
 		"deployment-type":           {}, // deployment type, e.g. "debugd", "k8s"
 	}
 )

--- a/terraform-provider-constellation/docs/data-sources/attestation.md
+++ b/terraform-provider-constellation/docs/data-sources/attestation.md
@@ -36,6 +36,7 @@ See the [full list of CSPs](https://docs.edgeless.systems/constellation/overview
 ### Optional
 
 - `image_version` (String) The image version to use. If not set, the provider version value is used.
+- `insecure` (Boolean) DON'T USE IN PRODUCTION Skip the signature verification when fetching measurements for the image.
 - `maa_url` (String) For Azure only, the URL of the Microsoft Azure Attestation service
 
 ### Read-Only


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
We want to test our Terraform provider the same way we test the CLI.
Instead of writing new test, we want to adapt the existing tests to allow creation of the Constellation cluster using Terraform.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a new GitHub workflow: Terraform e2e test
  - Same as manual e2e test (or self-managed-infra e2e test), but uses Terraform for cluster initialization
  - Uses the same e2e test template as other tests, which allows us to easily add Terraform provider tests to daily/weekly test runs

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3547](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3547)
- [quick e2e test](https://github.com/edgelesssys/constellation/actions/runs/7195061381)
- [e2e gcp](https://github.com/edgelesssys/constellation/actions/runs/7195429715)
- [e2e azure](https://github.com/edgelesssys/constellation/actions/runs/7195431527)
- [e2e aws](https://github.com/edgelesssys/constellation/actions/runs/7196873735)

