### PR TITLE
bazel: place Terraform provider binaries in local registry path on devbuild

### DIFF
--- a/bazel/devbuild/BUILD.bazel
+++ b/bazel/devbuild/BUILD.bazel
@@ -6,6 +6,7 @@ sh_template(
     data = [
         ":devbuild_cli_edition",
         "//bazel/release:container_sums",
+        "//bazel/settings:tag",
         "//bootstrapper/cmd/bootstrapper:bootstrapper_patched",
         "//cli:cli_edition_host",
         "//debugd/cmd/cdbg:cdbg_host",
@@ -25,8 +26,23 @@ sh_template(
         "@@TERRAFORM_PROVIDER@@": "$(rootpath //terraform-provider-constellation:tf_provider)",
         "@@TERRAFORM_RC@@": "$(rootpath //terraform-provider-constellation:terraform_rc)",
         "@@UPGRADE_AGENT@@": "$(rootpath //upgrade-agent/cmd:upgrade_agent_linux_amd64)",
+        "@@VERSION_FILE@@": "$(rootpath //bazel/settings:tag)",
         "@@YQ@@": "$(rootpath @yq_toolchains//:resolved_toolchain)",
-    },
+    } | select({
+        "@platforms//os:linux": {
+            "@@GOOS@@": "linux",
+        },
+        "@platforms//os:macos": {
+            "@@GOOS@@": "darwin",
+        },
+    }) | select({
+        "@platforms//cpu:arm64": {
+            "@@GOARCH@@": "arm64",
+        },
+        "@platforms//cpu:x86_64": {
+            "@@GOARCH@@": "amd64",
+        },
+    }),
     template = "prepare_developer_workspace.sh.in",
     visibility = ["//visibility:public"],
 )

--- a/bazel/devbuild/prepare_developer_workspace.sh.in
+++ b/bazel/devbuild/prepare_developer_workspace.sh.in
@@ -14,6 +14,15 @@ if ! source "${lib}"; then
   exit 1
 fi
 
+if [[ ${BUILD_WORKSPACE_DIRECTORY} == "${BUILD_WORKING_DIRECTORY}" ]]; then
+  echo "Error: You are trying to run a devbuild in the project root directory."
+  echo "You probably want to run it in a subdirectory instead:"
+  echo "mkdir -p build && cd build && bazel run //:devbuild"
+  exit 1
+fi
+
+goos=@@GOOS@@
+goarch=@@GOARCH@@
 yq=$(realpath @@YQ@@)
 stat "${yq}" >> /dev/null
 sed=$(realpath @@SED@@)
@@ -31,8 +40,11 @@ stat "${container_sums}" >> /dev/null
 edition=$(cat @@EDITION@@)
 terraform_provider=$(realpath @@TERRAFORM_PROVIDER@@)
 stat "${terraform_provider}" >> /dev/null
-terraform_rc=$(realpath @@TERRAFORM_RC@@)
-stat "${terraform_rc}" >> /dev/null
+build_version=$(cat @@VERSION_FILE@@)
+if [[ -z ${build_version} ]]; then
+  echo "Error: version file is empty"
+  exit 1
+fi
 
 cd "${BUILD_WORKING_DIRECTORY}"
 
@@ -68,13 +80,10 @@ ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${cdbg}")" "${workd
 ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${container_sums}")" "${workdir}/container_sums.sha256"
 ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${cli}")" "${workdir}/constellation"
 
-TF_PROVIDER_DIR="${workdir}/terraform"
-mkdir -p "${TF_PROVIDER_DIR}"
-ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${terraform_provider}")" "${TF_PROVIDER_DIR}/terraform-provider-constellation"
-cp "$(replace_prefix "${host_cache}" "${builder_cache}" "${terraform_rc}")" "${TF_PROVIDER_DIR}/config.tfrc"
-${sed} -i "s|@@TERRAFORM_PROVIDER_PATH@@|$(dirname "${terraform_provider}")|g" "${TF_PROVIDER_DIR}/config.tfrc"
+terraform_provider_dir=${HOME}/.terraform.d/plugins/registry.terraform.io/edgelesssys/constellation/${build_version#v}/${goos}_${goarch}/
+mkdir -p "${terraform_provider_dir}"
+ln -sf "${terraform_provider}" "${terraform_provider_dir}/terraform-provider-constellation_${build_version}"
 
-build_version=$("${cli}" version | grep ^Version: | awk '{print $2}')
 if [[ ! -f "${workdir}/constellation-conf.yaml" ]]; then
   echo "constellation-conf.yaml not present in workspace"
   echo "Build version: ${build_version}"

--- a/dev-docs/workflows/terraform-provider.md
+++ b/dev-docs/workflows/terraform-provider.md
@@ -21,9 +21,24 @@ bazel run //bazel/ci:terraform_docgen
 
 ## Using the Terraform Provider
 
-The Terraform provider binary can be used with the normal Terraform CLI, by setting a [development override](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers),
-so that the registry path to the provider is replaced with the path to the locally built provider. If using the [`devbuild` target](./build-develop-deploy.md), a `config.tfrc` file with the override set to the path
-of the built binary is placed automatically in the `terraform` directory in the current working directory. Otherwise, the file can be also built and copied to the current working directory explicitly via this command:
+If using the [`devbuild` target](./build-develop-deploy.md), the Terraform provider binary is automatically copied to your local registry cache
+at `${HOME}/.terraform.d/plugins/registry.terraform.io/edgelesssys/constellation/<version>/<os>_<arch>/`.
+After running `devbuild`, you can use the provider by simply adding the following to your Terraform configuration:
+
+```hcl
+terraform {
+  required_providers {
+    constellation = {
+      source = "edgelesssys/constellation"
+      version = "<version>"
+    }
+  }
+}
+```
+
+Alternatively, you can configure Terraform to use your binary by setting a [development override](https://developer.hashicorp.com/terraform/cli/config/config-file#development-overrides-for-provider-developers),
+so that the registry path to the provider is replaced with the path to the locally built provider.
+A `config.tfrc` file containing the necessary configuration can be created with the following commands:
 
 ```bash
 bazel build //terraform-provider-constellation:terraform_rc


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Thought I would move this to its own PR since we have multiple PRs depending on it now.

The `devbuild` target currently creates a config file that can be used as `.terraformrc` which overrides the provider when running Terraform commands with a local path.
However, this does not work when the provider is not available in the registry at all and one needs to run `terraform init` to initializes provides others than the Constellation provider.
Which is the case for use currently, and probably will always be when working on pseudo versions.

Instead, we can simply place the provider binary (or a symlink to it) in the local registry cache.
That way, Terraform will see the binary is already downloaded and will skip looking for it in the registry.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Update Bazel `devbuild` target to automatically place provider binaries in local registry path (`~/.terraform.d/plugins/registry.terraform.io/edglesssys/<version>/<os>_<arch>/<binary>`) to allow for easier testing
  - This makes `.terraformrc` files obsolete
  - provider binaries placed into the local registry are just links to the actual binary in your bazel cache, so they don't take up much space
- Throw an error when trying to run `bazel run //:devbuild` in the project root

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->
