### PR TITLE
terraform: use correct security group option for jump host

### DIFF
--- a/terraform/infrastructure/aws/main.tf
+++ b/terraform/infrastructure/aws/main.tf
@@ -218,7 +218,7 @@ module "jump_host" {
   lb_internal_ip       = aws_lb.front_end.dns_name
   ports                = [for port in local.load_balancer_ports : port.port]
   iam_instance_profile = var.iam_instance_profile_worker_nodes
-  security_group_id    = aws_security_group.security_group.id
+  security_groups      = [aws_security_group.security_group.id]
 }
 
 # TODO(31u3r): Remove once 2.12 is released

--- a/terraform/infrastructure/aws/modules/jump_host/main.tf
+++ b/terraform/infrastructure/aws/modules/jump_host/main.tf
@@ -23,9 +23,9 @@ resource "aws_instance" "jump_host" {
   instance_type               = "c5a.large"
   associate_public_ip_address = true
 
-  iam_instance_profile = var.iam_instance_profile
-  subnet_id            = var.subnet_id
-  security_groups      = [var.security_group_id]
+  iam_instance_profile   = var.iam_instance_profile
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = var.security_groups
 
   tags = {
     "Name" = "${var.base_name}-jump-host"

--- a/terraform/infrastructure/aws/modules/jump_host/variables.tf
+++ b/terraform/infrastructure/aws/modules/jump_host/variables.tf
@@ -23,7 +23,7 @@ variable "ports" {
   type        = list(number)
 }
 
-variable "security_group_id" {
-  description = "Security group to attach to the jump host"
-  type        = string
+variable "security_groups" {
+  type        = list(string)
+  description = "List of IDs of the security groups for an instance."
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Align security group naming for jump host
- use `vpc_security_group_ids` to set the security group since this is the correct setting (cf: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#security_groups)

Otherwise on every `constellation apply` the are terraform changes which are applied, forcing the re-creating of the jump host.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- Any additional information or context

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
