### PR TITLE
cli: fix upgrades when using outdated Kubernetes patch version

### DIFF
--- a/internal/versions/components/BUILD.bazel
+++ b/internal/versions/components/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("//bazel/go:go_test.bzl", "go_test")
 load("//bazel/proto:rules.bzl", "write_go_proto_srcs")
 
 go_library(
@@ -29,4 +30,14 @@ write_go_proto_srcs(
     src = "components.pb.go",
     go_proto_library = ":components_go_proto",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "components_test",
+    srcs = ["components_test.go"],
+    embed = [":components"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/internal/versions/components/components.go
+++ b/internal/versions/components/components.go
@@ -8,6 +8,7 @@ package components
 
 import (
 	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -15,6 +16,53 @@ import (
 
 // Components is a list of Kubernetes components.
 type Components []*Component
+
+type legacyComponent struct {
+	URL         string `json:"URL,omitempty"`
+	Hash        string `json:"Hash,omitempty"`
+	InstallPath string `json:"InstallPath,omitempty"`
+	Extract     bool   `json:"Extract,omitempty"`
+}
+
+// UnmarshalJSON implements a custom JSON unmarshaler to ensure backwards compatibility
+// with older components lists which had a different format for all keys.
+func (c *Components) UnmarshalJSON(b []byte) error {
+	var legacyComponents []*legacyComponent
+	if err := json.Unmarshal(b, &legacyComponents); err != nil {
+		return err
+	}
+	var components []*Component
+	if err := json.Unmarshal(b, &components); err != nil {
+		return err
+	}
+
+	if len(legacyComponents) != len(components) {
+		return errors.New("failed to unmarshal data: inconsistent number of components in list") // just a check, should never happen
+	}
+
+	// If a value is not set in the new format,
+	// it might have been set in the old format.
+	// In this case, we copy the value from the old format.
+	comps := make(Components, len(components))
+	for idx := 0; idx < len(components); idx++ {
+		comps[idx] = components[idx]
+		if comps[idx].Url == "" {
+			comps[idx].Url = legacyComponents[idx].URL
+		}
+		if comps[idx].Hash == "" {
+			comps[idx].Hash = legacyComponents[idx].Hash
+		}
+		if comps[idx].InstallPath == "" {
+			comps[idx].InstallPath = legacyComponents[idx].InstallPath
+		}
+		if !comps[idx].Extract {
+			comps[idx].Extract = legacyComponents[idx].Extract
+		}
+	}
+
+	*c = comps
+	return nil
+}
 
 // GetHash returns the hash over all component hashes.
 func (c Components) GetHash() string {

--- a/internal/versions/components/components_test.go
+++ b/internal/versions/components/components_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
+package components
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUnmarshalComponents(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	legacyFormat := `[{"URL":"https://example.com/foo.tar.gz","Hash":"1234567890","InstallPath":"/foo","Extract":true}]`
+	newFormat := `[{"url":"https://example.com/foo.tar.gz","hash":"1234567890","install_path":"/foo","extract":true}]`
+
+	var fromLegacy Components
+	require.NoError(json.Unmarshal([]byte(legacyFormat), &fromLegacy))
+
+	var fromNew Components
+	require.NoError(json.Unmarshal([]byte(newFormat), &fromNew))
+
+	assert.Equal(fromLegacy, fromNew)
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Users may choose to not upgrade their Kubernetes version when running a Constellation upgrade.
This includes not upgrading a patch version of Kubernetes.
We use the Kubernetes version set in a user's config to determine which image to use for the Constellation deployed cloud-controller-manager and cluster-autoscaler.
Currently, the CLI incorrectly sets the k8s version to an empty string if a user chooses to apply an upgrade with a no longer supported Kubernetes patch version.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix the issue by translating an outdated user's Kubernetes version to a currently supported Kubernetes version
  - Kubernetes upgrades are still skipped
  - This version is only used to determine which image to use for the cloud-controller-manager and cluster-autoscaler. Both of which are independent of the Kubernetes patch version

### Additional info
- [e2e test targeting Kubernetes v1.27.7](https://github.com/edgelesssys/constellation/actions/runs/7222740237)