### PR TITLE
cilium: enable bpf masquerading

### DIFF
--- a/internal/constellation/helm/overrides.go
+++ b/internal/constellation/helm/overrides.go
@@ -59,6 +59,12 @@ func extraCiliumValues(provider cloudprovider.Provider, conformanceMode bool, ou
 	extraVals["encryption"] = map[string]any{
 		"strictMode": strictMode,
 	}
+	extraVals["ipMasqAgent"] = map[string]any{
+		"config": map[string]any{
+			"nonMasqueradeCIDRs": []string{output.IPCidrNode},
+		},
+	}
+
 	return extraVals
 }
 

--- a/internal/constellation/helm/values.go
+++ b/internal/constellation/helm/values.go
@@ -52,6 +52,12 @@ var ciliumVals = map[string]map[string]any{
 		"bpf": map[string]any{
 			"masquerade": true,
 		},
+		"ipMasqAgent": map[string]any{
+			"enabled": true,
+			"config": map[string]any{
+				"masqLinkLocal": true,
+			},
+		},
 		"kubeProxyReplacement":                "strict",
 		"enableCiliumEndpointSlice":           true,
 		"kubeProxyReplacementHealthzBindAddr": "0.0.0.0:10256",
@@ -98,6 +104,12 @@ var ciliumVals = map[string]map[string]any{
 		"bpf": map[string]any{
 			"masquerade": true,
 		},
+		"ipMasqAgent": map[string]any{
+			"enabled": true,
+			"config": map[string]any{
+				"masqLinkLocal": true,
+			},
+		},
 		"egressMasqueradeInterfaces":          "eth0",
 		"enableIPv4Masquerade":                true,
 		"kubeProxyReplacement":                "strict",
@@ -141,6 +153,12 @@ var ciliumVals = map[string]map[string]any{
 		},
 		"bpf": map[string]any{
 			"masquerade": true,
+		},
+		"ipMasqAgent": map[string]any{
+			"enabled": true,
+			"config": map[string]any{
+				"masqLinkLocal": true,
+			},
 		},
 		"kubeProxyReplacement":                "strict",
 		"enableCiliumEndpointSlice":           true,
@@ -187,6 +205,12 @@ var ciliumVals = map[string]map[string]any{
 		"bpf": map[string]any{
 			"masquerade": true,
 		},
+		"ipMasqAgent": map[string]any{
+			"enabled": true,
+			"config": map[string]any{
+				"masqLinkLocal": true,
+			},
+		},
 		"kubeProxyReplacement":                "strict",
 		"enableCiliumEndpointSlice":           true,
 		"kubeProxyReplacementHealthzBindAddr": "0.0.0.0:10256",
@@ -229,6 +253,12 @@ var ciliumVals = map[string]map[string]any{
 		},
 		"bpf": map[string]any{
 			"masquerade": true,
+		},
+		"ipMasqAgent": map[string]any{
+			"enabled": true,
+			"config": map[string]any{
+				"masqLinkLocal": true,
+			},
 		},
 		"kubeProxyReplacement":                "strict",
 		"enableCiliumEndpointSlice":           true,

--- a/internal/constellation/helm/values.go
+++ b/internal/constellation/helm/values.go
@@ -110,8 +110,6 @@ var ciliumVals = map[string]map[string]any{
 				"masqLinkLocal": true,
 			},
 		},
-		"egressMasqueradeInterfaces":          "eth0",
-		"enableIPv4Masquerade":                true,
 		"kubeProxyReplacement":                "strict",
 		"enableCiliumEndpointSlice":           true,
 		"kubeProxyReplacementHealthzBindAddr": "0.0.0.0:10256",

--- a/internal/constellation/helm/values.go
+++ b/internal/constellation/helm/values.go
@@ -49,6 +49,9 @@ var ciliumVals = map[string]map[string]any{
 				"useDigest":     true,
 			},
 		},
+		"bpf": map[string]any{
+			"masquerade": true,
+		},
 		"kubeProxyReplacement":                "strict",
 		"enableCiliumEndpointSlice":           true,
 		"kubeProxyReplacementHealthzBindAddr": "0.0.0.0:10256",
@@ -92,6 +95,9 @@ var ciliumVals = map[string]map[string]any{
 				"useDigest":     true,
 			},
 		},
+		"bpf": map[string]any{
+			"masquerade": true,
+		},
 		"egressMasqueradeInterfaces":          "eth0",
 		"enableIPv4Masquerade":                true,
 		"kubeProxyReplacement":                "strict",
@@ -132,6 +138,9 @@ var ciliumVals = map[string]map[string]any{
 		"l7Proxy": false,
 		"ipam": map[string]any{
 			"mode": "kubernetes",
+		},
+		"bpf": map[string]any{
+			"masquerade": true,
 		},
 		"kubeProxyReplacement":                "strict",
 		"enableCiliumEndpointSlice":           true,
@@ -175,6 +184,9 @@ var ciliumVals = map[string]map[string]any{
 				"useDigest":     true,
 			},
 		},
+		"bpf": map[string]any{
+			"masquerade": true,
+		},
 		"kubeProxyReplacement":                "strict",
 		"enableCiliumEndpointSlice":           true,
 		"kubeProxyReplacementHealthzBindAddr": "0.0.0.0:10256",
@@ -214,6 +226,9 @@ var ciliumVals = map[string]map[string]any{
 					"10.244.0.0/16",
 				},
 			},
+		},
+		"bpf": map[string]any{
+			"masquerade": true,
 		},
 		"kubeProxyReplacement":                "strict",
 		"enableCiliumEndpointSlice":           true,


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Enable Cilium bpf masquerading in order to be able to configure masquerading through a configmap (see: https://docs.cilium.io/en/stable/network/concepts/masquerading/#ebpf-based)

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
This also enables full eBPF host routing:
Before:
```
root@fedora:/home/cilium# cilium status
KVStore:                 Ok   Disabled
Kubernetes:              Ok   1.28 (v1.28.3) [linux/amd64]
Kubernetes APIs:         ["cilium/v2::CiliumClusterwideNetworkPolicy", "cilium/v2::CiliumNetworkPolicy", "cilium/v2::CiliumNode", "cilium/v2alpha1::CiliumEndpointSlice", "core/v1::Namespace", "core/v1::Node", "core/v1::Pods", "core/v1::Service", "discovery/v1::EndpointSlice", "networking.k8s.io/v1::NetworkPolicy"]
KubeProxyReplacement:    Strict   [eth0 10.9.0.6]
Host firewall:           Disabled
CNI Chaining:            none
Cilium:                  Ok   1.12.1 (v1.12.1-d465085df1)
NodeMonitor:             Listening for events on 4 CPUs with 64x4096 of shared memory
Cilium health daemon:    Ok
IPAM:                    IPv4: 19/254 allocated from 10.244.0.0/24,
BandwidthManager:        Disabled
Host Routing:            Legacy
Masquerading:            IPTables [IPv4: Enabled, IPv6: Disabled]
Controller Status:       89/89 healthy
Proxy Status:            No managed proxy redirect
Global Identity Range:   min 256, max 65535
Hubble:                  Ok              Current/Max Flows: 3040/4095 (74.24%), Flows/s: 28.02   Metrics: Disabled
Encryption:              Wireguard       [cilium_wg0 (Pubkey: Y9fUb7bOQKvO9HgMxgttq0AOwnp10fVohMqAFrf7rSc=, Port: 51871, Peers: 0)]
Cluster health:          1/1 reachable   (2023-12-15T13:23:03Z)
```

After:
```
root@fedora:/home/cilium# cilium status
KVStore:                 Ok   Disabled
Kubernetes:              Ok   1.28 (v1.28.4) [linux/amd64]
Kubernetes APIs:         ["EndpointSliceOrEndpoint", "cilium/v2::CiliumClusterwideNetworkPolicy", "cilium/v2::CiliumNetworkPolicy", "cilium/v2::CiliumNode", "cilium/v2alpha1::CiliumCIDRGroup", "cilium/v2alpha1::CiliumEndpointSlice", "core/v1::Namespace", "core/v1::Pods", "core/v1::Service", "networking.k8s.io/v1::NetworkPolicy"]
KubeProxyReplacement:    Strict   [ens3 192.168.178.3 (Direct Routing), cilium_wg0 ]
Host firewall:           Disabled
CNI Chaining:            none
Cilium:                  Ok   1.15.0-pre.2 (v1.15.0-pre.2-0f91509967)
NodeMonitor:             Listening for events on 4 CPUs with 64x4096 of shared memory
Cilium health daemon:    Ok
IPAM:                    IPv4: 9/254 allocated from 10.10.3.0/24,
IPv4 BIG TCP:            Disabled
IPv6 BIG TCP:            Disabled
BandwidthManager:        Disabled
Host Routing:            BPF
Masquerading:            BPF (ip-masq-agent)   [ens3, cilium_wg0]   10.10.0.0/16 [IPv4: Enabled, IPv6: Disabled]
Controller Status:       47/47 healthy
Proxy Status:            No managed proxy redirect
Global Identity Range:   min 256, max 65535
Hubble:                  Ok              Current/Max Flows: 4095/4095 (100.00%), Flows/s: 47.66   Metrics: Disabled
Encryption:              Wireguard       [NodeEncryption: Enabled, cilium_wg0 (Pubkey: NQsZTCE7Z3/MA7jPNdRdaOPttZkVF+aUaijiEdd+2ww=, Port: 51871, Peers: 3)]
Cluster health:          4/4 reachable   (2023-12-15T13:28:37Z)
Modules Health:          Stopped(0) Degraded(0) OK(6) Unknown(1)
```

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
