### PR TITLE
terraform-provider: unify image in-/output

### DIFF
--- a/.github/actions/terraform_apply/action.yml
+++ b/.github/actions/terraform_apply/action.yml
@@ -64,7 +64,7 @@ runs:
         }
 
         data "constellation_image" "con_image" {
-          image_version       = "$(yq '.image' constellation-conf.yaml)"
+          version             = "$(yq '.image' constellation-conf.yaml)"
           attestation_variant = "${attestationVariant}"
           csp                 = "${{ inputs.cloudProvider }}"
           region              = "$(yq '.provider.aws.region' constellation-conf.yaml)"

--- a/.github/actions/terraform_apply/action.yml
+++ b/.github/actions/terraform_apply/action.yml
@@ -58,7 +58,7 @@ runs:
         data "constellation_attestation" "con_attestation" {
           csp                 = "${{ inputs.cloudProvider }}"
           attestation_variant = "${attestationVariant}"
-          image_version       = "$(yq '.image' constellation-conf.yaml)"
+          image               = data.constellation_image.con_image.image
           maa_url             = "$(yq '.infrastructure.azure.attestationURL' constellation-state.yaml)"
           insecure            = true
         }
@@ -75,8 +75,7 @@ runs:
           constellation_microservice_version = "$(yq '.microserviceVersion' constellation-conf.yaml)"
           name                               = "$(yq '.name' constellation-conf.yaml)"
           uid                                = "$(yq '.infrastructure.uid' constellation-state.yaml)"
-          image_reference                    = data.constellation_image.con_image.reference
-          image_version                      = "$(yq '.microserviceVersion' constellation-conf.yaml)"
+          image                              = data.constellation_image.con_image.image
           attestation                        = data.constellation_attestation.con_attestation.attestation
           init_secret                        = "$(yq '.infrastructure.initSecret' constellation-state.yaml | xxd -r -p)"
           master_secret                      = random_bytes.master_secret.hex

--- a/terraform-provider-constellation/docs/data-sources/attestation.md
+++ b/terraform-provider-constellation/docs/data-sources/attestation.md
@@ -48,8 +48,11 @@ See the [full list of CSPs](https://docs.edgeless.systems/constellation/overview
 
 Required:
 
-- `reference` (String) CSP-specific unique reference to the image.
-- `short_path` (String) CSP-agnostic short path to the image.
+- `reference` (String) CSP-specific unique reference to the image. The format differs per CSP.
+- `short_path` (String) CSP-agnostic short path to the image. The format is `vX.Y.Z` for release images and `ref/$GIT_REF/stream/$STREAM/$SEMANTIC_VERSION` for pre-release images.
+- `$GIT_REF` is the git reference (i.e. branch name) the image was built on, e.g. `main`.
+- `$STREAM` is the stream the image was built on, e.g. `nightly`.
+- `$SEMANTIC_VERSION` is the semantic version of the image, e.g. `vX.Y.Z` or `vX.Y.Z-pre...`.
 - `version` (String) Semantic version of the image.
 
 

--- a/terraform-provider-constellation/docs/data-sources/attestation.md
+++ b/terraform-provider-constellation/docs/data-sources/attestation.md
@@ -36,7 +36,6 @@ See the [full list of CSPs](https://docs.edgeless.systems/constellation/overview
 
 ### Optional
 
-- `image_version` (String) The image version to use. If not set, the provider version value is used.
 - `insecure` (Boolean) DON'T USE IN PRODUCTION Skip the signature verification when fetching measurements for the image.
 - `maa_url` (String) For Azure only, the URL of the Microsoft Azure Attestation service
 

--- a/terraform-provider-constellation/docs/data-sources/attestation.md
+++ b/terraform-provider-constellation/docs/data-sources/attestation.md
@@ -32,6 +32,7 @@ data "constellation_attestation" "test" {
   * `gcp-sev-es`
 - `csp` (String) CSP (Cloud Service Provider) to use. (e.g. `azure`)
 See the [full list of CSPs](https://docs.edgeless.systems/constellation/overview/clouds) that Constellation supports.
+- `image` (Attributes) Constellation OS Image to use on the nodes. (see [below for nested schema](#nestedatt--image))
 
 ### Optional
 
@@ -42,6 +43,16 @@ See the [full list of CSPs](https://docs.edgeless.systems/constellation/overview
 ### Read-Only
 
 - `attestation` (Attributes) Attestation comprises the measurements and SEV-SNP specific parameters. (see [below for nested schema](#nestedatt--attestation))
+
+<a id="nestedatt--image"></a>
+### Nested Schema for `image`
+
+Required:
+
+- `reference` (String) CSP-specific unique reference to the image.
+- `short_path` (String) CSP-agnostic short path to the image.
+- `version` (String) Semantic version of the image.
+
 
 <a id="nestedatt--attestation"></a>
 ### Nested Schema for `attestation`

--- a/terraform-provider-constellation/docs/data-sources/image.md
+++ b/terraform-provider-constellation/docs/data-sources/image.md
@@ -36,11 +36,20 @@ See the [full list of CSPs](https://docs.edgeless.systems/constellation/overview
 
 ### Optional
 
-- `image_version` (String) Version of the Constellation OS image to use. (e.g. `v2.13.0`). If not set, the provider version value is used.
 - `marketplace_image` (Boolean) Whether a marketplace image should be used. Currently only supported for Azure.
 - `region` (String) Region to retrieve the image for. Only required for AWS.
 The Constellation OS image must be [replicated to the region](https://docs.edgeless.systems/constellation/workflows/config),and the region must [support AMD SEV-SNP](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snp-requirements.html), if it is used for Attestation.
+- `version` (String) Version of the Constellation OS image to use. (e.g. `v2.13.0`). If not set, the provider version value is used.
 
 ### Read-Only
 
-- `reference` (String) CSP-specific reference to the image.
+- `image` (Attributes) Constellation OS Image to use on the nodes. (see [below for nested schema](#nestedatt--image))
+
+<a id="nestedatt--image"></a>
+### Nested Schema for `image`
+
+Read-Only:
+
+- `reference` (String) CSP-specific unique reference to the image.
+- `short_path` (String) CSP-agnostic short path to the image.
+- `version` (String) Semantic version of the image.

--- a/terraform-provider-constellation/docs/data-sources/image.md
+++ b/terraform-provider-constellation/docs/data-sources/image.md
@@ -50,6 +50,9 @@ The Constellation OS image must be [replicated to the region](https://docs.edgel
 
 Read-Only:
 
-- `reference` (String) CSP-specific unique reference to the image.
-- `short_path` (String) CSP-agnostic short path to the image.
+- `reference` (String) CSP-specific unique reference to the image. The format differs per CSP.
+- `short_path` (String) CSP-agnostic short path to the image. The format is `vX.Y.Z` for release images and `ref/$GIT_REF/stream/$STREAM/$SEMANTIC_VERSION` for pre-release images.
+- `$GIT_REF` is the git reference (i.e. branch name) the image was built on, e.g. `main`.
+- `$STREAM` is the stream the image was built on, e.g. `nightly`.
+- `$SEMANTIC_VERSION` is the semantic version of the image, e.g. `vX.Y.Z` or `vX.Y.Z-pre...`.
 - `version` (String) Semantic version of the image.

--- a/terraform-provider-constellation/docs/resources/cluster.md
+++ b/terraform-provider-constellation/docs/resources/cluster.md
@@ -137,8 +137,11 @@ Optional:
 
 Required:
 
-- `reference` (String) CSP-specific unique reference to the image.
-- `short_path` (String) CSP-agnostic short path to the image.
+- `reference` (String) CSP-specific unique reference to the image. The format differs per CSP.
+- `short_path` (String) CSP-agnostic short path to the image. The format is `vX.Y.Z` for release images and `ref/$GIT_REF/stream/$STREAM/$SEMANTIC_VERSION` for pre-release images.
+- `$GIT_REF` is the git reference (i.e. branch name) the image was built on, e.g. `main`.
+- `$STREAM` is the stream the image was built on, e.g. `nightly`.
+- `$SEMANTIC_VERSION` is the semantic version of the image, e.g. `vX.Y.Z` or `vX.Y.Z-pre...`.
 - `version` (String) Semantic version of the image.
 
 

--- a/terraform-provider-constellation/docs/resources/cluster.md
+++ b/terraform-provider-constellation/docs/resources/cluster.md
@@ -66,8 +66,7 @@ resource "constellation_cluster" "azure_example" {
 
 - `attestation` (Attributes) Attestation comprises the measurements and SEV-SNP specific parameters. The output of the [constellation_attestation](../data-sources/attestation.md) data source provides sensible defaults. (see [below for nested schema](#nestedatt--attestation))
 - `csp` (String) The Cloud Service Provider (CSP) the cluster should run on.
-- `image_reference` (String) Constellation OS image reference to use in the CSP specific reference format. Use the [`constellation_image`](../data-sources/image.md) data source to find the correct image reference for your CSP.
-- `image_version` (String) Constellation OS image version to use in the CSP specific reference format. Use the [`constellation_image`](../data-sources/image.md) data source to find the correct image version for your CSP.
+- `image` (Attributes) Constellation OS Image to use on the nodes. (see [below for nested schema](#nestedatt--image))
 - `init_secret` (String) Secret used for initialization of the cluster.
 - `master_secret` (String) Hex-encoded 32-byte master secret for the cluster.
 - `master_secret_salt` (String) Hex-encoded 32-byte master secret salt for the cluster.
@@ -90,7 +89,7 @@ resource "constellation_cluster" "azure_example" {
 ### Read-Only
 
 - `cluster_id` (String) The cluster ID of the cluster.
-- `kubeconfig` (String) The kubeconfig of the cluster.
+- `kubeconfig` (String, Sensitive) The kubeconfig of the cluster.
 - `owner_id` (String) The owner ID of the cluster.
 
 <a id="nestedatt--attestation"></a>
@@ -132,6 +131,16 @@ Optional:
 - `enforcement_policy` (String)
 - `maa_url` (String)
 
+
+
+<a id="nestedatt--image"></a>
+### Nested Schema for `image`
+
+Required:
+
+- `reference` (String) CSP-specific unique reference to the image.
+- `short_path` (String) CSP-agnostic short path to the image.
+- `version` (String) Semantic version of the image.
 
 
 <a id="nestedatt--network_config"></a>

--- a/terraform-provider-constellation/docs/resources/cluster.md
+++ b/terraform-provider-constellation/docs/resources/cluster.md
@@ -34,8 +34,7 @@ resource "constellation_cluster" "azure_example" {
   constellation_microservice_version = "vX.Y.Z"
   name                               = "constell"
   uid                                = "..."
-  image_version                      = "vX.Y.Z"
-  image_reference                    = data.constellation_image.bar.reference
+  image                              = data.constellation_image.bar.image
   attestation                        = data.constellation_attestation.foo.attestation
   init_secret                        = "..."
   master_secret                      = random_bytes.master_secret.hex

--- a/terraform-provider-constellation/examples/full/aws_cluster.tf
+++ b/terraform-provider-constellation/examples/full/aws_cluster.tf
@@ -67,7 +67,7 @@ module "aws_infrastructure" {
   }
   iam_instance_profile_name_worker_nodes  = module.aws_iam.iam_instance_profile_name_worker_nodes
   iam_instance_profile_name_control_plane = module.aws_iam.iam_instance_profile_name_control_plane
-  image_id                                = data.constellation_image.bar.reference
+  image_id                                = data.constellation_image.bar.image.reference
   region                                  = local.region
   zone                                    = local.zone
   debug                                   = false
@@ -78,13 +78,13 @@ module "aws_infrastructure" {
 data "constellation_attestation" "foo" {
   csp                 = local.csp
   attestation_variant = local.attestation_variant
-  image_version       = local.version
+  image               = data.constellation_image.bar.image
 }
 
 data "constellation_image" "bar" {
   csp                 = local.csp
   attestation_variant = local.attestation_variant
-  image_version       = local.version
+  version             = local.version
   region              = local.region
 }
 
@@ -93,8 +93,7 @@ resource "constellation_cluster" "aws_example" {
   constellation_microservice_version = local.version
   name                               = module.aws_infrastructure.name
   uid                                = module.aws_infrastructure.uid
-  image_version                      = local.version
-  image_reference                    = data.constellation_image.bar.reference
+  image                              = data.constellation_image.bar.image
   attestation                        = data.constellation_attestation.foo.attestation
   init_secret                        = module.aws_infrastructure.init_secret
   master_secret                      = local.master_secret

--- a/terraform-provider-constellation/examples/full/azure_cluster.tf
+++ b/terraform-provider-constellation/examples/full/azure_cluster.tf
@@ -65,7 +65,7 @@ module "azure_infrastructure" {
     }
   }
   location       = local.location
-  image_id       = data.constellation_image.bar.reference
+  image_id       = data.constellation_image.bar.image.reference
   resource_group = module.azure_iam.base_resource_group
   create_maa     = true
 }
@@ -73,14 +73,14 @@ module "azure_infrastructure" {
 data "constellation_attestation" "foo" {
   csp                 = local.csp
   attestation_variant = local.attestation_variant
-  image_version       = local.version
+  image               = data.constellation_image.bar.image
   maa_url             = module.azure_infrastructure.attestation_url
 }
 
 data "constellation_image" "bar" {
   csp                 = local.csp
   attestation_variant = local.attestation_variant
-  image_version       = local.version
+  version             = local.version
 }
 
 resource "constellation_cluster" "azure_example" {
@@ -88,8 +88,7 @@ resource "constellation_cluster" "azure_example" {
   constellation_microservice_version = local.version
   name                               = module.azure_infrastructure.name
   uid                                = module.azure_infrastructure.uid
-  image_version                      = local.version
-  image_reference                    = data.constellation_image.bar.reference
+  image                              = data.constellation_image.bar.image
   attestation                        = data.constellation_attestation.foo.attestation
   init_secret                        = module.azure_infrastructure.init_secret
   master_secret                      = local.master_secret

--- a/terraform-provider-constellation/examples/full/gcp_cluster.tf
+++ b/terraform-provider-constellation/examples/full/gcp_cluster.tf
@@ -68,7 +68,7 @@ module "gcp_infrastructure" {
       zone          = local.zone
     }
   }
-  image_id = data.constellation_image.bar.reference
+  image_id = data.constellation_image.bar.image.reference
   debug    = false
   zone     = local.zone
   region   = local.region
@@ -78,13 +78,13 @@ module "gcp_infrastructure" {
 data "constellation_attestation" "foo" {
   csp                 = local.csp
   attestation_variant = local.attestation_variant
-  image_version       = local.version
+  image               = data.constellation_image.bar.image
 }
 
 data "constellation_image" "bar" {
   csp                 = local.csp
   attestation_variant = local.attestation_variant
-  image_version       = local.version
+  version             = local.version
 }
 
 resource "constellation_cluster" "gcp_example" {
@@ -92,8 +92,7 @@ resource "constellation_cluster" "gcp_example" {
   constellation_microservice_version = local.version
   name                               = module.gcp_infrastructure.name
   uid                                = module.gcp_infrastructure.uid
-  image_version                      = local.version
-  image_reference                    = data.constellation_image.bar.reference
+  image                              = data.constellation_image.bar.image
   attestation                        = data.constellation_attestation.foo.attestation
   init_secret                        = module.gcp_infrastructure.init_secret
   master_secret                      = local.master_secret

--- a/terraform-provider-constellation/examples/resources/constellation_cluster/resource.tf
+++ b/terraform-provider-constellation/examples/resources/constellation_cluster/resource.tf
@@ -19,8 +19,7 @@ resource "constellation_cluster" "azure_example" {
   constellation_microservice_version = "vX.Y.Z"
   name                               = "constell"
   uid                                = "..."
-  image_version                      = "vX.Y.Z"
-  image_reference                    = data.constellation_image.bar.reference
+  image                              = data.constellation_image.bar.image
   attestation                        = data.constellation_attestation.foo.attestation
   init_secret                        = "..."
   master_secret                      = random_bytes.master_secret.hex

--- a/terraform-provider-constellation/internal/provider/BUILD.bazel
+++ b/terraform-provider-constellation/internal/provider/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     visibility = ["//terraform-provider-constellation:__subpackages__"],
     deps = [
         "//internal/api/attestationconfigapi",
+        "//internal/api/versionsapi",
         "//internal/atls",
         "//internal/attestation/choose",
         "//internal/attestation/idkeydigest",

--- a/terraform-provider-constellation/internal/provider/BUILD.bazel
+++ b/terraform-provider-constellation/internal/provider/BUILD.bazel
@@ -43,6 +43,8 @@ go_library(
         "@com_github_hashicorp_terraform_plugin_framework//provider/schema",
         "@com_github_hashicorp_terraform_plugin_framework//resource",
         "@com_github_hashicorp_terraform_plugin_framework//resource/schema",
+        "@com_github_hashicorp_terraform_plugin_framework//resource/schema/planmodifier",
+        "@com_github_hashicorp_terraform_plugin_framework//resource/schema/stringplanmodifier",
         "@com_github_hashicorp_terraform_plugin_framework//schema/validator",
         "@com_github_hashicorp_terraform_plugin_framework//types",
         "@com_github_hashicorp_terraform_plugin_framework//types/basetypes",

--- a/terraform-provider-constellation/internal/provider/attestation_data_source_test.go
+++ b/terraform-provider-constellation/internal/provider/attestation_data_source_test.go
@@ -17,32 +17,6 @@ func TestAccAttestationSource(t *testing.T) {
 	bazelPreCheck := func() { bazelSetTerraformBinaryPath(t) }
 
 	testCases := map[string]resource.TestCase{
-		"aws sev-snp succcess without explicit image_version": {
-			ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithVersion("v2.13.0"), // do this to test if a valid default version is set
-			PreCheck:                 bazelPreCheck,
-			Steps: []resource.TestStep{
-				{
-					Config: testingConfig + `
-					data "constellation_attestation" "test" {
-						csp = "aws"
-						attestation_variant = "aws-sev-snp"
-					}
-					`,
-					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("data.constellation_attestation.test", "attestation.variant", "aws-sev-snp"),
-
-						resource.TestCheckResourceAttr("data.constellation_attestation.test", "attestation.bootloader_version", "3"),
-						resource.TestCheckResourceAttr("data.constellation_attestation.test", "attestation.microcode_version", "209"),
-						resource.TestCheckResourceAttr("data.constellation_attestation.test", "attestation.snp_version", "20"),
-						resource.TestCheckResourceAttr("data.constellation_attestation.test", "attestation.tee_version", "0"),
-						resource.TestCheckResourceAttr("data.constellation_attestation.test", "attestation.amd_root_key", "\"-----BEGIN CERTIFICATE-----\\nMIIGYzCCBBKgAwIBAgIDAQAAMEYGCSqGSIb3DQEBCjA5oA8wDQYJYIZIAWUDBAIC\\nBQChHDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAICBQCiAwIBMKMDAgEBMHsxFDAS\\nBgNVBAsMC0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIGA1UEBwwLU2FudGEg\\nQ2xhcmExCzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNlZCBNaWNybyBEZXZp\\nY2VzMRIwEAYDVQQDDAlBUkstTWlsYW4wHhcNMjAxMDIyMTcyMzA1WhcNNDUxMDIy\\nMTcyMzA1WjB7MRQwEgYDVQQLDAtFbmdpbmVlcmluZzELMAkGA1UEBhMCVVMxFDAS\\nBgNVBAcMC1NhbnRhIENsYXJhMQswCQYDVQQIDAJDQTEfMB0GA1UECgwWQWR2YW5j\\nZWQgTWljcm8gRGV2aWNlczESMBAGA1UEAwwJQVJLLU1pbGFuMIICIjANBgkqhkiG\\n9w0BAQEFAAOCAg8AMIICCgKCAgEA0Ld52RJOdeiJlqK2JdsVmD7FktuotWwX1fNg\\nW41XY9Xz1HEhSUmhLz9Cu9DHRlvgJSNxbeYYsnJfvyjx1MfU0V5tkKiU1EesNFta\\n1kTA0szNisdYc9isqk7mXT5+KfGRbfc4V/9zRIcE8jlHN61S1ju8X93+6dxDUrG2\\nSzxqJ4BhqyYmUDruPXJSX4vUc01P7j98MpqOS95rORdGHeI52Naz5m2B+O+vjsC0\\n60d37jY9LFeuOP4Meri8qgfi2S5kKqg/aF6aPtuAZQVR7u3KFYXP59XmJgtcog05\\ngmI0T/OitLhuzVvpZcLph0odh/1IPXqx3+MnjD97A7fXpqGd/y8KxX7jksTEzAOg\\nbKAeam3lm+3yKIcTYMlsRMXPcjNbIvmsBykD//xSniusuHBkgnlENEWx1UcbQQrs\\n+gVDkuVPhsnzIRNgYvM48Y+7LGiJYnrmE8xcrexekBxrva2V9TJQqnN3Q53kt5vi\\nQi3+gCfmkwC0F0tirIZbLkXPrPwzZ0M9eNxhIySb2npJfgnqz55I0u33wh4r0ZNQ\\neTGfw03MBUtyuzGesGkcw+loqMaq1qR4tjGbPYxCvpCq7+OgpCCoMNit2uLo9M18\\nfHz10lOMT8nWAUvRZFzteXCm+7PHdYPlmQwUw3LvenJ/ILXoQPHfbkH0CyPfhl1j\\nWhJFZasCAwEAAaN+MHwwDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBSFrBrRQ/fI\\nrFXUxR1BSKvVeErUUzAPBgNVHRMBAf8EBTADAQH/MDoGA1UdHwQzMDEwL6AtoCuG\\nKWh0dHBzOi8va2RzaW50Zi5hbWQuY29tL3ZjZWsvdjEvTWlsYW4vY3JsMEYGCSqG\\nSIb3DQEBCjA5oA8wDQYJYIZIAWUDBAICBQChHDAaBgkqhkiG9w0BAQgwDQYJYIZI\\nAWUDBAICBQCiAwIBMKMDAgEBA4ICAQC6m0kDp6zv4Ojfgy+zleehsx6ol0ocgVel\\nETobpx+EuCsqVFRPK1jZ1sp/lyd9+0fQ0r66n7kagRk4Ca39g66WGTJMeJdqYriw\\nSTjjDCKVPSesWXYPVAyDhmP5n2v+BYipZWhpvqpaiO+EGK5IBP+578QeW/sSokrK\\ndHaLAxG2LhZxj9aF73fqC7OAJZ5aPonw4RE299FVarh1Tx2eT3wSgkDgutCTB1Yq\\nzT5DuwvAe+co2CIVIzMDamYuSFjPN0BCgojl7V+bTou7dMsqIu/TW/rPCX9/EUcp\\nKGKqPQ3P+N9r1hjEFY1plBg93t53OOo49GNI+V1zvXPLI6xIFVsh+mto2RtgEX/e\\npmMKTNN6psW88qg7c1hTWtN6MbRuQ0vm+O+/2tKBF2h8THb94OvvHHoFDpbCELlq\\nHnIYhxy0YKXGyaW1NjfULxrrmxVW4wcn5E8GddmvNa6yYm8scJagEi13mhGu4Jqh\\n3QU3sf8iUSUr09xQDwHtOQUVIqx4maBZPBtSMf+qUDtjXSSq8lfWcd8bLr9mdsUn\\nJZJ0+tuPMKmBnSH860llKk+VpVQsgqbzDIvOLvD6W1Umq25boxCYJ+TuBoa4s+HH\\nCViAvgT9kf/rBq1d+ivj6skkHxuzcxbk1xv6ZGxrteJxVH7KlX7YRdZ6eARKwLe4\\nAFZEAwoKCQ==\\n-----END CERTIFICATE-----\\n\""),
-
-						resource.TestCheckResourceAttr("data.constellation_attestation.test", "attestation.measurements.0.expected", "7b068c0c3ac29afe264134536b9be26f1d4ccd575b88d3c3ceabf36ac99c0278"),
-						resource.TestCheckResourceAttr("data.constellation_attestation.test", "attestation.measurements.0.warn_only", "true"),
-					),
-				},
-			},
-		},
 		"azure sev-snp success": {
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 			PreCheck:                 bazelPreCheck,
@@ -52,7 +26,11 @@ func TestAccAttestationSource(t *testing.T) {
 					data "constellation_attestation" "test" {
 						csp = "azure"
 						attestation_variant = "azure-sev-snp"
-						image_version = "v2.13.0"
+						image = {
+							version = "v2.13.0"
+							reference = "v2.13.0"
+							short_path = "v2.13.0"
+						}
 						maa_url = "https://www.example.com"
 					}
 					`,
@@ -84,7 +62,11 @@ func TestAccAttestationSource(t *testing.T) {
 					data "constellation_attestation" "test" {
 						csp = "gcp"
 						attestation_variant = "gcp-sev-es"
-						image_version = "v2.13.0"
+						image = {
+							version = "v2.13.0"
+							reference = "v2.13.0"
+							short_path = "v2.13.0"
+						}
 					}
 					`,
 					Check: resource.ComposeAggregateTestCheckFunc(

--- a/terraform-provider-constellation/internal/provider/cluster_resource.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource.go
@@ -37,6 +37,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -296,17 +298,29 @@ func (r *ClusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				MarkdownDescription: "The owner ID of the cluster.",
 				Description:         "The owner ID of the cluster.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					// We know that this value will never change after creation, so we can use the state value for upgrades.
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"cluster_id": schema.StringAttribute{
 				MarkdownDescription: "The cluster ID of the cluster.",
 				Description:         "The cluster ID of the cluster.",
 				Computed:            true,
+				PlanModifiers: []planmodifier.String{
+					// We know that this value will never change after creation, so we can use the state value for upgrades.
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"kubeconfig": schema.StringAttribute{
 				MarkdownDescription: "The kubeconfig of the cluster.",
 				Description:         "The kubeconfig of the cluster.",
 				Computed:            true,
 				Sensitive:           true,
+				PlanModifiers: []planmodifier.String{
+					// We know that this value will never change after creation, so we can use the state value for upgrades.
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 		},
 	}

--- a/terraform-provider-constellation/internal/provider/cluster_resource.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource.go
@@ -63,8 +63,7 @@ type ClusterResourceModel struct {
 	Name                 types.String `tfsdk:"name"`
 	CSP                  types.String `tfsdk:"csp"`
 	UID                  types.String `tfsdk:"uid"`
-	ImageVersion         types.String `tfsdk:"image_version"`
-	ImageReference       types.String `tfsdk:"image_reference"`
+	Image                types.Object `tfsdk:"image"`
 	KubernetesVersion    types.String `tfsdk:"kubernetes_version"`
 	MicroserviceVersion  types.String `tfsdk:"constellation_microservice_version"`
 	OutOfClusterEndpoint types.String `tfsdk:"out_of_cluster_endpoint"`
@@ -85,19 +84,22 @@ type ClusterResourceModel struct {
 	KubeConfig types.String `tfsdk:"kubeconfig"`
 }
 
-type networkConfig struct {
+// networkConfigAttribute is the network config attribute's data model.
+type networkConfigAttribute struct {
 	IPCidrNode    string `tfsdk:"ip_cidr_node"`
 	IPCidrPod     string `tfsdk:"ip_cidr_pod"`
 	IPCidrService string `tfsdk:"ip_cidr_service"`
 }
 
-type gcp struct {
+// gcpAttribute is the gcp attribute's data model.
+type gcpAttribute struct {
 	// ServiceAccountKey is the private key of the service account used within the cluster.
 	ServiceAccountKey string `tfsdk:"service_account_key"`
 	ProjectID         string `tfsdk:"project_id"`
 }
 
-type azure struct {
+// azureAttribute is the azure attribute's data model.
+type azureAttribute struct {
 	TenantID                 string `tfsdk:"tenant_id"`
 	Location                 string `tfsdk:"location"`
 	UamiClientID             string `tfsdk:"uami_client_id"`
@@ -106,6 +108,11 @@ type azure struct {
 	SubscriptionID           string `tfsdk:"subscription_id"`
 	NetworkSecurityGroupName string `tfsdk:"network_security_group_name"`
 	LoadBalancerName         string `tfsdk:"load_balancer_name"`
+}
+
+// extraMicroservicesAttribute is the extra microservices attribute's data model.
+type extraMicroservicesAttribute struct {
+	CSIDriver bool `tfsdk:"csi_driver"`
 }
 
 // Metadata returns the metadata of the resource.
@@ -136,16 +143,7 @@ func (r *ClusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Description:         "The UID of the cluster.",
 				Required:            true,
 			},
-			"image_version": schema.StringAttribute{
-				MarkdownDescription: "Constellation OS image version to use in the CSP specific reference format. Use the [`constellation_image`](../data-sources/image.md) data source to find the correct image version for your CSP.",
-				Description:         "Constellation OS image version to use in the CSP specific reference format. Use the `constellation_image` data source to find the correct image version for your CSP.",
-				Required:            true,
-			},
-			"image_reference": schema.StringAttribute{
-				MarkdownDescription: "Constellation OS image reference to use in the CSP specific reference format. Use the [`constellation_image`](../data-sources/image.md) data source to find the correct image reference for your CSP.",
-				Description:         "Constellation OS image reference to use in the CSP specific reference format. Use the `constellation_image` data source to find the correct image reference for your CSP.",
-				Required:            true,
-			},
+			"image": newImageAttributeSchema(attributeInput),
 			"kubernetes_version": schema.StringAttribute{
 				MarkdownDescription: fmt.Sprintf("The Kubernetes version to use for the cluster. When not set, version %s is used. The supported versions are %s.", versions.Default, versions.SupportedK8sVersions()),
 				Description:         fmt.Sprintf("The Kubernetes version to use for the cluster. When not set, version %s is used. The supported versions are %s.", versions.Default, versions.SupportedK8sVersions()),
@@ -227,7 +225,7 @@ func (r *ClusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Description:         "Secret used for initialization of the cluster.",
 				Required:            true,
 			},
-			"attestation": newAttestationConfigAttribute(attributeInput),
+			"attestation": newAttestationConfigAttributeSchema(attributeInput),
 			"gcp": schema.SingleNestedAttribute{
 				MarkdownDescription: "GCP-specific configuration.",
 				Description:         "GCP-specific configuration.",
@@ -308,6 +306,7 @@ func (r *ClusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				MarkdownDescription: "The kubeconfig of the cluster.",
 				Description:         "The kubeconfig of the cluster.",
 				Computed:            true,
+				Sensitive:           true,
 			},
 		},
 	}
@@ -510,7 +509,7 @@ func (r *ClusterResource) apply(ctx context.Context, data *ClusterResourceModel,
 	}
 
 	// parse network config
-	var networkCfg networkConfig
+	var networkCfg networkConfigAttribute
 	convertDiags = data.NetworkConfig.As(ctx, &networkCfg, basetypes.ObjectAsOptions{
 		UnhandledNullAsEmpty: true, // we want to allow null values, as some of the field's subfields are optional.
 	})
@@ -520,14 +519,11 @@ func (r *ClusterResource) apply(ctx context.Context, data *ClusterResourceModel,
 	}
 
 	// parse Constellation microservice config
-	var microserviceCfg extraMicroservices
+	var microserviceCfg extraMicroservicesAttribute
 	convertDiags = data.ExtraMicroservices.As(ctx, &microserviceCfg, basetypes.ObjectAsOptions{
 		UnhandledNullAsEmpty: true, // we want to allow null values, as the CSIDriver field is optional
 	})
 	diags.Append(convertDiags...)
-	if diags.HasError() {
-		return diags
-	}
 
 	// parse Constellation microservice version
 	microserviceVersion, err := semver.New(data.MicroserviceVersion.ValueString())
@@ -547,19 +543,25 @@ func (r *ClusterResource) apply(ctx context.Context, data *ClusterResourceModel,
 	}
 
 	// parse OS image version
-	imageVersion, err := semver.New(data.ImageVersion.ValueString())
+	var image imageAttribute
+	convertDiags = data.Image.As(ctx, &image, basetypes.ObjectAsOptions{})
+	diags.Append(convertDiags...)
+	if diags.HasError() {
+		return diags
+	}
+	imageSemver, err := semver.New(image.Version)
 	if err != nil {
 		diags.AddAttributeError(
-			path.Root("image_version"),
+			path.Root("image").AtName("version"),
 			"Invalid image version",
-			fmt.Sprintf("Parsing image version: %s", err))
+			fmt.Sprintf("Parsing image version (%s): %s", image.Version, err))
 		return diags
 	}
 
 	// Parse in-cluster service account info.
 	serviceAccPayload := constellation.ServiceAccountPayload{}
-	var gcpConfig gcp
-	var azureConfig azure
+	var gcpConfig gcpAttribute
+	var azureConfig azureAttribute
 	switch csp {
 	case cloudprovider.GCP:
 		convertDiags = data.GCP.As(ctx, &gcpConfig, basetypes.ObjectAsOptions{})
@@ -717,8 +719,8 @@ func (r *ClusterResource) apply(ctx context.Context, data *ClusterResourceModel,
 	if !skipNodeUpgrade {
 		// Upgrade node image
 		err = applier.UpgradeNodeImage(ctx,
-			imageVersion,
-			data.ImageReference.ValueString(),
+			imageSemver,
+			image.Reference,
 			false)
 		if err != nil {
 			diags.AddError("Upgrading node OS image", err.Error())
@@ -741,9 +743,9 @@ type initRPCPayload struct {
 	masterSecret      uri.MasterSecret         // master secret of the cluster.
 	measurementSalt   []byte                   // measurement salt of the cluster.
 	apiServerCertSANs []string                 // additional SANs to add to the API server certificate.
-	azureCfg          azure                    // Azure-specific configuration.
-	gcpCfg            gcp                      // GCP-specific configuration.
-	networkCfg        networkConfig            // network configuration of the cluster.
+	azureCfg          azureAttribute           // Azure-specific configuration.
+	gcpCfg            gcpAttribute             // GCP-specific configuration.
+	networkCfg        networkConfigAttribute   // network configuration of the cluster.
 	maaURL            string                   // URL of the MAA service. Only used for Azure clusters.
 	k8sVersion        versions.ValidK8sVersion // Kubernetes version of the cluster.
 	// Internal Endpoint of the cluster.
@@ -845,7 +847,7 @@ type attestationInput struct {
 // used by the Constellation library.
 func (r *ClusterResource) convertAttestationConfig(ctx context.Context, data ClusterResourceModel) (attestationInput, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
-	var tfAttestation attestation
+	var tfAttestation attestationAttribute
 	castDiags := data.Attestation.As(ctx, &tfAttestation, basetypes.ObjectAsOptions{})
 	diags.Append(castDiags...)
 	if diags.HasError() {

--- a/terraform-provider-constellation/internal/provider/cluster_resource.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource.go
@@ -524,6 +524,9 @@ func (r *ClusterResource) apply(ctx context.Context, data *ClusterResourceModel,
 		UnhandledNullAsEmpty: true, // we want to allow null values, as the CSIDriver field is optional
 	})
 	diags.Append(convertDiags...)
+	if diags.HasError() {
+		return diags
+	}
 
 	// parse Constellation microservice version
 	microserviceVersion, err := semver.New(data.MicroserviceVersion.ValueString())

--- a/terraform-provider-constellation/internal/provider/convert_test.go
+++ b/terraform-provider-constellation/internal/provider/convert_test.go
@@ -18,18 +18,18 @@ import (
 )
 
 func TestParseAttestationConfig(t *testing.T) {
-	testAttestation := attestation{
+	testAttestation := attestationAttribute{
 		BootloaderVersion: 1,
 		TEEVersion:        2,
 		SNPVersion:        3,
 		MicrocodeVersion:  4,
 		AMDRootKey:        "\"-----BEGIN CERTIFICATE-----\\nMIIGYzCCBBKgAwIBAgIDAQAAMEYGCSqGSIb3DQEBCjA5oA8wDQYJYIZIAWUDBAIC\\nBQChHDAaBgkqhkiG9w0BAQgwDQYJYIZIAWUDBAICBQCiAwIBMKMDAgEBMHsxFDAS\\nBgNVBAsMC0VuZ2luZWVyaW5nMQswCQYDVQQGEwJVUzEUMBIGA1UEBwwLU2FudGEg\\nQ2xhcmExCzAJBgNVBAgMAkNBMR8wHQYDVQQKDBZBZHZhbmNlZCBNaWNybyBEZXZp\\nY2VzMRIwEAYDVQQDDAlBUkstTWlsYW4wHhcNMjAxMDIyMTcyMzA1WhcNNDUxMDIy\\nMTcyMzA1WjB7MRQwEgYDVQQLDAtFbmdpbmVlcmluZzELMAkGA1UEBhMCVVMxFDAS\\nBgNVBAcMC1NhbnRhIENsYXJhMQswCQYDVQQIDAJDQTEfMB0GA1UECgwWQWR2YW5j\\nZWQgTWljcm8gRGV2aWNlczESMBAGA1UEAwwJQVJLLU1pbGFuMIICIjANBgkqhkiG\\n9w0BAQEFAAOCAg8AMIICCgKCAgEA0Ld52RJOdeiJlqK2JdsVmD7FktuotWwX1fNg\\nW41XY9Xz1HEhSUmhLz9Cu9DHRlvgJSNxbeYYsnJfvyjx1MfU0V5tkKiU1EesNFta\\n1kTA0szNisdYc9isqk7mXT5+KfGRbfc4V/9zRIcE8jlHN61S1ju8X93+6dxDUrG2\\nSzxqJ4BhqyYmUDruPXJSX4vUc01P7j98MpqOS95rORdGHeI52Naz5m2B+O+vjsC0\\n60d37jY9LFeuOP4Meri8qgfi2S5kKqg/aF6aPtuAZQVR7u3KFYXP59XmJgtcog05\\ngmI0T/OitLhuzVvpZcLph0odh/1IPXqx3+MnjD97A7fXpqGd/y8KxX7jksTEzAOg\\nbKAeam3lm+3yKIcTYMlsRMXPcjNbIvmsBykD//xSniusuHBkgnlENEWx1UcbQQrs\\n+gVDkuVPhsnzIRNgYvM48Y+7LGiJYnrmE8xcrexekBxrva2V9TJQqnN3Q53kt5vi\\nQi3+gCfmkwC0F0tirIZbLkXPrPwzZ0M9eNxhIySb2npJfgnqz55I0u33wh4r0ZNQ\\neTGfw03MBUtyuzGesGkcw+loqMaq1qR4tjGbPYxCvpCq7+OgpCCoMNit2uLo9M18\\nfHz10lOMT8nWAUvRZFzteXCm+7PHdYPlmQwUw3LvenJ/ILXoQPHfbkH0CyPfhl1j\\nWhJFZasCAwEAAaN+MHwwDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBSFrBrRQ/fI\\nrFXUxR1BSKvVeErUUzAPBgNVHRMBAf8EBTADAQH/MDoGA1UdHwQzMDEwL6AtoCuG\\nKWh0dHBzOi8va2RzaW50Zi5hbWQuY29tL3ZjZWsvdjEvTWlsYW4vY3JsMEYGCSqG\\nSIb3DQEBCjA5oA8wDQYJYIZIAWUDBAICBQChHDAaBgkqhkiG9w0BAQgwDQYJYIZI\\nAWUDBAICBQCiAwIBMKMDAgEBA4ICAQC6m0kDp6zv4Ojfgy+zleehsx6ol0ocgVel\\nETobpx+EuCsqVFRPK1jZ1sp/lyd9+0fQ0r66n7kagRk4Ca39g66WGTJMeJdqYriw\\nSTjjDCKVPSesWXYPVAyDhmP5n2v+BYipZWhpvqpaiO+EGK5IBP+578QeW/sSokrK\\ndHaLAxG2LhZxj9aF73fqC7OAJZ5aPonw4RE299FVarh1Tx2eT3wSgkDgutCTB1Yq\\nzT5DuwvAe+co2CIVIzMDamYuSFjPN0BCgojl7V+bTou7dMsqIu/TW/rPCX9/EUcp\\nKGKqPQ3P+N9r1hjEFY1plBg93t53OOo49GNI+V1zvXPLI6xIFVsh+mto2RtgEX/e\\npmMKTNN6psW88qg7c1hTWtN6MbRuQ0vm+O+/2tKBF2h8THb94OvvHHoFDpbCELlq\\nHnIYhxy0YKXGyaW1NjfULxrrmxVW4wcn5E8GddmvNa6yYm8scJagEi13mhGu4Jqh\\n3QU3sf8iUSUr09xQDwHtOQUVIqx4maBZPBtSMf+qUDtjXSSq8lfWcd8bLr9mdsUn\\nJZJ0+tuPMKmBnSH860llKk+VpVQsgqbzDIvOLvD6W1Umq25boxCYJ+TuBoa4s+HH\\nCViAvgT9kf/rBq1d+ivj6skkHxuzcxbk1xv6ZGxrteJxVH7KlX7YRdZ6eARKwLe4\\nAFZEAwoKCQ==\\n-----END CERTIFICATE-----\\n\"",
-		AzureSNPFirmwareSignerConfig: azureSnpFirmwareSignerConfig{
+		AzureSNPFirmwareSignerConfig: azureSnpFirmwareSignerConfigAttribute{
 			AcceptedKeyDigests: []string{"0356215882a825279a85b300b0b742931d113bf7e32dde2e50ffde7ec743ca491ecdd7f336dc28a6e0b2bb57af7a44a3"},
 			EnforcementPolicy:  "equal",
 			MAAURL:             "https://example.com",
 		},
-		Measurements: map[string]measurement{
+		Measurements: map[string]measurementAttribute{
 			"1": {Expected: "48656c6c6f", WarnOnly: false}, // "Hello" in hex
 			"2": {Expected: "776f726c64", WarnOnly: true},  // "world" in hex
 		},
@@ -65,7 +65,7 @@ func TestParseAttestationConfig(t *testing.T) {
 
 	// Test error scenarios
 	t.Run("invalid_measurement_index", func(t *testing.T) {
-		testAttestation.Measurements = map[string]measurement{"invalid": {Expected: "data"}}
+		testAttestation.Measurements = map[string]measurementAttribute{"invalid": {Expected: "data"}}
 		attestationVariant := variant.AzureSEVSNP{}
 
 		_, err := convertFromTfAttestationCfg(testAttestation, attestationVariant)

--- a/terraform-provider-constellation/internal/provider/image_data_source_test.go
+++ b/terraform-provider-constellation/internal/provider/image_data_source_test.go
@@ -18,7 +18,7 @@ func TestAccImageDataSource(t *testing.T) {
 	bazelPreCheck := func() { bazelSetTerraformBinaryPath(t) }
 
 	testCases := map[string]resource.TestCase{
-		"no image_version succeeds": {
+		"no version succeeds": {
 			ProtoV6ProviderFactories: testAccProtoV6ProviderFactoriesWithVersion("v2.13.0"),
 			PreCheck:                 bazelPreCheck,
 			Steps: []resource.TestStep{
@@ -30,7 +30,11 @@ func TestAccImageDataSource(t *testing.T) {
 						region              = "eu-west-1"
 					}
 				`,
-					Check: resource.TestCheckResourceAttrSet("data.constellation_image.test", "reference"),
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttrSet("data.constellation_image.test", "image.reference"),
+						resource.TestCheckResourceAttrSet("data.constellation_image.test", "image.version"),
+						resource.TestCheckResourceAttrSet("data.constellation_image.test", "image.short_path"),
+					),
 				},
 			},
 		},
@@ -42,13 +46,13 @@ func TestAccImageDataSource(t *testing.T) {
 				{
 					Config: testingConfig + `
 					data "constellation_image" "test" {
-						image_version       = "v2.13.0"
+						version       = "v2.13.0"
 						attestation_variant = "aws-sev-snp"
 						csp                 = "aws"
 						region              = "eu-west-1"
 					}
 				`,
-					Check: resource.TestCheckResourceAttr("data.constellation_image.test", "reference", "ami-04f8d522b113b73bf"), // should be immutable
+					Check: resource.TestCheckResourceAttr("data.constellation_image.test", "image.reference", "ami-04f8d522b113b73bf"), // should be immutable
 
 				},
 			},
@@ -61,7 +65,7 @@ func TestAccImageDataSource(t *testing.T) {
 				{
 					Config: testingConfig + `
 					data "constellation_image" "test" {
-						image_version       = "v2.13.0"
+						version       = "v2.13.0"
 						attestation_variant = "aws-sev-snp"
 						csp                 = "aws"
 					}
@@ -78,12 +82,12 @@ func TestAccImageDataSource(t *testing.T) {
 				{
 					Config: testingConfig + `
 					data "constellation_image" "test" {
-						image_version       = "v2.13.0"
+						version       = "v2.13.0"
 						attestation_variant = "azure-sev-snp"
 						csp                 = "azure"
 					}
 				`,
-					Check: resource.TestCheckResourceAttr("data.constellation_image.test", "reference", "/communityGalleries/ConstellationCVM-b3782fa0-0df7-4f2f-963e-fc7fc42663df/images/constellation/versions/2.13.0"), // should be immutable
+					Check: resource.TestCheckResourceAttr("data.constellation_image.test", "image.reference", "/communityGalleries/ConstellationCVM-b3782fa0-0df7-4f2f-963e-fc7fc42663df/images/constellation/versions/2.13.0"), // should be immutable
 
 				},
 			},
@@ -96,13 +100,13 @@ func TestAccImageDataSource(t *testing.T) {
 				{
 					Config: testingConfig + `
 					data "constellation_image" "test" {
-						image_version       = "v2.13.0"
+						version       = "v2.13.0"
 						attestation_variant = "azure-sev-snp"
 						csp                 = "azure"
 						marketplace_image   = true
 					}
 				`,
-					Check: resource.TestCheckResourceAttr("data.constellation_image.test", "reference", "constellation-marketplace-image://Azure?offer=constellation&publisher=edgelesssystems&sku=constellation&version=2.13.0"), // should be immutable
+					Check: resource.TestCheckResourceAttr("data.constellation_image.test", "image.reference", "constellation-marketplace-image://Azure?offer=constellation&publisher=edgelesssystems&sku=constellation&version=2.13.0"), // should be immutable
 
 				},
 			},
@@ -115,12 +119,12 @@ func TestAccImageDataSource(t *testing.T) {
 				{
 					Config: testingConfig + `
 					data "constellation_image" "test" {
-						image_version       = "v2.13.0"
+						version       = "v2.13.0"
 						attestation_variant = "gcp-sev-es"
 						csp                 = "gcp"
 					}
 				`,
-					Check: resource.TestCheckResourceAttr("data.constellation_image.test", "reference", "projects/constellation-images/global/images/v2-13-0-gcp-sev-es-stable"), // should be immutable,
+					Check: resource.TestCheckResourceAttr("data.constellation_image.test", "image.reference", "projects/constellation-images/global/images/v2-13-0-gcp-sev-es-stable"), // should be immutable,
 				},
 			},
 		},
@@ -132,7 +136,7 @@ func TestAccImageDataSource(t *testing.T) {
 				{
 					Config: testingConfig + `
 					data "constellation_image" "test" {
-						image_version       = "v2.13.0"
+						version       = "v2.13.0"
 						attestation_variant = "unknown"
 						csp                 = "azure"
 					}
@@ -149,7 +153,7 @@ func TestAccImageDataSource(t *testing.T) {
 				{
 					Config: testingConfig + `
 					data "constellation_image" "test" {
-						image_version       = "v2.13.0"
+						version       = "v2.13.0"
 						attestation_variant = "azure-sev-snp"
 						csp                 = "unknown"
 					}

--- a/terraform-provider-constellation/internal/provider/shared_attributes.go
+++ b/terraform-provider-constellation/internal/provider/shared_attributes.go
@@ -168,16 +168,19 @@ func newImageAttributeSchema(t attributeType) schema.Attribute {
 				Required:            isInput,
 			},
 			"reference": schema.StringAttribute{
-				Description:         "CSP-specific unique reference to the image.",
-				MarkdownDescription: "CSP-specific unique reference to the image.",
+				Description:         "CSP-specific unique reference to the image. The format differs per CSP.",
+				MarkdownDescription: "CSP-specific unique reference to the image. The format differs per CSP.",
 				Computed:            !isInput,
 				Required:            isInput,
 			},
 			"short_path": schema.StringAttribute{
-				Description:         "CSP-agnostic short path to the image.",
-				MarkdownDescription: "CSP-agnostic short path to the image.",
-				Computed:            !isInput,
-				Required:            isInput,
+				Description: "CSP-agnostic short path to the image. The format is `vX.Y.Z` for release images and `ref/$GIT_REF/stream/$STREAM/$SEMANTIC_VERSION` for pre-release images.",
+				MarkdownDescription: "CSP-agnostic short path to the image. The format is `vX.Y.Z` for release images and `ref/$GIT_REF/stream/$STREAM/$SEMANTIC_VERSION` for pre-release images.\n" +
+					"- `$GIT_REF` is the git reference (i.e. branch name) the image was built on, e.g. `main`.\n" +
+					"- `$STREAM` is the stream the image was built on, e.g. `nightly`.\n" +
+					"- `$SEMANTIC_VERSION` is the semantic version of the image, e.g. `vX.Y.Z` or `vX.Y.Z-pre...`.",
+				Computed: !isInput,
+				Required: isInput,
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We can improve the UX of the Terraform provider by unifying the passing of OS image information to one nested attribute that comprises all the information about a Constellation OS image (Semantic version, CSP-reference, Versionsapi short-path).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Create an `image` attribute that comprises all of the aforementioned information.
- (Unrelated) Mark the `kubeconfig` output as sensitive.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [E2E Test](https://github.com/edgelesssys/constellation/actions/runs/7224107793)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
