### PR TITLE
ci: remove conditional from AWS login in e2e verify test

### DIFF
--- a/.github/actions/e2e_verify/action.yml
+++ b/.github/actions/e2e_verify/action.yml
@@ -78,7 +78,7 @@ runs:
         done
 
     - name: Login to AWS
-      if: github.ref_name == 'main' && inputs.cloudProvider == 'azure'
+      if: github.ref_name == 'main'
       uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
       with:
         role-to-assume: arn:aws:iam::795746500882:role/GitHubConstellationImagePipeline


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Verify e2e test was not authorized to upload TCBs for AWS, since the login was ran only with csp == azure

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove the CSP conditional for the login action, since the upload step is already restricted to only run on specific inputs

### Related issue
- fixes https://github.com/edgelesssys/issues/issues/109
