### PR TITLE
deps: update rules_oci to a pre-release version to fix memory leak

### DIFF
--- a/bazel/release/BUILD.bazel
+++ b/bazel/release/BUILD.bazel
@@ -29,16 +29,6 @@ load("//bazel/oci:pin.bzl", "oci_sum", "oci_sum_merge")
     for container in containers()
 ]
 
-# TODO(3u13r): re-enable target once https://github.com/bazel-contrib/rules_oci/issues/184 is fixed
-# [
-#     oci_tarball(
-#         name = container["name"] + "_tar",
-#         image = container["oci"],
-#         repotag_file = container["repotag_file"],
-#     )
-#     for container in containers()
-# ]
-
 [
     oci_sum(
         name = container["name"] + "_sum",
@@ -62,7 +52,8 @@ oci_sum_merge(
     oci_push(
         name = container["name"] + "_push",
         image = container["oci"],
-        repotags = container["repotag_file"],
+        remote_tags = "//bazel/settings:tag",
+        repository_file = "//bazel/release:" + container["name"] + "_reponame",
     )
     for container in containers()
 ]

--- a/bazel/toolchains/oci_deps.bzl
+++ b/bazel/toolchains/oci_deps.bzl
@@ -3,13 +3,15 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def oci_deps():
+    # TODO(malt3): This uses a patch on top of the normal rules_oci that removes broken Windows support.
+    # Remove this override once https://github.com/bazel-contrib/rules_oci/issues/420 is fixed.
     http_archive(
         name = "rules_oci",
-        strip_prefix = "rules_oci-0.4.0",
+        strip_prefix = "rules_oci-c622bf79d269473d3d9bc33510e16cfd9a1142bc",
         type = "tar.gz",
         urls = [
-            "https://cdn.confidential.cloud/constellation/cas/sha256/d7b0760ba28554b71941ea0bbfd0a9f089bf250fd4448f9c116e1cb7a63b3933",
-            "https://github.com/bazel-contrib/rules_oci/releases/download/v0.4.0/rules_oci-v0.4.0.tar.gz",
+            "https://cdn.confidential.cloud/constellation/cas/sha256/dca0cfa2a8eb4ab79c231617964fc821f6d1a3bb9d996358975a5ceee5b8d25f",
+            "https://github.com/bazel-contrib/rules_oci/archive/c622bf79d269473d3d9bc33510e16cfd9a1142bc.tar.gz",
         ],
-        sha256 = "d7b0760ba28554b71941ea0bbfd0a9f089bf250fd4448f9c116e1cb7a63b3933",
+        sha256 = "dca0cfa2a8eb4ab79c231617964fc821f6d1a3bb9d996358975a5ceee5b8d25f",
     )

--- a/e2e/malicious-join/BUILD.bazel
+++ b/e2e/malicious-join/BUILD.bazel
@@ -67,7 +67,8 @@ genrule(
 oci_push(
     name = "malicious-join_push",
     image = ":malicious-join_image",
-    repotags = ":repotag.txt",
+    remote_tags = "//bazel/settings:tag",
+    repository_file = ":container_name",
 )
 
 sh_template(


### PR DESCRIPTION

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

`rules_oci` spawns local container registry processes and in the past, those would not be cleaned up explicitly, leading to an accumulation of processes when using remote execution with buildbarn. This pre-release contains a fix: https://github.com/bazel-contrib/rules_oci/pull/421 Additionally, windows support for rules_oci was removed in this fork, since it is currently broken.


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- deps: update rules_oci to a pre-release version to fix memory leak

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#3566](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3566)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
