### PR TITLE
ci: add burgerdev to e2e failure assignees

### DIFF
--- a/.github/actions/pick_assignee/action.yml
+++ b/.github/actions/pick_assignee/action.yml
@@ -20,6 +20,7 @@ runs:
           "daniel-weisse"
           "derpsteb"
           "msanft"
+          "burgerdev"
         )
         assignee=${possibleAssignees[$RANDOM % ${#possibleAssignees[@]}]}
         echo "assignee=$assignee" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Context

I should be included in the list of assignees for failed tests.

### Proposed change(s)

- Add myself to the list.

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
