### PR TITLE
ci: don't run unit tests in integration test workflow

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -38,4 +38,4 @@ jobs:
       - name: Integration Tests
         env:
           TMPDIR: ${{ runner.temp }}
-        run: sudo -E "PATH=$PATH" bazel test //... --config=nostamp --remote_download_minimal --config=integration  --spawn_strategy=standalone
+        run: sudo -E "PATH=$PATH" bazel test //... --config=nostamp --remote_download_minimal --config=integration-only  --spawn_strategy=standalone


### PR DESCRIPTION
### Context

The `integration` config runs all tests - unit and integration. Since we already have a workflow for unit tests, we should not be running these again in the integration test workflow. There's a dedicated config for running only integration tests: `integration-only`.

### Proposed change(s)

- Use the `integration-only` config in the integration test workflow.

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
