### PR TITLE
terraform-provider: lock-step microservice version

### DIFF
--- a/terraform-provider-constellation/docs/resources/cluster.md
+++ b/terraform-provider-constellation/docs/resources/cluster.md
@@ -31,7 +31,6 @@ resource "random_bytes" "measurement_salt" {
 
 resource "constellation_cluster" "azure_example" {
   csp                                = "azure"
-  constellation_microservice_version = "vX.Y.Z"
   name                               = "constell"
   uid                                = "..."
   image                              = data.constellation_image.bar.image
@@ -79,7 +78,7 @@ resource "constellation_cluster" "azure_example" {
 
 - `api_server_cert_sans` (List of String) List of Subject Alternative Names (SANs) for the API server certificate. Usually, this will be the out-of-cluster endpoint and the in-cluster endpoint, if existing.
 - `azure` (Attributes) Azure-specific configuration. (see [below for nested schema](#nestedatt--azure))
-- `constellation_microservice_version` (String) The version of Constellation's microservices used within the cluster. When not set, the provider default version is used.
+- `constellation_microservice_version` (String) The version of Constellation's microservices used within the cluster. When not set, the provider version is used.
 - `extra_microservices` (Attributes) Extra microservice settings. (see [below for nested schema](#nestedatt--extra_microservices))
 - `gcp` (Attributes) GCP-specific configuration. (see [below for nested schema](#nestedatt--gcp))
 - `in_cluster_endpoint` (String) The endpoint of the cluster. When not set, the out-of-cluster endpoint is used.

--- a/terraform-provider-constellation/examples/full/aws_cluster.tf
+++ b/terraform-provider-constellation/examples/full/aws_cluster.tf
@@ -89,18 +89,17 @@ data "constellation_image" "bar" {
 }
 
 resource "constellation_cluster" "aws_example" {
-  csp                                = local.csp
-  constellation_microservice_version = local.version
-  name                               = module.aws_infrastructure.name
-  uid                                = module.aws_infrastructure.uid
-  image                              = data.constellation_image.bar.image
-  attestation                        = data.constellation_attestation.foo.attestation
-  init_secret                        = module.aws_infrastructure.init_secret
-  master_secret                      = local.master_secret
-  master_secret_salt                 = local.master_secret_salt
-  measurement_salt                   = local.measurement_salt
-  out_of_cluster_endpoint            = module.aws_infrastructure.out_of_cluster_endpoint
-  in_cluster_endpoint                = module.aws_infrastructure.in_cluster_endpoint
+  csp                     = local.csp
+  name                    = module.aws_infrastructure.name
+  uid                     = module.aws_infrastructure.uid
+  image                   = data.constellation_image.bar.image
+  attestation             = data.constellation_attestation.foo.attestation
+  init_secret             = module.aws_infrastructure.init_secret
+  master_secret           = local.master_secret
+  master_secret_salt      = local.master_secret_salt
+  measurement_salt        = local.measurement_salt
+  out_of_cluster_endpoint = module.aws_infrastructure.out_of_cluster_endpoint
+  in_cluster_endpoint     = module.aws_infrastructure.in_cluster_endpoint
   network_config = {
     ip_cidr_node    = module.aws_infrastructure.ip_cidr_node
     ip_cidr_service = "10.96.0.0/12"

--- a/terraform-provider-constellation/examples/full/azure_cluster.tf
+++ b/terraform-provider-constellation/examples/full/azure_cluster.tf
@@ -84,18 +84,17 @@ data "constellation_image" "bar" {
 }
 
 resource "constellation_cluster" "azure_example" {
-  csp                                = local.csp
-  constellation_microservice_version = local.version
-  name                               = module.azure_infrastructure.name
-  uid                                = module.azure_infrastructure.uid
-  image                              = data.constellation_image.bar.image
-  attestation                        = data.constellation_attestation.foo.attestation
-  init_secret                        = module.azure_infrastructure.init_secret
-  master_secret                      = local.master_secret
-  master_secret_salt                 = local.master_secret_salt
-  measurement_salt                   = local.measurement_salt
-  out_of_cluster_endpoint            = module.azure_infrastructure.out_of_cluster_endpoint
-  in_cluster_endpoint                = module.azure_infrastructure.in_cluster_endpoint
+  csp                     = local.csp
+  name                    = module.azure_infrastructure.name
+  uid                     = module.azure_infrastructure.uid
+  image                   = data.constellation_image.bar.image
+  attestation             = data.constellation_attestation.foo.attestation
+  init_secret             = module.azure_infrastructure.init_secret
+  master_secret           = local.master_secret
+  master_secret_salt      = local.master_secret_salt
+  measurement_salt        = local.measurement_salt
+  out_of_cluster_endpoint = module.azure_infrastructure.out_of_cluster_endpoint
+  in_cluster_endpoint     = module.azure_infrastructure.in_cluster_endpoint
   azure = {
     tenant_id                   = module.azure_iam.tenant_id
     subscription_id             = module.azure_iam.subscription_id

--- a/terraform-provider-constellation/examples/full/gcp_cluster.tf
+++ b/terraform-provider-constellation/examples/full/gcp_cluster.tf
@@ -88,18 +88,17 @@ data "constellation_image" "bar" {
 }
 
 resource "constellation_cluster" "gcp_example" {
-  csp                                = local.csp
-  constellation_microservice_version = local.version
-  name                               = module.gcp_infrastructure.name
-  uid                                = module.gcp_infrastructure.uid
-  image                              = data.constellation_image.bar.image
-  attestation                        = data.constellation_attestation.foo.attestation
-  init_secret                        = module.gcp_infrastructure.init_secret
-  master_secret                      = local.master_secret
-  master_secret_salt                 = local.master_secret_salt
-  measurement_salt                   = local.measurement_salt
-  out_of_cluster_endpoint            = module.gcp_infrastructure.out_of_cluster_endpoint
-  in_cluster_endpoint                = module.gcp_infrastructure.in_cluster_endpoint
+  csp                     = local.csp
+  name                    = module.gcp_infrastructure.name
+  uid                     = module.gcp_infrastructure.uid
+  image                   = data.constellation_image.bar.image
+  attestation             = data.constellation_attestation.foo.attestation
+  init_secret             = module.gcp_infrastructure.init_secret
+  master_secret           = local.master_secret
+  master_secret_salt      = local.master_secret_salt
+  measurement_salt        = local.measurement_salt
+  out_of_cluster_endpoint = module.gcp_infrastructure.out_of_cluster_endpoint
+  in_cluster_endpoint     = module.gcp_infrastructure.in_cluster_endpoint
   gcp = {
     project_id          = module.gcp_infrastructure.project
     service_account_key = module.gcp_iam.service_account_key

--- a/terraform-provider-constellation/examples/resources/constellation_cluster/resource.tf
+++ b/terraform-provider-constellation/examples/resources/constellation_cluster/resource.tf
@@ -16,7 +16,6 @@ resource "random_bytes" "measurement_salt" {
 
 resource "constellation_cluster" "azure_example" {
   csp                                = "azure"
-  constellation_microservice_version = "vX.Y.Z"
   name                               = "constell"
   uid                                = "..."
   image                              = data.constellation_image.bar.image

--- a/terraform-provider-constellation/internal/data/BUILD.bazel
+++ b/terraform-provider-constellation/internal/data/BUILD.bazel
@@ -8,4 +8,5 @@ go_library(
     ],
     importpath = "github.com/edgelesssys/constellation/v2/terraform-provider-constellation/internal/data",
     visibility = ["//terraform-provider-constellation:__subpackages__"],
+    deps = ["//internal/semver"],
 )

--- a/terraform-provider-constellation/internal/data/providerdata.go
+++ b/terraform-provider-constellation/internal/data/providerdata.go
@@ -6,8 +6,10 @@ SPDX-License-Identifier: AGPL-3.0-only
 
 package data
 
+import "github.com/edgelesssys/constellation/v2/internal/semver"
+
 // ProviderData is the data that get's passed down from the provider
 // configuration to the resources and data sources.
 type ProviderData struct {
-	Version string
+	Version semver.Semver
 }

--- a/terraform-provider-constellation/internal/provider/attestation_data_source.go
+++ b/terraform-provider-constellation/internal/provider/attestation_data_source.go
@@ -66,7 +66,7 @@ func (d *AttestationDataSource) Configure(_ context.Context, req datasource.Conf
 		)
 		return
 	}
-	d.version = providerData.Version
+	d.version = providerData.Version.String()
 
 	d.client = http.DefaultClient
 	d.fetcher = attestationconfigapi.NewFetcher()

--- a/terraform-provider-constellation/internal/provider/image_data_source.go
+++ b/terraform-provider-constellation/internal/provider/image_data_source.go
@@ -136,7 +136,7 @@ func (d *ImageDataSource) Configure(_ context.Context, req datasource.ConfigureR
 		return
 	}
 
-	d.version = providerData.Version
+	d.version = providerData.Version.String()
 }
 
 // Read reads from the data source.

--- a/terraform-provider-constellation/internal/provider/provider.go
+++ b/terraform-provider-constellation/internal/provider/provider.go
@@ -11,7 +11,9 @@ package provider
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/edgelesssys/constellation/v2/internal/semver"
 	datastruct "github.com/edgelesssys/constellation/v2/terraform-provider-constellation/internal/data"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
@@ -69,8 +71,16 @@ func (p *ConstellationProvider) Configure(ctx context.Context, req provider.Conf
 		return
 	}
 
+	ver, err := semver.New(p.version)
+	if err != nil {
+		resp.Diagnostics.AddError("Invalid provider version",
+			fmt.Sprintf("Expected a valid semantic version, got %s: %s", p.version, err),
+		)
+		return
+	}
+
 	config := datastruct.ProviderData{
-		Version: p.version,
+		Version: ver,
 	}
 
 	// Make the clients available during data source and resource "Configure" methods.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We want to have the `microserviceVersion` be in lock-step with the provider version, since a normal user will always be in sync between "Constellation version" and microservice version.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Default the microservice version to the provider version if not set.
- Remove the microservice version from the examples for simplicity.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
-  [E2E Test](https://github.com/edgelesssys/constellation/actions/runs/7247698551)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
