### PR TITLE
ci: remove Windows Terraform provider

### DIFF
--- a/.github/actions/download_release_binaries/action.yml
+++ b/.github/actions/download_release_binaries/action.yml
@@ -53,8 +53,3 @@ runs:
       uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: terraform-provider-constellation-linux-arm64
-
-    - name: Download Terraform provider binary windows-amd64
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-      with:
-        name: terraform-provider-constellation-windows-amd64

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -246,7 +246,6 @@ jobs:
             terraform-provider-constellation-darwin-arm64 \
             terraform-provider-constellation-linux-amd64 \
             terraform-provider-constellation-linux-arm64)
-          # terraform-provider-constellation-windows-amd64.exe)
           HASHESB64=$(echo "${HASHES}" | base64 -w0)
           echo "${HASHES}"
           echo "${HASHESB64}"
@@ -385,9 +384,6 @@ jobs:
           slsa-verifier verify-artifact terraform-provider-constellation-linux-arm64 \
             --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
             --source-uri github.com/edgelesssys/constellation
-          #slsa-verifier verify-artifact terraform-provider-constellation-windows-amd64.exe \
-          #  --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-          #  --source-uri github.com/edgelesssys/constellation
 
           slsa-verifier verify-artifact constellation.spdx.sbom \
             --provenance-path ${{ needs.provenance.outputs.provenance-name }} \


### PR DESCRIPTION
### Context

The Terraform provider is currently not built for Windows, but still referenced in Github Actions. This leads to [failures in the release pipeline](https://github.com/edgelesssys/constellation/actions/runs/7249441540/job/19750116323).

### Proposed change(s)

- Remove Windows provider from the `download_release_binaries` action.
- Remove commented references to the provider. These can easily be restored or copy-pasted when needed.

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
