### PR TITLE
terraform: add module deprecation notice

### DIFF
--- a/terraform/legacy-module/README.md
+++ b/terraform/legacy-module/README.md
@@ -3,6 +3,4 @@
 > [!WARNING]
 > The Constellation Terraform modules are deprecated, and support will be discontinued in v2.15.0.
 > To continue managing Constellation clusters through Terraform, you can use the [Constellation Terraform provider](https://docs.edgeless.systems/constellation/workflows/terraform-provider).
-> Clusters created through the Constellation Terraform modules can also be imported to the Constellation Terraform provider.
-
-TODO: Leave a link to the import-docs of the `constellation_cluster` resource, once provider documentation is published.
+> Clusters created through the Constellation Terraform modules can also be [imported](https://registry.terraform.io/providers/edgelesssys/constellation/latest/docs/resources/cluster#import) to the Constellation Terraform provider.

--- a/terraform/legacy-module/README.md
+++ b/terraform/legacy-module/README.md
@@ -1,0 +1,8 @@
+## Constellation Terraform Modules
+
+> [!WARNING]
+> The Constellation Terraform modules are deprecated, and support will be discontinued in v2.15.0.
+> To continue managing Constellation clusters through Terraform, you can use the [Constellation Terraform provider](https://docs.edgeless.systems/constellation/workflows/terraform-provider).
+> Clusters created through the Constellation Terraform modules can also be imported to the Constellation Terraform provider.
+
+TODO: Leave a link to the import-docs of the `constellation_cluster` resource, once provider documentation is published.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
With Constellation v2.14.0, we introduced the Constellation Terraform provider, which is now the recommended way to manage Constellation clusters through Terraform. With that, the legacy modules can be deprecated (our docs don't link to them anymore anyways) and should be removed with or before v2.15.0.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a deprecation notice in the directory of the legacy module. 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- ~~TODO: Leave a link to the import-docs of the `constellation_cluster` resource, once provider documentation is published.~~

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
