### PR TITLE
ci: repair on-release workflow

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -130,4 +130,6 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Remove temporary branch
+        env:
+          WORKING_BRANCH: ${{needs.complete-release-branch-transaction.outputs.WORKING_BRANCH}}
         run: git push origin --delete "${WORKING_BRANCH}"

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
-      contents: read
+      contents: write
     env:
       FULL_VERSION: ${{ github.event.release.tag_name }}${{ github.event.inputs.tag }}
     outputs:
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
-      contents: read
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -32,11 +32,7 @@ jobs:
 
       - name: Determine branch names
         run: |
-          WITHOUT_V=${FULL_VERSION#v}
-          PART_MAJOR=${WITHOUT_V%%.*}
-          PART_MINOR=${WITHOUT_V#*.}
-          MAJOR_MINOR=${PART_MAJOR}.${PART_MINOR}
-          RELEASE_BRANCH="release/v${MAJOR_MINOR}"
+          RELEASE_BRANCH="release/${FULL_VERSION%.*}"
           WORKING_BRANCH="tmp/${FULL_VERSION}"
           echo "RELEASE_BRANCH=${RELEASE_BRANCH}" | tee -a "$GITHUB_ENV"
           echo "WORKING_BRANCH=${WORKING_BRANCH}" | tee -a "$GITHUB_ENV"


### PR DESCRIPTION
### Context

* The on-release workflow did not succeed for v2.14.0 due to permission errors. 
* The later part of the workflow seems not to be using the Github outputs correctly.
* The branches created were not correctly named (expected `release/v2.14`, got `release/v2.14.0`).

https://github.com/edgelesssys/constellation/actions/runs/7263610857

### Proposed change(s)

- Give repo write permission to the jobs that manipulate remote branches.
- Use job outputs to determine working branch.
- Fix branch name.

Run with fixes: https://github.com/edgelesssys/constellation/actions/runs/7266599601.

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
