### PR TITLE
ci: fix artifacts download/upload for release draft workflow

### DIFF
--- a/.github/actions/artifact_download/action.yml
+++ b/.github/actions/artifact_download/action.yml
@@ -28,7 +28,7 @@ runs:
       run: echo "directory=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
     - name: Download the artifact
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: ${{ inputs.name }}
         path: ${{ steps.tempdir.outputs.directory }}

--- a/.github/actions/artifact_upload/action.yml
+++ b/.github/actions/artifact_upload/action.yml
@@ -52,7 +52,7 @@ runs:
         fi
 
     - name: Upload archive as artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: ${{ inputs.name }}
         path: ${{ steps.tempdir.outputs.directory }}/archive.zip

--- a/.github/actions/download_release_binaries/action.yml
+++ b/.github/actions/download_release_binaries/action.yml
@@ -1,69 +1,55 @@
 name: Download release binaries
 description: "Downloads all binaries created by a different job (and therefore not available in this job) in the release pipeline."
-inputs:
-  encryption-secret:
-    description: 'The secret to use for decrypting the artifact.'
-    required: true
 
 runs:
   using: "composite"
   steps:
     - name: Download CLI binaries darwin-amd64
-      uses: ./.github/actions/artifact_download
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: constellation-darwin-amd64
-        encryption-secret: ${{ inputs.encryption-secret }}
 
     - name: Download CLI binaries darwin-arm64
-      uses: ./.github/actions/artifact_download
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: constellation-darwin-arm64
-        encryption-secret: ${{ inputs.encryption-secret }}
 
     - name: Download CLI binaries linux-amd64
-      uses: ./.github/actions/artifact_download
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: constellation-linux-amd64
-        encryption-secret: ${{ inputs.encryption-secret }}
 
     - name: Download CLI binaries linux-arm64
-      uses: ./.github/actions/artifact_download
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: constellation-linux-arm64
-        encryption-secret: ${{ inputs.encryption-secret }}
 
     - name: Download CLI binaries windows-amd64
-      uses: ./.github/actions/artifact_download
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: constellation-windows-amd64
-        encryption-secret: ${{ inputs.encryption-secret }}
 
     - name: Download Terraform module
-      uses: ./.github/actions/artifact_download
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: terraform-module
-        encryption-secret: ${{ inputs.encryption-secret }}
 
     - name: Download Terraform provider binary darwin-amd64
-      uses: ./.github/actions/artifact_download
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: terraform-provider-constellation-darwin-amd64
-        encryption-secret: ${{ inputs.encryption-secret }}
 
     - name: Download Terraform provider binary darwin-arm64
-      uses: ./.github/actions/artifact_download
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: terraform-provider-constellation-darwin-arm64
-        encryption-secret: ${{ inputs.encryption-secret }}
 
     - name: Download Terraform provider binary linux-amd64
-      uses: ./.github/actions/artifact_download
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: terraform-provider-constellation-linux-amd64
-        encryption-secret: ${{ inputs.encryption-secret }}
 
     - name: Download Terraform provider binary linux-arm64
-      uses: ./.github/actions/artifact_download
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
         name: terraform-provider-constellation-linux-arm64
-        encryption-secret: ${{ inputs.encryption-secret }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -227,8 +227,6 @@ jobs:
 
       - name: Download release binaries
         uses: ./.github/actions/download_release_binaries
-        with:
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Download CLI SBOM
         uses: ./.github/actions/artifact_download
@@ -343,8 +341,6 @@ jobs:
 
       - name: Download release binaries
         uses: ./.github/actions/download_release_binaries
-        with:
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Download CLI SBOM
         uses: ./.github/actions/artifact_download
@@ -425,8 +421,6 @@ jobs:
 
       - name: Download binaries
         uses: ./.github/actions/download_release_binaries
-        with:
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Download CLI SBOM
         uses: ./.github/actions/artifact_download


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
We decided to not encrypt the artifacts we pass around in the release workflow (since they will be published anyways).
The grouped download action was still expecting them to be encrypted tho.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Don't try to decrypt unencrypted artifacts when downloading Constellation artifacts during the release draft workflow
- Pin upload and download actions by hash

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->
