### PR TITLE
ci: fix artifact upload in image build pipeline

### DIFF
--- a/.github/actions/artifact_download/action.yml
+++ b/.github/actions/artifact_download/action.yml
@@ -36,4 +36,5 @@ runs:
     - name: Decrypt and unzip archive
       shell: bash
       run: |
+        mkdir -p ${{ inputs.path }}
         unzip -P '${{ inputs.encryption-secret }}' -qq -d ${{ inputs.path }} ${{ steps.tempdir.outputs.directory }}/archive.zip

--- a/.github/actions/artifact_download/action.yml
+++ b/.github/actions/artifact_download/action.yml
@@ -9,7 +9,7 @@ inputs:
     description: 'Download to a specified path.'
     required: false
     default: ./
-  encryption-secret:
+  encryptionSecret:
     description: 'The secret to use for decrypting the artifact.'
     required: true
 
@@ -37,4 +37,4 @@ runs:
       shell: bash
       run: |
         mkdir -p ${{ inputs.path }}
-        unzip -P '${{ inputs.encryption-secret }}' -qq -d ${{ inputs.path }} ${{ steps.tempdir.outputs.directory }}/archive.zip
+        unzip -P '${{ inputs.encryptionSecret }}' -qq -d ${{ inputs.path }} ${{ steps.tempdir.outputs.directory }}/archive.zip

--- a/.github/actions/artifact_upload/action.yml
+++ b/.github/actions/artifact_upload/action.yml
@@ -34,10 +34,13 @@ runs:
       run: |
         shopt -s extglob
 
+        paths="${{ inputs.path }}"
+        paths=${paths%$'\n'} # Remove trailing newline
+
         # Check if any file matches the given pattern(s).
         something_exists=false
-        for pattern in ${{ inputs.path }}; do
-          if compgen -G $pattern > /dev/null; then
+        for pattern in ${paths}; do
+          if compgen -G ${pattern} > /dev/null; then
             something_exists=true
           fi
         done
@@ -45,10 +48,10 @@ runs:
         # Create an archive if files exist.
         # Don't create an archive file if no files are found
         # and warn.
-        if $something_exists; then
-          zip -e -P '${{ inputs.encryption-secret }}' -qq -r ${{ steps.tempdir.outputs.directory }}/archive.zip ${{ inputs.path }}
+        if ${something_exists}; then
+          zip -e -P '${{ inputs.encryption-secret }}' -qq -r ${{ steps.tempdir.outputs.directory }}/archive.zip ${paths}
         else
-          echo "::warning:: No files/directories found with the provided path(s) $(echo -n ${{ inputs.path }}). No artifact will be uploaded."
+          echo "::warning:: No files/directories found with the provided path(s): ${paths}. No artifact will be uploaded."
         fi
 
     - name: Upload archive as artifact

--- a/.github/actions/artifact_upload/action.yml
+++ b/.github/actions/artifact_upload/action.yml
@@ -3,7 +3,7 @@ description: Upload an encrypted zip archive as a github artifact.
 
 inputs:
   path:
-    description: 'The path(s) that should be uploaded. Those are evaluated with bash and the extglob option.'
+    description: 'The path(s) that should be uploaded. Paths may contain globs. Only the final component of a path is uploaded.'
     required: true
   name:
     description: 'The name of the artifact.'

--- a/.github/actions/artifact_upload/action.yml
+++ b/.github/actions/artifact_upload/action.yml
@@ -57,7 +57,6 @@ runs:
 
         for target in ${paths}
         do
-          echo "Adding ${target} to archive"
           pushd "$(dirname "${target}")" || exit 1
           zip -e -P '${{ inputs.encryptionSecret }}' -r "${{ steps.tempdir.outputs.directory }}/archive.zip" "$(basename "${target}")"
           popd || exit 1

--- a/.github/actions/artifact_upload/action.yml
+++ b/.github/actions/artifact_upload/action.yml
@@ -11,7 +11,7 @@ inputs:
   retention-days:
     description: 'How long the artifact should be retained for.'
     default: 60
-  encryption-secret:
+  encryptionSecret:
     description: 'The secret to use for encrypting the files.'
     required: true
 
@@ -49,7 +49,7 @@ runs:
         # Don't create an archive file if no files are found
         # and warn.
         if ${something_exists}; then
-          zip -e -P '${{ inputs.encryption-secret }}' -qq -r ${{ steps.tempdir.outputs.directory }}/archive.zip ${paths}
+          zip -e -P '${{ inputs.encryptionSecret }}' -qq -r ${{ steps.tempdir.outputs.directory }}/archive.zip ${paths}
         else
           echo "::warning:: No files/directories found with the provided path(s): ${paths}. No artifact will be uploaded."
         fi

--- a/.github/actions/artifact_upload/action.yml
+++ b/.github/actions/artifact_upload/action.yml
@@ -39,8 +39,9 @@ runs:
 
         # Check if any file matches the given pattern(s).
         something_exists=false
-        for pattern in ${paths}; do
-          if compgen -G ${pattern} > /dev/null; then
+        for pattern in ${paths}
+        do
+          if compgen -G "${pattern}" > /dev/null; then
             something_exists=true
           fi
         done
@@ -48,11 +49,19 @@ runs:
         # Create an archive if files exist.
         # Don't create an archive file if no files are found
         # and warn.
-        if ${something_exists}; then
-          zip -e -P '${{ inputs.encryptionSecret }}' -qq -r ${{ steps.tempdir.outputs.directory }}/archive.zip ${paths}
-        else
+        if ! ${something_exists}
+        then
           echo "::warning:: No files/directories found with the provided path(s): ${paths}. No artifact will be uploaded."
+          exit 0
         fi
+
+        for target in ${paths}
+        do
+          echo "Adding ${target} to archive"
+          pushd "$(dirname "${target}")" || exit 1
+          zip -e -P '${{ inputs.encryptionSecret }}' -r "${{ steps.tempdir.outputs.directory }}/archive.zip" "$(basename "${target}")"
+          popd || exit 1
+        done
 
     - name: Upload archive as artifact
       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -59,7 +59,7 @@ inputs:
   force:
     description: "Set the force-flag on apply to ignore version mismatches."
     required: false
-  encryption-secret:
+  encryptionSecret:
     description: "The secret to use for encrypting the artifact."
     required: true
 
@@ -267,4 +267,4 @@ runs:
         name: serial-logs-${{ inputs.artifactNameSuffix }}
         path: >
           !(terraform).log
-        encryption-secret: ${{ inputs.encryption-secret }}
+        encryptionSecret: ${{ inputs.encryptionSecret }}

--- a/.github/actions/e2e_benchmark/action.yml
+++ b/.github/actions/e2e_benchmark/action.yml
@@ -17,7 +17,7 @@ inputs:
   awsOpenSearchPwd:
     description: "AWS OpenSearch Password to upload the results."
     required: false
-  encryption-secret:
+  encryptionSecret:
     description: 'The secret to use for encrypting the artifact.'
     required: true
 
@@ -100,7 +100,7 @@ runs:
       with:
         path: "out/fio-constellation-${{ inputs.cloudProvider }}.json"
         name: "fio-constellation-${{ inputs.cloudProvider }}.json"
-        encryption-secret: ${{ inputs.encryption-secret }}
+        encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Run knb benchmark
       shell: bash
@@ -122,7 +122,7 @@ runs:
       with:
         path: "out/knb-constellation-${{ inputs.cloudProvider }}.json"
         name: "knb-constellation-${{ inputs.cloudProvider }}.json"
-        encryption-secret: ${{ inputs.encryption-secret }}
+        encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Assume AWS role to retrieve and update benchmarks in S3
       uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
@@ -176,7 +176,7 @@ runs:
         path: >
           benchmarks/constellation-${{ inputs.cloudProvider }}.json
         name: "benchmarks"
-        encryption-secret: ${{ inputs.encryption-secret }}
+        encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Upload benchmark results to opensearch
       if: (!env.ACT)

--- a/.github/actions/e2e_sonobuoy/action.yml
+++ b/.github/actions/e2e_sonobuoy/action.yml
@@ -11,7 +11,7 @@ inputs:
   kubeconfig:
     description: "The kubeconfig of the cluster to test."
     required: true
-  encryption-secret:
+  encryptionSecret:
     description: 'The secret to use for encrypting the artifact.'
     required: true
 
@@ -51,7 +51,7 @@ runs:
       with:
         name: "sonobuoy-logs-${{ inputs.artifactNameSuffix }}.tar.gz"
         path: "*_sonobuoy_*.tar.gz"
-        encryption-secret: ${{ inputs.encryption-secret }}
+        encryptionSecret: ${{ inputs.encryptionSecret }}
 
     # Only works on "sonobuoy full" tests (e2e plugin)
     - name: Extract test results

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -86,7 +86,7 @@ inputs:
   force:
     description: "Set the force-flag on apply to ignore version mismatches."
     required: false
-  encryption-secret:
+  encryptionSecret:
     description: 'The secret to use for decrypting the artifact.'
     required: true
 
@@ -299,7 +299,7 @@ runs:
         clusterCreation: ${{ inputs.clusterCreation }}
         marketplaceImageVersion: ${{ inputs.marketplaceImageVersion }}
         force: ${{ inputs.force }}
-        encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+        encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
     - name: Deploy log- and metrics-collection (Kubernetes)
       id: deploy-logcollection
@@ -334,7 +334,7 @@ runs:
         sonobuoyTestSuiteCmd: "--mode quick"
         kubeconfig: ${{ steps.constellation-create.outputs.kubeconfig }}
         artifactNameSuffix: ${{ steps.create-prefix.outputs.prefix }}
-        encryption-secret: ${{ inputs.encryption-secret }}
+        encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Run sonobuoy full test
       if: inputs.test == 'sonobuoy full'
@@ -344,7 +344,7 @@ runs:
         sonobuoyTestSuiteCmd: '--plugin e2e --plugin-env e2e.E2E_FOCUS="\[Conformance\]" --plugin-env e2e.E2E_SKIP="for service with type clusterIP|HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol" --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-plugin.yaml --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-master-plugin.yaml'
         kubeconfig: ${{ steps.constellation-create.outputs.kubeconfig }}
         artifactNameSuffix: ${{ steps.create-prefix.outputs.prefix }}
-        encryption-secret: ${{ inputs.encryption-secret }}
+        encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Run autoscaling test
       if: inputs.test == 'autoscaling'
@@ -367,7 +367,7 @@ runs:
         awsOpenSearchDomain: ${{ inputs.awsOpenSearchDomain }}
         awsOpenSearchUsers: ${{ inputs.awsOpenSearchUsers }}
         awsOpenSearchPwd: ${{ inputs.awsOpenSearchPwd }}
-        encryption-secret: ${{ inputs.encryption-secret }}
+        encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Run constellation verify test
       if: inputs.test == 'verify'

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -299,7 +299,7 @@ runs:
         clusterCreation: ${{ inputs.clusterCreation }}
         marketplaceImageVersion: ${{ inputs.marketplaceImageVersion }}
         force: ${{ inputs.force }}
-        encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+        encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Deploy log- and metrics-collection (Kubernetes)
       id: deploy-logcollection

--- a/.github/actions/upload_terraform_module/action.yml
+++ b/.github/actions/upload_terraform_module/action.yml
@@ -1,7 +1,7 @@
 name: Upload Terraform infrastructure module
 description: "Upload the Terraform infrastructure module as an artifact."
 inputs:
-  encryption-secret:
+  encryptionSecret:
       description: 'The secret to use for encrypting the artifact.'
       required: true
 
@@ -24,7 +24,7 @@ runs:
       with:
         name: terraform-module
         path: terraform-module.zip
-        encryption-secret: ${{ inputs.encryption-secret }}
+        encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Cleanup Terraform module dir
       shell: bash

--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -182,7 +182,7 @@ jobs:
         with:
           name: image-${{ matrix.csp }}-${{ matrix.attestation_variant }}
           path: ${{ steps.build.outputs.image-dir }}/constellation.raw
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Upload individual OS parts as artifacts
         uses: ./.github/actions/artifact_upload
@@ -192,14 +192,14 @@ jobs:
             ${{ steps.build.outputs.image-dir }}/constellation.efi
             ${{ steps.build.outputs.image-dir }}/constellation.initrd
             ${{ steps.build.outputs.image-dir }}/constellation.vmlinuz
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Upload sbom info as artifact
         uses: ./.github/actions/artifact_upload
         with:
           name: sbom-${{ matrix.csp }}-${{ matrix.attestation_variant }}
           path: ${{ steps.build.outputs.rpmdb }}
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
   upload-os-image:
     name: "Upload OS image to CSP"
@@ -248,7 +248,7 @@ jobs:
         with:
           name: image-${{ matrix.csp }}-${{ matrix.attestation_variant }}
           path: ${{ github.workspace }}/image/mkosi.output.${{ matrix.csp }}_${{ matrix.attestation_variant }}/fedora~38
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Install tools
         shell: bash
@@ -361,7 +361,7 @@ jobs:
         with:
           name: lookup-table
           path: ${{ github.workspace }}/image/mkosi.output.*/*/image-upload*.json
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
   calculate-pcrs:
     name: "Calculate PCRs"
@@ -398,7 +398,7 @@ jobs:
         uses: ./.github/actions/artifact_download
         with:
           name: image-${{ matrix.csp }}-${{ matrix.attestation_variant }}
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - uses: ./.github/actions/setup_bazel_nix
         with:
@@ -545,7 +545,7 @@ jobs:
         with:
           name: measurements
           path: pcrs-${{ matrix.csp }}-${{ matrix.attestation_variant }}.json
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
   upload-pcrs:
     name: "Sign & upload PCRs"
@@ -568,7 +568,7 @@ jobs:
         uses: ./.github/actions/artifact_download
         with:
           name: measurements
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Login to AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
@@ -652,7 +652,7 @@ jobs:
           # downloading / using only the QEMU manifest is fine
           # since the images only differ in the ESP partition
           name: sbom-qemu-qemu-vtpm
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Upload SBOMs to S3
         shell: bash
@@ -683,7 +683,7 @@ jobs:
         uses: ./.github/actions/artifact_download
         with:
           name: lookup-table
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Login to AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1

--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -316,6 +316,7 @@ jobs:
         working-directory: ${{ github.workspace }}/image
         run: |
           echo "::group::Upload Azure image"
+          chmod +w "${RAW_IMAGE_PATH}"
           upload/pack.sh azure "${RAW_IMAGE_PATH}" "${AZURE_IMAGE_PATH}"
           bazel run //image/upload -- image azure \
             --verbose \

--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -640,6 +640,10 @@ jobs:
       contents: read
     runs-on: ubuntu-22.04
     steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          ref: ${{ inputs.ref || github.head_ref }}
+
       - name: Login to AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:

--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -698,12 +698,7 @@ jobs:
 
       - name: Upload lookup table to S3
         shell: bash
-        run: bazel run //image/upload -- info --verbose mkosi.output.*/*/image-upload*.json
-
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          ref: ${{ inputs.ref || github.head_ref }}
+        run: bazel run //image/upload -- info --verbose image-upload*.json
 
       - name: Create CLI compatibility information artifact
         shell: bash

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Upload Terraform infrastructure module
         uses: ./.github/actions/upload_terraform_module
         with:
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
   push-containers:
     runs-on: ubuntu-22.04
@@ -232,7 +232,7 @@ jobs:
         uses: ./.github/actions/artifact_download
         with:
           name: constellation.spdx.sbom
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Generate provenance subjects
         id: provenance-subjects
@@ -346,13 +346,13 @@ jobs:
         uses: ./.github/actions/artifact_download
         with:
           name: constellation.spdx.sbom
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Download provenance
         uses: ./.github/actions/artifact_download
         with:
           name: ${{ needs.provenance.outputs.provenance-name }}
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Install slsa-verifier
         run: |
@@ -426,19 +426,19 @@ jobs:
         uses: ./.github/actions/artifact_download
         with:
           name: constellation.spdx.sbom
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Download Constellation CLI SBOM's signature
         uses: ./.github/actions/artifact_download
         with:
           name: constellation.spdx.sbom.sig
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Download Constellation provenance
         uses: ./.github/actions/artifact_download
         with:
           name: ${{ needs.provenance.outputs.provenance-name }}
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Rename provenance file
         run: |

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -91,7 +91,7 @@ jobs:
           awsOpenSearchUsers: ${{ secrets.AWS_OPENSEARCH_USER }}
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
           clusterCreation: "cli"
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -265,7 +265,7 @@ jobs:
           clusterCreation: ${{ matrix.clusterCreation }}
           s3AccessKey: ${{ secrets.AWS_ACCESS_KEY_ID_S3PROXY }}
           s3SecretKey: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3PROXY }}
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -305,7 +305,7 @@ jobs:
           clusterCreation: ${{ matrix.clusterCreation }}
           s3AccessKey: ${{ secrets.AWS_ACCESS_KEY_ID_S3PROXY }}
           s3SecretKey: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3PROXY }}
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -246,7 +246,7 @@ jobs:
           s3SecretKey: ${{ secrets.AWS_SECRET_ACCESS_KEY_S3PROXY }}
           marketplaceImageVersion: ${{ inputs.marketplaceImageVersion }}
           force: ${{ inputs.force }}
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -183,7 +183,7 @@ jobs:
           awsOpenSearchUsers: ${{ secrets.AWS_OPENSEARCH_USER }}
           awsOpenSearchPwd: ${{ secrets.AWS_OPENSEARCH_PWD }}
           clusterCreation: "cli"
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Build CLI
         uses: ./.github/actions/build_cli
@@ -283,7 +283,7 @@ jobs:
             node-operator.logs
             node-maintenance-operator.logs
             constellation-version.yaml
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Always terminate cluster
         if: always()

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           path: "bazel-bin/cli/cli_enterprise_windows_amd64"
           name: "constell-exe"
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
   e2e-test:
     name: E2E Test Windows
@@ -54,7 +54,7 @@ jobs:
         uses: ./.github/actions/artifact_download
         with:
           name: "constell-exe"
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Check CLI version
         shell: pwsh

--- a/.github/workflows/reproducible-builds.yml
+++ b/.github/workflows/reproducible-builds.yml
@@ -57,14 +57,14 @@ jobs:
         with:
           name: "binaries-${{ matrix.target }}"
           path: "${{ env.binary }}"
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Upload hash artifact
         uses: ./.github/actions/artifact_upload
         with:
           name: "sha256sums"
           path: "${{ env.binary }}.sha256"
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
   build-osimages:
     strategy:
@@ -139,7 +139,7 @@ jobs:
           uses: ./.github/actions/artifact_download
           with:
             name: "binaries-${{ matrix.target }}"
-            encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+            encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
         - name: Hash
           shell: bash
@@ -169,7 +169,7 @@ jobs:
           uses: ./.github/actions/artifact_download
           with:
             name: "osimages-${{ matrix.target }}"
-            encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+            encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
         - name: Hash
           shell: bash

--- a/.github/workflows/reproducible-builds.yml
+++ b/.github/workflows/reproducible-builds.yml
@@ -135,27 +135,27 @@ jobs:
             - "cli_enterprise_windows_amd64"
     runs-on: ubuntu-22.04
     steps:
-        - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-          with:
-            ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
-        - name: Download binaries
-          uses: ./.github/actions/artifact_download
-          with:
-            name: "binaries-${{ matrix.target }}"
-            encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+      - name: Download binaries
+        uses: ./.github/actions/artifact_download
+        with:
+          name: "binaries-${{ matrix.target }}"
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
-        - name: Hash
-          shell: bash
-          if: runner.os == 'Linux'
-          run: sha256sum cli_enterprise*
+      - name: Hash
+        shell: bash
+        if: runner.os == 'Linux'
+        run: sha256sum cli_enterprise*
 
-        - name: Compare binaries
-          shell: bash
-          run: |
-            # shellcheck disable=SC2207,SC2116
-            list=($(echo "cli_enterprise*"))
-            diff -s --to-file="${list[0]}" "${list[@]:1}" | tee "${GITHUB_STEP_SUMMARY}"
+      - name: Compare binaries
+        shell: bash
+        run: |
+          # shellcheck disable=SC2207,SC2116
+          list=($(echo "cli_enterprise*"))
+          diff -s --to-file="${list[0]}" "${list[@]:1}" | tee "${GITHUB_STEP_SUMMARY}"
 
   compare-osimages:
     needs: build-osimages
@@ -169,24 +169,24 @@ jobs:
               - "gcp_gcp-sev-snp_nightly"
     runs-on: ubuntu-22.04
     steps:
-        - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-          with:
-            ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
-        - name: Download os images
-          uses: ./.github/actions/artifact_download
-          with:
-            name: "osimages-${{ matrix.target }}"
-            encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+      - name: Download os images
+        uses: ./.github/actions/artifact_download
+        with:
+          name: "osimages-${{ matrix.target }}"
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
-        - name: Hash
-          shell: bash
-          if: runner.os == 'Linux'
-          run: sha256sum osimage-*
+      - name: Hash
+        shell: bash
+        if: runner.os == 'Linux'
+        run: sha256sum osimage-*
 
-        - name: Compare os images
-          shell: bash
-          run: |
-            # shellcheck disable=SC2207,SC2116
-            list=($(echo "osimage-*"))
-            diff -s --to-file="${list[0]}" "${list[@]:1}" | tee "${GITHUB_STEP_SUMMARY}"
+      - name: Compare os images
+        shell: bash
+        run: |
+          # shellcheck disable=SC2207,SC2116
+          list=($(echo "osimage-*"))
+          diff -s --to-file="${list[0]}" "${list[@]:1}" | tee "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/reproducible-builds.yml
+++ b/.github/workflows/reproducible-builds.yml
@@ -135,6 +135,10 @@ jobs:
             - "cli_enterprise_windows_amd64"
     runs-on: ubuntu-22.04
     steps:
+        - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+          with:
+            ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
+
         - name: Download binaries
           uses: ./.github/actions/artifact_download
           with:
@@ -165,6 +169,10 @@ jobs:
               - "gcp_gcp-sev-snp_nightly"
     runs-on: ubuntu-22.04
     steps:
+        - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+          with:
+            ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
+
         - name: Download os images
           uses: ./.github/actions/artifact_download
           with:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -35,7 +35,7 @@ jobs:
           name: SARIF file
           path: results.sarif
           retention-days: 5
-          encryption-secret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
+          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Upload to code-scanning
         uses: github/codeql-action/upload-sarif@fdcae64e1484d349b3366718cdfef3d404390e85 # v2.22.1


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
https://github.com/edgelesssys/constellation/pull/2567 introduced some minor issues in the image build pipeline.
This PR aims to fix the issues and clean up some things

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix encrypted uploading of multiple artifacts in one action
- Fix downloading of encrypted artifacts if the directory we want to extract to does not yet exist on the actions runner
- Fix archives containing directory structure that shouldn't be there
  - If we specify we want a file at `someDir/someSubDir/targetFile`, the action would not create an archive containing `targetFile`, but `someDir/someSubDir/targetFile`. This is different behavior from the regular artifact upload action
  - We can't use the `-j` (junk paths) option from `unzip`, because that would destroy **all** directory structure on unpacking. This is a problem if we want to specifically upload directories, e.g. `somePath/dir1` and `somePath/dir2`, each containing multiple files. If we unpack an archive of those directories using the `-j` option, the output directory would contain all files of the directories, but not the directories themselves (`dir1` and `dir2`)
- Rename `encryption-secret` input to `encryptionSecret` to stay consistent with input naming formats across our actions
- Remove access to the `ARTIFACT_ENCRYPT_PASSWD` from `.github/actions/e2e_test`, since actions are not allowed to access secrets

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/146


### Additional info
- [image build pipeline](https://github.com/edgelesssys/constellation/actions/runs/7286853467)