### PR TITLE
Revert "deps: update actions/download-artifact action to v4 (#2753)"

### DIFF
--- a/.github/actions/artifact_download/action.yml
+++ b/.github/actions/artifact_download/action.yml
@@ -28,7 +28,7 @@ runs:
       run: echo "directory=$(mktemp -d)" >> "$GITHUB_OUTPUT"
 
     - name: Download the artifact
-      uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4
+      uses: actions/download-artifact@v3
       with:
         name: ${{ inputs.name }}
         path: ${{ steps.tempdir.outputs.directory }}


### PR DESCRIPTION
This reverts commit b550c92ac930d4b5a757aa04c865f9442f6b119a.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
* Download v4 requires upload v4
* Upload v4 contains breaking changes that require time to work around in our CI
  * Limit of 10 uploads per job
  * Cant upload artifacts with names that already exist

