### PR TITLE
terraform-provider: only build as enterprise user

### DIFF
--- a/bazel/devbuild/BUILD.bazel
+++ b/bazel/devbuild/BUILD.bazel
@@ -19,6 +19,7 @@ sh_template(
                 "//terraform-provider-constellation:terraform_rc",
                 "//terraform-provider-constellation:tf_provider",
             ],
+            "//conditions:default": [],
         },
     ),
     substitutions = {
@@ -50,6 +51,10 @@ sh_template(
             "//bazel/settings:cli_edition_enterprise": {
                 "@@TERRAFORM_PROVIDER@@": "$(rootpath //terraform-provider-constellation:tf_provider)",
                 "@@TERRAFORM_RC@@": "$(rootpath //terraform-provider-constellation:terraform_rc)",
+            },
+            "//conditions:default": {
+                "@@TERRAFORM_PROVIDER@@": "",
+                "@@TERRAFORM_RC@@": "",
             },
         },
     ),

--- a/bazel/devbuild/BUILD.bazel
+++ b/bazel/devbuild/BUILD.bazel
@@ -10,12 +10,17 @@ sh_template(
         "//bootstrapper/cmd/bootstrapper:bootstrapper_patched",
         "//cli:cli_edition_host",
         "//debugd/cmd/cdbg:cdbg_host",
-        "//terraform-provider-constellation:terraform_rc",
-        "//terraform-provider-constellation:tf_provider",
         "//upgrade-agent/cmd:upgrade_agent_linux_amd64",
         "@gnused//:bin/sed",
         "@yq_toolchains//:resolved_toolchain",
-    ],
+    ] + select(
+        {
+            "//bazel/settings:cli_edition_enterprise": [
+                "//terraform-provider-constellation:terraform_rc",
+                "//terraform-provider-constellation:tf_provider",
+            ],
+        },
+    ),
     substitutions = {
         "@@BOOTSTRAPPER@@": "$(rootpath //bootstrapper/cmd/bootstrapper:bootstrapper_patched)",
         "@@CDBG@@": "$(rootpath //debugd/cmd/cdbg:cdbg_host)",
@@ -23,8 +28,6 @@ sh_template(
         "@@CONTAINER_SUMS@@": "$(rootpath //bazel/release:container_sums)",
         "@@EDITION@@": "$(rootpath :devbuild_cli_edition)",
         "@@SED@@": "$(rootpath @gnused//:bin/sed)",
-        "@@TERRAFORM_PROVIDER@@": "$(rootpath //terraform-provider-constellation:tf_provider)",
-        "@@TERRAFORM_RC@@": "$(rootpath //terraform-provider-constellation:terraform_rc)",
         "@@UPGRADE_AGENT@@": "$(rootpath //upgrade-agent/cmd:upgrade_agent_linux_amd64)",
         "@@VERSION_FILE@@": "$(rootpath //bazel/settings:tag)",
         "@@YQ@@": "$(rootpath @yq_toolchains//:resolved_toolchain)",
@@ -42,7 +45,14 @@ sh_template(
         "@platforms//cpu:x86_64": {
             "@@GOARCH@@": "amd64",
         },
-    }),
+    }) | select(
+        {
+            "//bazel/settings:cli_edition_enterprise": {
+                "@@TERRAFORM_PROVIDER@@": "$(rootpath //terraform-provider-constellation:tf_provider)",
+                "@@TERRAFORM_RC@@": "$(rootpath //terraform-provider-constellation:terraform_rc)",
+            },
+        },
+    ),
     template = "prepare_developer_workspace.sh.in",
     visibility = ["//visibility:public"],
 )

--- a/bazel/devbuild/prepare_developer_workspace.sh.in
+++ b/bazel/devbuild/prepare_developer_workspace.sh.in
@@ -38,8 +38,13 @@ stat "${cdbg}" >> /dev/null
 container_sums=$(realpath @@CONTAINER_SUMS@@)
 stat "${container_sums}" >> /dev/null
 edition=$(cat @@EDITION@@)
-terraform_provider=$(realpath @@TERRAFORM_PROVIDER@@)
-stat "${terraform_provider}" >> /dev/null
+raw_provider="@@TERRAFORM_PROVIDER@@"
+if [[ -n ${raw_provider} ]]; then
+  terraform_provider=$(realpath "${raw_provider}")
+  stat "${terraform_provider}" >> /dev/null
+else
+  terraform_provider=""
+fi
 build_version=$(cat @@VERSION_FILE@@)
 if [[ -z ${build_version} ]]; then
   echo "Error: version file is empty"
@@ -80,9 +85,11 @@ ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${cdbg}")" "${workd
 ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${container_sums}")" "${workdir}/container_sums.sha256"
 ln -sf "$(replace_prefix "${host_cache}" "${builder_cache}" "${cli}")" "${workdir}/constellation"
 
-terraform_provider_dir=${HOME}/.terraform.d/plugins/registry.terraform.io/edgelesssys/constellation/${build_version#v}/${goos}_${goarch}/
-mkdir -p "${terraform_provider_dir}"
-ln -sf "${terraform_provider}" "${terraform_provider_dir}/terraform-provider-constellation_${build_version}"
+if [[ -n ${terraform_provider} ]]; then
+  terraform_provider_dir=${HOME}/.terraform.d/plugins/registry.terraform.io/edgelesssys/constellation/${build_version#v}/${goos}_${goarch}/
+  mkdir -p "${terraform_provider_dir}"
+  ln -sf "${terraform_provider}" "${terraform_provider_dir}/terraform-provider-constellation_${build_version}"
+fi
 
 if [[ ! -f "${workdir}/constellation-conf.yaml" ]]; then
   echo "constellation-conf.yaml not present in workspace"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We want to make it explicit in the build process that the Terraform provider is under the enterprise license terms.
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
-

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
How to test:
`bazel run //:devbuild --cli_edition=oss`
should not build the TF provider binary and link it under `~/.terraform.d/plugins/registry.terraform.io/edgelesssys/constellationc`.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
