### PR TITLE
ci: don't use disallowed action when uploading scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,12 +30,11 @@ jobs:
           publish_results: true
 
       - name: Upload artifact
-        uses: ./.github/actions/artifact_upload
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Upload to code-scanning
         uses: github/codeql-action/upload-sarif@fdcae64e1484d349b3366718cdfef3d404390e85 # v2.22.1


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The Scorecard uploading workflow broke (on main), causing CI checks to fail and our scorecard not to update. This got caused by the artifact encryption, which is a wrapper to GitHub's `upload_artifact` action, that was previously used directly in the scorecard workflow. The scorecard workflow has a restrictive [set of actions](https://github.com/ossf/scorecard-action#restrictions-on-the-job-containing-ossfscorecard-action) that may be called in the workflow the scorecard is created in, which includes the `upload_artifact` action from GitHub, but naturally not our custom wrapper around it. Therefore, we can fix the problem by going back to using GitHub's action for this workflow.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use GitHub's `upload_artifact` action in the scorecard workflow, instead of our custom wrapper.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional Information
- Unsure how to test this, since the scorecard action seems to only be able to be ran from the default branch. (`main`)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
