### PR TITLE
ci: selectively remove artifact encryption

### DIFF
--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -542,11 +542,10 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload expected measurements as artifact
-        uses: ./.github/actions/artifact_upload
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: measurements
           path: pcrs-${{ matrix.csp }}-${{ matrix.attestation_variant }}.json
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
   upload-pcrs:
     name: "Sign & upload PCRs"
@@ -566,10 +565,9 @@ jobs:
           useCache: "false"
 
       - name: Download measurements
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: measurements
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Login to AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1

--- a/.github/workflows/reproducible-builds.yml
+++ b/.github/workflows/reproducible-builds.yml
@@ -53,18 +53,16 @@ jobs:
         run: shasum -a 256 "${binary}" | tee "${binary}.sha256"
 
       - name: Upload binary artifact
-        uses: ./.github/actions/artifact_upload
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: "binaries-${{ matrix.target }}"
           path: "${{ env.binary }}"
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Upload hash artifact
-        uses: ./.github/actions/artifact_upload
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: "sha256sums"
           path: "${{ env.binary }}.sha256"
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
   build-osimages:
     strategy:
@@ -140,10 +138,9 @@ jobs:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
       - name: Download binaries
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "binaries-${{ matrix.target }}"
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Hash
         shell: bash
@@ -174,10 +171,9 @@ jobs:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
       - name: Download os images
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "osimages-${{ matrix.target }}"
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Hash
         shell: bash


### PR DESCRIPTION
### Context

The encrypted artifact actions introduced in #2567 are not drop-in replacements for the regular actions: if you use the artifact upload action multiple times for the same artifact, the default action will append to the outputs, while our action replaces the artifact.

This is only a problem when we actually upload multiple times to the same artifact, usually from matrix runs. I did a quick search for call sites of the upload action, and the only places where the artifact name is fixed but the paths are matrix-dependent were `build-os-image` and `reproducible-builds`. This PR fixes these call sites.

cc @miampf 

### Proposed change(s)

- Revert problematic call sites to the default upload action.
- Revert consumers of the problematic artifacts to the default download action.

I don't see an issue with keeping the affected artifacts unencrypted.

### Related issue

- Fixes edgelesssys/issues#155

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
- [x] test-drive affected workflows
  * [Reproducible Builds](https://github.com/edgelesssys/constellation/actions/runs/7301296268)
  * [Build and Upload OS Image](https://github.com/edgelesssys/constellation/actions/runs/7300237509)