### PR TITLE
ci: remove artifact encryption for public artifacts

### DIFF
--- a/.github/actions/upload_terraform_module/action.yml
+++ b/.github/actions/upload_terraform_module/action.yml
@@ -20,11 +20,10 @@ runs:
         zip -r terraform-module.zip terraform-module
 
     - name: Upload artifact
-      uses: ./.github/actions/artifact_upload
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
         name: terraform-module
         path: terraform-module.zip
-        encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Cleanup Terraform module dir
       shell: bash

--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -187,7 +187,7 @@ jobs:
         uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: parts-${{ matrix.csp }}-${{ matrix.attestation_variant }}
-          path: >
+          path: |
             ${{ steps.build.outputs.image-dir }}/constellation.efi
             ${{ steps.build.outputs.image-dir }}/constellation.initrd
             ${{ steps.build.outputs.image-dir }}/constellation.vmlinuz
@@ -312,7 +312,6 @@ jobs:
         working-directory: ${{ github.workspace }}/image
         run: |
           echo "::group::Upload Azure image"
-          chmod +w "${RAW_IMAGE_PATH}"
           upload/pack.sh azure "${RAW_IMAGE_PATH}" "${AZURE_IMAGE_PATH}"
           bazel run //image/upload -- image azure \
             --verbose \
@@ -633,10 +632,6 @@ jobs:
       contents: read
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-        with:
-          ref: ${{ inputs.ref || github.head_ref }}
-
       - name: Login to AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
         with:
@@ -688,7 +683,12 @@ jobs:
 
       - name: Upload lookup table to S3
         shell: bash
-        run: bazel run //image/upload -- info --verbose image-upload*.json
+        run: bazel run //image/upload -- info --verbose mkosi.output.*/*/image-upload*.json
+
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ inputs.ref || github.head_ref }}
 
       - name: Create CLI compatibility information artifact
         shell: bash

--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -178,28 +178,25 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload raw OS image as artifact
-        uses: ./.github/actions/artifact_upload
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: image-${{ matrix.csp }}-${{ matrix.attestation_variant }}
           path: ${{ steps.build.outputs.image-dir }}/constellation.raw
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Upload individual OS parts as artifacts
-        uses: ./.github/actions/artifact_upload
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: parts-${{ matrix.csp }}-${{ matrix.attestation_variant }}
           path: >
             ${{ steps.build.outputs.image-dir }}/constellation.efi
             ${{ steps.build.outputs.image-dir }}/constellation.initrd
             ${{ steps.build.outputs.image-dir }}/constellation.vmlinuz
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Upload sbom info as artifact
-        uses: ./.github/actions/artifact_upload
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: sbom-${{ matrix.csp }}-${{ matrix.attestation_variant }}
           path: ${{ steps.build.outputs.rpmdb }}
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
   upload-os-image:
     name: "Upload OS image to CSP"
@@ -244,11 +241,10 @@ jobs:
           useCache: "false"
 
       - name: Download OS image artifact
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: image-${{ matrix.csp }}-${{ matrix.attestation_variant }}
           path: ${{ github.workspace }}/image/mkosi.output.${{ matrix.csp }}_${{ matrix.attestation_variant }}/fedora~38
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Install tools
         shell: bash
@@ -358,11 +354,10 @@ jobs:
           echo "::endgroup::"
 
       - name: Upload image lookup table as artifact
-        uses: ./.github/actions/artifact_upload
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: lookup-table
           path: ${{ github.workspace }}/image/mkosi.output.*/*/image-upload*.json
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
   calculate-pcrs:
     name: "Calculate PCRs"
@@ -396,10 +391,9 @@ jobs:
           ref: ${{ inputs.ref || github.head_ref }}
 
       - name: Download OS image artifact
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: image-${{ matrix.csp }}-${{ matrix.attestation_variant }}
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - uses: ./.github/actions/setup_bazel_nix
         with:
@@ -650,12 +644,11 @@ jobs:
           aws-region: eu-central-1
 
       - name: Download sbom
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           # downloading / using only the QEMU manifest is fine
           # since the images only differ in the ESP partition
           name: sbom-qemu-qemu-vtpm
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Upload SBOMs to S3
         shell: bash
@@ -683,10 +676,9 @@ jobs:
           useCache: "false"
 
       - name: Download image lookup table
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: lookup-table
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Login to AWS
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -229,10 +229,9 @@ jobs:
         uses: ./.github/actions/download_release_binaries
 
       - name: Download CLI SBOM
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: constellation.spdx.sbom
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Generate provenance subjects
         id: provenance-subjects
@@ -343,16 +342,14 @@ jobs:
         uses: ./.github/actions/download_release_binaries
 
       - name: Download CLI SBOM
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: constellation.spdx.sbom
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Download provenance
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.provenance-name }}
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Install slsa-verifier
         run: |
@@ -423,22 +420,19 @@ jobs:
         uses: ./.github/actions/download_release_binaries
 
       - name: Download CLI SBOM
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: constellation.spdx.sbom
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Download Constellation CLI SBOM's signature
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: constellation.spdx.sbom.sig
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Download Constellation provenance
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.provenance-name }}
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Rename provenance file
         run: |

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -34,11 +34,10 @@ jobs:
           enterpriseCLI: true
 
       - name: Upload CLI artifact
-        uses: ./.github/actions/artifact_upload
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           path: "bazel-bin/cli/cli_enterprise_windows_amd64"
           name: "constell-exe"
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
   e2e-test:
     name: E2E Test Windows
@@ -51,10 +50,9 @@ jobs:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
       - name: Download CLI artifact
-        uses: ./.github/actions/artifact_download
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: "constell-exe"
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Check CLI version
         shell: pwsh

--- a/bazel/ci/unused_gh_actions.sh.in
+++ b/bazel/ci/unused_gh_actions.sh.in
@@ -50,7 +50,7 @@ for action in ${actionNames}; do
     fi
   done
 
-  if ! ${used}; then
+  if [[ ${used} == "false" && ${action} != ".github/actions/artifact_download" ]]; then
     echo "Action ${action} is unused"
     exitcode=1
   fi


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove artifact encryption/decryption where the artifacts might as well be public (e.g. the windows Constellation CLI)
- Remove artifact encryption/decryption where it just didn't make sense (the Terraform modules)

This should fix our build-os-image pipeline so the images are also usable. Currently, the pipeline is green but misses all-1 entries in the v2.15.0.pre-... --> CSP image ref lookup table.

Test: https://github.com/edgelesssys/constellation/actions/runs/7338017372

Note that the uploaded map (https://cdn.confidential.cloud/constellation/v2/ref/fix-ci-remove-artifact-encryption/stream/debug/v2.15.0-pre.0.20231227125133-35eca6437c37/image/info.json) now contains all image references again.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
