### PR TITLE
ci: fix provider release through correct zipping

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -464,7 +464,7 @@ jobs:
             else
               cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}"
             fi
-            zip -r "${folder_name}.zip" "${folder_name}"
+            (cd "${folder_name}" && zip "../${folder_name}.zip" ./*) # do not zip the folder itself
             rm -r "${folder_name}"
           done
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The current Terraform provider release is broken because of wrong zipping.
Terraform expects the zip files to only contain the binary file, but our zip inflates to a directory. This leads to TF not finding the binary:
https://github.com/edgelesssys/constellation/actions/runs/7339043840/job/19982584425#step:18:62
 
See the relevant zipping line:
https://github.com/edgelesssys/constellation/blob/48343dde4b64d03db6d9c352c854d5d739e543ab/.github/workflows/draft-release.yml#L465
 
You can check that this is done correctly for the edgelesstest, which works:

```bash
unzip terraform-provider-edgelesstest_1.0.0_linux_amd64.zip
Archive:  terraform-provider-edgelesstest_1.0.0_linux_amd64.zip
  inflating: CHANGELOG.md
  inflating: LICENSE.txt
  inflating: README.md
  inflating: terraform-provider-edgelesstest_1.0.0
```

Otherwise when downloading the provider release, the provider structure has an unexpected directory nesting, i.e.
the last directory of `providers/registry.terraform.io/edgelesssys/constellation/2.14.0/darwin_arm64/terraform-provider-constellation_2.14.0_darwin_arm64` should not be there, and leads to TF not finding the binary.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- only zip the binary and not the directory

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- starting a [draft release](https://github.com/edgelesssys/constellation/actions/runs/7339773009)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
