### PR TITLE
ci: give exec permission to provider binaries

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -462,6 +462,7 @@ jobs:
             if [[ "${ext}" = "exe" ]]; then
               cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}.exe"
             else
+              chmod 755 "${file}" # the upload artifact does not preserve file permissions (https://github.com/actions/upload-artifact/tree/main/?tab=readme-ov-file#permission-loss)
               cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}"
             fi
             (cd "${folder_name}" && zip "../${folder_name}.zip" ./*) # do not zip the folder itself


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The provider binaries need execution permissions. In the current v2.14.1 release, it is necessary to manually provide the permission after `terraform init`:

```bash
chmod +x .terraform/providers/registry.terraform.io/edgelesssys/constellation/2.14.1/darwin_arm64/terraform-provider-constellation_v2.14.1
````

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add x permission to the provider binary

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
