### PR TITLE
helm: masq traffic to the mini-qemu-metadata container so that the join-service can retrieve it's metadata

### DIFF
--- a/internal/constellation/helm/overrides.go
+++ b/internal/constellation/helm/overrides.go
@@ -59,9 +59,18 @@ func extraCiliumValues(provider cloudprovider.Provider, conformanceMode bool, ou
 	extraVals["encryption"] = map[string]any{
 		"strictMode": strictMode,
 	}
+
+	// On QEMU e.g. the join-service must talk to our mini-qemu-metadata docker container
+	// This container runs inside the node CIDR, so we need to masq any pod traffic to it
+	// with the node's IP address. To archive that, we override Cilium's default masq ranges
+	// with an empty list.
+	masqCIDRs := []string{}
+	if provider != cloudprovider.QEMU {
+		masqCIDRs = append(masqCIDRs, output.IPCidrNode)
+	}
 	extraVals["ipMasqAgent"] = map[string]any{
 		"config": map[string]any{
-			"nonMasqueradeCIDRs": []string{output.IPCidrNode},
+			"nonMasqueradeCIDRs": masqCIDRs,
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Masquerade traffic to the qemu metadata docker container running inside the node CIDR.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
Fixes: https://github.com/edgelesssys/constellation/issues/2780
This bug was introduced in: https://github.com/edgelesssys/constellation/pull/2723
The e2e miniconstellation test was supposed to catch that (e.g. in the release pipeline) but the check that all nodes have joined was wrong.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
