### PR TITLE
node-operator: fix setting Azure node image

### DIFF
--- a/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup.go
+++ b/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup.go
@@ -165,7 +165,7 @@ func imageReferenceFromImage(img string) (*armcompute.ImageReference, error) {
 	}
 
 	// expecting image to not be a marketplace image
-	if strings.HasPrefix(img, "/CommunityGalleries") {
+	if strings.HasPrefix(img, "/communityGalleries") {
 		ref.CommunityGalleryImageID = to.Ptr(img)
 	} else {
 		ref.ID = to.Ptr(img)

--- a/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup.go
+++ b/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup.go
@@ -165,7 +165,7 @@ func imageReferenceFromImage(img string) (*armcompute.ImageReference, error) {
 	}
 
 	// expecting image to not be a marketplace image
-	if strings.HasPrefix(img, "/communityGalleries") {
+	if strings.HasPrefix(strings.ToLower(img), "/communitygalleries") {
 		ref.CommunityGalleryImageID = to.Ptr(img)
 	} else {
 		ref.ID = to.Ptr(img)

--- a/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup_test.go
+++ b/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup_test.go
@@ -49,13 +49,13 @@ func TestGetScalingGroupImage(t *testing.T) {
 					VirtualMachineProfile: &armcompute.VirtualMachineScaleSetVMProfile{
 						StorageProfile: &armcompute.VirtualMachineScaleSetStorageProfile{
 							ImageReference: &armcompute.ImageReference{
-								CommunityGalleryImageID: to.Ptr("/CommunityGalleries/gallery-name/Images/image-name/Versions/1.2.3"),
+								CommunityGalleryImageID: to.Ptr("/communityGalleries/gallery-name/Images/image-name/Versions/1.2.3"),
 							},
 						},
 					},
 				},
 			},
-			wantImage: "/CommunityGalleries/gallery-name/Images/image-name/Versions/1.2.3",
+			wantImage: "/communityGalleries/gallery-name/Images/image-name/Versions/1.2.3",
 		},
 		"splitting scalingGroupID fails": {
 			scalingGroupID: "invalid",
@@ -299,8 +299,8 @@ func TestImageReferenceFromImage(t *testing.T) {
 			wantID: to.Ptr("/subscriptions/0d202bbb-4fa7-4af8-8125-58c269a05435/resourceGroups/constellation-images/providers/Microsoft.Compute/galleries/Constellation/images/constellation/versions/1.5.0"),
 		},
 		"Community": {
-			img:             "/CommunityGalleries/ConstellationCVM-728bd310-e898-4450-a1ed-21cf2fb0d735/Images/feat-azure-cvm-sharing/Versions/2022.0826.084922",
-			wantCommunityID: to.Ptr("/CommunityGalleries/ConstellationCVM-728bd310-e898-4450-a1ed-21cf2fb0d735/Images/feat-azure-cvm-sharing/Versions/2022.0826.084922"),
+			img:             "/communityGalleries/ConstellationCVM-728bd310-e898-4450-a1ed-21cf2fb0d735/Images/feat-azure-cvm-sharing/Versions/2022.0826.084922",
+			wantCommunityID: to.Ptr("/communityGalleries/ConstellationCVM-728bd310-e898-4450-a1ed-21cf2fb0d735/Images/feat-azure-cvm-sharing/Versions/2022.0826.084922"),
 		},
 		"Marketplace": {
 			img:           "constellation-marketplace-image://Azure?offer=constellation&publisher=edgelesssystems&sku=constellation&version=1.2.3",


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The Azure upgrade is currently broken in both the CLI and the Terraform provider. Azure must have recently changed its API spec, basically requiring to set the community image ID in the communityID field. This path is however broken, since the image path /communityGalleries/... does not match the case:
https://github.com/edgelesssys/constellation/blob/c15e4efef6844aad55d344089d5e40ab1a75b184/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup.go#L168
 
This led to this error in the operator:
```
ERROR    Unable to set ScalingGroup NodeImage    {"controller": "scalinggroup", "controllerGroup": "update.
edgeless.systems", "controllerKind": "ScalingGroup", "ScalingGroup": {"name":"e2e-222-7d279332-worker-44bdb38a"}, "namespace": "", "name":
"e2e-222-7d279332-worker-44bdb38a", "reconcileID": "55fb92f7-4625-4b43-bf3a-4c3dcef839dd", "error": "PATCH
https://management.azure.com/sub
scriptions/0d202bbb-4fa7-4af8-8125-58c269a05435/resourceGroups/e2e-222-test-rg/providers/Microsoft.Compute/virtualMachineScaleSets/e2e-222-
7d279332-worker-44bdb38a\n--------------------------------------------------------------------------------\nRESPONSE 400: 400 Bad Request\n
ERROR CODE: LinkedInvalidPropertyId\n--------------------------------------------------------------------------------\n{\n  \"error\": {\n
   \"code\": \"LinkedInvalidPropertyId\",\n    \"message\": \"Property id '/communityGalleries/ConstellationCVM-728bd310-e898-4450-a1ed-21c
f2fb0d735/images/main-nightly/versions/2023.1229.102745' at path 'properties.virtualMachineProfile.storageProfile.imageReference.id' is inv
alid. Expect fully qualified resource Id that start with '/subscriptions/{subscriptionId}' or '/providers/{resourceProviderNamespace}/'.\"\
n  }\n}\n--------------------------------------------------------------------------------\n"}
 ```
 
This affects any node upgrade, hence requiring a patch release.
The Azure upgrade was still working during the 2.14.0 release, so the change must have happened in the last 2 weeks.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- change the matching case to lowercase

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#1234](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/1234)
- Any additional information or context

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
