### PR TITLE
terraform-provider: require kubernetes and microservice version

### DIFF
--- a/.github/workflows/e2e-test-provider-example.yml
+++ b/.github/workflows/e2e-test-provider-example.yml
@@ -185,6 +185,9 @@ jobs:
             fi
           fi
 
+          # take the middle (2nd) supported Kubernetes version (default)
+          kubernetes_version="$(../build/constellation config kubernetes-versions | awk 'NR==3{print $1}')"
+
           cat > _override.tf <<EOF
           terraform {
             required_providers {
@@ -197,6 +200,8 @@ jobs:
           locals {
             name                = "${{ steps.create-prefix.outputs.prefix }}"
             version            = "${image_version}"
+            microservice_version= "${prefixed_version}"
+            kubernetes_version = "${kubernetes_version}"
           }
           module "${{ inputs.cloudProvider }}_iam" {
             source = "${iam_src}"

--- a/terraform-provider-constellation/docs/resources/cluster.md
+++ b/terraform-provider-constellation/docs/resources/cluster.md
@@ -63,10 +63,12 @@ resource "constellation_cluster" "azure_example" {
 ### Required
 
 - `attestation` (Attributes) Attestation comprises the measurements and SEV-SNP specific parameters. The output of the [constellation_attestation](../data-sources/attestation.md) data source provides sensible defaults. (see [below for nested schema](#nestedatt--attestation))
+- `constellation_microservice_version` (String) The version of Constellation's microservices used within the cluster.
 - `csp` (String) CSP (Cloud Service Provider) to use. (e.g. `azure`)
 See the [full list of CSPs](https://docs.edgeless.systems/constellation/overview/clouds) that Constellation supports.
 - `image` (Attributes) Constellation OS Image to use on the nodes. (see [below for nested schema](#nestedatt--image))
 - `init_secret` (String) Secret used for initialization of the cluster.
+- `kubernetes_version` (String) The Kubernetes version to use for the cluster. The supported versions are [v1.26.12 v1.27.9 v1.28.5].
 - `master_secret` (String) Hex-encoded 32-byte master secret for the cluster.
 - `master_secret_salt` (String) Hex-encoded 32-byte master secret salt for the cluster.
 - `measurement_salt` (String) Hex-encoded 32-byte measurement salt for the cluster.
@@ -79,11 +81,9 @@ See the [full list of CSPs](https://docs.edgeless.systems/constellation/overview
 
 - `api_server_cert_sans` (List of String) List of Subject Alternative Names (SANs) for the API server certificate. Usually, this will be the out-of-cluster endpoint and the in-cluster endpoint, if existing.
 - `azure` (Attributes) Azure-specific configuration. (see [below for nested schema](#nestedatt--azure))
-- `constellation_microservice_version` (String) The version of Constellation's microservices used within the cluster. When not set, the provider version is used.
 - `extra_microservices` (Attributes) Extra microservice settings. (see [below for nested schema](#nestedatt--extra_microservices))
 - `gcp` (Attributes) GCP-specific configuration. (see [below for nested schema](#nestedatt--gcp))
 - `in_cluster_endpoint` (String) The endpoint of the cluster. When not set, the out-of-cluster endpoint is used.
-- `kubernetes_version` (String) The Kubernetes version to use for the cluster. When not set, version v1.27.9 is used. The supported versions are [v1.26.12 v1.27.9 v1.28.5].
 - `license_id` (String) Constellation license ID. When not set, the community license is used.
 
 ### Read-Only

--- a/terraform-provider-constellation/examples/full/aws/main.tf
+++ b/terraform-provider-constellation/examples/full/aws/main.tf
@@ -14,6 +14,7 @@ terraform {
 locals {
   name                = "constell"
   version             = "vX.Y.Z"
+  kubernetes_version  = "vX.Y.Z"
   csp                 = "aws"
   attestation_variant = "aws-sev-snp"
   region              = "us-east-2"
@@ -95,6 +96,7 @@ resource "constellation_cluster" "aws_example" {
   uid                     = module.aws_infrastructure.uid
   image                   = data.constellation_image.bar.image
   attestation             = data.constellation_attestation.foo.attestation
+  kubernetes_version      = local.kubernetes_version
   init_secret             = module.aws_infrastructure.init_secret
   master_secret           = local.master_secret
   master_secret_salt      = local.master_secret_salt

--- a/terraform-provider-constellation/examples/full/aws/main.tf
+++ b/terraform-provider-constellation/examples/full/aws/main.tf
@@ -12,13 +12,14 @@ terraform {
 }
 
 locals {
-  name                = "constell"
-  version             = "vX.Y.Z"
-  kubernetes_version  = "vX.Y.Z"
-  csp                 = "aws"
-  attestation_variant = "aws-sev-snp"
-  region              = "us-east-2"
-  zone                = "us-east-2c"
+  name                 = "constell"
+  version              = "vX.Y.Z"
+  kubernetes_version   = "vX.Y.Z"
+  microservice_version = "vX.Y.Z"
+  csp                  = "aws"
+  attestation_variant  = "aws-sev-snp"
+  region               = "us-east-2"
+  zone                 = "us-east-2c"
 
   master_secret      = random_bytes.master_secret.hex
   master_secret_salt = random_bytes.master_secret_salt.hex
@@ -91,19 +92,20 @@ data "constellation_image" "bar" {
 }
 
 resource "constellation_cluster" "aws_example" {
-  csp                     = local.csp
-  name                    = module.aws_infrastructure.name
-  uid                     = module.aws_infrastructure.uid
-  image                   = data.constellation_image.bar.image
-  attestation             = data.constellation_attestation.foo.attestation
-  kubernetes_version      = local.kubernetes_version
-  init_secret             = module.aws_infrastructure.init_secret
-  master_secret           = local.master_secret
-  master_secret_salt      = local.master_secret_salt
-  measurement_salt        = local.measurement_salt
-  out_of_cluster_endpoint = module.aws_infrastructure.out_of_cluster_endpoint
-  in_cluster_endpoint     = module.aws_infrastructure.in_cluster_endpoint
-  api_server_cert_sans    = module.aws_infrastructure.api_server_cert_sans
+  csp                                = local.csp
+  name                               = module.aws_infrastructure.name
+  uid                                = module.aws_infrastructure.uid
+  image                              = data.constellation_image.bar.image
+  attestation                        = data.constellation_attestation.foo.attestation
+  kubernetes_version                 = local.kubernetes_version
+  constellation_microservice_version = local.microservice_version
+  init_secret                        = module.aws_infrastructure.init_secret
+  master_secret                      = local.master_secret
+  master_secret_salt                 = local.master_secret_salt
+  measurement_salt                   = local.measurement_salt
+  out_of_cluster_endpoint            = module.aws_infrastructure.out_of_cluster_endpoint
+  in_cluster_endpoint                = module.aws_infrastructure.in_cluster_endpoint
+  api_server_cert_sans               = module.aws_infrastructure.api_server_cert_sans
   network_config = {
     ip_cidr_node    = module.aws_infrastructure.ip_cidr_node
     ip_cidr_service = "10.96.0.0/12"

--- a/terraform-provider-constellation/examples/full/azure/main.tf
+++ b/terraform-provider-constellation/examples/full/azure/main.tf
@@ -12,12 +12,13 @@ terraform {
 }
 
 locals {
-  name                = "constell"
-  version             = "vX.Y.Z"
-  kubernetes_version  = "vX.Y.Z"
-  csp                 = "azure"
-  attestation_variant = "azure-sev-snp"
-  location            = "northeurope"
+  name                 = "constell"
+  version              = "vX.Y.Z"
+  kubernetes_version   = "vX.Y.Z"
+  microservice_version = "vX.Y.Z"
+  csp                  = "azure"
+  attestation_variant  = "azure-sev-snp"
+  location             = "northeurope"
 
   master_secret      = random_bytes.master_secret.hex
   master_secret_salt = random_bytes.master_secret_salt.hex
@@ -86,19 +87,20 @@ data "constellation_image" "bar" {
 }
 
 resource "constellation_cluster" "azure_example" {
-  csp                     = local.csp
-  name                    = module.azure_infrastructure.name
-  uid                     = module.azure_infrastructure.uid
-  image                   = data.constellation_image.bar.image
-  attestation             = data.constellation_attestation.foo.attestation
-  kubernetes_version      = local.kubernetes_version
-  init_secret             = module.azure_infrastructure.init_secret
-  master_secret           = local.master_secret
-  master_secret_salt      = local.master_secret_salt
-  measurement_salt        = local.measurement_salt
-  out_of_cluster_endpoint = module.azure_infrastructure.out_of_cluster_endpoint
-  in_cluster_endpoint     = module.azure_infrastructure.in_cluster_endpoint
-  api_server_cert_sans    = module.azure_infrastructure.api_server_cert_sans
+  csp                                = local.csp
+  name                               = module.azure_infrastructure.name
+  uid                                = module.azure_infrastructure.uid
+  image                              = data.constellation_image.bar.image
+  attestation                        = data.constellation_attestation.foo.attestation
+  kubernetes_version                 = local.kubernetes_version
+  constellation_microservice_version = local.microservice_version
+  init_secret                        = module.azure_infrastructure.init_secret
+  master_secret                      = local.master_secret
+  master_secret_salt                 = local.master_secret_salt
+  measurement_salt                   = local.measurement_salt
+  out_of_cluster_endpoint            = module.azure_infrastructure.out_of_cluster_endpoint
+  in_cluster_endpoint                = module.azure_infrastructure.in_cluster_endpoint
+  api_server_cert_sans               = module.azure_infrastructure.api_server_cert_sans
   azure = {
     tenant_id                   = module.azure_iam.tenant_id
     subscription_id             = module.azure_iam.subscription_id

--- a/terraform-provider-constellation/examples/full/azure/main.tf
+++ b/terraform-provider-constellation/examples/full/azure/main.tf
@@ -14,6 +14,7 @@ terraform {
 locals {
   name                = "constell"
   version             = "vX.Y.Z"
+  kubernetes_version  = "vX.Y.Z"
   csp                 = "azure"
   attestation_variant = "azure-sev-snp"
   location            = "northeurope"
@@ -90,6 +91,7 @@ resource "constellation_cluster" "azure_example" {
   uid                     = module.azure_infrastructure.uid
   image                   = data.constellation_image.bar.image
   attestation             = data.constellation_attestation.foo.attestation
+  kubernetes_version      = local.kubernetes_version
   init_secret             = module.azure_infrastructure.init_secret
   master_secret           = local.master_secret
   master_secret_salt      = local.master_secret_salt

--- a/terraform-provider-constellation/examples/full/gcp/main.tf
+++ b/terraform-provider-constellation/examples/full/gcp/main.tf
@@ -14,6 +14,7 @@ terraform {
 locals {
   name                = "constell"
   version             = "vX.Y.Z"
+  kubernetes_version  = "vX.Y.Z"
   csp                 = "gcp"
   attestation_variant = "gcp-sev-es"
   region              = "europe-west3"
@@ -94,6 +95,7 @@ resource "constellation_cluster" "gcp_example" {
   uid                     = module.gcp_infrastructure.uid
   image                   = data.constellation_image.bar.image
   attestation             = data.constellation_attestation.foo.attestation
+  kubernetes_version      = local.kubernetes_version
   init_secret             = module.gcp_infrastructure.init_secret
   master_secret           = local.master_secret
   master_secret_salt      = local.master_secret_salt

--- a/terraform-provider-constellation/examples/full/gcp/main.tf
+++ b/terraform-provider-constellation/examples/full/gcp/main.tf
@@ -12,14 +12,15 @@ terraform {
 }
 
 locals {
-  name                = "constell"
-  version             = "vX.Y.Z"
-  kubernetes_version  = "vX.Y.Z"
-  csp                 = "gcp"
-  attestation_variant = "gcp-sev-es"
-  region              = "europe-west3"
-  zone                = "europe-west3-b"
-  project_id          = "constellation-331613"
+  name                 = "constell"
+  version              = "vX.Y.Z"
+  kubernetes_version   = "vX.Y.Z"
+  microservice_version = "vX.Y.Z"
+  csp                  = "gcp"
+  attestation_variant  = "gcp-sev-es"
+  region               = "europe-west3"
+  zone                 = "europe-west3-b"
+  project_id           = "constellation-331613"
 
   master_secret      = random_bytes.master_secret.hex
   master_secret_salt = random_bytes.master_secret_salt.hex
@@ -90,19 +91,20 @@ data "constellation_image" "bar" {
 }
 
 resource "constellation_cluster" "gcp_example" {
-  csp                     = local.csp
-  name                    = module.gcp_infrastructure.name
-  uid                     = module.gcp_infrastructure.uid
-  image                   = data.constellation_image.bar.image
-  attestation             = data.constellation_attestation.foo.attestation
-  kubernetes_version      = local.kubernetes_version
-  init_secret             = module.gcp_infrastructure.init_secret
-  master_secret           = local.master_secret
-  master_secret_salt      = local.master_secret_salt
-  measurement_salt        = local.measurement_salt
-  out_of_cluster_endpoint = module.gcp_infrastructure.out_of_cluster_endpoint
-  in_cluster_endpoint     = module.gcp_infrastructure.in_cluster_endpoint
-  api_server_cert_sans    = module.gcp_infrastructure.api_server_cert_sans
+  csp                                = local.csp
+  name                               = module.gcp_infrastructure.name
+  uid                                = module.gcp_infrastructure.uid
+  image                              = data.constellation_image.bar.image
+  attestation                        = data.constellation_attestation.foo.attestation
+  kubernetes_version                 = local.kubernetes_version
+  constellation_microservice_version = local.microservice_version
+  init_secret                        = module.gcp_infrastructure.init_secret
+  master_secret                      = local.master_secret
+  master_secret_salt                 = local.master_secret_salt
+  measurement_salt                   = local.measurement_salt
+  out_of_cluster_endpoint            = module.gcp_infrastructure.out_of_cluster_endpoint
+  in_cluster_endpoint                = module.gcp_infrastructure.in_cluster_endpoint
+  api_server_cert_sans               = module.gcp_infrastructure.api_server_cert_sans
   gcp = {
     project_id          = module.gcp_infrastructure.project
     service_account_key = module.gcp_iam.service_account_key

--- a/terraform-provider-constellation/internal/provider/BUILD.bazel
+++ b/terraform-provider-constellation/internal/provider/BUILD.bazel
@@ -94,6 +94,7 @@ go_test(
         "//internal/config",
         "//internal/constants",
         "//internal/semver",
+        "//internal/versions",
         "//terraform-provider-constellation/internal/data",
         "@com_github_hashicorp_terraform_plugin_framework//attr",
         "@com_github_hashicorp_terraform_plugin_framework//providerserver",

--- a/terraform-provider-constellation/internal/provider/cluster_resource.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource.go
@@ -470,13 +470,13 @@ func (r *ClusterResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 		}
 
 		// Warn the user about possibly destructive changes in case microservice changes are to be applied.
-		currVer, diags := r.getMicroserviceVersion(ctx, &currentState)
+		currVer, diags := r.getMicroserviceVersion(&currentState)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
 		}
 
-		plannedVer, diags := r.getMicroserviceVersion(ctx, &plannedState)
+		plannedVer, diags := r.getMicroserviceVersion(&plannedState)
 		resp.Diagnostics.Append(diags...)
 		if resp.Diagnostics.HasError() {
 			return
@@ -718,14 +718,14 @@ func (r *ClusterResource) apply(ctx context.Context, data *ClusterResourceModel,
 	}
 
 	// parse Constellation microservice version
-	microserviceVersion, convertDiags := r.getMicroserviceVersion(ctx, data)
+	microserviceVersion, convertDiags := r.getMicroserviceVersion(data)
 	diags.Append(convertDiags...)
 	if diags.HasError() {
 		return diags
 	}
 
 	// parse Kubernetes version
-	k8sVersion, getDiags := r.getK8sVersion(ctx, data)
+	k8sVersion, getDiags := r.getK8sVersion(data)
 	diags.Append(getDiags...)
 	if diags.HasError() {
 		return diags
@@ -1163,7 +1163,7 @@ func (r *ClusterResource) convertSecrets(data ClusterResourceModel) (secretInput
 
 // getK8sVersion returns the Kubernetes version from the Terraform state if set, and the default
 // version otherwise.
-func (r *ClusterResource) getK8sVersion(ctx context.Context, data *ClusterResourceModel) (versions.ValidK8sVersion, diag.Diagnostics) {
+func (r *ClusterResource) getK8sVersion(data *ClusterResourceModel) (versions.ValidK8sVersion, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 	k8sVersion, err := versions.NewValidK8sVersion(data.KubernetesVersion.ValueString(), true)
 	if err != nil {
@@ -1178,7 +1178,7 @@ func (r *ClusterResource) getK8sVersion(ctx context.Context, data *ClusterResour
 
 // getK8sVersion returns the Microservice version from the Terraform state if set, and the default
 // version otherwise.
-func (r *ClusterResource) getMicroserviceVersion(ctx context.Context, data *ClusterResourceModel) (semver.Semver, diag.Diagnostics) {
+func (r *ClusterResource) getMicroserviceVersion(data *ClusterResourceModel) (semver.Semver, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
 	ver, err := semver.New(data.MicroserviceVersion.ValueString())
 	if err != nil {

--- a/terraform-provider-constellation/internal/provider/cluster_resource.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource.go
@@ -160,9 +160,9 @@ func (r *ClusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 			},
 			"image": newImageAttributeSchema(attributeInput),
 			"kubernetes_version": schema.StringAttribute{
-				MarkdownDescription: fmt.Sprintf("The Kubernetes version to use for the cluster. When not set, version %s is used. The supported versions are %s.", versions.Default, versions.SupportedK8sVersions()),
-				Description:         fmt.Sprintf("The Kubernetes version to use for the cluster. When not set, version %s is used. The supported versions are %s.", versions.Default, versions.SupportedK8sVersions()),
-				Optional:            true,
+				MarkdownDescription: fmt.Sprintf("The Kubernetes version to use for the cluster. The supported versions are %s.", versions.SupportedK8sVersions()),
+				Description:         fmt.Sprintf("The Kubernetes version to use for the cluster. The supported versions are %s.", versions.SupportedK8sVersions()),
+				Required:            true,
 			},
 			"constellation_microservice_version": schema.StringAttribute{
 				MarkdownDescription: "The version of Constellation's microservices used within the cluster. When not set, the provider version is used.",
@@ -1165,20 +1165,13 @@ func (r *ClusterResource) convertSecrets(data ClusterResourceModel) (secretInput
 // version otherwise.
 func (r *ClusterResource) getK8sVersion(ctx context.Context, data *ClusterResourceModel) (versions.ValidK8sVersion, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
-	var k8sVersion versions.ValidK8sVersion
-	var err error
-	if data.KubernetesVersion.ValueString() != "" {
-		k8sVersion, err = versions.NewValidK8sVersion(data.KubernetesVersion.ValueString(), true)
-		if err != nil {
-			diags.AddAttributeError(
-				path.Root("kubernetes_vesion"),
-				"Invalid Kubernetes version",
-				fmt.Sprintf("Parsing Kubernetes version: %s", err))
-			return "", diags
-		}
-	} else {
-		tflog.Info(ctx, fmt.Sprintf("No Kubernetes version specified. Using default version %s.", versions.Default))
-		k8sVersion = versions.Default
+	k8sVersion, err := versions.NewValidK8sVersion(data.KubernetesVersion.ValueString(), true)
+	if err != nil {
+		diags.AddAttributeError(
+			path.Root("kubernetes_version"),
+			"Invalid Kubernetes version",
+			fmt.Sprintf("Parsing Kubernetes version: %s", err))
+		return "", diags
 	}
 	return k8sVersion, diags
 }

--- a/terraform-provider-constellation/internal/provider/cluster_resource.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource.go
@@ -165,9 +165,9 @@ func (r *ClusterResource) Schema(_ context.Context, _ resource.SchemaRequest, re
 				Required:            true,
 			},
 			"constellation_microservice_version": schema.StringAttribute{
-				MarkdownDescription: "The version of Constellation's microservices used within the cluster. When not set, the provider version is used.",
-				Description:         "The version of Constellation's microservices used within the cluster. When not set, the provider version is used.",
-				Optional:            true,
+				MarkdownDescription: "The version of Constellation's microservices used within the cluster.",
+				Description:         "The version of Constellation's microservices used within the cluster.",
+				Required:            true,
 			},
 			"out_of_cluster_endpoint": schema.StringAttribute{
 				MarkdownDescription: "The endpoint of the cluster. Typically, this is the public IP of a loadbalancer.",
@@ -1180,20 +1180,13 @@ func (r *ClusterResource) getK8sVersion(ctx context.Context, data *ClusterResour
 // version otherwise.
 func (r *ClusterResource) getMicroserviceVersion(ctx context.Context, data *ClusterResourceModel) (semver.Semver, diag.Diagnostics) {
 	diags := diag.Diagnostics{}
-	var ver semver.Semver
-	var err error
-	if data.MicroserviceVersion.ValueString() != "" {
-		ver, err = semver.New(data.MicroserviceVersion.ValueString())
-		if err != nil {
-			diags.AddAttributeError(
-				path.Root("constellation_microservice_version"),
-				"Invalid microservice version",
-				fmt.Sprintf("Parsing microservice version: %s", err))
-			return semver.Semver{}, diags
-		}
-	} else {
-		tflog.Info(ctx, fmt.Sprintf("No Microservice version specified. Using default version %s.", r.providerData.Version))
-		ver = r.providerData.Version
+	ver, err := semver.New(data.MicroserviceVersion.ValueString())
+	if err != nil {
+		diags.AddAttributeError(
+			path.Root("constellation_microservice_version"),
+			"Invalid microservice version",
+			fmt.Sprintf("Parsing microservice version: %s", err))
+		return semver.Semver{}, diags
 	}
 	if err := config.ValidateMicroserviceVersion(r.providerData.Version, ver); err != nil {
 		diags.AddAttributeError(

--- a/terraform-provider-constellation/internal/provider/cluster_resource_test.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource_test.go
@@ -54,7 +54,7 @@ func TestMicroserviceConstraint(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			_, diags := sut.getMicroserviceVersion(context.Background(), &ClusterResourceModel{
+			_, diags := sut.getMicroserviceVersion(&ClusterResourceModel{
 				MicroserviceVersion: basetypes.NewStringValue(tc.version),
 			})
 			require.Equal(t, tc.expectedErrorCount, diags.ErrorsCount())

--- a/terraform-provider-constellation/internal/provider/cluster_resource_test.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource_test.go
@@ -23,10 +23,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var providerVersion = semver.NewFromInt(2, 15, 0, "")
+
 func TestMicroserviceConstraint(t *testing.T) {
 	sut := &ClusterResource{
 		providerData: data.ProviderData{
-			Version: semver.NewFromInt(2, 15, 0, ""),
+			Version: providerVersion,
 		},
 	}
 	testCases := []struct {
@@ -228,8 +230,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_service = "0.0.0.0/24"
 						}
 						kubernetes_version = "%s"
+						constellation_microservice_version = "%s"
 					  }
-				`, versions.Default),
+				`, versions.Default, providerVersion.String()),
 					ExpectError: regexp.MustCompile(".*Master secret must be a hex-encoded 32-byte.*"),
 				},
 			},
@@ -257,8 +260,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_service = "0.0.0.0/24"
 						}
 						kubernetes_version = "%s"
+						constellation_microservice_version = "%s"
 					  }
-				`, versions.Default),
+				`, versions.Default, providerVersion.String()),
 					ExpectError: regexp.MustCompile(".*Master secret salt must be a hex-encoded 32-byte.*"),
 				},
 			},
@@ -286,8 +290,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_service = "0.0.0.0/24"
 						}
 						kubernetes_version = "%s"
+						constellation_microservice_version = "%s"
 					  }
-				`, versions.Default),
+				`, versions.Default, providerVersion.String()),
 					ExpectError: regexp.MustCompile(".*Measurement salt must be a hex-encoded 32-byte.*"),
 				},
 			},
@@ -315,8 +320,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_service = "0.0.0.0/24"
 						}
 						kubernetes_version = "%s"
+						constellation_microservice_version = "%s"
 					  }
-				`, versions.Default),
+				`, versions.Default, providerVersion.String()),
 					ExpectError: regexp.MustCompile(".*Node IP CIDR must be a valid CIDR.*"),
 				},
 			},
@@ -344,8 +350,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_service = "0.0.0x.0/xxx"
 						}
 						kubernetes_version = "%s"
+						constellation_microservice_version = "%s"
 					  }
-				`, versions.Default),
+				`, versions.Default, providerVersion.String()),
 					ExpectError: regexp.MustCompile(".*Service IP CIDR must be a valid CIDR.*"),
 				},
 			},
@@ -373,8 +380,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_service = "0.0.0.0/24"
 						}
 						kubernetes_version = "%s"
+						constellation_microservice_version = "%s"
 					  }
-				`, versions.Default),
+				`, versions.Default, providerVersion.String()),
 					ExpectError: regexp.MustCompile(".*When csp is set to 'azure', the 'azure' configuration must be set.*"),
 				},
 			},
@@ -403,8 +411,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_pod    = "0.0.0.0/24"
 						}
 						kubernetes_version = "%s"
+						constellation_microservice_version = "%s"
 					  }
-				`, versions.Default),
+				`, versions.Default, providerVersion.String()),
 					ExpectError: regexp.MustCompile(".*When csp is set to 'gcp', the 'gcp' configuration must be set.*"),
 				},
 			},
@@ -436,7 +445,9 @@ func TestAccClusterResource(t *testing.T) {
 									service_account_key = "eyJ0ZXN0IjogInRlc3QifQ=="
 							}
 							kubernetes_version = "%s"
-					}`, versions.Default),
+							constellation_microservice_version = "%s"
+					  }
+				`, versions.Default, providerVersion.String()),
 					ExpectError: regexp.MustCompile(".*When csp is set to 'gcp', 'ip_cidr_pod' must be set.*"),
 				},
 			},

--- a/terraform-provider-constellation/internal/provider/cluster_resource_test.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource_test.go
@@ -8,10 +8,12 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/internal/semver"
+	"github.com/edgelesssys/constellation/v2/internal/versions"
 	"github.com/edgelesssys/constellation/v2/terraform-provider-constellation/internal/data"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
@@ -208,7 +210,7 @@ func TestAccClusterResource(t *testing.T) {
 			PreCheck:                 bazelPreCheck,
 			Steps: []resource.TestStep{
 				{
-					Config: fullClusterTestingConfig(t, "aws") + `
+					Config: fullClusterTestingConfig(t, "aws") + fmt.Sprintf(`
 					resource "constellation_cluster" "test" {
 						csp                     = "aws"
 						name                    = "constell"
@@ -225,8 +227,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_node    = "0.0.0.0/24"
 						  ip_cidr_service = "0.0.0.0/24"
 						}
+						kubernetes_version = "%s"
 					  }
-				`,
+				`, versions.Default),
 					ExpectError: regexp.MustCompile(".*Master secret must be a hex-encoded 32-byte.*"),
 				},
 			},
@@ -236,7 +239,7 @@ func TestAccClusterResource(t *testing.T) {
 			PreCheck:                 bazelPreCheck,
 			Steps: []resource.TestStep{
 				{
-					Config: fullClusterTestingConfig(t, "aws") + `
+					Config: fullClusterTestingConfig(t, "aws") + fmt.Sprintf(`
 					resource "constellation_cluster" "test" {
 						csp                     = "aws"
 						name                    = "constell"
@@ -253,8 +256,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_node    = "0.0.0.0/24"
 						  ip_cidr_service = "0.0.0.0/24"
 						}
+						kubernetes_version = "%s"
 					  }
-				`,
+				`, versions.Default),
 					ExpectError: regexp.MustCompile(".*Master secret salt must be a hex-encoded 32-byte.*"),
 				},
 			},
@@ -264,7 +268,7 @@ func TestAccClusterResource(t *testing.T) {
 			PreCheck:                 bazelPreCheck,
 			Steps: []resource.TestStep{
 				{
-					Config: fullClusterTestingConfig(t, "aws") + `
+					Config: fullClusterTestingConfig(t, "aws") + fmt.Sprintf(`
 					resource "constellation_cluster" "test" {
 						csp                     = "aws"
 						name                    = "constell"
@@ -281,8 +285,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_node    = "0.0.0.0/24"
 						  ip_cidr_service = "0.0.0.0/24"
 						}
+						kubernetes_version = "%s"
 					  }
-				`,
+				`, versions.Default),
 					ExpectError: regexp.MustCompile(".*Measurement salt must be a hex-encoded 32-byte.*"),
 				},
 			},
@@ -292,7 +297,7 @@ func TestAccClusterResource(t *testing.T) {
 			PreCheck:                 bazelPreCheck,
 			Steps: []resource.TestStep{
 				{
-					Config: fullClusterTestingConfig(t, "aws") + `
+					Config: fullClusterTestingConfig(t, "aws") + fmt.Sprintf(`
 					resource "constellation_cluster" "test" {
 						csp                     = "aws"
 						name                    = "constell"
@@ -309,8 +314,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_node    = "0.0.0x.0/xxx"
 						  ip_cidr_service = "0.0.0.0/24"
 						}
+						kubernetes_version = "%s"
 					  }
-				`,
+				`, versions.Default),
 					ExpectError: regexp.MustCompile(".*Node IP CIDR must be a valid CIDR.*"),
 				},
 			},
@@ -320,7 +326,7 @@ func TestAccClusterResource(t *testing.T) {
 			PreCheck:                 bazelPreCheck,
 			Steps: []resource.TestStep{
 				{
-					Config: fullClusterTestingConfig(t, "aws") + `
+					Config: fullClusterTestingConfig(t, "aws") + fmt.Sprintf(`
 					resource "constellation_cluster" "test" {
 						csp                     = "aws"
 						name                    = "constell"
@@ -337,8 +343,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_node    = "0.0.0.0/24"
 						  ip_cidr_service = "0.0.0x.0/xxx"
 						}
+						kubernetes_version = "%s"
 					  }
-				`,
+				`, versions.Default),
 					ExpectError: regexp.MustCompile(".*Service IP CIDR must be a valid CIDR.*"),
 				},
 			},
@@ -348,7 +355,7 @@ func TestAccClusterResource(t *testing.T) {
 			PreCheck:                 bazelPreCheck,
 			Steps: []resource.TestStep{
 				{
-					Config: fullClusterTestingConfig(t, "azure") + `
+					Config: fullClusterTestingConfig(t, "azure") + fmt.Sprintf(`
 					resource "constellation_cluster" "test" {
 						csp                     = "azure"
 						name                    = "constell"
@@ -365,8 +372,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_node    = "0.0.0.0/24"
 						  ip_cidr_service = "0.0.0.0/24"
 						}
+						kubernetes_version = "%s"
 					  }
-				`,
+				`, versions.Default),
 					ExpectError: regexp.MustCompile(".*When csp is set to 'azure', the 'azure' configuration must be set.*"),
 				},
 			},
@@ -376,7 +384,7 @@ func TestAccClusterResource(t *testing.T) {
 			PreCheck:                 bazelPreCheck,
 			Steps: []resource.TestStep{
 				{
-					Config: fullClusterTestingConfig(t, "gcp") + `
+					Config: fullClusterTestingConfig(t, "gcp") + fmt.Sprintf(`
 					resource "constellation_cluster" "test" {
 						csp                     = "gcp"
 						name                    = "constell"
@@ -394,8 +402,9 @@ func TestAccClusterResource(t *testing.T) {
 						  ip_cidr_service = "0.0.0.0/24"
 						  ip_cidr_pod    = "0.0.0.0/24"
 						}
+						kubernetes_version = "%s"
 					  }
-				`,
+				`, versions.Default),
 					ExpectError: regexp.MustCompile(".*When csp is set to 'gcp', the 'gcp' configuration must be set.*"),
 				},
 			},
@@ -405,29 +414,29 @@ func TestAccClusterResource(t *testing.T) {
 			PreCheck:                 bazelPreCheck,
 			Steps: []resource.TestStep{
 				{
-					Config: fullClusterTestingConfig(t, "gcp") + `
+					Config: fullClusterTestingConfig(t, "gcp") + fmt.Sprintf(`
 					resource "constellation_cluster" "test" {
-						csp                     = "gcp"
-						name                    = "constell"
-						uid                     = "test"
-						image                   = data.constellation_image.bar.image
-						attestation             = data.constellation_attestation.foo.attestation
-						init_secret             = "deadbeef"
-						master_secret           = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-						master_secret_salt      = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-						measurement_salt        = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
-						out_of_cluster_endpoint = "192.0.2.1"
-						in_cluster_endpoint     = "192.0.2.1"
-						network_config = {
-						  ip_cidr_node    = "0.0.0.0/24"
-						  ip_cidr_service = "0.0.0.0/24"
-						}
-						gcp = {
-							project_id = "test"
-							service_account_key = "eyJ0ZXN0IjogInRlc3QifQ=="
-						}
-					  }
-				`,
+							csp                     = "gcp"
+							name                    = "constell"
+							uid                     = "test"
+							image                   = data.constellation_image.bar.image
+							attestation             = data.constellation_attestation.foo.attestation
+							init_secret             = "deadbeef"
+							master_secret           = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+							master_secret_salt      = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+							measurement_salt        = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+							out_of_cluster_endpoint = "192.0.2.1"
+							in_cluster_endpoint     = "192.0.2.1"
+							network_config = {
+									ip_cidr_node    = "0.0.0.0/24"
+									ip_cidr_service = "0.0.0.0/24"
+							}
+							gcp = {
+									project_id = "test"
+									service_account_key = "eyJ0ZXN0IjogInRlc3QifQ=="
+							}
+							kubernetes_version = "%s"
+					}`, versions.Default),
 					ExpectError: regexp.MustCompile(".*When csp is set to 'gcp', 'ip_cidr_pod' must be set.*"),
 				},
 			},


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The provider is currently using a default when no version is specified for these fields. This however leads to an unexpected upgrade state, because new versions defaults, as part of provider upgrades, are not seen as state change by Terraform. Consequently, the new defaults are not applied. This is especially undesired for the microservice version, which should always coincide with the provider version.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- marking as `breaking change` to make users aware
- make fields required
- adjust provider e2e test

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
