### PR TITLE
e2e: dynamically create rg resource group for minicon

### DIFF
--- a/e2e/miniconstellation/main.tf
+++ b/e2e/miniconstellation/main.tf
@@ -46,36 +46,37 @@ data "cloudinit_config" "cloud_init" {
   }
 }
 
-data "azurerm_resource_group" "main" {
-  name = "e2e-miniconstellation"
+resource "azurerm_resource_group" "main" {
+  name     = "e2e-mini-${random_string.suffix.result}"
+  location = "North Europe"
 }
 
 resource "azurerm_virtual_network" "main" {
   name                = "e2e-mini-${random_string.suffix.result}"
   address_space       = ["10.0.0.0/16"]
-  location            = data.azurerm_resource_group.main.location
-  resource_group_name = data.azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "main" {
   name                 = "e2e-mini-${random_string.suffix.result}"
-  resource_group_name  = data.azurerm_resource_group.main.name
+  resource_group_name  = azurerm_resource_group.main.name
   virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "main" {
   name                = "e2e-mini-${random_string.suffix.result}"
-  location            = data.azurerm_resource_group.main.location
-  resource_group_name = data.azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
   allocation_method   = "Static"
   sku                 = "Standard"
 }
 
 resource "azurerm_network_interface" "main" {
   name                = "e2e-mini-${random_string.suffix.result}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
 
   ip_configuration {
     name                          = "main"
@@ -87,8 +88,8 @@ resource "azurerm_network_interface" "main" {
 
 resource "azurerm_network_security_group" "ssh" {
   name                = "e2e-mini-${random_string.suffix.result}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
 
   security_rule {
     name                       = "ssh"
@@ -110,8 +111,8 @@ resource "azurerm_subnet_network_security_group_association" "ssh" {
 
 resource "azurerm_linux_virtual_machine" "main" {
   name                = "e2e-mini-${random_string.suffix.result}"
-  resource_group_name = data.azurerm_resource_group.main.name
-  location            = data.azurerm_resource_group.main.location
+  resource_group_name = azurerm_resource_group.main.name
+  location            = azurerm_resource_group.main.location
 
   # Standard_D8s_v5 provides nested virtualization support
   size = "Standard_D8s_v5"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Dynamically create resource group for miniconstellation e2e test

Now we don't depend on the "e2e-miniconstellation" rg existing.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
