### PR TITLE
ci: don't export e2e metrics to OpenSearch

### DIFF
--- a/.github/actions/deploy_logcollection/action.yml
+++ b/.github/actions/deploy_logcollection/action.yml
@@ -90,17 +90,3 @@ runs:
         helm repo update
         helm install filebeat elastic/filebeat \
           --wait --timeout=1200s --values values.yml
-
-    - name: Deploy Metricbeat
-      id: deploy-metricbeat
-      shell: bash
-      working-directory: ./metricbeat
-      env:
-        KUBECONFIG: ${{ inputs.kubeconfig }}
-      run: |
-        helm repo add elastic https://helm.elastic.co
-        helm repo update
-        helm install metricbeat-k8s elastic/metricbeat \
-          --wait --timeout=1200s --values values-control-plane.yml
-        helm install metricbeat-system elastic/metricbeat \
-          --wait --timeout=1200s --values values-all-nodes.yml


### PR DESCRIPTION
### Context

Our OpenSearch instance is running full quickly and we're trying to stop collecting data that we don't need.

### Proposed change(s)
- Don't export metrics to OpenSearch. Metrics are not ideal for a log-processing engine and we don't have a good use case for storing metrics right now.
  * Remove metricbeat from e2e tests.
  * Deactivate metricbeat in debugd. 

### Related issue

- Fixes edgelesssys/issues#228.

### Additional info

- 

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
