### PR TITLE
ci: ignore Wireguard pdf in lychee

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@ec3ed119d4f44ad2673a7232460dc7dff59d2421 # v1.8.0
         with:
-          args: "--verbose --no-progress --max-concurrency 5 --exclude-path './internal/constellation/helm/charts/cilium' './**/*.md' './**/*.html'"
+          args: "--config ./.lychee.toml './**/*.md' './**/*.html'"
           fail: true
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -29,5 +29,3 @@ jobs:
         with:
           args: "--config ./.lychee.toml './**/*.md' './**/*.html'"
           fail: true
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ __pycache__/
 # s3proxy misc files
 port-forward.log
 s3proxy-ca.crt
+
+# Lychee link checker
+.lycheecache

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,45 @@
+# Verbose program output
+# Accepts log level: "error", "warn", "info", "debug", "trace"
+verbose = "info"
+
+# Don't show interactive progress bar while checking links.
+no_progress = true
+
+# Enable link caching. This can be helpful to avoid checking the same links on
+# multiple runs.
+cache = true
+
+# Discard all cached requests older than this duration.
+max_cache_age = "10m"
+
+# Maximum number of concurrent link checks.
+max_concurrency = 5
+
+# Comma-separated list of accepted status codes for valid links.
+# accept = ["200"]
+
+# Request method
+method = "head"
+
+# Check links inside `<code>` and `<pre>` blocks as well as Markdown code
+# blocks.
+include_verbatim = false
+
+# Exclude URLs and mail addresses from checking (supports regex).
+exclude = [
+    # Blocked for robots.
+    '^https://twitter\.com',
+    # Only available when logged in.
+    '^https://portal\.azure\.com/',
+]
+
+# Exclude these filesystem paths from getting checked.
+exclude_path = ["internal/constellation/helm/charts/cilium"]
+
+# Exclude all private IPs from checking.
+# Equivalent to setting `exclude_private`, `exclude_link_local`, and
+# `exclude_loopback` to true.
+exclude_all_private = true
+
+# Check mail addresses
+include_mail = false

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -31,6 +31,8 @@ exclude = [
     '^https://twitter\.com',
     # Only available when logged in.
     '^https://portal\.azure\.com/',
+    # The Wireguard PDF sproadically returns 500.
+    'wireguard\.pdf$',
 ]
 
 # Exclude these filesystem paths from getting checked.

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -19,7 +19,7 @@ max_concurrency = 5
 # accept = ["200"]
 
 # Request method
-method = "head"
+method = "get"
 
 # Check links inside `<code>` and `<pre>` blocks as well as Markdown code
 # blocks.

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -1,7 +1,0 @@
-http://localhost:
-# TODO: Remove when site fixed their TLS chain (<https://github.com/edgelesssys/constellation/pull/430>)
-https://www.ntia.gov/SBOM
-# Twitter times out on request, maybe someone pulled the plug of this subsystem
-https://twitter.com/EdgelessSystems
-# Azure portal internal link, will return 403 for crawlers, or error when not logged in
-https://portal.azure.com/#view/HubsExtension/BrowseResource/resourceType/Microsoft.Compute%2Fgalleries

--- a/docs/docs/overview/performance/io.md
+++ b/docs/docs/overview/performance/io.md
@@ -58,7 +58,7 @@ The following infrastructure configurations was used:
 This section gives a thorough analysis of the network performance of Constellation, specifically focusing on measuring TCP and UDP bandwidth.
 The benchmark measured the bandwidth of pod-to-pod and pod-to-service connections between two different nodes using [`iperf`](https://iperf.fr/).
 
-GKE and Constellation on GCP had a maximum network bandwidth of [10 Gbps](https://cloud.google.com/compute/docs/general-purpose-machines#n2d_machineshttps://cloud.google.com/compute/docs/general-purpose-machines#n2d_machines).
+GKE and Constellation on GCP had a maximum network bandwidth of [10 Gbps](https://cloud.google.com/compute/docs/general-purpose-machines#n2d_machines).
 AKS with `Standard_D4as_v5` machines a maximum network bandwidth of [12.5 Gbps](https://learn.microsoft.com/en-us/azure/virtual-machines/dasv5-dadsv5-series#dasv5-series).
 The Confidential VM equivalent `Standard_DC4as_v5` currently  has a network bandwidth of [1.25 Gbps](https://learn.microsoft.com/en-us/azure/virtual-machines/dcasv5-dcadsv5-series#dcasv5-series-products).
 Therefore, to make the test comparable, both AKS and Constellation on Azure were running with `Standard_DC4as_v5` machines and 1.25 Gbps bandwidth.


### PR DESCRIPTION
### Context

We're using Lychee to check links. The configuration is currently split between `.lycheeignore` and arguments.

### Proposed change(s)

- Unify lychee configuration in one file.
- Remove the GITHUB_TOKEN from the lychee action - it's not needed.
- Ignore Wireguard pdf.
- Fix invalid fragment in a user docs URL.

### Related issue

* Fixes edgelesssys/issues#142.

### Checklist

- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
