### PR TITLE
ci: reproducible builds test on artifacts v2

### DIFF
--- a/.github/workflows/reproducible-builds.yml
+++ b/.github/workflows/reproducible-builds.yml
@@ -1,4 +1,4 @@
-# Build Constellation CLI and check for reproducible builds
+# Build Constellation CLI + OS images and check for reproducible builds
 name: Reproducible Builds
 
 on:
@@ -53,13 +53,13 @@ jobs:
         run: shasum -a 256 "${binary}" | tee "${binary}.sha256"
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: "binaries-${{ matrix.target }}"
           path: "${{ env.binary }}"
 
       - name: Upload hash artifact
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: "sha256sums"
           path: "${{ env.binary }}.sha256"
@@ -109,13 +109,13 @@ jobs:
         run: shasum -a 256 "${binary}" | tee "${binary}.sha256"
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: "osimages-${{ matrix.target }}"
           path: "${{ env.binary }}"
 
       - name: Upload hash artifact
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
           name: "sha256sums"
           path: "${{ env.binary }}.sha256"
@@ -138,7 +138,7 @@ jobs:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
       - name: Download binaries
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: "binaries-${{ matrix.target }}"
 
@@ -171,7 +171,7 @@ jobs:
           ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
 
       - name: Download os images
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
           name: "osimages-${{ matrix.target }}"
 

--- a/.github/workflows/reproducible-builds.yml
+++ b/.github/workflows/reproducible-builds.yml
@@ -55,13 +55,13 @@ jobs:
       - name: Upload binary artifact
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: "binaries-${{ matrix.target }}"
+          name: "binaries-${{ matrix.target }}-${{ matrix.runner }}"
           path: "${{ env.binary }}"
 
       - name: Upload hash artifact
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: "sha256sums"
+          name: "sha256sums-${{ matrix.target }}-${{ matrix.runner }}"
           path: "${{ env.binary }}.sha256"
 
   build-osimages:
@@ -111,13 +111,13 @@ jobs:
       - name: Upload binary artifact
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: "osimages-${{ matrix.target }}"
+          name: "osimages-${{ matrix.target }}-${{ matrix.runner }}"
           path: "${{ env.binary }}"
 
       - name: Upload hash artifact
         uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
         with:
-          name: "sha256sums"
+          name: "sha256sums-${{ matrix.target }}-${{ matrix.runner }}"
           path: "${{ env.binary }}.sha256"
 
   compare-binaries:
@@ -140,7 +140,8 @@ jobs:
       - name: Download binaries
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
-          name: "binaries-${{ matrix.target }}"
+          pattern: "binaries-${{ matrix.target }}-*"
+          merge-multiple: true
 
       - name: Hash
         shell: bash
@@ -173,7 +174,8 @@ jobs:
       - name: Download os images
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
-          name: "osimages-${{ matrix.target }}"
+          pattern: "osimages-${{ matrix.target }}-*"
+          merge-multiple: true
 
       - name: Hash
         shell: bash


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

GitHub Actions [has changed the API for Artifacts](https://github.com/actions/toolkit/tree/main/packages/artifact#v2---whats-new). This limits the amount of artifacts per workflow, doesn't allow overwriting artifacts in a Workflow run and changed the way globs are handled.
Since the old API will likely be disabled soon, we have to refactor the reproducible builds test.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- upgrade reproducible builds test to new artifacts api (see what breaks)
- fix matrix up/downloads using `pattern` field

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [CI run](https://github.com/edgelesssys/constellation/actions/runs/7423223631)
