### PR TITLE
ci: explicitly build s3proxy container image tag before referencing

### DIFF
--- a/.github/actions/e2e_s3proxy/action.yml
+++ b/.github/actions/e2e_s3proxy/action.yml
@@ -46,7 +46,9 @@ runs:
       shell: bash
       run: |
         bazel run //bazel/release:s3proxy_push
-        echo s3proxyImage=$(cat ./bazel-bin/bazel/release/s3proxy_tag.txt) | tee -a "$GITHUB_OUTPUT"
+        bazel build //bazel/release:s3proxy_tag.txt
+        tagpath=$(bazel cquery --output=files //bazel/release:s3proxy_tag.txt)
+        echo s3proxyImage=$(cat "${tagpath}") | tee -a "$GITHUB_OUTPUT"
 
     - name: Setup s3proxy
       shell: bash


### PR DESCRIPTION
Otherwise, the file might not exist.

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

CI was referencing a file generated during a bazel build without building it first.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Explicitly build s3proxy container image tag


### Related issue
- https://github.com/edgelesssys/constellation/actions/runs/7429031582/job/20217110581#step:3:7119)

