### PR TITLE
cli: fix AWS SEV-SNP latest version resolution in cluster

### DIFF
--- a/internal/config/aws.go
+++ b/internal/config/aws.go
@@ -16,6 +16,8 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 )
 
+var _ sevsnpMarshaller = &AWSSEVSNP{}
+
 // DefaultForAWSSEVSNP provides a valid default configuration for AWS SEV-SNP attestation.
 func DefaultForAWSSEVSNP() *AWSSEVSNP {
 	return &AWSSEVSNP{
@@ -59,6 +61,15 @@ func (c AWSSEVSNP) EqualTo(other AttestationCfg) (bool, error) {
 	signingKeyEqual := bytes.Equal(c.AMDSigningKey.Raw, otherCfg.AMDSigningKey.Raw)
 
 	return measurementsEqual && bootloaderEqual && teeEqual && snpEqual && microcodeEqual && rootKeyEqual && signingKeyEqual, nil
+}
+
+func (c *AWSSEVSNP) getToMarshallLatestWithResolvedVersions() AttestationCfg {
+	cp := *c
+	cp.BootloaderVersion.WantLatest = false
+	cp.TEEVersion.WantLatest = false
+	cp.SNPVersion.WantLatest = false
+	cp.MicrocodeVersion.WantLatest = false
+	return &cp
 }
 
 // FetchAndSetLatestVersionNumbers fetches the latest version numbers from the configapi and sets them.

--- a/internal/config/azure.go
+++ b/internal/config/azure.go
@@ -17,6 +17,8 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
 )
 
+var _ sevsnpMarshaller = &AzureSEVSNP{}
+
 // DefaultForAzureSEVSNP returns the default configuration for Azure SEV-SNP attestation.
 // Version numbers have placeholder values and the latest available values can be fetched using [AzureSEVSNP.FetchAndSetLatestVersionNumbers].
 func DefaultForAzureSEVSNP() *AzureSEVSNP {
@@ -96,6 +98,15 @@ func (c *AzureSEVSNP) mergeWithLatestVersion(latest attestationconfigapi.SEVSNPV
 	if c.MicrocodeVersion.WantLatest {
 		c.MicrocodeVersion.Value = latest.Microcode
 	}
+}
+
+func (c *AzureSEVSNP) getToMarshallLatestWithResolvedVersions() AttestationCfg {
+	cp := *c
+	cp.BootloaderVersion.WantLatest = false
+	cp.TEEVersion.WantLatest = false
+	cp.SNPVersion.WantLatest = false
+	cp.MicrocodeVersion.WantLatest = false
+	return &cp
 }
 
 // GetVariant returns azure-trusted-launch as the variant.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -629,15 +629,13 @@ func (c *Config) GetProvider() cloudprovider.Provider {
 // GetAttestationConfig returns the configured attestation config.
 func (c *Config) GetAttestationConfig() AttestationCfg {
 	if c.Attestation.AWSSEVSNP != nil {
-		return c.Attestation.AWSSEVSNP
+		return c.Attestation.AWSSEVSNP.getToMarshallLatestWithResolvedVersions()
 	}
 	if c.Attestation.AWSNitroTPM != nil {
 		return c.Attestation.AWSNitroTPM
 	}
 	if c.Attestation.AzureSEVSNP != nil {
-		cp := *c.Attestation.AzureSEVSNP
-		cp.setWantLatestToFalse()
-		return &cp
+		return c.Attestation.AzureSEVSNP.getToMarshallLatestWithResolvedVersions()
 	}
 	if c.Attestation.AzureTrustedLaunch != nil {
 		return c.Attestation.AzureTrustedLaunch
@@ -1114,17 +1112,15 @@ type AzureSEVSNP struct {
 	AMDSigningKey Certificate `json:"amdSigningKey,omitempty" yaml:"amdSigningKey,omitempty" validate:"len=0"`
 }
 
-// setWantLatestToFalse sets the WantLatest field to false for all versions in order to unmarshal the numerical versions instead of the string "latest".
-func (c *AzureSEVSNP) setWantLatestToFalse() {
-	c.BootloaderVersion.WantLatest = false
-	c.TEEVersion.WantLatest = false
-	c.SNPVersion.WantLatest = false
-	c.MicrocodeVersion.WantLatest = false
-}
-
 // AzureTrustedLaunch is the configuration for Azure Trusted Launch attestation.
 type AzureTrustedLaunch struct {
 	// description: |
 	//   Expected TPM measurements.
 	Measurements measurements.M `json:"measurements" yaml:"measurements" validate:"required,no_placeholders"`
+}
+
+// sevsnpMarshaller is used to marshall "latest" versions with resolved version numbers.
+type sevsnpMarshaller interface {
+	// getToMarshallLatestWithResolvedVersions brings the attestation config into a state where marshalling uses the numerical version numbers for "latest" versions.
+	getToMarshallLatestWithResolvedVersions() AttestationCfg
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
When setting "latest" for the SNP versions, the numerical values should be persisted in the `join-config` on `apply`, so that the user knows the currently deployed latest version value.
This was missing in AWS SEV-SNP, because of a hidden code path.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- make the need for latest version resolution more visible through an interface, which needs to be assigned to every new SEV-SNP type

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
Tested that `constellation status` shows the resolved versions after `constellation apply`

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
