### PR TITLE
ci: remove reference to absent go.mod file

### DIFF
--- a/.github/actions/versionsapi/Dockerfile
+++ b/.github/actions/versionsapi/Dockerfile
@@ -4,8 +4,6 @@ FROM golang:1.21.5@sha256:1a9d253b11048b1c76b690b0c09d78d200652e4e913d5d1dcc8eb8
 WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
-COPY operators/constellation-node-operator/api/go.mod ./operators/constellation-node-operator/api/go.mod
-COPY operators/constellation-node-operator/api/go.sum ./operators/constellation-node-operator/api/go.sum
 # cache deps before building and copying source so that we don't need to re-download as much
 # and so that source changes don't invalidate our downloaded layer
 RUN go mod download

--- a/.github/actions/versionsapi/action.yml
+++ b/.github/actions/versionsapi/action.yml
@@ -54,6 +54,7 @@ runs:
   steps:
     - name: Get versionsapi binary
       shell: bash
+      # TODO: This should probably be `bazel run`.
       run: |
         containerID=$(docker create "ghcr.io/edgelesssys/constellation/versionsapi-ci-cli:latest")
         docker cp ${containerID}:/versionsapi .

--- a/.github/workflows/build-versionsapi-ci-image.yml
+++ b/.github/workflows/build-versionsapi-ci-image.yml
@@ -9,6 +9,7 @@ on:
       - "internal/api/versionsapi/**"
       - ".github/workflows/build-versionsapi-ci-image.yml"
       - ".github/actions/versionsapi/**"
+      - "go.mod"
 
 jobs:
   build-versionsapi-ci-cli:


### PR DESCRIPTION
### Context

`operators/constellation-node-operator/api/go.mod` was removed in #2769, but is still referenced in Github actions, causing [CI failures](https://github.com/edgelesssys/constellation/actions/runs/7465442722).

### Proposed change(s)

- Remove explicit reference to obsolete file.
- Add go.mod to workflow triggers to avoid this problem in the future.

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
- [x] Test run: https://github.com/edgelesssys/constellation/actions/runs/7465706479
