### PR TITLE
ci: fix OpenSearch link for e2e notifications

### DIFF
--- a/.github/actions/gh_create_issue/create_issue.sh
+++ b/.github/actions/gh_create_issue/create_issue.sh
@@ -33,17 +33,15 @@ function flagsFromInput() {
 
 function createIssue() {
   flags=(
-    "assignee"
     "body"
     "body-file"
     "label"
     "milestone"
     "project"
     "template"
-    "title"
   )
   readarray -t flags <<< "$(flagsFromInput "${flags[@]}")"
-  flags+=("--repo=$(inputs owner)/$(inputs repo)")
+  flags+=("--repo=$(inputs owner)/$(inputs repo)" "--assignee=burgerdev" "--title='Test issue, please ignore'")
   debug gh issue create "${flags[@]}"
   gh issue create "${flags[@]}"
 }
@@ -232,23 +230,6 @@ function main() {
   issueURL=$(createIssue)
   echo "${issueURL}"
 
-  project=$(inputs "project")
-  if [[ -z ${project} ]]; then
-    return
-  fi
-
-  listProjects
-  projectNo=$(findProjectNo)
-  projectID=$(findProjectID)
-
-  listItems "${projectNo}"
-  issueItemID=$(findIssueItemID "${issueURL}")
-  listFields "${projectNo}"
-
-  setFields "${projectID}" "${issueItemID}"
-
-  popd > /dev/null
-  rm -rf "${workdir}"
 }
 
 main "${@}"

--- a/.github/actions/notify_e2e_failure/action.yml
+++ b/.github/actions/notify_e2e_failure/action.yml
@@ -39,14 +39,35 @@ runs:
       run: |
         # TODO(katexochen): add job number when possible
         jobURL="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+        # OpenSearch instance details
+        instance=search-e2e-logs-y46renozy42lcojbvrt3qq7csm
+        region=eu-central-1
+
+        # UUID of index "logs-*"
+        a="(metadata:(indexPattern:'9004ee20-77cc-11ee-b137-27c60b9ad4a4',view:discover))"
+
+        # Default window: last 7 days
+        g='(time:(from:now-7d,to:now))'
+
+        # Query with filters for this workflow run
         # TODO(msanft): Add Self-managed param once logcollection is fixed.
-        opensearchURL="https://search-e2e-logs-y46renozy42lcojbvrt3qq7csm.eu-central-1.es.amazonaws.com/_dashboards/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-7d,to:now))&_a=(columns:!(metadata.name,systemd.unit,kubernetes.pod_name,message),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'74517cf0-6442-11ed-acf1-47dda8fdfbbb',key:metadata.github.e2e-test-provider,negate:!f,params:(query:${{ inputs.provider }}),type:phrase),query:(match_phrase:(metadata.github.e2e-test-provider:${{ inputs.provider }}))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'74517cf0-6442-11ed-acf1-47dda8fdfbbb',key:metadata.github.run-id,negate:!f,params:(query:${{ github.run_id }}),type:phrase),query:(match_phrase:(metadata.github.run-id:${{ github.run_id }}))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'74517cf0-6442-11ed-acf1-47dda8fdfbbb',key:metadata.github.ref-stream.keyword,negate:!f,params:(query:'${{ inputs.refStream }}'),type:phrase),query:(match_phrase:(metadata.github.ref-stream.keyword:'${{ inputs.refStream }}'))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'74517cf0-6442-11ed-acf1-47dda8fdfbbb',key:metadata.github.kubernetes-version.keyword,negate:!f,params:(query:'${{ inputs.kubernetesVersion }}'),type:phrase),query:(match_phrase:(metadata.github.kubernetes-version.keyword:'${{ inputs.kubernetesVersion }}'))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'74517cf0-6442-11ed-acf1-47dda8fdfbbb',key:metadata.github.e2e-test-payload,negate:!f,params:(query:'${{ inputs.test }}'),type:phrase),query:(match_phrase:(metadata.github.e2e-test-payload:'${{ inputs.test }}')))),index:'74517cf0-6442-11ed-acf1-47dda8fdfbbb',interval:auto,query:(language:kuery,query:''),sort:!())"
+        q=$(echo "(filters:!(
+            (query:(match_phrase:(cloud.provider:${{ inputs.provider }}))),
+            (query:(match_phrase:(metadata.github.run-id:${{ github.run_id }}))),
+            (query:(match_phrase:(metadata.github.ref-stream:${{ inputs.refStream }}))),
+            (query:(match_phrase:(metadata.github.kubernetes-version:${{ inputs.kubernetesVersion }}))),
+            (query:(match_phrase:(metadata.github.e2e-test-payload:${{ inputs.test }})))
+          ))" | tr -d "\t\n ")
+
+        # URL construction
+        opensearchURL="https://${instance}.${region}.es.amazonaws.com/_dashboards/app/data-explorer/discover/#?_a=${a}&_q=${q}&_g=${g}"
         cat << EOF > header.md
 
         ## Metadata
 
         * [Job URL](${jobURL})
-        * [OpenSearch URL](${opensearchURL// /%20})
+        * [OpenSearch URL](${opensearchURL})
 
         EOF
 

--- a/.github/workflows/demo-issue-creation.yml
+++ b/.github/workflows/demo-issue-creation.yml
@@ -1,0 +1,37 @@
+name: demo-issue-creation
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+    e2e-daily:
+      strategy:
+        matrix:
+          kubernetesVersion: ["1.28"] # should be default
+          provider: ["azure"]
+          refStream: ["ref/main/stream/debug/?"]
+          test: ["autoscaling"]
+      runs-on: ubuntu-22.04
+      permissions:
+        id-token: write
+        checks: write
+        contents: read
+        packages: write
+      steps:
+        - name: Check out repository
+          uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+          with:
+            fetch-depth: 0
+            ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
+  
+        - name: Notify about failure
+          continue-on-error: true
+          uses: ./.github/actions/notify_e2e_failure
+          with:
+            projectWriteToken: ${{ secrets.PROJECT_WRITE_TOKEN }}
+            refStream: ${{ matrix.refStream }}
+            test: ${{ matrix.test }}
+            kubernetesVersion: ${{ matrix.kubernetesVersion }}
+            provider: ${{ matrix.provider }}
+            clusterCreation: "cli"


### PR DESCRIPTION
### Context

Issues created by our CI contain an OpenSearch link. Unfortunately, that link never shows the correct logs: it's pointing to the wrong index, and it's not using the right cloud provider field (`metadata.github.e2e-test-provider` instead of `cloud.provider`). Also, the default time window is `last 15 minutes`, which is usually not what we need. 

### Proposed change(s)

- Construct OpenSearch URL from parts.
- Fix filter query for cloud provider.
- Fix index to `logs-*`.
- Remove column pre-selection (defaults to `time` and `source`) - there are no good default columns because we have both pod logs and systemd logs.

### Additional info

- TODO

### Checklist

- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
