### PR TITLE
image: lower file limit for containerd

### DIFF
--- a/image/base/mkosi.skeleton/usr/lib/systemd/system/containerd.service.d/local.conf
+++ b/image/base/mkosi.skeleton/usr/lib/systemd/system/containerd.service.d/local.conf
@@ -1,3 +1,11 @@
 [Service]
 ExecStart=
 ExecStart=/usr/bin/containerd --config /usr/etc/containerd/config.toml
+
+# Until https://github.com/containerd/containerd/pull/8924 lands in our
+# containerd version, we need to decrease the default ulimit that
+# is set in the upstream containerd service of infinity which newer
+# systemd versions resolve to 2**30 which is way too large and
+# results in various inspecific errors such as excessive resource (e.g., memory)
+# usage.
+LimitNOFILE=524288


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Until https://github.com/containerd/containerd/pull/8924 lands in our
containerd version, we need to decrease the default ulimit that
is set in the upstream containerd service of infinity which newer
systemd versions resolve to 2**30 which is way too large and
results in various inspecific errors such as excessive resource (e.g., memory)
usage.


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- set LimitNOFILE=524288 for containerd

debug image: https://github.com/edgelesssys/constellation/actions/runs/7482948530

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
How to test:
* create a Constellation with this image
* execute ulimit -a and verify that the file limit is LimitNOFILE=524288

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
