### PR TITLE
ci: remove derpsteb from e2e assignee list

### DIFF
--- a/.github/actions/pick_assignee/action.yml
+++ b/.github/actions/pick_assignee/action.yml
@@ -18,7 +18,6 @@ runs:
           "malt3"
           "3u13r"
           "daniel-weisse"
-          "derpsteb"
           "msanft"
           "burgerdev"
         )


### PR DESCRIPTION
### Context

@derpsteb is not actively working on Constellation - remove the stone of e2e debugging.

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
