### PR TITLE
ci: fetch OpenSearch password from e2e test project

### DIFF
--- a/debugd/internal/debugd/logcollector/credentials.go
+++ b/debugd/internal/debugd/logcollector/credentials.go
@@ -86,7 +86,7 @@ func newGCPCloudCredentialGetter(ctx context.Context) (*gcpCloudCredentialGetter
 }
 
 func (g *gcpCloudCredentialGetter) GetOpensearchCredentials(ctx context.Context) (credentials, error) {
-	const secretName = "projects/796962942582/secrets/e2e-logs-OpenSearch-password/versions/1"
+	const secretName = "projects/1052692473304/secrets/e2e-logs-OpenSearch-password/versions/1"
 	const username = "cluster-instance-gcp"
 
 	req := &gcpsecretmanagerpb.AccessSecretVersionRequest{Name: secretName}


### PR DESCRIPTION
### Context

Our e2e tests moved to a different GCP project. We need to tell the logcollection to also fetch the password from the new project.

### Proposed change(s)

- Use OpenSearch password from constellation-e2e.


### Related issue
- Fixes edgelesssys/issues#243


### Additional info

- [AB#3750](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3750)

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
