### PR TITLE
ci: use sonobuoy 0.57.1 and skip cilium conformance problem

### DIFF
--- a/.github/actions/e2e_sonobuoy/action.yml
+++ b/.github/actions/e2e_sonobuoy/action.yml
@@ -21,7 +21,7 @@ runs:
     - name: Install sonobuoy
       shell: bash
       env:
-        SONOBUOY_VER: "0.56.17"
+        SONOBUOY_VER: "0.57.1"
       run: |
         HOSTOS="$(go env GOOS)"
         HOSTARCH="$(go env GOARCH)"
@@ -43,7 +43,10 @@ runs:
       shell: bash
       env:
         KUBECONFIG: ${{ inputs.kubeconfig }}
-      run: sonobuoy retrieve --kubeconfig constellation-admin.conf
+      run: |
+        sonobuoy retrieve --kubeconfig constellation-admin.conf
+        sonobuoy results *_sonobuoy_*.tar.gz
+        sonobuoy results *_sonobuoy_*.tar.gz --mode detailed | jq 'select(.status!="passed")' | jq 'select(.status!="skipped")' || true
 
     - name: Upload test results
       if: always() && !env.ACT

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -341,7 +341,7 @@ runs:
       uses: ./.github/actions/e2e_sonobuoy
       with:
         # TODO(3u13r): Remove E2E_SKIP once AB#2174 is resolved
-        sonobuoyTestSuiteCmd: '--plugin e2e --plugin-env e2e.E2E_FOCUS="\[Conformance\]" --plugin-env e2e.E2E_SKIP="for service with type clusterIP|HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol" --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-plugin.yaml --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-master-plugin.yaml'
+        sonobuoyTestSuiteCmd: '--plugin e2e --plugin-env e2e.E2E_FOCUS="\[Conformance\]" --plugin-env e2e.E2E_SKIP="for service with type clusterIP|HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol|Services should serve endpoints on same port and different protocols" --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-plugin.yaml --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-master-plugin.yaml'
         kubeconfig: ${{ steps.constellation-create.outputs.kubeconfig }}
         artifactNameSuffix: ${{ steps.create-prefix.outputs.prefix }}
         encryptionSecret: ${{ inputs.encryptionSecret }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

While this doesn't seem to resolve all issues, it does improve the situation and makes remaining issue easily discoverable.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- use sonobuoy 0.57.1 
- print test failures more prominently
- skip conformance test that is [known to be broken with cilium and k8s 1.29](https://github.com/cilium/cilium/issues/29913)

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [e2e](https://github.com/edgelesssys/constellation/actions/runs/7528645597/job/20491290770)
