### PR TITLE
ci: don't check Wireguard weblinks

### DIFF
--- a/.lychee.toml
+++ b/.lychee.toml
@@ -31,8 +31,8 @@ exclude = [
     '^https://twitter\.com',
     # Only available when logged in.
     '^https://portal\.azure\.com/',
-    # The Wireguard PDF sproadically returns 500.
-    'wireguard\.pdf$',
+    # The Wireguard website sproadically returns 500.
+    '^https://www\.wireguard\.com/',
 ]
 
 # Exclude these filesystem paths from getting checked.


### PR DESCRIPTION
### Context

The Wireguard website sporadically serves error 500 on all pages, not only on the PDF download. Examples from the last days:

* https://github.com/edgelesssys/constellation/actions/runs/7529507475/job/20493858220
* https://github.com/edgelesssys/constellation/actions/runs/7529133518/job/20492744374
* https://github.com/edgelesssys/constellation/actions/runs/7491445446/job/20392674195
* https://github.com/edgelesssys/constellation/actions/runs/7447431073/job/20259729210

### Proposed change(s)

- Ignore all of `www.wireguard.com` when checking links.


### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
