### PR TITLE
deps: bazel, Go, nix

### DIFF
--- a/.github/actions/versionsapi/Dockerfile
+++ b/.github/actions/versionsapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.5@sha256:1a9d253b11048b1c76b690b0c09d78d200652e4e913d5d1dcc8eb8d0d932bfe4 as builder
+FROM golang:1.21.6@sha256:6fbd2d3398db924f8d708cf6e94bd3a436bb468195daa6a96e80504e0a9615f2 as builder
 
 # Download project root dependencies
 WORKDIR /workspace

--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.21.5"
+          go-version: "1.21.6"
           cache: false
 
       - name: Install Crane

--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.21.5"
+          go-version: "1.21.6"
           cache: false
 
       - name: Determine version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.21.5"
+          go-version: "1.21.6"
           cache: false
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.21.5"
+          go-version: "1.21.6"
           cache: true
 
       - name: Build generateMeasurements tool

--- a/.github/workflows/test-operator-codegen.yml
+++ b/.github/workflows/test-operator-codegen.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.21.5"
+          go-version: "1.21.6"
           cache: true
 
       - name: Run code generation

--- a/3rdparty/gcp-guest-agent/Dockerfile
+++ b/3rdparty/gcp-guest-agent/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
     git
 
 # Install Go
-ARG GO_VER=1.21.5
+ARG GO_VER=1.21.6
 RUN wget -q https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go${GO_VER}.linux-amd64.tar.gz && \
     rm go${GO_VER}.linux-amd64.tar.gz

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -157,7 +157,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.21.5")
+go_register_toolchains(version = "1.21.6")
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 

--- a/bazel/toolchains/go_rules_deps.bzl
+++ b/bazel/toolchains/go_rules_deps.bzl
@@ -9,21 +9,21 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def go_deps():
     http_archive(
         name = "io_bazel_rules_go",
-        sha256 = "91585017debb61982f7054c9688857a2ad1fd823fc3f9cb05048b0025c47d023",
+        sha256 = "de7974538c31f76658e0d333086c69efdf6679dbc6a466ac29e65434bf47076d",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
-            "https://cdn.confidential.cloud/constellation/cas/sha256/91585017debb61982f7054c9688857a2ad1fd823fc3f9cb05048b0025c47d023",
-            "https://github.com/bazelbuild/rules_go/releases/download/v0.42.0/rules_go-v0.42.0.zip",
+            "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.45.0/rules_go-v0.45.0.zip",
+            "https://cdn.confidential.cloud/constellation/cas/sha256/de7974538c31f76658e0d333086c69efdf6679dbc6a466ac29e65434bf47076d",
+            "https://github.com/bazelbuild/rules_go/releases/download/v0.45.0/rules_go-v0.45.0.zip",
         ],
         type = "zip",
     )
     http_archive(
         name = "bazel_gazelle",
-        sha256 = "b7387f72efb59f876e4daae42f1d3912d0d45563eac7cb23d1de0b094ab588cf",
+        sha256 = "32938bda16e6700063035479063d9d24c60eda8d79fd4739563f50d331cb3209",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz",
-            "https://cdn.confidential.cloud/constellation/cas/sha256/b7387f72efb59f876e4daae42f1d3912d0d45563eac7cb23d1de0b094ab588cf",
-            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.34.0/bazel-gazelle-v0.34.0.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz",
+            "https://cdn.confidential.cloud/constellation/cas/sha256/32938bda16e6700063035479063d9d24c60eda8d79fd4739563f50d331cb3209",
+            "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.35.0/bazel-gazelle-v0.35.0.tar.gz",
         ],
         type = "tar.gz",
     )

--- a/bazel/toolchains/hermetic_cc_deps.bzl
+++ b/bazel/toolchains/hermetic_cc_deps.bzl
@@ -8,9 +8,9 @@ def hermetic_cc_deps():
     http_archive(
         name = "hermetic_cc_toolchain",
         urls = [
-            "https://cdn.confidential.cloud/constellation/cas/sha256/a5caccbf6d86d4f60afd45b541a05ca4cc3f5f523aec7d3f7711e584600fb075",
-            "https://github.com/uber/hermetic_cc_toolchain/releases/download/v2.1.3/hermetic_cc_toolchain-v2.1.3.tar.gz",
+            "https://cdn.confidential.cloud/constellation/cas/sha256/3b8107de0d017fe32e6434086a9568f97c60a111b49dc34fc7001e139c30fdea",
+            "https://github.com/uber/hermetic_cc_toolchain/releases/download/v2.2.1/hermetic_cc_toolchain-v2.2.1.tar.gz",
         ],
         type = "tar.gz",
-        sha256 = "a5caccbf6d86d4f60afd45b541a05ca4cc3f5f523aec7d3f7711e584600fb075",
+        sha256 = "3b8107de0d017fe32e6434086a9568f97c60a111b49dc34fc7001e139c30fdea",
     )

--- a/bootstrapper/internal/clean/clean_test.go
+++ b/bootstrapper/internal/clean/clean_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestNew(t *testing.T) {

--- a/bootstrapper/internal/diskencryption/diskencryption_test.go
+++ b/bootstrapper/internal/diskencryption/diskencryption_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestUpdatePassphrase(t *testing.T) {

--- a/bootstrapper/internal/initserver/initserver_test.go
+++ b/bootstrapper/internal/initserver/initserver_test.go
@@ -38,6 +38,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		// https://github.com/census-instrumentation/opencensus-go/issues/1262
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 	)
 }
 

--- a/bootstrapper/internal/joinclient/joinclient_test.go
+++ b/bootstrapper/internal/joinclient/joinclient_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestClient(t *testing.T) {

--- a/bootstrapper/internal/kubernetes/k8sapi/kubeadm_config_test.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/kubeadm_config_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestInitConfiguration(t *testing.T) {

--- a/bootstrapper/internal/kubernetes/kubernetes_test.go
+++ b/bootstrapper/internal/kubernetes/kubernetes_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestInitCluster(t *testing.T) {

--- a/bootstrapper/internal/kubernetes/kubewaiter/kubewaiter_test.go
+++ b/bootstrapper/internal/kubernetes/kubewaiter/kubewaiter_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestCloudKubeAPIWaiter(t *testing.T) {

--- a/cli/internal/cloudcmd/clients_test.go
+++ b/cli/internal/cloudcmd/clients_test.go
@@ -23,6 +23,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		// https://github.com/census-instrumentation/opencensus-go/issues/1262
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 	)
 }
 

--- a/cli/internal/cmd/cloud_test.go
+++ b/cli/internal/cmd/cloud_test.go
@@ -23,6 +23,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		// https://github.com/census-instrumentation/opencensus-go/issues/1262
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 	)
 }
 

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestPrepareCluster(t *testing.T) {

--- a/csi/cryptmapper/cryptmapper_test.go
+++ b/csi/cryptmapper/cryptmapper_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestCloseCryptDevice(t *testing.T) {

--- a/csi/kms/constellation_test.go
+++ b/csi/kms/constellation_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 type stubKMSClient struct {

--- a/csi/test/mount_integration_test.go
+++ b/csi/test/mount_integration_test.go
@@ -91,7 +91,7 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 
 	result := m.Run()
 	os.Exit(result)

--- a/debugd/internal/debugd/deploy/download_test.go
+++ b/debugd/internal/debugd/deploy/download_test.go
@@ -27,6 +27,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		// https://github.com/census-instrumentation/opencensus-go/issues/1262
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 	)
 }
 

--- a/debugd/internal/debugd/metadata/cloudprovider/cloudprovider_test.go
+++ b/debugd/internal/debugd/metadata/cloudprovider/cloudprovider_test.go
@@ -22,6 +22,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		// https://github.com/census-instrumentation/opencensus-go/issues/1262
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 	)
 }
 

--- a/debugd/internal/debugd/metadata/fallback/fallback_test.go
+++ b/debugd/internal/debugd/metadata/fallback/fallback_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestDiscoverDebugdIPs(t *testing.T) {

--- a/debugd/internal/debugd/metadata/scheduler_test.go
+++ b/debugd/internal/debugd/metadata/scheduler_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestSchedulerStart(t *testing.T) {

--- a/debugd/internal/debugd/server/server_test.go
+++ b/debugd/internal/debugd/server/server_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestSetInfo(t *testing.T) {

--- a/debugd/internal/filetransfer/filetransfer_test.go
+++ b/debugd/internal/filetransfer/filetransfer_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestSendFiles(t *testing.T) {

--- a/debugd/internal/filetransfer/streamer/streamer_test.go
+++ b/debugd/internal/filetransfer/streamer/streamer_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestWriteStream(t *testing.T) {

--- a/disk-mapper/internal/recoveryserver/recoveryserver_test.go
+++ b/disk-mapper/internal/recoveryserver/recoveryserver_test.go
@@ -29,6 +29,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		// https://github.com/census-instrumentation/opencensus-go/issues/1262
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 	)
 }
 

--- a/disk-mapper/internal/rejoinclient/rejoinclient_test.go
+++ b/disk-mapper/internal/rejoinclient/rejoinclient_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestStartCancel(t *testing.T) {

--- a/disk-mapper/internal/setup/setup_test.go
+++ b/disk-mapper/internal/setup/setup_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestPrepareExistingDisk(t *testing.T) {

--- a/disk-mapper/internal/systemd/systemd_test.go
+++ b/disk-mapper/internal/systemd/systemd_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestConfigureUnit(t *testing.T) {

--- a/disk-mapper/internal/test/integration_test.go
+++ b/disk-mapper/internal/test/integration_test.go
@@ -87,6 +87,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		// https://github.com/census-instrumentation/opencensus-go/issues/1262
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 	)
 
 	result := m.Run()

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1701680307,
-        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
+        "lastModified": 1705309234,
+        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
     },
     "nixpkgsUnstable": {
       "locked": {
-        "lastModified": 1702206697,
-        "narHash": "sha256-vE9oEx3Y8TO5MnWwFlmopjHd1JoEBno+EhsfUCq5iR8=",
+        "lastModified": 1705242415,
+        "narHash": "sha256-a8DRYrNrzTudvO7XHUPNJD89Wbf1ZZT0VbwCsPnHWaE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "29d6c96900b9b576c2fb89491452f283aa979819",
+        "rev": "ea780f3de2d169f982564128804841500e85e373",
         "type": "github"
       },
       "original": {

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.21.1
+go 1.21.6
 
-toolchain go1.21.5
+toolchain go1.21.6
 
 use (
 	.

--- a/hack/bazel-deps-mirror/internal/bazelfiles/files_test.go
+++ b/hack/bazel-deps-mirror/internal/bazelfiles/files_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestFindFiles(t *testing.T) {

--- a/hack/bazel-deps-mirror/internal/issues/issues_test.go
+++ b/hack/bazel-deps-mirror/internal/issues/issues_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestMap(t *testing.T) {

--- a/hack/bazel-deps-mirror/internal/mirror/mirror_test.go
+++ b/hack/bazel-deps-mirror/internal/mirror/mirror_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestMirrorURL(t *testing.T) {

--- a/hack/bazel-deps-mirror/internal/rules/rules_test.go
+++ b/hack/bazel-deps-mirror/internal/rules/rules_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestRules(t *testing.T) {

--- a/image/measured-boot/extract/extract_test.go
+++ b/image/measured-boot/extract/extract_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestPeSectionReader(t *testing.T) {

--- a/image/measured-boot/measure/measure_test.go
+++ b/image/measured-boot/measure/measure_test.go
@@ -13,5 +13,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }

--- a/image/system/BUILD.bazel
+++ b/image/system/BUILD.bazel
@@ -53,6 +53,9 @@ load(":variants.bzl", "CSPS", "STREAMS", "VARIANTS", "autologin", "base_image", 
     upload_os_images(
         name = "upload_" + variant["csp"] + "_" + variant["attestation_variant"] + "_" + stream,
         image_dirs = [":" + variant["csp"] + "_" + variant["attestation_variant"] + "_" + stream],
+        tags = [
+            "manual",
+        ],
     )
     for variant in VARIANTS
     for stream in STREAMS
@@ -75,6 +78,9 @@ load(":variants.bzl", "CSPS", "STREAMS", "VARIANTS", "autologin", "base_image", 
     upload_os_images(
         name = "upload_" + stream,
         image_dirs = [":" + stream],
+        tags = [
+            "manual",
+        ],
     )
     for stream in STREAMS
 ]

--- a/internal/api/versionsapi/fetcher_test.go
+++ b/internal/api/versionsapi/fetcher_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestFetchVersionList(t *testing.T) {

--- a/internal/atls/atls_test.go
+++ b/internal/atls/atls_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestTLSConfig(t *testing.T) {

--- a/internal/attestation/measurements/measurement-generator/generate_test.go
+++ b/internal/attestation/measurements/measurement-generator/generate_test.go
@@ -13,5 +13,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }

--- a/internal/attestation/vtpm/vtpm_test.go
+++ b/internal/attestation/vtpm/vtpm_test.go
@@ -13,5 +13,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }

--- a/internal/cloud/aws/logger_test.go
+++ b/internal/cloud/aws/logger_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestCreateStream(t *testing.T) {

--- a/internal/cloud/azure/azure_test.go
+++ b/internal/cloud/azure/azure_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestGetInstance(t *testing.T) {

--- a/internal/cloud/azureshared/appcredentials_test.go
+++ b/internal/cloud/azureshared/appcredentials_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestApplicationCredentialsFromURI(t *testing.T) {

--- a/internal/cloud/gcp/gcp_test.go
+++ b/internal/cloud/gcp/gcp_test.go
@@ -27,6 +27,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		// https://github.com/census-instrumentation/opencensus-go/issues/1262
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 	)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestDefaultConfig(t *testing.T) {

--- a/internal/crypto/crypto_test.go
+++ b/internal/crypto/crypto_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestDeriveKey(t *testing.T) {

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestWrite(t *testing.T) {

--- a/internal/grpc/atlscredentials/atlscredentials_test.go
+++ b/internal/grpc/atlscredentials/atlscredentials_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestATLSCredentials(t *testing.T) {

--- a/internal/grpc/dialer/dialer_test.go
+++ b/internal/grpc/dialer/dialer_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestDial(t *testing.T) {

--- a/internal/imagefetcher/imagefetcher_test.go
+++ b/internal/imagefetcher/imagefetcher_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestGetReference(t *testing.T) {

--- a/internal/kms/kms/cluster/cluster_test.go
+++ b/internal/kms/kms/cluster/cluster_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestClusterKMS(t *testing.T) {

--- a/internal/kms/kms/internal/internal_test.go
+++ b/internal/kms/kms/internal/internal_test.go
@@ -27,6 +27,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		// https://github.com/census-instrumentation/opencensus-go/issues/1262
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 	)
 }
 

--- a/internal/kms/setup/setup_test.go
+++ b/internal/kms/setup/setup_test.go
@@ -19,6 +19,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		// https://github.com/census-instrumentation/opencensus-go/issues/1262
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 	)
 }
 

--- a/internal/kms/storage/memfs/memfs_test.go
+++ b/internal/kms/storage/memfs/memfs_test.go
@@ -19,6 +19,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		// https://github.com/census-instrumentation/opencensus-go/issues/1262
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 	)
 }
 

--- a/internal/kms/uri/uri_test.go
+++ b/internal/kms/uri/uri_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestMasterSecretURI(t *testing.T) {

--- a/internal/nodestate/nodestate_test.go
+++ b/internal/nodestate/nodestate_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestFromFile(t *testing.T) {

--- a/internal/osimage/secureboot/secureboot_test.go
+++ b/internal/osimage/secureboot/secureboot_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestDatabaseFromFile(t *testing.T) {

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestDo(t *testing.T) {

--- a/internal/role/role_test.go
+++ b/internal/role/role_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestMarshal(t *testing.T) {

--- a/internal/sigstore/rekor_integration_test.go
+++ b/internal/sigstore/rekor_integration_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestRekorSearchByHash(t *testing.T) {

--- a/internal/staticupload/staticupload_test.go
+++ b/internal/staticupload/staticupload_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestUpload(t *testing.T) {

--- a/internal/versions/hash-generator/generate_test.go
+++ b/internal/versions/hash-generator/generate_test.go
@@ -13,5 +13,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }

--- a/joinservice/internal/kms/kms_test.go
+++ b/joinservice/internal/kms/kms_test.go
@@ -29,7 +29,7 @@ func (c *stubClient) GetDataKey(context.Context, *keyserviceproto.GetDataKeyRequ
 }
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestGetDataKey(t *testing.T) {

--- a/joinservice/internal/kubeadm/kubeadm_test.go
+++ b/joinservice/internal/kubeadm/kubeadm_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestGetJoinToken(t *testing.T) {

--- a/joinservice/internal/kubernetes/kubernetes_test.go
+++ b/joinservice/internal/kubernetes/kubernetes_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestK8sCompliantHostname(t *testing.T) {

--- a/joinservice/internal/kubernetesca/kubernetesca_test.go
+++ b/joinservice/internal/kubernetesca/kubernetesca_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestGetCertificate(t *testing.T) {

--- a/joinservice/internal/server/server_test.go
+++ b/joinservice/internal/server/server_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestIssueJoinTicket(t *testing.T) {

--- a/joinservice/internal/watcher/validator_test.go
+++ b/joinservice/internal/watcher/validator_test.go
@@ -35,6 +35,7 @@ func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
 		// https://github.com/census-instrumentation/opencensus-go/issues/1262
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"),
 	)
 }
 

--- a/keyservice/internal/server/server_test.go
+++ b/keyservice/internal/server/server_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestGetDataKey(t *testing.T) {

--- a/operators/constellation-node-operator/internal/executor/executor_test.go
+++ b/operators/constellation-node-operator/internal/executor/executor_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestStartTriggersImmediateReconciliation(t *testing.T) {

--- a/s3proxy/internal/kms/kms_test.go
+++ b/s3proxy/internal/kms/kms_test.go
@@ -29,7 +29,7 @@ func (c *stubClient) GetDataKey(context.Context, *keyserviceproto.GetDataKeyRequ
 }
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestGetDataKey(t *testing.T) {

--- a/verify/server/server_test.go
+++ b/verify/server/server_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	goleak.VerifyTestMain(m)
+	goleak.VerifyTestMain(m, goleak.IgnoreAnyFunction("github.com/bazelbuild/rules_go/go/tools/bzltestutil.RegisterTimeoutHandler.func1"))
 }
 
 func TestRun(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Combined deps update for everything that invalidates the full build cache.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- deps: update hermetic_cc_toolchain
- deps: update gazelle and rules_go
- nix: update flake.lock
- deps: Go 1.21.6

### Related issue
-Unfortunately, we have to ignore a source of leaking go routines, until this is resolved: https://github.com/uber-go/goleak/issues/119
