### PR TITLE
image upload: use unique blob name for AWS images uploaded to S3

### DIFF
--- a/internal/osimage/uplosi/uplosiupload.go
+++ b/internal/osimage/uplosi/uplosiupload.go
@@ -173,7 +173,7 @@ func imageVersion(csp cloudprovider.Provider, version versionsapi.Version, times
 func extendAWSConfig(awsConfig map[string]any, version versionsapi.Version, attestationVariant string, timestamp time.Time) {
 	awsConfig["amiName"] = awsAMIName(version, attestationVariant, timestamp)
 	awsConfig["snapshotName"] = awsAMIName(version, attestationVariant, timestamp)
-	awsConfig["blobName"] = fmt.Sprintf("image-%s-%s-%d.raw", version.Stream(), version.Version(), timestamp.Unix())
+	awsConfig["blobName"] = fmt.Sprintf("image-%s-%s-%s-%d.raw", version.Stream(), version.Version(), attestationVariant, timestamp.Unix())
 }
 
 func awsAMIName(version versionsapi.Version, attestationVariant string, timestamp time.Time) string {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

When uploading images to AWS, they need to be uploaded to S3 first. Since blob names were not unique between attestation variants, there was a possibility for one S3 upload to be used for the wrong AMI.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- [image upload: use unique blob name for AWS images uploaded to S3](https://github.com/edgelesssys/constellation/commit/db645ee4adee89877f5628166979050f184f1683)

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- Fixes https://github.com/edgelesssys/issues/issues/272

