### PR TITLE
ci: add TF provider example test to weekly

### DIFF
--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -415,3 +415,18 @@ jobs:
     uses: ./.github/workflows/e2e-windows.yml
     with:
       scheduled: ${{ github.event_name == 'schedule' }}
+
+  e2e-terraform-provider-example:
+    name: Run Terraform provider example E2E test
+    strategy:
+      fail-fast: false
+      matrix:
+        cloudProvider: ["gcp", "azure", "aws"]
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    secrets: inherit
+    uses: ./.github/workflows/e2e-test-provider-example.yml
+    with:
+      cloudProvider: ${{ matrix.cloudProvider }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We do not run the Terraform provider example tests regularly yet, though they replicate the user's path the best. Hence, they should be run in any of the regularly run pipelines. (i.e. daily or weekly)

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Run the E2E test using the Terraform provider examples in the weekly E2E pipeline.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
