### PR TITLE
helm: re-enable native routing for gcp

### DIFF
--- a/internal/constellation/helm/loader.go
+++ b/internal/constellation/helm/loader.go
@@ -392,7 +392,7 @@ func (i *chartLoader) loadCiliumValues(cloudprovider.Provider) (map[string]any, 
 		cloudprovider.AWS.String():   {},
 		cloudprovider.Azure.String(): {},
 		cloudprovider.GCP.String(): {
-			"tunnel": "disabled",
+			"routingMode": "native",
 			"encryption": map[string]any{
 				"strictMode": map[string]any{
 					"podCIDRList": []string{""},


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Set `routingMode` to `native` for GCP. The `tunnel` option was fully removed in https://github.com/edgelesssys/constellation/pull/2808 which included https://github.com/cilium/cilium/pull/29053

This change did not hit any released Constellation version yet.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
