### PR TITLE
helm: remove kube-rbac-proxy

### DIFF
--- a/internal/constellation/helm/charts/edgeless/operators/charts/constellation-operator/templates/deployment.yaml
+++ b/internal/constellation/helm/charts/edgeless/operators/charts/constellation-operator/templates/deployment.yaml
@@ -30,25 +30,8 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        env:
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: {{ .Values.kubernetesClusterDomain }}
-        image: {{ .Values.controllerManager.kubeRbacProxy.image.repository }}:{{ .Values.controllerManager.kubeRbacProxy.image.tag
-          | default .Chart.AppVersion }}
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources: {{- toYaml .Values.controllerManager.kubeRbacProxy.resources | nindent
-          10 }}
-      - args:
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+        - --metrics-bind-address=:8080
         - --leader-elect
         command:
         -  /node-operator

--- a/internal/constellation/helm/charts/edgeless/operators/charts/constellation-operator/values.yaml
+++ b/internal/constellation/helm/charts/edgeless/operators/charts/constellation-operator/values.yaml
@@ -1,15 +1,4 @@
 controllerManager:
-  kubeRbacProxy:
-    image:
-      repository: gcr.io/kubebuilder/kube-rbac-proxy
-      tag: v0.14.1
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 5m
-        memory: 64Mi
   manager:
     resources:
       limits:

--- a/internal/constellation/helm/testdata/AWS/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/internal/constellation/helm/testdata/AWS/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -38,29 +38,8 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        env:
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: cluster.local
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-      - args:
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+        - --metrics-bind-address=:8080
         - --leader-elect
         command:
         - /node-operator

--- a/internal/constellation/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/internal/constellation/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -38,29 +38,8 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        env:
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: cluster.local
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-      - args:
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+        - --metrics-bind-address=:8080
         - --leader-elect
         command:
         - /node-operator

--- a/internal/constellation/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/internal/constellation/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -38,29 +38,8 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        env:
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: cluster.local
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-      - args:
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+        - --metrics-bind-address=:8080
         - --leader-elect
         command:
         - /node-operator

--- a/internal/constellation/helm/testdata/OpenStack/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/internal/constellation/helm/testdata/OpenStack/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -38,29 +38,8 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        env:
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: cluster.local
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-      - args:
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+        - --metrics-bind-address=:8080
         - --leader-elect
         command:
         - /node-operator

--- a/internal/constellation/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/deployment.yaml
+++ b/internal/constellation/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/deployment.yaml
@@ -38,29 +38,8 @@ spec:
     spec:
       containers:
       - args:
-        - --secure-listen-address=0.0.0.0:8443
-        - --upstream=http://127.0.0.1:8080/
-        - --logtostderr=true
-        - --v=0
-        env:
-        - name: KUBERNETES_CLUSTER_DOMAIN
-          value: cluster.local
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
-        name: kube-rbac-proxy
-        ports:
-        - containerPort: 8443
-          name: https
-          protocol: TCP
-        resources:
-          limits:
-            cpu: 500m
-            memory: 128Mi
-          requests:
-            cpu: 5m
-            memory: 64Mi
-      - args:
         - --health-probe-bind-address=:8081
-        - --metrics-bind-address=127.0.0.1:8080
+        - --metrics-bind-address=:8080
         - --leader-elect
         command:
         - /node-operator


### PR DESCRIPTION
### Context

This is the quick alternative to #2837 that only removes kube-rbac-proxy while ignoring all of the kubebuilder legacy.

### Proposed change(s)
- Remove kube-rbac-proxy sidecar from the constellation operator. We don't have any sensitive metrics to guard.
- There are a lot of defunct resources lying around (some new, some existing) that should be cleaned up as part of #2837.

### Additional info
<!-- Remove items that do not apply -->
- [AB#3611](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3611)

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
