### PR TITLE
ci: fix e2e_benchmark comparison

### DIFF
--- a/.github/actions/e2e_benchmark/.gitignore
+++ b/.github/actions/e2e_benchmark/.gitignore
@@ -1,0 +1,2 @@
+benchmarks/
+out/

--- a/.github/actions/e2e_benchmark/action.yml
+++ b/.github/actions/e2e_benchmark/action.yml
@@ -124,6 +124,27 @@ runs:
         name: "knb-constellation-${{ inputs.cloudProvider }}.json"
         encryptionSecret: ${{ inputs.encryptionSecret }}
 
+    - name: Parse results, create diagrams and post the progression summary
+      shell: bash
+      env:
+        # Original result directory
+        BENCH_RESULTS: out/
+        # Working directory containing the previous results as JSON and to contain the graphs
+        BDIR: benchmarks
+        CSP: ${{ inputs.cloudProvider }}
+      run: |
+        mkdir -p benchmarks
+        python .github/actions/e2e_benchmark/evaluate/parse.py
+
+    - name: Upload benchmark results to action run
+      if: (!env.ACT)
+      uses: ./.github/actions/artifact_upload
+      with:
+        path: >
+          benchmarks/constellation-${{ inputs.cloudProvider }}.json
+        name: "benchmarks"
+        encryptionSecret: ${{ inputs.encryptionSecret }}
+
     - name: Assume AWS role to retrieve and update benchmarks in S3
       uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
       with:
@@ -141,42 +162,24 @@ runs:
       env:
         CSP: ${{ inputs.cloudProvider }}
       run: |
-        mkdir -p benchmarks
-        aws s3 cp --recursive ${S3_PATH} benchmarks --no-progress
-        if [[ -f benchmarks/constellation-${CSP}.json ]]; then
-          mv benchmarks/constellation-${CSP}.json benchmarks/constellation-${CSP}-previous.json
+        aws s3 cp --recursive ${S3_PATH} ./ --no-progress
+        if [[ -f constellation-${CSP}.json ]]; then
+          mv constellation-${CSP}.json benchmarks/constellation-${CSP}-previous.json
         else
             echo "::warning::Couldn't retrieve previous benchmark records from s3"
         fi
 
-    - name: Parse results, create diagrams and post the progression summary
+    - name: Compare results
       shell: bash
       env:
-        # Original result directory
-        BENCH_RESULTS: out/
-        # Working directory containing the previous results as JSON and to contain the graphs
-        BDIR: benchmarks
         # Paths to benchmark results as JSON of the previous run and the current run
         PREV_BENCH: benchmarks/constellation-${{ inputs.cloudProvider }}-previous.json
         CURR_BENCH: benchmarks/constellation-${{ inputs.cloudProvider }}.json
-        CSP: ${{ inputs.cloudProvider }}
       run: |
-        python .github/actions/e2e_benchmark/evaluate/parse.py
-        export BENCHMARK_SUCCESS=true
         if [[ -f "$PREV_BENCH" ]]; then
-          # Sets $BENCHMARK_SUCCESS=false if delta is bigger than defined in compare.py
+          # Fails if the results are outside the threshold range
           python .github/actions/e2e_benchmark/evaluate/compare.py >> $GITHUB_STEP_SUMMARY
         fi
-        echo BENCHMARK_SUCCESS=$BENCHMARK_SUCCESS >> $GITHUB_ENV
-
-    - name: Upload benchmark results to action run
-      if: (!env.ACT)
-      uses: ./.github/actions/artifact_upload
-      with:
-        path: >
-          benchmarks/constellation-${{ inputs.cloudProvider }}.json
-        name: "benchmarks"
-        encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Upload benchmark results to opensearch
       if: (!env.ACT)
@@ -199,13 +202,3 @@ runs:
         CSP: ${{ inputs.cloudProvider }}
       run: |
         aws s3 cp benchmarks/constellation-${CSP}.json ${S3_PATH}/constellation-${CSP}.json
-
-    - name: Check performance comparison result
-      shell: bash
-      run: |
-        if [[ $BENCHMARK_SUCCESS == true ]] ; then
-          echo "Benchmark successful, all metrics in the expected range."
-        else
-          echo "::error::Benchmark failed, some metrics are outside of the expected range."
-          exit 1
-        fi

--- a/.github/actions/e2e_benchmark/evaluate/compare.py
+++ b/.github/actions/e2e_benchmark/evaluate/compare.py
@@ -40,11 +40,14 @@ API_UNIT_STR = "ms"
 
 # List of allowed deviation
 ALLOWED_RATIO_DELTA = {
-    'iops': 0.7,
-    'bw_kbytes': 0.7,
-    'tcp_bw_mbit': 0.7,
-    'udp_bw_mbit': 0.7,
+    'iops': 0.8,
+    'bw_kbytes': 0.8,
+    'tcp_bw_mbit': 0.8,
+    'udp_bw_mbit': 0.8,
 }
+
+# Track failed comparison status
+failed = False
 
 
 def is_bigger_better(bench_suite: str) -> bool:
@@ -171,7 +174,8 @@ class BenchmarkComparer:
 
 
 def set_failed() -> None:
-    os.environ['COMPARISON_SUCCESS'] = str(False)
+    global failed
+    failed = True
 
 
 def main():
@@ -179,6 +183,8 @@ def main():
     c = BenchmarkComparer(path_prev, path_curr)
     output = c.compare()
     print(output)
+    if failed:
+        exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The e2e_benchmark test correctly compares the current benchmark with the previous one.
However, there are two problems:
1. The comparison results do not lead to a failed test due to wrong/missing error handling
2. The test ALWAYS overwrites the stored results in the S3 bucket with the new results, leading to a degradation of our baseline

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Update comparison to fail when the new values are outside the threshold (80% of the previous benchmark)
- Only upload new results if the comparison succeeds -> Baseline can still slowly degrade, but I'd suspect the performance to either be stable or drop significantly in a single step


<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- https://github.com/edgelesssys/constellation/actions/runs/7637200058
- Keeping a longer history of results is out of scope for this PR
- We could introduce fixed baseline values if we want to
### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?

