### PR TITLE
ci: Upload e2e terraform state as artifact

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -282,7 +282,6 @@ runs:
       with:
         name: terraform-state-${{ inputs.artifactNameSuffix }}
         path: >
-          constellation-terraform/!(.terraform|plan.zip)
-          constellation-iam-terraform/!(.terraform)
+          constellation*-terraform/!(.terraform|plan.zip)
         encryptionSecret: ${{ inputs.encryptionSecret }}
 

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -275,6 +275,7 @@ runs:
         path: >
           !(terraform).log
         encryptionSecret: ${{ inputs.encryptionSecret }}
+
     - name: Upload terraform state
       if: always()
       uses: ./.github/actions/artifact_upload

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -276,14 +276,12 @@ runs:
           !(terraform).log
         encryptionSecret: ${{ inputs.encryptionSecret }}
 
-    - name: Get terraform state paths
+    - name: Prepare terraform state folders
       if: always()
       shell: bash
       run: |
-        shopt -s extglob
-
-        paths=constellation*-terraform/!(plan.zip|.terraform)
-        echo "TF_PATHS=$paths" >> $GITHUB_ENV
+        rm constellation-terraform/plan.zip
+        rm -rf constellation-terraform/.terraform constellation-iam-terraform/.terraform
 
     - name: Upload terraform state
       if: always()
@@ -291,6 +289,7 @@ runs:
       with:
         name: terraform-state-${{ inputs.artifactNameSuffix }}
         path: >
-          ${{ env.TF_PATHS }}
+          constellation-terraform
+          constellation-iam-terraform
         encryptionSecret: ${{ inputs.encryptionSecret }}
 

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -282,7 +282,7 @@ runs:
       with:
         name: terraform-state-${{ inputs.artifactNameSuffix }}
         path: >
-          constellation-terraform
-          constellation-iam-terraform
+          constellation-terraform/!(.terraform|plan.zip)
+          constellation-iam-terraform/!(.terraform)
         encryptionSecret: ${{ inputs.encryptionSecret }}
 

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -276,12 +276,21 @@ runs:
           !(terraform).log
         encryptionSecret: ${{ inputs.encryptionSecret }}
 
+    - name: Get terraform state paths
+      if: always()
+      shell: bash
+      run: |
+        shopt -s extglob
+
+        paths=constellation*-terraform/!(plan.zip|.terraform)
+        echo "TF_PATHS=$paths" >> $GITHUB_ENV
+
     - name: Upload terraform state
       if: always()
       uses: ./.github/actions/artifact_upload
       with:
         name: terraform-state-${{ inputs.artifactNameSuffix }}
         path: >
-          constellation*-terraform/!(.terraform|plan.zip)
+          ${{ env.TF_PATHS }}
         encryptionSecret: ${{ inputs.encryptionSecret }}
 

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -275,3 +275,13 @@ runs:
         path: >
           !(terraform).log
         encryptionSecret: ${{ inputs.encryptionSecret }}
+    - name: Upload terraform state
+      if: always()
+      uses: ./.github/actions/artifact_upload
+      with:
+        name: terraform-state
+        path: >
+          constellation_terraform
+          constellation_iam_terraform
+        encryptionSecret: ${{ inputs.encryptionSecret }}
+

--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -279,9 +279,9 @@ runs:
       if: always()
       uses: ./.github/actions/artifact_upload
       with:
-        name: terraform-state
+        name: terraform-state-${{ inputs.artifactNameSuffix }}
         path: >
-          constellation_terraform
-          constellation_iam_terraform
+          constellation-terraform
+          constellation-iam-terraform
         encryptionSecret: ${{ inputs.encryptionSecret }}
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Upload the terraform state of E2E tests (and other actions that use `constellation_create/action.yml`) as a github artifact. This allows to manually clean up resources and makes automation later on easy.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add a step to upload `constellation-terraform` and `constellation-iam-terraform` in `.github/actions/constellation_create/action.yml`

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
