### PR TITLE
ci: pin the kube-bench plugin definitions for sonobuoy

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -341,7 +341,7 @@ runs:
       uses: ./.github/actions/e2e_sonobuoy
       with:
         # TODO(3u13r): Remove E2E_SKIP once AB#2174 is resolved
-        sonobuoyTestSuiteCmd: '--plugin e2e --plugin-env e2e.E2E_FOCUS="\[Conformance\]" --plugin-env e2e.E2E_SKIP="for service with type clusterIP|HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol|Services should serve endpoints on same port and different protocols" --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-plugin.yaml --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/master/cis-benchmarks/kube-bench-master-plugin.yaml'
+        sonobuoyTestSuiteCmd: '--plugin e2e --plugin-env e2e.E2E_FOCUS="\[Conformance\]" --plugin-env e2e.E2E_SKIP="for service with type clusterIP|HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol|Services should serve endpoints on same port and different protocols" --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/102cd62a4091f80a795189f64ccc20738f931ef0/cis-benchmarks/kube-bench-plugin.yaml --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/102cd62a4091f80a795189f64ccc20738f931ef0/cis-benchmarks/kube-bench-master-plugin.yaml'
         kubeconfig: ${{ steps.constellation-create.outputs.kubeconfig }}
         artifactNameSuffix: ${{ steps.create-prefix.outputs.prefix }}
         encryptionSecret: ${{ inputs.encryptionSecret }}


### PR DESCRIPTION
### Context

The kube-bench definitions are currently pulled from the master branch of the sonobuoy-plugins repo. This makes our CI susceptible for regressions due to uncoordinated upstream changes. One such change was the upstream bump to https://hub.docker.com/layers/sonobuoy/kube-bench/v0.6.17/images/sha256-e031ba8457a8e2c5823533dd8aa7c57b67de0c9298cba949669bd4a4edd022c9?context=explore, which is only available on arm64.

### Proposed change(s)

- Refer to plugins via concrete commit hash.

### Additional info

- This may have caused problems in benchmarking or the sonobuoy execution, but it's not entirely clear to me how this would have manifested.

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
- [ ] [sonobuoy full AWS](https://github.com/edgelesssys/constellation/actions/runs/7670374038)
