### PR TITLE
terraform-provider: only print license warning once in provider

### DIFF
--- a/terraform-provider-constellation/internal/provider/cluster_resource.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource.go
@@ -451,8 +451,7 @@ func (r *ClusterResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 	if licenseID == "" {
 		resp.Diagnostics.AddWarning("Constellation license not found.",
 			"Using community license.\nFor details, see https://docs.edgeless.systems/constellation/overview/license")
-	}
-	if licenseID == license.CommunityLicense {
+	} else if licenseID == license.CommunityLicense {
 		resp.Diagnostics.AddWarning("Using community license.",
 			"For details, see https://docs.edgeless.systems/constellation/overview/license")
 	}

--- a/terraform-provider-constellation/internal/provider/cluster_resource.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource.go
@@ -449,9 +449,10 @@ func (r *ClusterResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 
 	licenseID := plannedState.LicenseID.ValueString()
 	if licenseID == "" {
-		resp.Diagnostics.AddWarning("Constellation license not found.",
-			"Using community license.\nFor details, see https://docs.edgeless.systems/constellation/overview/license")
-	} else if licenseID == license.CommunityLicense {
+		resp.Diagnostics.AddWarning("Constellation license ID not set.",
+			"Will use community license.")
+	}
+	if licenseID == license.CommunityLicense {
 		resp.Diagnostics.AddWarning("Using community license.",
 			"For details, see https://docs.edgeless.systems/constellation/overview/license")
 	}

--- a/terraform-provider-constellation/internal/provider/cluster_resource.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource.go
@@ -450,7 +450,7 @@ func (r *ClusterResource) ModifyPlan(ctx context.Context, req resource.ModifyPla
 	licenseID := plannedState.LicenseID.ValueString()
 	if licenseID == "" {
 		resp.Diagnostics.AddWarning("Constellation license ID not set.",
-			"Will use community license.")
+			"Continuing with community license.")
 	}
 	if licenseID == license.CommunityLicense {
 		resp.Diagnostics.AddWarning("Using community license.",


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The output is duplicated at the moment:
```
╷
│ Warning: Constellation license not found.
│ 
│   with constellation_cluster.aws_example,
│   on main.tf line 96, in resource "constellation_cluster" "aws_example":
│   96: resource "constellation_cluster" "aws_example" {
│ 
│ Using community license.
│ For details, see
│ https://docs.edgeless.systems/constellation/overview/license
│ 
│ (and one more similar warning elsewhere)
╵
╷
│ Warning: Using community license.
│ 
│   with constellation_cluster.aws_example,
│   on main.tf line 96, in resource "constellation_cluster" "aws_example":
│   96: resource "constellation_cluster" "aws_example" {
│ 
│ For details, see
│ https://docs.edgeless.systems/constellation/overview/license
╵
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Only print one of the warnings.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
