### PR TITLE
ci: run provider upgrade test only once

### DIFF
--- a/e2e/provider-upgrade/BUILD.bazel
+++ b/e2e/provider-upgrade/BUILD.bazel
@@ -4,6 +4,7 @@ go_test(
     name = "provider-upgrade_test",
     srcs = ["upgrade_test.go"],
     # keep
+    count = 1,
     gotags = ["e2e"],
     tags = ["manual"],
     deps = [


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
[Terraform provider ugrade tests are run with our default Go test policy of `count=3`](https://github.com/edgelesssys/constellation/blob/6d4a8d594eed031246ef1c0283a1e600b81bf14e/e2e/internal/upgrade/BUILD.bazel#L35)
This causes them to run for ~6 hours in case of failures.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Run the test only once
