### PR TITLE
image: replicate to us-east-1 for aws marketplace

### DIFF
--- a/internal/osimage/uplosi/uplosi.conf.in
+++ b/internal/osimage/uplosi/uplosi.conf.in
@@ -3,7 +3,7 @@ name = "constellation"
 
 [base.aws]
 region = "eu-central-1"
-replicationRegions = ["eu-west-1", "eu-west-3", "us-east-2", "ap-south-1"]
+replicationRegions = ["eu-west-1", "eu-west-3", "us-east-1", "us-east-2", "ap-south-1"]
 bucket = "constellation-images"
 publish = true
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Images for AWS Marketplace publishing need to be present in us-east-1

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add us-east-1 to AWS image replication

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
