### PR TITLE
ci: fix empty run-id in OpenSearch URL

### DIFF
--- a/.github/actions/notify_e2e_failure/action.yml
+++ b/.github/actions/notify_e2e_failure/action.yml
@@ -76,7 +76,7 @@ runs:
           $(queryGen metadata.github.attestation-variant "${{ inputs.attestationVariant }}")
           $(queryGen metadata.github.cluster-creation "${{ inputs.clusterCreation }}")
           $(queryGen metadata.github.e2e-test-payload "${{ steps.encode-uri-component.outputs.string }}")
-          (query:(match_phrase:(metadata.github.run-id:${run_id})))
+          (query:(match_phrase:(metadata.github.run-id:${{ github.run_id }})))
           ))" | tr -d "\t\n ")
 
         # URL construction
@@ -105,6 +105,7 @@ runs:
         fields: |
           workflow: ${{ github.workflow }}
           kubernetesVersion: ${{ inputs.kubernetesVersion }}
+          cloudProvider: ${{ inputs.provider }}
           attestationVariant: ${{ inputs.attestationVariant }}
           clusterCreation: ${{ inputs.clusterCreation }}
           test: ${{ inputs.test }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Field was missing

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix empty run-id in OpenSearch URL
- Re-add `cloudProvider` field to Issue board items
  - Technically not needed anymore since we have `attestationVariant`, but leaving it empty doesn't look very nice, and I don't want to remove the field from the project since we still have a bunch of open Issues using that field

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

