### PR TITLE
ci: fix upload CLI path line splitting

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -55,17 +55,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          #- arch: amd64
-          #  os: linux
+          - arch: amd64
+            os: linux
 
-          #- arch: amd64
-          #  os: darwin
+          - arch: amd64
+            os: darwin
 
-          #- arch: amd64
-          #  os: windows
+          - arch: amd64
+            os: windows
 
-          #- arch: arm64
-          #  os: linux
+          - arch: arm64
+            os: linux
 
           - arch: arm64
             os: darwin
@@ -344,158 +344,158 @@ jobs:
         with:
           name: constellation.spdx.sbom
 
-  #    - name: Download provenance
-  #      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-  #      with:
-  #        name: ${{ needs.provenance.outputs.provenance-name }}
+      - name: Download provenance
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: ${{ needs.provenance.outputs.provenance-name }}
 
-  #    - name: Install slsa-verifier
-  #      run: |
-  #        curl -fsSLO https://github.com/slsa-framework/slsa-verifier/releases/download/v${{ env.SLSA_VERIFIER_VERSION }}/slsa-verifier-linux-amd64
-  #        install slsa-verifier-linux-amd64 /usr/local/bin/slsa-verifier
+      - name: Install slsa-verifier
+        run: |
+          curl -fsSLO https://github.com/slsa-framework/slsa-verifier/releases/download/v${{ env.SLSA_VERIFIER_VERSION }}/slsa-verifier-linux-amd64
+          install slsa-verifier-linux-amd64 /usr/local/bin/slsa-verifier
 
-  #    - name: Verify provenance
-  #      run: |
-  #        slsa-verifier verify-artifact constellation-darwin-amd64 \
-  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-  #          --source-uri github.com/edgelesssys/constellation
-  #        slsa-verifier verify-artifact constellation-darwin-arm64 \
-  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-  #          --source-uri github.com/edgelesssys/constellation
-  #        slsa-verifier verify-artifact constellation-linux-amd64 \
-  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-  #          --source-uri github.com/edgelesssys/constellation
-  #        slsa-verifier verify-artifact constellation-linux-arm64 \
-  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-  #          --source-uri github.com/edgelesssys/constellation
-  #        slsa-verifier verify-artifact constellation-windows-amd64.exe \
-  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-  #          --source-uri github.com/edgelesssys/constellation
+      - name: Verify provenance
+        run: |
+          slsa-verifier verify-artifact constellation-darwin-amd64 \
+            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+            --source-uri github.com/edgelesssys/constellation
+          slsa-verifier verify-artifact constellation-darwin-arm64 \
+            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+            --source-uri github.com/edgelesssys/constellation
+          slsa-verifier verify-artifact constellation-linux-amd64 \
+            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+            --source-uri github.com/edgelesssys/constellation
+          slsa-verifier verify-artifact constellation-linux-arm64 \
+            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+            --source-uri github.com/edgelesssys/constellation
+          slsa-verifier verify-artifact constellation-windows-amd64.exe \
+            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+            --source-uri github.com/edgelesssys/constellation
 
-  #        slsa-verifier verify-artifact terraform-provider-constellation-darwin-amd64 \
-  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-  #          --source-uri github.com/edgelesssys/constellation
-  #        slsa-verifier verify-artifact terraform-provider-constellation-darwin-arm64 \
-  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-  #          --source-uri github.com/edgelesssys/constellation
-  #        slsa-verifier verify-artifact terraform-provider-constellation-linux-amd64 \
-  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-  #          --source-uri github.com/edgelesssys/constellation
-  #        slsa-verifier verify-artifact terraform-provider-constellation-linux-arm64 \
-  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-  #          --source-uri github.com/edgelesssys/constellation
+          slsa-verifier verify-artifact terraform-provider-constellation-darwin-amd64 \
+            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+            --source-uri github.com/edgelesssys/constellation
+          slsa-verifier verify-artifact terraform-provider-constellation-darwin-arm64 \
+            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+            --source-uri github.com/edgelesssys/constellation
+          slsa-verifier verify-artifact terraform-provider-constellation-linux-amd64 \
+            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+            --source-uri github.com/edgelesssys/constellation
+          slsa-verifier verify-artifact terraform-provider-constellation-linux-arm64 \
+            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+            --source-uri github.com/edgelesssys/constellation
 
-  #        slsa-verifier verify-artifact constellation.spdx.sbom \
-  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-  #          --source-uri github.com/edgelesssys/constellation
-  #        slsa-verifier verify-artifact terraform-module.zip \
-  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-  #          --source-uri github.com/edgelesssys/constellation
+          slsa-verifier verify-artifact constellation.spdx.sbom \
+            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+            --source-uri github.com/edgelesssys/constellation
+          slsa-verifier verify-artifact terraform-module.zip \
+            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+            --source-uri github.com/edgelesssys/constellation
 
-  #release:
-  #  permissions:
-  #    contents: write
-  #  runs-on: ubuntu-22.04
-  #  needs:
-  #    - build-cli
-  #    - provenance
-  #    - signed-sbom
-  #    - upload-terraform-module
-  #    - build-terraform-provider
-  #  steps:
-  #    - name: Checkout
-  #      id: checkout
-  #      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-  #      with:
-  #        ref: ${{ inputs.ref || github.head_ref }}
+  release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-22.04
+    needs:
+      - build-cli
+      - provenance
+      - signed-sbom
+      - upload-terraform-module
+      - build-terraform-provider
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ inputs.ref || github.head_ref }}
 
-  #    - name: Write cosign public key
-  #      run: echo "$COSIGN_PUBLIC_KEY" > cosign.pub
-  #      env:
-  #        COSIGN_PUBLIC_KEY: ${{ inputs.key == 'release' && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
+      - name: Write cosign public key
+        run: echo "$COSIGN_PUBLIC_KEY" > cosign.pub
+        env:
+          COSIGN_PUBLIC_KEY: ${{ inputs.key == 'release' && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
 
-  #    - name: Download binaries
-  #      uses: ./.github/actions/download_release_binaries
+      - name: Download binaries
+        uses: ./.github/actions/download_release_binaries
 
-  #    - name: Download CLI SBOM
-  #      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-  #      with:
-  #        name: constellation.spdx.sbom
+      - name: Download CLI SBOM
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: constellation.spdx.sbom
 
-  #    - name: Download Constellation CLI SBOM's signature
-  #      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-  #      with:
-  #        name: constellation.spdx.sbom.sig
+      - name: Download Constellation CLI SBOM's signature
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: constellation.spdx.sbom.sig
 
-  #    - name: Download Constellation provenance
-  #      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-  #      with:
-  #        name: ${{ needs.provenance.outputs.provenance-name }}
+      - name: Download Constellation provenance
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: ${{ needs.provenance.outputs.provenance-name }}
 
-  #    - name: Rename provenance file
-  #      run: |
-  #        mv ${{ needs.provenance.outputs.provenance-name }} constellation.intoto.jsonl
+      - name: Rename provenance file
+        run: |
+          mv ${{ needs.provenance.outputs.provenance-name }} constellation.intoto.jsonl
 
-  #    - name: Create Terraform provider release files
-  #      run: |
-  #        # Remove the "v" prefix from the version as required by the Terraform registry
-  #        version="${{ inputs.versionName }}"
-  #        version="${version#v}"
+      - name: Create Terraform provider release files
+        run: |
+          # Remove the "v" prefix from the version as required by the Terraform registry
+          version="${{ inputs.versionName }}"
+          version="${version#v}"
 
-  #        # Create a zip file with the Terraform provider binaries
-  #        for file in terraform-provider-constellation-*; do
-  #          # Special case for Windows binaries: They need to keep the .exe extension
-  #          ext="${file##*.}"
-  #          distribution_arch="${file#terraform-provider-constellation-}"
-  #          distribution_arch="${distribution_arch%.exe}"
-  #          folder_name="terraform-provider-constellation_${version}_${distribution_arch//-/_}"
+          # Create a zip file with the Terraform provider binaries
+          for file in terraform-provider-constellation-*; do
+            # Special case for Windows binaries: They need to keep the .exe extension
+            ext="${file##*.}"
+            distribution_arch="${file#terraform-provider-constellation-}"
+            distribution_arch="${distribution_arch%.exe}"
+            folder_name="terraform-provider-constellation_${version}_${distribution_arch//-/_}"
 
-  #          mkdir -p "${folder_name}"
-  #          if [[ "${ext}" = "exe" ]]; then
-  #            cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}.exe"
-  #          else
-  #            chmod 755 "${file}" # the upload artifact does not preserve file permissions (https://github.com/actions/upload-artifact/tree/main/?tab=readme-ov-file#permission-loss)
-  #            cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}"
-  #          fi
-  #          (cd "${folder_name}" && zip "../${folder_name}.zip" ./*) # do not zip the folder itself
-  #          rm -r "${folder_name}"
-  #        done
+            mkdir -p "${folder_name}"
+            if [[ "${ext}" = "exe" ]]; then
+              cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}.exe"
+            else
+              chmod 755 "${file}" # the upload artifact does not preserve file permissions (https://github.com/actions/upload-artifact/tree/main/?tab=readme-ov-file#permission-loss)
+              cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}"
+            fi
+            (cd "${folder_name}" && zip "../${folder_name}.zip" ./*) # do not zip the folder itself
+            rm -r "${folder_name}"
+          done
 
-  #        # Create a manifest file for the Terraform provider
-  #        echo '{"version":1,"metadata":{"protocol_versions":["6.0"]}}' > "terraform-provider-constellation_${version}_manifest.json"
+          # Create a manifest file for the Terraform provider
+          echo '{"version":1,"metadata":{"protocol_versions":["6.0"]}}' > "terraform-provider-constellation_${version}_manifest.json"
 
-  #        # Create a SHA256SUMS file of the zip files and manifest, and sign it
-  #        shasum -a 256 "terraform-provider-constellation_${version}"* > "terraform-provider-constellation_${version}_SHA256SUMS"
-  #        echo "${{ secrets.TERRAFORM_GPG_SIGNING_KEY }}" | gpg --import --batch --yes
-  #        gpg -u 3C75E56351F8F3F6 --batch --yes --detach-sign "terraform-provider-constellation_${version}_SHA256SUMS"
+          # Create a SHA256SUMS file of the zip files and manifest, and sign it
+          shasum -a 256 "terraform-provider-constellation_${version}"* > "terraform-provider-constellation_${version}_SHA256SUMS"
+          echo "${{ secrets.TERRAFORM_GPG_SIGNING_KEY }}" | gpg --import --batch --yes
+          gpg -u 3C75E56351F8F3F6 --batch --yes --detach-sign "terraform-provider-constellation_${version}_SHA256SUMS"
 
-  #    - name: Create release with artifacts
-  #      id: create-release
-  #      # GitHub endorsed release project. See: https://github.com/actions/create-release
-  #      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
-  #      with:
-  #        draft: true
-  #        generate_release_notes: true
-  #        tag_name: ${{ inputs.versionName || inputs.ref || github.head_ref }}
-  #        target_commitish: ${{ inputs.ref }}
-  #        files: |
-  #          constellation-*
-  #          cosign.pub
-  #          constellation.spdx.sbom
-  #          constellation.spdx.sbom.sig
-  #          constellation.intoto.jsonl
-  #          terraform-module.zip
+      - name: Create release with artifacts
+        id: create-release
+        # GitHub endorsed release project. See: https://github.com/actions/create-release
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        with:
+          draft: true
+          generate_release_notes: true
+          tag_name: ${{ inputs.versionName || inputs.ref || github.head_ref }}
+          target_commitish: ${{ inputs.ref }}
+          files: |
+            constellation-*
+            cosign.pub
+            constellation.spdx.sbom
+            constellation.spdx.sbom.sig
+            constellation.intoto.jsonl
+            terraform-module.zip
 
-  #    - name: Create Terraform provider release with artifcats
-  #      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
-  #      with:
-  #        draft: true
-  #        generate_release_notes: false
-  #        body: |
-  #          This release contains the Terraform provider binaries for Constellation ${{ inputs.versionName }}.
-  #          Check out [the release page](https://github.com/edgelesssys/constellation/releases/tag/${{ inputs.versionName }}) for more information and a full changelog.
-  #        token: ${{ secrets.CI_GITHUB_REPOSITORY }}
-  #        repository: edgelesssys/terraform-provider-constellation
-  #        tag_name: ${{ inputs.versionName || inputs.ref || github.head_ref }}
-  #        files: |
-  #          terraform-provider-constellation_*
+      - name: Create Terraform provider release with artifcats
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        with:
+          draft: true
+          generate_release_notes: false
+          body: |
+            This release contains the Terraform provider binaries for Constellation ${{ inputs.versionName }}.
+            Check out [the release page](https://github.com/edgelesssys/constellation/releases/tag/${{ inputs.versionName }}) for more information and a full changelog.
+          token: ${{ secrets.CI_GITHUB_REPOSITORY }}
+          repository: edgelesssys/terraform-provider-constellation
+          tag_name: ${{ inputs.versionName || inputs.ref || github.head_ref }}
+          files: |
+            terraform-provider-constellation_*

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -55,17 +55,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - arch: amd64
-            os: linux
+          #- arch: amd64
+          #  os: linux
 
-          - arch: amd64
-            os: darwin
+          #- arch: amd64
+          #  os: darwin
 
-          - arch: amd64
-            os: windows
+          #- arch: amd64
+          #  os: windows
 
-          - arch: arm64
-            os: linux
+          #- arch: arm64
+          #  os: linux
 
           - arch: arm64
             os: darwin
@@ -344,158 +344,158 @@ jobs:
         with:
           name: constellation.spdx.sbom
 
-      - name: Download provenance
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: ${{ needs.provenance.outputs.provenance-name }}
+  #    - name: Download provenance
+  #      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+  #      with:
+  #        name: ${{ needs.provenance.outputs.provenance-name }}
 
-      - name: Install slsa-verifier
-        run: |
-          curl -fsSLO https://github.com/slsa-framework/slsa-verifier/releases/download/v${{ env.SLSA_VERIFIER_VERSION }}/slsa-verifier-linux-amd64
-          install slsa-verifier-linux-amd64 /usr/local/bin/slsa-verifier
+  #    - name: Install slsa-verifier
+  #      run: |
+  #        curl -fsSLO https://github.com/slsa-framework/slsa-verifier/releases/download/v${{ env.SLSA_VERIFIER_VERSION }}/slsa-verifier-linux-amd64
+  #        install slsa-verifier-linux-amd64 /usr/local/bin/slsa-verifier
 
-      - name: Verify provenance
-        run: |
-          slsa-verifier verify-artifact constellation-darwin-amd64 \
-            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-            --source-uri github.com/edgelesssys/constellation
-          slsa-verifier verify-artifact constellation-darwin-arm64 \
-            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-            --source-uri github.com/edgelesssys/constellation
-          slsa-verifier verify-artifact constellation-linux-amd64 \
-            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-            --source-uri github.com/edgelesssys/constellation
-          slsa-verifier verify-artifact constellation-linux-arm64 \
-            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-            --source-uri github.com/edgelesssys/constellation
-          slsa-verifier verify-artifact constellation-windows-amd64.exe \
-            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-            --source-uri github.com/edgelesssys/constellation
+  #    - name: Verify provenance
+  #      run: |
+  #        slsa-verifier verify-artifact constellation-darwin-amd64 \
+  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+  #          --source-uri github.com/edgelesssys/constellation
+  #        slsa-verifier verify-artifact constellation-darwin-arm64 \
+  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+  #          --source-uri github.com/edgelesssys/constellation
+  #        slsa-verifier verify-artifact constellation-linux-amd64 \
+  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+  #          --source-uri github.com/edgelesssys/constellation
+  #        slsa-verifier verify-artifact constellation-linux-arm64 \
+  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+  #          --source-uri github.com/edgelesssys/constellation
+  #        slsa-verifier verify-artifact constellation-windows-amd64.exe \
+  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+  #          --source-uri github.com/edgelesssys/constellation
 
-          slsa-verifier verify-artifact terraform-provider-constellation-darwin-amd64 \
-            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-            --source-uri github.com/edgelesssys/constellation
-          slsa-verifier verify-artifact terraform-provider-constellation-darwin-arm64 \
-            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-            --source-uri github.com/edgelesssys/constellation
-          slsa-verifier verify-artifact terraform-provider-constellation-linux-amd64 \
-            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-            --source-uri github.com/edgelesssys/constellation
-          slsa-verifier verify-artifact terraform-provider-constellation-linux-arm64 \
-            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-            --source-uri github.com/edgelesssys/constellation
+  #        slsa-verifier verify-artifact terraform-provider-constellation-darwin-amd64 \
+  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+  #          --source-uri github.com/edgelesssys/constellation
+  #        slsa-verifier verify-artifact terraform-provider-constellation-darwin-arm64 \
+  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+  #          --source-uri github.com/edgelesssys/constellation
+  #        slsa-verifier verify-artifact terraform-provider-constellation-linux-amd64 \
+  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+  #          --source-uri github.com/edgelesssys/constellation
+  #        slsa-verifier verify-artifact terraform-provider-constellation-linux-arm64 \
+  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+  #          --source-uri github.com/edgelesssys/constellation
 
-          slsa-verifier verify-artifact constellation.spdx.sbom \
-            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-            --source-uri github.com/edgelesssys/constellation
-          slsa-verifier verify-artifact terraform-module.zip \
-            --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
-            --source-uri github.com/edgelesssys/constellation
+  #        slsa-verifier verify-artifact constellation.spdx.sbom \
+  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+  #          --source-uri github.com/edgelesssys/constellation
+  #        slsa-verifier verify-artifact terraform-module.zip \
+  #          --provenance-path ${{ needs.provenance.outputs.provenance-name }} \
+  #          --source-uri github.com/edgelesssys/constellation
 
-  release:
-    permissions:
-      contents: write
-    runs-on: ubuntu-22.04
-    needs:
-      - build-cli
-      - provenance
-      - signed-sbom
-      - upload-terraform-module
-      - build-terraform-provider
-    steps:
-      - name: Checkout
-        id: checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          ref: ${{ inputs.ref || github.head_ref }}
+  #release:
+  #  permissions:
+  #    contents: write
+  #  runs-on: ubuntu-22.04
+  #  needs:
+  #    - build-cli
+  #    - provenance
+  #    - signed-sbom
+  #    - upload-terraform-module
+  #    - build-terraform-provider
+  #  steps:
+  #    - name: Checkout
+  #      id: checkout
+  #      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+  #      with:
+  #        ref: ${{ inputs.ref || github.head_ref }}
 
-      - name: Write cosign public key
-        run: echo "$COSIGN_PUBLIC_KEY" > cosign.pub
-        env:
-          COSIGN_PUBLIC_KEY: ${{ inputs.key == 'release' && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
+  #    - name: Write cosign public key
+  #      run: echo "$COSIGN_PUBLIC_KEY" > cosign.pub
+  #      env:
+  #        COSIGN_PUBLIC_KEY: ${{ inputs.key == 'release' && secrets.COSIGN_PUBLIC_KEY || secrets.COSIGN_DEV_PUBLIC_KEY }}
 
-      - name: Download binaries
-        uses: ./.github/actions/download_release_binaries
+  #    - name: Download binaries
+  #      uses: ./.github/actions/download_release_binaries
 
-      - name: Download CLI SBOM
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: constellation.spdx.sbom
+  #    - name: Download CLI SBOM
+  #      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+  #      with:
+  #        name: constellation.spdx.sbom
 
-      - name: Download Constellation CLI SBOM's signature
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: constellation.spdx.sbom.sig
+  #    - name: Download Constellation CLI SBOM's signature
+  #      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+  #      with:
+  #        name: constellation.spdx.sbom.sig
 
-      - name: Download Constellation provenance
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: ${{ needs.provenance.outputs.provenance-name }}
+  #    - name: Download Constellation provenance
+  #      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+  #      with:
+  #        name: ${{ needs.provenance.outputs.provenance-name }}
 
-      - name: Rename provenance file
-        run: |
-          mv ${{ needs.provenance.outputs.provenance-name }} constellation.intoto.jsonl
+  #    - name: Rename provenance file
+  #      run: |
+  #        mv ${{ needs.provenance.outputs.provenance-name }} constellation.intoto.jsonl
 
-      - name: Create Terraform provider release files
-        run: |
-          # Remove the "v" prefix from the version as required by the Terraform registry
-          version="${{ inputs.versionName }}"
-          version="${version#v}"
+  #    - name: Create Terraform provider release files
+  #      run: |
+  #        # Remove the "v" prefix from the version as required by the Terraform registry
+  #        version="${{ inputs.versionName }}"
+  #        version="${version#v}"
 
-          # Create a zip file with the Terraform provider binaries
-          for file in terraform-provider-constellation-*; do
-            # Special case for Windows binaries: They need to keep the .exe extension
-            ext="${file##*.}"
-            distribution_arch="${file#terraform-provider-constellation-}"
-            distribution_arch="${distribution_arch%.exe}"
-            folder_name="terraform-provider-constellation_${version}_${distribution_arch//-/_}"
+  #        # Create a zip file with the Terraform provider binaries
+  #        for file in terraform-provider-constellation-*; do
+  #          # Special case for Windows binaries: They need to keep the .exe extension
+  #          ext="${file##*.}"
+  #          distribution_arch="${file#terraform-provider-constellation-}"
+  #          distribution_arch="${distribution_arch%.exe}"
+  #          folder_name="terraform-provider-constellation_${version}_${distribution_arch//-/_}"
 
-            mkdir -p "${folder_name}"
-            if [[ "${ext}" = "exe" ]]; then
-              cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}.exe"
-            else
-              chmod 755 "${file}" # the upload artifact does not preserve file permissions (https://github.com/actions/upload-artifact/tree/main/?tab=readme-ov-file#permission-loss)
-              cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}"
-            fi
-            (cd "${folder_name}" && zip "../${folder_name}.zip" ./*) # do not zip the folder itself
-            rm -r "${folder_name}"
-          done
+  #          mkdir -p "${folder_name}"
+  #          if [[ "${ext}" = "exe" ]]; then
+  #            cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}.exe"
+  #          else
+  #            chmod 755 "${file}" # the upload artifact does not preserve file permissions (https://github.com/actions/upload-artifact/tree/main/?tab=readme-ov-file#permission-loss)
+  #            cp "${file}" "${folder_name}/terraform-provider-constellation_v${version}"
+  #          fi
+  #          (cd "${folder_name}" && zip "../${folder_name}.zip" ./*) # do not zip the folder itself
+  #          rm -r "${folder_name}"
+  #        done
 
-          # Create a manifest file for the Terraform provider
-          echo '{"version":1,"metadata":{"protocol_versions":["6.0"]}}' > "terraform-provider-constellation_${version}_manifest.json"
+  #        # Create a manifest file for the Terraform provider
+  #        echo '{"version":1,"metadata":{"protocol_versions":["6.0"]}}' > "terraform-provider-constellation_${version}_manifest.json"
 
-          # Create a SHA256SUMS file of the zip files and manifest, and sign it
-          shasum -a 256 "terraform-provider-constellation_${version}"* > "terraform-provider-constellation_${version}_SHA256SUMS"
-          echo "${{ secrets.TERRAFORM_GPG_SIGNING_KEY }}" | gpg --import --batch --yes
-          gpg -u 3C75E56351F8F3F6 --batch --yes --detach-sign "terraform-provider-constellation_${version}_SHA256SUMS"
+  #        # Create a SHA256SUMS file of the zip files and manifest, and sign it
+  #        shasum -a 256 "terraform-provider-constellation_${version}"* > "terraform-provider-constellation_${version}_SHA256SUMS"
+  #        echo "${{ secrets.TERRAFORM_GPG_SIGNING_KEY }}" | gpg --import --batch --yes
+  #        gpg -u 3C75E56351F8F3F6 --batch --yes --detach-sign "terraform-provider-constellation_${version}_SHA256SUMS"
 
-      - name: Create release with artifacts
-        id: create-release
-        # GitHub endorsed release project. See: https://github.com/actions/create-release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
-        with:
-          draft: true
-          generate_release_notes: true
-          tag_name: ${{ inputs.versionName || inputs.ref || github.head_ref }}
-          target_commitish: ${{ inputs.ref }}
-          files: |
-            constellation-*
-            cosign.pub
-            constellation.spdx.sbom
-            constellation.spdx.sbom.sig
-            constellation.intoto.jsonl
-            terraform-module.zip
+  #    - name: Create release with artifacts
+  #      id: create-release
+  #      # GitHub endorsed release project. See: https://github.com/actions/create-release
+  #      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+  #      with:
+  #        draft: true
+  #        generate_release_notes: true
+  #        tag_name: ${{ inputs.versionName || inputs.ref || github.head_ref }}
+  #        target_commitish: ${{ inputs.ref }}
+  #        files: |
+  #          constellation-*
+  #          cosign.pub
+  #          constellation.spdx.sbom
+  #          constellation.spdx.sbom.sig
+  #          constellation.intoto.jsonl
+  #          terraform-module.zip
 
-      - name: Create Terraform provider release with artifcats
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
-        with:
-          draft: true
-          generate_release_notes: false
-          body: |
-            This release contains the Terraform provider binaries for Constellation ${{ inputs.versionName }}.
-            Check out [the release page](https://github.com/edgelesssys/constellation/releases/tag/${{ inputs.versionName }}) for more information and a full changelog.
-          token: ${{ secrets.CI_GITHUB_REPOSITORY }}
-          repository: edgelesssys/terraform-provider-constellation
-          tag_name: ${{ inputs.versionName || inputs.ref || github.head_ref }}
-          files: |
-            terraform-provider-constellation_*
+  #    - name: Create Terraform provider release with artifcats
+  #      uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+  #      with:
+  #        draft: true
+  #        generate_release_notes: false
+  #        body: |
+  #          This release contains the Terraform provider binaries for Constellation ${{ inputs.versionName }}.
+  #          Check out [the release page](https://github.com/edgelesssys/constellation/releases/tag/${{ inputs.versionName }}) for more information and a full changelog.
+  #        token: ${{ secrets.CI_GITHUB_REPOSITORY }}
+  #        repository: edgelesssys/terraform-provider-constellation
+  #        tag_name: ${{ inputs.versionName || inputs.ref || github.head_ref }}
+  #        files: |
+  #          terraform-provider-constellation_*

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -96,7 +96,7 @@ jobs:
         if : ${{ matrix.os != 'windows' }}
         with:
           name: constellation-${{ matrix.os }}-${{ matrix.arch }}
-          path: >
+          path: |
             build/constellation-${{ matrix.os }}-${{ matrix.arch }}
             build/constellation-${{ matrix.os }}-${{ matrix.arch }}.sig
 
@@ -105,7 +105,7 @@ jobs:
         if : ${{ matrix.os == 'windows' }}
         with:
           name: constellation-${{ matrix.os }}-${{ matrix.arch }}
-          path: >
+          path: |
             build/constellation-${{ matrix.os }}-${{ matrix.arch }}.exe
             build/constellation-${{ matrix.os }}-${{ matrix.arch }}.exe.sig
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The action for encrypting artifacts merged in #2567 and it's reversal introduced a bug here, as one requires multiple upload targets to split by spaces, and one by newlines. The reversal only changed the action path, but not the operator concatenating multiple lines in the upload targets, causing the upload to [fail](https://github.com/edgelesssys/constellation/actions/runs/7707757698).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use the previously used operator `|`, which concatenates the lines with `\n`s, as required by [actions/upload-artifact](https://github.com/actions/upload-artifact?tab=readme-ov-file#upload-using-multiple-paths-and-exclusions).

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
