### PR TITLE
ci: don't delete local cached providers when uploading Terraform state

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -280,8 +280,11 @@ runs:
       if: always()
       shell: bash
       run: |
-        rm constellation-terraform/plan.zip
-        rm -rf constellation-terraform/.terraform constellation-iam-terraform/.terraform
+        mkdir to-zip
+        cp -r constellation-terraform to-zip
+        cp -r constellation-iam-terraform to-zip
+        rm to-zip/constellation-terraform/plan.zip
+        rm -rf to-zip/constellation-terraform/.terraform to-zip/constellation-iam-terraform/.terraform
 
     - name: Upload terraform state
       if: always()
@@ -289,7 +292,6 @@ runs:
       with:
         name: terraform-state-${{ inputs.artifactNameSuffix }}
         path: >
-          constellation-terraform
-          constellation-iam-terraform
+          to-zip/constellation-terraform
+          to-zip/constellation-iam-terraform
         encryptionSecret: ${{ inputs.encryptionSecret }}
-


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
To allow for easier debugging and clean-up, we upload the terraform state/files used by the CI to create clusters.
To reduce the size of the artifacts we remove the cached providers before upload.
This causes problems for tests on GCP, since the CLI performs some actions depending on the providers still being present after we upload the state (which deletes the providers).
This is not an issue for AWS and Azure, since they will implicitly run `terraform init` before performing any action depending on the Terraform state. 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Move files to upload to temporary directory and delete the providers from said temp dir before uploading it.

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/347

### Additional info
- [GCP e2e test](https://github.com/edgelesssys/constellation/actions/runs/7738258938/job/21098731334#step:8:1)
- [Failed GCP e2e test from the daily run](https://github.com/edgelesssys/constellation/actions/runs/7735666481/job/21091727142#step:6:1)
