### PR TITLE
cleanup: various minor debugging improvements

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -221,7 +221,9 @@ runs:
             sleep 30
         done
         if [[ $JOINWAIT -gt $JOINTIMEOUT ]]; then
-            echo "Timed out waiting for nodes to join"
+            kubectl get nodes -o wide
+            echo "::error::Timed out waiting for nodes to join"
+            echo "::endgroup::"
             exit 1
         fi
         echo "$(kubectl get nodes -o json | jq '.items | length')/"${NODES_COUNT}" nodes have joined"

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -524,8 +524,7 @@ jobs:
       - name: Notify about failure
         if: |
           always() &&
-          needs.create-cluster.result != 'success' &&
-          needs.e2e-upgrade.result != 'success' &&
+          ( needs.create-cluster.result != 'success' || needs.e2e-upgrade.result != 'success' ) &&
           github.ref == 'refs/heads/main' &&
           inputs.scheduled
         continue-on-error: true

--- a/internal/atls/atls.go
+++ b/internal/atls/atls.go
@@ -200,6 +200,7 @@ func processCertificate(rawCerts [][]byte, _ [][]*x509.Certificate) (*x509.Certi
 
 // verifyEmbeddedReport verifies an aTLS certificate by validating the attestation document embedded in the TLS certificate.
 func verifyEmbeddedReport(validators []Validator, cert *x509.Certificate, hash, nonce []byte) error {
+	var exts []string
 	for _, ex := range cert.Extensions {
 		for _, validator := range validators {
 			if ex.Id.Equal(validator.OID()) {
@@ -216,9 +217,10 @@ func verifyEmbeddedReport(validators []Validator, cert *x509.Certificate, hash, 
 				return nil
 			}
 		}
+		exts = append(exts, ex.Id.String())
 	}
 
-	return errors.New("certificate does not contain attestation document")
+	return fmt.Errorf("certificate does not contain compatible attestation documents: got extension OIDs %#v", exts)
 }
 
 func hashPublicKey(pub any) ([]byte, error) {

--- a/internal/constellation/kubecmd/kubecmd.go
+++ b/internal/constellation/kubecmd/kubecmd.go
@@ -303,7 +303,7 @@ func (k *KubeCmd) getConstellationVersion(ctx context.Context) (updatev1alpha1.N
 		Group:    "update.edgeless.systems",
 		Version:  "v1alpha1",
 		Resource: "nodeversions",
-	}, "constellation-version")
+	}, constants.NodeVersionResourceName)
 	if err != nil {
 		return updatev1alpha1.NodeVersion{}, err
 	}

--- a/joinservice/internal/server/server.go
+++ b/joinservice/internal/server/server.go
@@ -197,7 +197,7 @@ func (s *Server) IssueRejoinTicket(ctx context.Context, req *joinproto.IssueRejo
 
 // getK8sComponentsConfigMapName reads the k8s components config map name from a VolumeMount that is backed by the k8s-version ConfigMap.
 func (s *Server) getK8sComponentsConfigMapName(ctx context.Context) (string, error) {
-	k8sComponentsRef, err := s.kubeClient.GetK8sComponentsRefFromNodeVersionCRD(ctx, "constellation-version")
+	k8sComponentsRef, err := s.kubeClient.GetK8sComponentsRefFromNodeVersionCRD(ctx, constants.NodeVersionResourceName)
 	if err != nil {
 		return "", fmt.Errorf("could not get k8s components config map name: %w", err)
 	}


### PR DESCRIPTION
### Context

I collected some smaller issues while debugging failing e2e tests - this PR fixes some.

### Proposed change(s)

See also commit messages.

- atls: report cert extension OIDs on mismatch
- ci: correctly notify on e2e upgrade error
- cleanup: use NodeVersionResourceName constant
- ci: improve constellation_create error message

### Checklist

- [ ] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
