### PR TITLE
ci: fix workspace related errors when setting up k8s version for test

### DIFF
--- a/.github/workflows/e2e-test-provider-example.yml
+++ b/.github/workflows/e2e-test-provider-example.yml
@@ -143,8 +143,8 @@ jobs:
         id: build
         shell: bash
         run: |
-          mkdir build
-          cd build
+          mkdir -p ${{ github.workspace }}/build
+          cd ${{ github.workspace }}/build
           bazel run //:devbuild --cli_edition=enterprise
 
           bazel build //bazel/settings:tag
@@ -189,12 +189,15 @@ jobs:
       - name: Set Kubernetes version
         id: kubernetes
         run: |
+          set -e
+
           # take the middle (2nd) supported Kubernetes version (default)
           if [[ "${{ inputs.providerVersion }}" != "" ]]; then
-            echo "VERSION=$(../release/constellation config kubernetes-versions | awk 'NR==3{print $1}')" | tee -a "$GITHUB_OUTPUT"
+            cli_output=$(${{ github.workspace }}/release/constellation config kubernetes-versions)
           else
-            echo "VERSION=$(../build/constellation config kubernetes-versions | awk 'NR==3{print $1}')" | tee -a "$GITHUB_OUTPUT"
+            cli_output=$(${{ github.workspace }}/build/constellation config kubernetes-versions)
           fi
+          echo "version=$(echo "${cli_output}" | awk 'NR==3{print $1}')" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Common CSP Terraform overrides
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/e2e-test-provider-example.yml
+++ b/.github/workflows/e2e-test-provider-example.yml
@@ -313,7 +313,7 @@ jobs:
         shell: bash
         run: |
           terraform init
-          if [[ "${{ steps.determine.outputs.cloudProvider }}" == "azure" ]]; then
+          if [[ "${{ inputs.attestationVariant }}" == "azure-sev-snp" ]]; then
             terraform apply -target module.azure_iam -auto-approve
             terraform apply -target module.azure_infrastructure -auto-approve
             ${{ github.workspace }}/build/constellation maa-patch "$(terraform output -raw maa_url)"

--- a/.github/workflows/e2e-test-provider-example.yml
+++ b/.github/workflows/e2e-test-provider-example.yml
@@ -203,8 +203,8 @@ jobs:
         working-directory: ${{ github.workspace }}
         shell: bash
         run: |
-          mkdir cluster
-          cd cluster
+          mkdir -p ${{ github.workspace }}/cluster
+          cd ${{ github.workspace }}/cluster
           if [[ "${{ inputs.providerVersion }}" == "" ]]; then
             prefixed_version=${{ steps.build.outputs.build_version }}
           else
@@ -213,8 +213,8 @@ jobs:
           version=${prefixed_version#v} # remove v prefix
 
           if [[ "${{ inputs.providerVersion }}" == "" ]]; then
-            iam_src="../terraform-module/iam/${{ steps.determine.outputs.cloudProvider }}"
-            infra_src="../terraform-module/${{ steps.determine.outputs.cloudProvider }}"
+            iam_src="${{ github.workspace }}/terraform-module/iam/${{ steps.determine.outputs.cloudProvider }}"
+            infra_src="${{ github.workspace }}/terraform-module/${{ steps.determine.outputs.cloudProvider }}"
           else
             iam_src="https://github.com/edgelesssys/constellation/releases/download/${{ inputs.providerVersion }}/terraform-module.zip//terraform-module/iam/${{ steps.determine.outputs.cloudProvider }}"
             infra_src="https://github.com/edgelesssys/constellation/releases/download/${{ inputs.providerVersion }}/terraform-module.zip//terraform-module/${{ steps.determine.outputs.cloudProvider }}"
@@ -316,7 +316,7 @@ jobs:
           if [[ "${{ steps.determine.outputs.cloudProvider }}" == "azure" ]]; then
             terraform apply -target module.azure_iam -auto-approve
             terraform apply -target module.azure_infrastructure -auto-approve
-            ../build/constellation maa-patch "$(terraform output -raw maa_url)"
+            ${{ github.workspace }}/build/constellation maa-patch "$(terraform output -raw maa_url)"
             terraform apply -target constellation_cluster.azure_example -auto-approve
           else
             terraform apply -auto-approve
@@ -408,7 +408,7 @@ jobs:
           fi
 
           # cfg must be in same dir as KUBECONFIG
-          ../build/constellation config generate "${{ steps.determine.outputs.cloudProvider }}"
+          ${{ github.workspace }}/build/constellation config generate "${{ steps.determine.outputs.cloudProvider }}"
           # make cfg valid with fake data
           # IMPORTANT: zone needs to be correct because it is used to resolve the CSP image ref
           if [[ "${{ steps.determine.outputs.cloudProvider }}" == "azure" ]]; then


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Determining the default Kubernetes version for the test failed, which was no caught by the test, since the relevant command was executed in a subshell.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Properly fail if the command in the subshell failed
- Replace relative paths with github workspace absolute paths

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/352

### Additional info
<!-- Remove items that do not apply -->
Terraform e2e tests:

- [GCP](https://github.com/edgelesssys/constellation/actions/runs/7781986706)
- [Azure SEV-SNP](https://github.com/edgelesssys/constellation/actions/runs/7783895875)
- TDX test non functional since it selects the wrong instance type. Will fix in separate PR
- [AWS SEV-SNP](https://github.com/edgelesssys/constellation/actions/runs/7783906335)

