### PR TITLE
ci: make instance type configurable for provider sample

### DIFF
--- a/.github/workflows/e2e-test-provider-example.yml
+++ b/.github/workflows/e2e-test-provider-example.yml
@@ -420,7 +420,7 @@ jobs:
           fi
 
           # cfg must be in same dir as KUBECONFIG
-          ${{ github.workspace }}/build/constellation config generate "${{ steps.determine.outputs.cloudProvider }}"
+          ${{ github.workspace }}/build/constellation config generate "${{ steps.determine.outputs.cloudProvider }}" --attestation ${{ inputs.attestationVariant}}
           # make cfg valid with fake data
           # IMPORTANT: zone needs to be correct because it is used to resolve the CSP image ref
           if [[ "${{ steps.determine.outputs.cloudProvider }}" == "azure" ]]; then

--- a/.github/workflows/e2e-test-provider-example.yml
+++ b/.github/workflows/e2e-test-provider-example.yml
@@ -301,6 +301,18 @@ jobs:
           EOF
           cat _override.tf
 
+      - name: Create Azure TDX Terraform overrides
+        if: inputs.attestationVariant == 'azure-tdx'
+        working-directory: ${{ github.workspace }}/cluster
+        shell: bash
+        run: |
+          cat >> _override.tf <<EOF
+          locals {
+            instance_type = "Standard_DC4es_v5"
+          }
+          EOF
+          cat _override.tf
+
       - name: Copy example Terraform file
         working-directory: ${{ github.workspace }}
         shell: bash

--- a/terraform-provider-constellation/examples/full/aws/main.tf
+++ b/terraform-provider-constellation/examples/full/aws/main.tf
@@ -22,6 +22,7 @@ locals {
   zone                 = "us-east-2c"
   control_plane_count  = 3
   worker_count         = 2
+  instance_type        = "m6a.xlarge"
 
   master_secret      = random_bytes.master_secret.hex
   master_secret_salt = random_bytes.master_secret_salt.hex
@@ -54,7 +55,7 @@ module "aws_infrastructure" {
   node_groups = {
     control_plane_default = {
       role          = "control-plane"
-      instance_type = "m6a.xlarge"
+      instance_type = local.instance_type
       disk_size     = 30
       disk_type     = "gp3"
       initial_count = local.control_plane_count
@@ -62,7 +63,7 @@ module "aws_infrastructure" {
     },
     worker_default = {
       role          = "worker"
-      instance_type = "m6a.xlarge"
+      instance_type = local.instance_type
       disk_size     = 30
       disk_type     = "gp3"
       initial_count = local.worker_count

--- a/terraform-provider-constellation/examples/full/azure/main.tf
+++ b/terraform-provider-constellation/examples/full/azure/main.tf
@@ -21,6 +21,7 @@ locals {
   location             = "northeurope"
   control_plane_count  = 3
   worker_count         = 2
+  instance_type        = "Standard_DC4as_v5"
 
   master_secret      = random_bytes.master_secret.hex
   master_secret_salt = random_bytes.master_secret_salt.hex
@@ -55,14 +56,14 @@ module "azure_infrastructure" {
   node_groups = {
     control_plane_default = {
       role          = "control-plane"
-      instance_type = "Standard_DC4as_v5"
+      instance_type = local.instance_type
       disk_size     = 30
       disk_type     = "Premium_LRS"
       initial_count = local.control_plane_count
     },
     worker_default = {
       role          = "worker"
-      instance_type = "Standard_DC4as_v5"
+      instance_type = local.instance_type
       disk_size     = 30
       disk_type     = "Premium_LRS"
       initial_count = local.worker_count

--- a/terraform-provider-constellation/examples/full/gcp/main.tf
+++ b/terraform-provider-constellation/examples/full/gcp/main.tf
@@ -23,6 +23,7 @@ locals {
   project_id           = "constellation-331613"
   control_plane_count  = 3
   worker_count         = 2
+  instance_type        = "n2d-standard-4"
 
   master_secret      = random_bytes.master_secret.hex
   master_secret_salt = random_bytes.master_secret_salt.hex
@@ -57,7 +58,7 @@ module "gcp_infrastructure" {
   node_groups = {
     control_plane_default = {
       role          = "control-plane"
-      instance_type = "n2d-standard-4"
+      instance_type = local.instance_type
       disk_size     = 30
       disk_type     = "pd-ssd"
       initial_count = local.control_plane_count
@@ -65,7 +66,7 @@ module "gcp_infrastructure" {
     },
     worker_default = {
       role          = "worker"
-      instance_type = "n2d-standard-4"
+      instance_type = local.instance_type
       disk_size     = 30
       disk_type     = "pd-ssd"
       initial_count = local.worker_count


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
1. Terraform provider test for Azure TDX was using the default instance type for SEV-SNP resulting in failed initialization of the cluster.
2. Terraform provider test tries to upgrade TDX images to SEV-SNP images

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Make instance type configurable for provider sample
- Select the correct instance type for TDX e2e test
- TODO: Fix image upgrade issue

### Additional info
- [Azure e2e TDX](https://github.com/edgelesssys/constellation/actions/runs/7785773077)