### PR TITLE
helm: change chart order to allow early node joining

### DIFF
--- a/internal/cloud/openstack/openstack.go
+++ b/internal/cloud/openstack/openstack.go
@@ -307,16 +307,6 @@ func (c *Cloud) getLoadBalancerHost(ctx context.Context) (string, error) {
 	return "", errors.New("no load balancer endpoint found")
 }
 
-// GetNetworkIDs returns the IDs of the networks the current instance is part of.
-// This method is OpenStack specific.
-func (c *Cloud) GetNetworkIDs(ctx context.Context) ([]string, error) {
-	networkIDs, err := c.imds.networkIDs(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("retrieving network IDs: %w", err)
-	}
-	return networkIDs, nil
-}
-
 func (c *Cloud) getSubnetCIDR(uidTag string) (netip.Prefix, error) {
 	listSubnetsOpts := subnets.ListOpts{Tags: uidTag}
 	subnetsPage, err := c.api.ListSubnets(listSubnetsOpts).AllPages()

--- a/internal/cloud/openstack/openstack_test.go
+++ b/internal/cloud/openstack/openstack_test.go
@@ -654,46 +654,6 @@ func TestGetLoadBalancerEndpoint(t *testing.T) {
 	}
 }
 
-func TestGetNetworkIDs(t *testing.T) {
-	someErr := fmt.Errorf("failed")
-
-	testCases := map[string]struct {
-		imds    imdsAPI
-		want    []string
-		wantErr bool
-	}{
-		"success": {
-			imds: &stubIMDSClient{
-				networkIDsResult: []string{"id1", "id2"},
-			},
-			want: []string{"id1", "id2"},
-		},
-		"fail to get network IDs": {
-			imds: &stubIMDSClient{
-				networkIDsErr: someErr,
-			},
-			wantErr: true,
-		},
-	}
-
-	for name, tc := range testCases {
-		t.Run(name, func(t *testing.T) {
-			assert := assert.New(t)
-
-			c := &Cloud{imds: tc.imds}
-
-			got, err := c.GetNetworkIDs(context.Background())
-
-			if tc.wantErr {
-				assert.Error(err)
-			} else {
-				assert.NoError(err)
-				assert.Equal(tc.want, got)
-			}
-		})
-	}
-}
-
 // newSubnetPager returns a subnet pager as we would get from a ListSubnets.
 func newSubnetPager(nets []subnets.Subnet, err error) stubPager {
 	return stubPager{

--- a/internal/constellation/helm/loader.go
+++ b/internal/constellation/helm/loader.go
@@ -148,7 +148,7 @@ func (i *chartLoader) loadReleases(conformanceMode, deployCSIDriver bool, helmWa
 	}
 	conServicesRelease.values = mergeMaps(conServicesRelease.values, svcVals)
 
-	releases := releaseApplyOrder{ciliumRelease, conServicesRelease, certManagerRelease}
+	releases := releaseApplyOrder{ciliumRelease, certManagerRelease, operatorRelease, conServicesRelease}
 	if deployCSIDriver {
 		csiRelease, err := i.loadRelease(csiInfo, helmWaitMode)
 		if err != nil {
@@ -168,7 +168,6 @@ func (i *chartLoader) loadReleases(conformanceMode, deployCSIDriver bool, helmWa
 		}
 		releases = append(releases, awsRelease)
 	}
-	releases = append(releases, operatorRelease)
 
 	return releases, nil
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Some helm charts (including yawol on OpenStack) require worker nodes to join the cluster.
Also, the constellation-node-operator is a prerequisite to allow nodes to join. 
By changing the order, we make the process more reliable.
I do plan on moving the yawol helm chart away from constellation-services in a follow-up, but this is a better order anyways.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- helm: change chart order to allow early node joining

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
- [ ] [e2e azure](https://github.com/edgelesssys/constellation/actions/runs/7846879945)
- [ ] [e2e gcp](https://github.com/edgelesssys/constellation/actions/runs/7846890667)
- [ ] [e2e AWS](https://github.com/edgelesssys/constellation/actions/runs/7846898393)
