### PR TITLE
ci: prevent duplicate artifact naming in same workflow

### DIFF
--- a/.github/workflows/e2e-test-provider-example.yml
+++ b/.github/workflows/e2e-test-provider-example.yml
@@ -83,20 +83,6 @@ jobs:
           ref: main
           stream: nightly
 
-      - name: Upload Terraform module
-        uses: ./.github/actions/upload_terraform_module
-
-      - name: Download Terraform module
-        uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
-        with:
-          name: terraform-module
-
-      - name: Unzip Terraform module
-        shell: bash
-        run: |
-          unzip terraform-module.zip -d ${{ github.workspace }}
-          rm terraform-module.zip
-
       - name: Create resource prefix
         id: create-prefix
         shell: bash
@@ -213,8 +199,8 @@ jobs:
           version=${prefixed_version#v} # remove v prefix
 
           if [[ "${{ inputs.providerVersion }}" == "" ]]; then
-            iam_src="${{ github.workspace }}/terraform-module/iam/${{ steps.determine.outputs.cloudProvider }}"
-            infra_src="${{ github.workspace }}/terraform-module/${{ steps.determine.outputs.cloudProvider }}"
+            iam_src="${{ github.workspace }}/terraform/infrastructure/iam/${{ steps.determine.outputs.cloudProvider }}"
+            infra_src="${{ github.workspace }}/terraform/infrastructure/${{ steps.determine.outputs.cloudProvider }}"
           else
             iam_src="https://github.com/edgelesssys/constellation/releases/download/${{ inputs.providerVersion }}/terraform-module.zip//terraform-module/iam/${{ steps.determine.outputs.cloudProvider }}"
             infra_src="https://github.com/edgelesssys/constellation/releases/download/${{ inputs.providerVersion }}/terraform-module.zip//terraform-module/${{ steps.determine.outputs.cloudProvider }}"

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Upload CLI binary
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          name: constellation
+          name: constellation-upgrade-${{ inputs.attestationVariant }}
           path: build/constellation
 
   create-cluster:
@@ -336,7 +336,7 @@ jobs:
       - name: Download CLI
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
-          name: constellation
+          name: constellation-upgrade-${{ inputs.attestationVariant }}
           path: build
 
       - name: Download Working Directory (Pre-test)
@@ -459,7 +459,7 @@ jobs:
       - name: Download CLI
         uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
         with:
-          name: constellation
+          name: constellation-upgrade-${{ inputs.attestationVariant }}
           path: build
 
       - name: Download Working Directory (Pre-test)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Our weekly tests had multiple different workflows that uploaded to the same artifact name, overwriting it for all workflows, which was not intended behavior.
Additionally, the actions/upload-artifact@v4 action now throws an error when uploading artifacts with the same name in one workflow run.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use workflow unique name for CLI binary in upgrade workflow
- Skip unnecessary Terraform module upload in provider example test

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/376

### Additional info
- [Terraform provider example test](https://github.com/edgelesssys/constellation/actions/runs/7868855242)
- [e2e upgrade test](https://github.com/edgelesssys/constellation/actions/runs/7868866271)
