### PR TITLE
helm: fix log formatting

### DIFF
--- a/internal/constellation/helm/action.go
+++ b/internal/constellation/helm/action.go
@@ -37,7 +37,7 @@ type applyAction interface {
 func newActionConfig(kubeConfig []byte, logger debugLog) (*action.Configuration, error) {
 	actionConfig := &action.Configuration{}
 	if err := actionConfig.Init(&clientGetter{kubeConfig: kubeConfig}, constants.HelmNamespace,
-		"secret", logger.Debug); err != nil {
+		"secret", helmLog(logger)); err != nil {
 		return nil, err
 	}
 	return actionConfig, nil
@@ -221,4 +221,10 @@ func (c *clientGetter) ToRESTMapper() (meta.RESTMapper, error) {
 // ToRawKubeConfigLoader implements the genericclioptions.RESTClientGetter interface.
 func (c *clientGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
 	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(&clientcmd.ClientConfigLoadingRules{}, &clientcmd.ConfigOverrides{})
+}
+
+func helmLog(log debugLog) action.DebugLog {
+	return func(format string, v ...interface{}) {
+		log.Debug(fmt.Sprintf(format, v...))
+	}
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
We recently switched our logging from `Log(format string, args ...any)` to `Log(message string, args ...any)`.
This causes problems with the helm library which expects format strings.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a wrapping function to provide helm a logger with format strings

### Additional info
- [e2e test with fixed logging](https://github.com/edgelesssys/constellation/actions/runs/7883947085/job/21511909342)

