### PR TITLE
ci: fix artifact overwriting in upgrade test

### DIFF
--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -245,7 +245,7 @@ jobs:
         if: always()
         uses: ./.github/actions/artifact_upload
         with:
-          name: constellation-pre-test
+          name: constellation-pre-test-${{ inputs.attestationVariant }}
           path: >
             ${{ steps.e2e_test.outputs.kubeconfig }}
             constellation-terraform
@@ -259,7 +259,7 @@ jobs:
         if: always() && needs.generate-input-parameters.outputs.cloudProvider == 'gcp'
         uses: ./.github/actions/artifact_upload
         with:
-          name: sa-key
+          name: sa-key-${{ inputs.attestationVariant }}
           path: >
             gcpServiceAccountKey.json
           encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
@@ -342,14 +342,14 @@ jobs:
       - name: Download Working Directory (Pre-test)
         uses: ./.github/actions/artifact_download
         with:
-          name: constellation-pre-test
+          name: constellation-pre-test-${{ inputs.attestationVariant }}
           encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Download SA Key
         if: needs.generate-input-parameters.outputs.cloudProvider == 'gcp'
         uses: ./.github/actions/artifact_download
         with:
-          name: sa-key
+          name: sa-key-${{ inputs.attestationVariant }}
           encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Make Constellation executable and add to PATH
@@ -421,7 +421,7 @@ jobs:
         if: always()
         uses: ./.github/actions/artifact_upload
         with:
-          name: constellation-post-test
+          name: constellation-post-test-${{ inputs.attestationVariant }}
           path: |
             ${{ needs.create-cluster.outputs.kubeconfig }}
             constellation-terraform
@@ -466,14 +466,14 @@ jobs:
         if: always() && needs.e2e-upgrade.result != 'success'
         uses: ./.github/actions/artifact_download
         with:
-          name: constellation-pre-test
+          name: constellation-pre-test-${{ inputs.attestationVariant }}
           encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Download Working Directory (Post-test)
         if: always() && needs.e2e-upgrade.result == 'success'
         uses: ./.github/actions/artifact_download
         with:
-          name: constellation-post-test
+          name: constellation-post-test-${{ inputs.attestationVariant }}
           encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 
       - name: Make Constellation executable and add to PATH


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
In v4 of the artifact-upload action, which is used in the upgrade E2E test, it is no longer possible to [upload multiple artifacts with the same name](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes). This caused race conditions when running multiple upgrade tests in parallel, and tests would [occasionally get artifacts that aren't meant for them](https://github.com/edgelesssys/constellation/actions/runs/7914280183/job/21642199733). 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Give each of the uploaded artifacts individual names.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
