### PR TITLE
bootstrapper: enable feature gate EtcdLearnerMode

### DIFF
--- a/bootstrapper/internal/kubernetes/k8sapi/kubeadm_config.go
+++ b/bootstrapper/internal/kubernetes/k8sapi/kubeadm_config.go
@@ -122,6 +122,9 @@ func (c *KubdeadmConfiguration) InitConfiguration(externalCloudProvider bool, cl
 					"profiling": "false",
 				},
 			},
+			FeatureGates: map[string]bool{
+				"EtcdLearnerMode": true,
+			},
 		},
 		// warning: this config is applied to every node in the cluster!
 		KubeletConfiguration: kubeletconf.KubeletConfiguration{


### PR DESCRIPTION
### Context

When the second control-plane node joins a Constellation, we observe an etcd outage of ~15s, which is due to two factors:

1. kubeadm first adds the new etcd to the cluster, then writes the static pod manifest ([source](https://github.com/kubernetes/kubernetes/blob/3516bc6f49eee4ca2d45ad3a13385c22ea76c247/cmd/kubeadm/app/phases/etcd/local.go#L155-L172)). As soon as a second member is known, the current leader steps down because it does not have quorum anymore. Since we do not pre-pull the images, there are a couple of seconds delay until the new etcd starts.
2. While starting up, the new etcd tries to find out whether cluster version downgrades are enabled ([source](https://github.com/etcd-io/etcd/blob/8814e03e33d9d7d00938655b43534f1e5ba180a2/server/etcdserver/cluster_util.go#L383-L416)). This API is linearized and requires quorum, but we don't have a leader, so the new member waits 7s for this call to time out before continuing to fully start up.

### Proposed change(s)

Enable the `EtcdLearnerMode` feature. When a new control plane node joins the cluster, it will be put into _learner mode_ until it's fully started up. Learners do not count towards the quorum, which prevents the existing leader from stepping down (in a 1->2 scenario) before the new node is ready. This should address both of the above problems.


### Related issue

- Fixes edgelesssys/issues#30
- Fixes edgelesssys/issues#36

### Additional info

- [AB#3812](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3812)
- More info: https://kubernetes.io/blog/2023/09/25/kubeadm-use-etcd-learner-mode/


### Checklist

- [ ] Run the E2E tests that are relevant to this PR's changes: https://github.com/edgelesssys/constellation/actions/runs/7962971594
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
