### PR TITLE
debugd: enable debug logging for systemd units

### DIFF
--- a/debugd/internal/debugd/deploy/service.go
+++ b/debugd/internal/debugd/deploy/service.go
@@ -172,7 +172,7 @@ func (s *ServiceManager) OverrideServiceUnitExecStart(ctx context.Context, unitN
 	if strings.Contains(execStart, "\n") || strings.Contains(execStart, "\r") {
 		return fmt.Errorf("execStart must not contain newlines")
 	}
-	overrideUnitContents := fmt.Sprintf("[Service]\nExecStart=\nExecStart=%s\n", execStart)
+	overrideUnitContents := fmt.Sprintf("[Service]\nExecStart=\nExecStart=%s $CONSTELLATION_DEBUG_FLAGS\n", execStart)
 	s.systemdUnitFilewriteLock.Lock()
 	defer s.systemdUnitFilewriteLock.Unlock()
 	path := filepath.Join(systemdUnitFolder, unitName+".service.d", "override.conf")

--- a/debugd/internal/debugd/deploy/service_test.go
+++ b/debugd/internal/debugd/deploy/service_test.go
@@ -218,7 +218,7 @@ func TestOverrideServiceUnitExecStart(t *testing.T) {
 			},
 			unitName:         "test",
 			execStart:        "/run/state/bin/test",
-			wantFileContents: "[Service]\nExecStart=\nExecStart=/run/state/bin/test\n",
+			wantFileContents: "[Service]\nExecStart=\nExecStart=/run/state/bin/test $CONSTELLATION_DEBUG_FLAGS\n",
 			wantActionCalls: []dbusConnActionInput{
 				{name: "test.service", mode: "replace"},
 			},
@@ -264,7 +264,7 @@ func TestOverrideServiceUnitExecStart(t *testing.T) {
 			},
 			unitName:         "test",
 			execStart:        "/run/state/bin/test",
-			wantFileContents: "[Service]\nExecStart=\nExecStart=/run/state/bin/test\n",
+			wantFileContents: "[Service]\nExecStart=\nExecStart=/run/state/bin/test $CONSTELLATION_DEBUG_FLAGS\n",
 			wantActionCalls: []dbusConnActionInput{
 				{name: "test.service", mode: "replace"},
 			},


### PR DESCRIPTION
### Proposed change(s)

- Expose debug options to systemd overrides provided by debugd. The `--debug` is supported by upgrade-agent and bootstrapper.

### Related issue
- Fixes edgelesssys/issues#133.

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
