### PR TITLE
ci: fetch latest console logs on aws

### DIFF
--- a/.github/actions/constellation_create/aws-logs.sh
+++ b/.github/actions/constellation_create/aws-logs.sh
@@ -25,20 +25,20 @@ workerInstances=$(
     yq eval '.Reservations[].Instances[].InstanceId' -
 )
 
-echo "Fetching logs from control planes"
+for flag in "" "--latest"; do
+  echo "Fetching ${flag} logs from control planes"
+  for instance in ${controlInstances}; do
+    printf "Fetching for %s\n" "${instance}"
+    aws ec2 get-console-output "${flag}" --region "${1}" --instance-id "${instance}" |
+      jq -r .'Output' |
+      tail -n +2 > "control-plane-${instance}${flag}.log"
+  done
 
-for instance in ${controlInstances}; do
-  printf "Fetching for %s\n" "${instance}"
-  aws ec2 get-console-output --region "${1}" --instance-id "${instance}" |
-    jq -r .'Output' |
-    tail -n +2 > control-plane-"${instance}".log
-done
-
-echo "Fetching logs from worker nodes"
-
-for instance in ${workerInstances}; do
-  printf "Fetching for %s\n" "${instance}"
-  aws ec2 get-console-output --region "${1}" --instance-id "${instance}" |
-    jq -r .'Output' |
-    tail -n +2 > worker-"${instance}".log
+  echo "Fetching ${flag} logs from worker nodes"
+  for instance in ${workerInstances}; do
+    printf "Fetching for %s\n" "${instance}"
+    aws ec2 get-console-output "${flag}" --region "${1}" --instance-id "${instance}" |
+      jq -r .'Output' |
+      tail -n +2 > "worker-${instance}${flag}.log"
+  done
 done


### PR DESCRIPTION
### Context

When we collect serial console logs of EC2 instances, we usually get truncated logs (e.g., somewhere around the disk-mapper 80% completion log). This is confusing during debugging, because it's unclear at which point a failing machine actually failed, and sometimes serial logs are the only thing we have about an instance. 

The [AWS docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/troubleshoot-unreachable-instance.html#instance-console-console-output) state:

> The console output returns buffered information that was posted shortly after an instance transition state (start, stop, reboot, and terminate). The posted output is not continuously updated; only when it is likely to be of the most value.
> You can optionally retrieve the latest serial console output at any time during the instance lifecycle.

It turns out that even after terminating the instances, AWS often decides that the tail is not of value, and only serves the first 50k byte. Thus, we'd like to use the option for fetching the latest messages.

However, AWS only buffers the most recent 64k of console output. If there's more output on the console, we're going to only see the latest 64k and lose access to early boot messages. In order to get both the earliest and the latest messages, we need to fetch the logs twice. 

### Proposed change(s)

- Pull the latest console logs in addition to the default logs.

### Checklist

- [x] Run the E2E tests that are relevant to this PR's changes
  * https://github.com/edgelesssys/constellation/actions/runs/7972631133 (check serial logs artifact)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
