### PR TITLE
ci: fix duplicate benchmark artificat name

### DIFF
--- a/.github/actions/e2e_benchmark/action.yml
+++ b/.github/actions/e2e_benchmark/action.yml
@@ -146,7 +146,7 @@ runs:
       with:
         path: >
           benchmarks/constellation-${{ inputs.cloudProvider }}.json
-        name: "benchmarks"
+        name: "benchmarks-${{ inputs.attestationVariant }}"
         encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Assume AWS role to retrieve and update benchmarks in S3


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The performance benchmark used a non unique name to upload the benchmark results as a GitHub artifact.
This causes unseen problems with upload@v3, since results from concurrent benchmark runs in the same workflow get overwritten, and causes hard errors with upload@v4.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Append attestation variant to artifact name in GitHub

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/399

