### PR TITLE
ci: disable e2e-attestationconfigapi on PRs

### DIFF
--- a/.github/workflows/e2e-attestationconfigapi.yml
+++ b/.github/workflows/e2e-attestationconfigapi.yml
@@ -10,11 +10,6 @@ on:
       - "internal/api/**"
       - ".github/workflows/e2e-attestationconfigapi.yml"
       - "go.mod"
-  pull_request:
-    paths:
-      - "internal/api/**"
-      - ".github/workflows/e2e-attestationconfigapi.yml"
-      - "go.mod"
 
 jobs:
   e2e-api:


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

This workflow touches shared state by deleting all objects of a bucket and then
uploading a signed blob of data to that S3 bucket under a fixed name.
It also does so multiple times in a row, while invalidating the cloudfront
cache and checking if the uploaded object exists.
All runs of this workflow share the same bucket.
Since this pipeline runs on any modification of go.mod, it is very prone
to race condition between PRs (or PRs and main).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: disable e2e-attestationconfigapi on PRs

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
