### PR TITLE
ci: fix artifact naming problems in e2e test

### DIFF
--- a/.github/actions/e2e_benchmark/action.yml
+++ b/.github/actions/e2e_benchmark/action.yml
@@ -21,6 +21,9 @@ inputs:
   awsOpenSearchPwd:
     description: "AWS OpenSearch Password to upload the results."
     required: false
+  artifactNameSuffix:
+    description: "Suffix for artifact naming."
+    required: true
   encryptionSecret:
     description: 'The secret to use for encrypting the artifact.'
     required: true
@@ -103,7 +106,7 @@ runs:
       uses: ./.github/actions/artifact_upload
       with:
         path: "out/fio-constellation-${{ inputs.cloudProvider }}.json"
-        name: "fio-constellation-${{ inputs.cloudProvider }}.json"
+        name: "fio-constellation-${{ inputs.artifactNameSuffix }}.json"
         encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Run knb benchmark
@@ -125,7 +128,7 @@ runs:
       uses: ./.github/actions/artifact_upload
       with:
         path: "out/knb-constellation-${{ inputs.cloudProvider }}.json"
-        name: "knb-constellation-${{ inputs.cloudProvider }}.json"
+        name: "knb-constellation-${{ inputs.artifactNameSuffix }}.json"
         encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Parse results, create diagrams and post the progression summary
@@ -146,7 +149,7 @@ runs:
       with:
         path: >
           benchmarks/constellation-${{ inputs.cloudProvider }}.json
-        name: "benchmarks-${{ inputs.attestationVariant }}"
+        name: "benchmarks-${{ inputs.artifactNameSuffix }}"
         encryptionSecret: ${{ inputs.encryptionSecret }}
 
     - name: Assume AWS role to retrieve and update benchmarks in S3

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -377,6 +377,7 @@ runs:
         awsOpenSearchUsers: ${{ inputs.awsOpenSearchUsers }}
         awsOpenSearchPwd: ${{ inputs.awsOpenSearchPwd }}
         encryptionSecret: ${{ inputs.encryptionSecret }}
+        artifactNameSuffix: ${{ steps.create-prefix.outputs.prefix }}
 
     - name: Run constellation verify test
       if: inputs.test == 'verify'

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -496,7 +496,7 @@ jobs:
         if: always()
         uses: ./.github/actions/artifact_upload
         with:
-          name: upgrade-logs
+          name: upgrade-logs-${{ inputs.attestationVariant }}
           path: >
             node-operator.logs
             node-maintenance-operator.logs


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Fixes another issue in regards to duplicate artifact naming, discovered by using upload@v4

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use workflow unique artifact for e2e upgrade log
- Use `artifactNameSuffix` variable for e2e benchmark artifacts naming

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [upgrade test](https://github.com/edgelesssys/constellation/actions/runs/8049475888)
  - [x] [e2e benchmark](https://github.com/edgelesssys/constellation/actions/runs/8049466065)
