### PR TITLE
terraform: allow STACKIT / OpenStack instance type to be UUID or name

### DIFF
--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -77,8 +77,17 @@ The Constellation CLI can also print the supported instance types with: `constel
 </tabItem>
 <tabItem value="stackit" label="STACKIT">
 
-By default, Constellation uses `m1a.8d-sev` VMs (8 vCPUs, 64 GB RAM) to create your cluster.
+By default, Constellation uses `m1a.4cd` VMs (4 vCPUs, 32 GB RAM) to create your cluster.
 Optionally, you can switch to a different VM type by modifying `instanceType` in the configuration file.
+
+The following instance types are known to be supported:
+
+| name     | vCPUs | GB RAM |
+|----------|-------|--------|
+| m1a.4cd  | 4     | 32     |
+| m1a.8cd  | 8     | 64     |
+| m1a.16cd | 16    | 120    |
+| m1a.30cd | 30    | 238    |
 
 You can choose any of the SEV-enabled instance types. You can find a list of all supported instance types in the [STACKIT documentation](https://docs.stackit.cloud/stackit/en/virtual-machine-flavors-75137231.html).
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -913,7 +913,7 @@ func (c *Config) WithOpenStackProviderDefaults(openStackProvider string) *Config
 		c.Provider.OpenStack.YawolFlavorID = "3b11b27e-6c73-470d-b595-1d85b95a8cdf"
 		c.Provider.OpenStack.DeployCSIDriver = toPtr(true)
 		for groupName, group := range c.NodeGroups {
-			group.InstanceType = "2715eabe-3ffc-4c36-b02a-efa8c141a96a"
+			group.InstanceType = "m1a.4cd"
 			group.StateDiskType = "storage_premium_perf6"
 			c.NodeGroups[groupName] = group
 		}

--- a/terraform/infrastructure/openstack/modules/instance_group/main.tf
+++ b/terraform/infrastructure/openstack/modules/instance_group/main.tf
@@ -58,7 +58,8 @@ resource "openstack_compute_instance_v2" "instance_group_member" {
   block_device {
     uuid                  = var.image_id
     source_type           = "image"
-    destination_type      = "local"
+    destination_type      = "volume"
+    volume_size           = "5"
     boot_index            = 0
     delete_on_termination = true
   }


### PR DESCRIPTION
We are currently testing with the `m1a.8d-sev` instance type (2715eabe-3ffc-4c36-b02a-efa8c141a96a) and we know that this will be replaced by the following flavors:

| name     | vCPUs | GB RAM |
|----------|-------|--------|
| m1a.2cd  | 2     | 16     |
| m1a.4cd  | 4     | 32     |
| m1a.8cd  | 8     | 64     |
| m1a.16cd | 16    | 120    |
| m1a.30cd | 30    | 238    |

Since we do not know the flavor UUIDs today, we need to also accept instance type names.
This change allows the terraform code to accept either a flavor name or UUID and derive the correct UUID in any case.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- terraform: allow STACKIT / OpenStack instance type to be UUID or name

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
