### PR TITLE
ci: match version of actions/download-artifact for slsa provenance

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -345,7 +345,9 @@ jobs:
           name: constellation.spdx.sbom
 
       - name: Download provenance
-        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+        # Need to use the same major version as slsa-github-generator to find uploaded artifacts
+        # https://github.com/slsa-framework/slsa-github-generator/issues/3068
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.provenance-name }}
 
@@ -428,7 +430,9 @@ jobs:
           name: constellation.spdx.sbom.sig
 
       - name: Download Constellation provenance
-        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+        # Need to use the same major version as slsa-github-generator to find uploaded artifacts
+        # https://github.com/slsa-framework/slsa-github-generator/issues/3068
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
         with:
           name: ${{ needs.provenance.outputs.provenance-name }}
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Release breaks since slsa generator uses v3 of upload action, while we use v4 of download action.

References: [failed run](https://github.com/edgelesssys/constellation/actions/runs/8083325581/job/22114196641), [upstream issue](https://github.com/slsa-framework/slsa-github-generator/issues/3068)

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: match version of actions/download-artifact for slsa provenance

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->
