### PR TITLE
ci: use collision resistant name for Terraform e2e test

### DIFF
--- a/.github/workflows/e2e-test-provider-example.yml
+++ b/.github/workflows/e2e-test-provider-example.yml
@@ -121,9 +121,10 @@ jobs:
         shell: bash
         run: |
           uuid=$(uuidgen | tr "[:upper:]" "[:lower:]")
-          uuid=${uuid%%-*}
-          echo "uuid=${uuid}" | tee -a $GITHUB_OUTPUT
-          echo "prefix=e2e-${{ github.run_id }}-${{ github.run_attempt }}-${uuid}" | tee -a $GITHUB_OUTPUT
+          uuid="${uuid%%-*}"
+          uuid="${uuid: -3}" # Final resource name must be no longer than 10 characters on AWS
+          echo "uuid=${uuid}" | tee -a "${GITHUB_OUTPUT}"
+          echo "prefix=e2e-${uuid}" | tee -a "${GITHUB_OUTPUT}"
 
       - name: Build Constellation provider and CLI # CLI is needed for the upgrade assert and container push is needed for the microservice upgrade
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/e2e-test-provider-example.yml
+++ b/.github/workflows/e2e-test-provider-example.yml
@@ -83,14 +83,6 @@ jobs:
           ref: main
           stream: nightly
 
-      - name: Create resource prefix
-        id: create-prefix
-        shell: bash
-        run: |
-          run_id=${{ github.run_id }}
-          last_three="${run_id: -3}"
-          echo "prefix=e2e-${last_three}" | tee -a "$GITHUB_OUTPUT"
-
       - name: Determine cloudprovider from attestation variant
         id: determine
         shell: bash
@@ -123,6 +115,15 @@ jobs:
           useCache: "true"
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
           nixTools: terraform
+
+      - name: Create prefix
+        id: create-prefix
+        shell: bash
+        run: |
+          uuid=$(uuidgen | tr "[:upper:]" "[:lower:]")
+          uuid=${uuid%%-*}
+          echo "uuid=${uuid}" | tee -a $GITHUB_OUTPUT
+          echo "prefix=e2e-${{ github.run_id }}-${{ github.run_attempt }}-${uuid}" | tee -a $GITHUB_OUTPUT
 
       - name: Build Constellation provider and CLI # CLI is needed for the upgrade assert and container push is needed for the microservice upgrade
         working-directory: ${{ github.workspace }}

--- a/terraform-provider-constellation/examples/full/azure/main.tf
+++ b/terraform-provider-constellation/examples/full/azure/main.tf
@@ -44,8 +44,8 @@ module "azure_iam" {
   // replace $VERSION with the Constellation version you want to use, e.g., v2.14.0
   source                 = "https://github.com/edgelesssys/constellation/releases/download/$VERSION/terraform-module.zip//terraform-module/iam/azure"
   location               = local.location
-  service_principal_name = "${local.name}-test-sp"
-  resource_group_name    = "${local.name}-test-rg"
+  service_principal_name = "${local.name}-sp"
+  resource_group_name    = "${local.name}-rg"
 }
 
 module "azure_infrastructure" {

--- a/terraform-provider-constellation/examples/full/gcp/main.tf
+++ b/terraform-provider-constellation/examples/full/gcp/main.tf
@@ -46,7 +46,7 @@ module "gcp_iam" {
   // replace $VERSION with the Constellation version you want to use, e.g., v2.14.0
   source             = "https://github.com/edgelesssys/constellation/releases/download/$VERSION/terraform-module.zip//terraform-module/iam/gcp"
   project_id         = local.project_id
-  service_account_id = "${local.name}-test-sa"
+  service_account_id = "${local.name}-sa"
   zone               = local.zone
   region             = local.region
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The Terraform e2e test uses the last 3 digits of the workflow run for various resource names.
This causes issues when running more than one test on the same CSP in the same workflow.
Notably this occurs for `azure-tdx` and `azure-sev-snp` in our weekly tests.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use the same collision resistant naming scheme as used by our other e2e tests

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/423


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [Azure e2e test](https://github.com/edgelesssys/constellation/actions/runs/8138543909)
  - [x] [GCP e2e test](https://github.com/edgelesssys/constellation/actions/runs/8138560914)
  - [x] [AWS e2e test](https://github.com/edgelesssys/constellation/actions/runs/8139083377)