### PR TITLE
bootstrapper: wipe disk and reboot on non-recoverable error

### DIFF
--- a/bootstrapper/cmd/bootstrapper/run.go
+++ b/bootstrapper/cmd/bootstrapper/run.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/edgelesssys/constellation/v2/bootstrapper/internal/clean"
 	"github.com/edgelesssys/constellation/v2/bootstrapper/internal/diskencryption"
@@ -74,7 +75,8 @@ func run(issuer atls.Issuer, openDevice vtpm.TPMOpenFunc, fileHandler file.Handl
 	go func() {
 		defer wg.Done()
 		if err := joinClient.Start(cleaner); err != nil {
-			log.With(slog.Any("error", err)).Error("Failed to join cluster")
+			log.With(slog.Any("error", err)).Error("Failed to join cluster. Rebooting...")
+			time.Sleep(20 * time.Second) // ensure log message is written
 			reboot()
 		}
 	}()
@@ -83,7 +85,8 @@ func run(issuer atls.Issuer, openDevice vtpm.TPMOpenFunc, fileHandler file.Handl
 	go func() {
 		defer wg.Done()
 		if err := initServer.Serve(bindIP, bindPort, cleaner); err != nil {
-			log.With(slog.Any("error", err)).Error("Failed to serve init server")
+			log.With(slog.Any("error", err)).Error("Failed to serve init server. Rebooting...")
+			time.Sleep(20 * time.Second) // ensure log message is written
 			reboot()
 		}
 	}()

--- a/bootstrapper/cmd/bootstrapper/run.go
+++ b/bootstrapper/cmd/bootstrapper/run.go
@@ -35,7 +35,8 @@ func run(issuer atls.Issuer, openDevice vtpm.TPMOpenFunc, fileHandler file.Handl
 ) {
 	log.With(slog.String("version", constants.BinaryVersion().String())).Info("Starting bootstrapper")
 
-	uuid, err := getDiskUUID()
+	disk := diskencryption.New()
+	uuid, err := getDiskUUID(disk)
 	if err != nil {
 		log.With(slog.Any("error", err)).Error("Failed to get disk UUID")
 	} else {
@@ -57,14 +58,14 @@ func run(issuer atls.Issuer, openDevice vtpm.TPMOpenFunc, fileHandler file.Handl
 	}
 
 	nodeLock := nodelock.New(openDevice)
-	initServer, err := initserver.New(context.Background(), nodeLock, kube, issuer, fileHandler, metadata, log)
+	initServer, err := initserver.New(context.Background(), nodeLock, kube, issuer, disk, fileHandler, metadata, log)
 	if err != nil {
 		log.With(slog.Any("error", err)).Error("Failed to create init server")
 		reboot(fmt.Errorf("creating init server: %w", err))
 	}
 
 	dialer := dialer.New(issuer, nil, &net.Dialer{})
-	joinClient := joinclient.New(nodeLock, dialer, kube, metadata, log)
+	joinClient := joinclient.New(nodeLock, dialer, kube, metadata, disk, log)
 
 	cleaner := clean.New().With(initServer).With(joinClient)
 	go cleaner.Start()
@@ -77,6 +78,7 @@ func run(issuer atls.Issuer, openDevice vtpm.TPMOpenFunc, fileHandler file.Handl
 		defer wg.Done()
 		if err := joinClient.Start(cleaner); err != nil {
 			log.With(slog.Any("error", err)).Error("Failed to join cluster")
+			markDiskForReset(disk)
 			reboot(fmt.Errorf("joining cluster: %w", err))
 		}
 	}()
@@ -86,6 +88,7 @@ func run(issuer atls.Issuer, openDevice vtpm.TPMOpenFunc, fileHandler file.Handl
 		defer wg.Done()
 		if err := initServer.Serve(bindIP, bindPort, cleaner); err != nil {
 			log.With(slog.Any("error", err)).Error("Failed to serve init server")
+			markDiskForReset(disk)
 			reboot(fmt.Errorf("serving init server: %w", err))
 		}
 	}()
@@ -94,14 +97,29 @@ func run(issuer atls.Issuer, openDevice vtpm.TPMOpenFunc, fileHandler file.Handl
 	log.Info("bootstrapper done")
 }
 
-func getDiskUUID() (string, error) {
-	disk := diskencryption.New()
+func getDiskUUID(disk *diskencryption.DiskEncryption) (string, error) {
 	free, err := disk.Open()
 	if err != nil {
 		return "", err
 	}
 	defer free()
 	return disk.UUID()
+}
+
+// markDiskForReset sets a token in the cryptsetup header of the disk to indicate the disk should be reset on next boot.
+// This is used to reset all state of a node in case the bootstrapper encountered a non recoverable error
+// after the node successfully retrieved a join ticket from the JoinService.
+// As setting this token is safe as long as we are certain we don't need the data on the disk anymore, we call this
+// unconditionally when either the JoinClient or the InitServer encounter an error.
+// We don't call it before that, as the node may be restarting after a previous, successful bootstrapping,
+// and now encountered a transient error on rejoining the cluster. Wiping the disk now would delete existing data.
+func markDiskForReset(disk *diskencryption.DiskEncryption) {
+	free, err := disk.Open()
+	if err != nil {
+		return
+	}
+	defer free()
+	_ = disk.MarkDiskForReset()
 }
 
 // reboot writes an error message to the system log and reboots the system.

--- a/bootstrapper/internal/diskencryption/diskencryption.go
+++ b/bootstrapper/internal/diskencryption/diskencryption.go
@@ -60,7 +60,7 @@ func (c *DiskEncryption) UpdatePassphrase(passphrase string) error {
 	return c.device.SetConstellationStateDiskToken(cryptsetup.SetDiskInitialized)
 }
 
-// MarkDiskForReset marks the state disk as not initialized.
+// MarkDiskForReset marks the state disk as not initialized so it may be wiped (reset) on reboot.
 func (c *DiskEncryption) MarkDiskForReset() error {
 	return c.device.SetConstellationStateDiskToken(cryptsetup.SetDiskNotInitialized)
 }

--- a/bootstrapper/internal/diskencryption/diskencryption.go
+++ b/bootstrapper/internal/diskencryption/diskencryption.go
@@ -60,6 +60,11 @@ func (c *DiskEncryption) UpdatePassphrase(passphrase string) error {
 	return c.device.SetConstellationStateDiskToken(cryptsetup.SetDiskInitialized)
 }
 
+// MarkDiskForReset marks the state disk as not initialized.
+func (c *DiskEncryption) MarkDiskForReset() error {
+	return c.device.SetConstellationStateDiskToken(cryptsetup.SetDiskNotInitialized)
+}
+
 // getInitialPassphrase retrieves the initial passphrase used on first boot.
 func (c *DiskEncryption) getInitialPassphrase() (string, error) {
 	passphrase, err := afero.ReadFile(c.fs, initialKeyPath)

--- a/bootstrapper/internal/initserver/BUILD.bazel
+++ b/bootstrapper/internal/initserver/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     visibility = ["//bootstrapper:__subpackages__"],
     deps = [
         "//bootstrapper/initproto",
-        "//bootstrapper/internal/diskencryption",
         "//bootstrapper/internal/journald",
         "//internal/atls",
         "//internal/attestation",

--- a/bootstrapper/internal/initserver/initserver.go
+++ b/bootstrapper/internal/initserver/initserver.go
@@ -129,7 +129,9 @@ func (s *Server) Serve(ip, port string, cleaner cleaner) error {
 	// If Init failed, we mark the disk for reset, so the node can restart the process
 	// In this case we don't care about any potential errors from the grpc server
 	if s.initFailure != nil {
-		return errors.Join(s.initFailure, s.markDiskForReset())
+		s.log.Error("Fatal error during Init request", "error", s.initFailure)
+		resetErr := s.markDiskForReset()
+		return errors.Join(s.initFailure, resetErr)
 	}
 
 	return err

--- a/bootstrapper/internal/initserver/initserver.go
+++ b/bootstrapper/internal/initserver/initserver.go
@@ -376,6 +376,7 @@ type encryptedDisk interface {
 	UUID() (string, error)
 	// UpdatePassphrase switches the initial random passphrase of the encrypted disk to a permanent passphrase.
 	UpdatePassphrase(passphrase string) error
+	// MarkDiskForReset marks the state disk as not initialized so it may be wiped (reset) on reboot.
 	MarkDiskForReset() error
 }
 

--- a/bootstrapper/internal/initserver/initserver_test.go
+++ b/bootstrapper/internal/initserver/initserver_test.go
@@ -67,7 +67,10 @@ func TestNew(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			server, err := New(context.TODO(), newFakeLock(), &stubClusterInitializer{}, atls.NewFakeIssuer(variant.Dummy{}), fh, &tc.metadata, logger.NewTest(t))
+			server, err := New(
+				context.TODO(), newFakeLock(), &stubClusterInitializer{}, atls.NewFakeIssuer(variant.Dummy{}),
+				&stubDisk{}, fh, &tc.metadata, logger.NewTest(t),
+			)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/bootstrapper/internal/initserver/initserver_test.go
+++ b/bootstrapper/internal/initserver/initserver_test.go
@@ -381,6 +381,10 @@ func (d *fakeDisk) UpdatePassphrase(passphrase string) error {
 	return nil
 }
 
+func (d *fakeDisk) MarkDiskForReset() error {
+	return nil
+}
+
 type stubDisk struct {
 	openErr                error
 	uuid                   string
@@ -400,6 +404,10 @@ func (d *stubDisk) UUID() (string, error) {
 func (d *stubDisk) UpdatePassphrase(string) error {
 	d.updatePassphraseCalled = true
 	return d.updatePassphraseErr
+}
+
+func (d *stubDisk) MarkDiskForReset() error {
+	return nil
 }
 
 type stubClusterInitializer struct {

--- a/bootstrapper/internal/joinclient/BUILD.bazel
+++ b/bootstrapper/internal/joinclient/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     visibility = ["//bootstrapper:__subpackages__"],
     deps = [
         "//bootstrapper/internal/certificate",
-        "//bootstrapper/internal/diskencryption",
         "//internal/attestation",
         "//internal/cloud/metadata",
         "//internal/constants",

--- a/bootstrapper/internal/joinclient/joinclient.go
+++ b/bootstrapper/internal/joinclient/joinclient.go
@@ -431,6 +431,7 @@ type encryptedDisk interface {
 	UUID() (string, error)
 	// UpdatePassphrase switches the initial random passphrase of the encrypted disk to a permanent passphrase.
 	UpdatePassphrase(passphrase string) error
+	// MarkDiskForReset marks the state disk as not initialized so it may be wiped (reset) on reboot.
 	MarkDiskForReset() error
 }
 

--- a/bootstrapper/internal/joinclient/joinclient.go
+++ b/bootstrapper/internal/joinclient/joinclient.go
@@ -255,6 +255,15 @@ func (c *JoinClient) startNodeAndJoin(ticket *joinproto.IssueJoinTicketResponse,
 	ctx, cancel := context.WithTimeout(context.Background(), c.joinTimeout)
 	defer cancel()
 
+	// [REMOVE THIS BLOCK] TEST @daniel-weisse
+	if true {
+		c.log.Error("Simulating fatal node failure...")
+		c.log.Error("Returning error from startNodeAndJoin in 1 Minute...")
+		time.Sleep(1 * time.Minute)
+		return errors.New("simulated fatal node failure")
+	}
+	// [REMOVE THIS BLOCK] TEST @daniel-weisse
+
 	clusterID, err := attestation.DeriveClusterID(ticket.MeasurementSecret, ticket.MeasurementSalt)
 	if err != nil {
 		return err

--- a/bootstrapper/internal/joinclient/joinclient.go
+++ b/bootstrapper/internal/joinclient/joinclient.go
@@ -164,9 +164,6 @@ func (c *JoinClient) Stop() {
 	c.stopC <- struct{}{}
 	<-c.stopDone
 
-	c.stopC = make(chan struct{}, 1)
-	c.stopDone = make(chan struct{}, 1)
-
 	c.log.Info("Stopped")
 }
 

--- a/bootstrapper/internal/joinclient/joinclient_test.go
+++ b/bootstrapper/internal/joinclient/joinclient_test.go
@@ -379,6 +379,10 @@ func (d *stubDisk) UpdatePassphrase(string) error {
 	return d.updatePassphraseErr
 }
 
+func (d *stubDisk) MarkDiskForReset() error {
+	return nil
+}
+
 type stubCleaner struct{}
 
 func (c stubCleaner) Clean() {}

--- a/csi/test/mount_integration_test.go
+++ b/csi/test/mount_integration_test.go
@@ -31,7 +31,7 @@ const (
 	deviceName string = "testDeviceName"
 )
 
-var toolsEnvs []string = []string{"CP", "DD", "RM", "FSCK_EXT4", "MKFS_EXT4", "BLKID", "FSCK", "MOUNT", "UMOUNT"}
+var toolsEnvs = []string{"CP", "DD", "RM", "FSCK_EXT4", "MKFS_EXT4", "BLKID", "FSCK", "MOUNT", "UMOUNT"}
 
 // addToolsToPATH is used to update the PATH to contain necessary tool binaries for
 // coreutils, util-linux and ext4.

--- a/disk-mapper/internal/test/integration_test.go
+++ b/disk-mapper/internal/test/integration_test.go
@@ -37,7 +37,7 @@ const (
 
 var diskPath = flag.String("disk", "", "Path to the disk to use for the benchmark")
 
-var toolsEnvs []string = []string{"DD", "RM"}
+var toolsEnvs = []string{"DD", "RM"}
 
 // addToolsToPATH is used to update the PATH to contain necessary tool binaries for
 // coreutils.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Constellation's bootstrapper may fail at multiple stages.
Some of these failures are transient, like joining an existing cluster using `kubeadm` and may be retried.
Others are not recoverable, meaning one can no longer re-run `constellation apply` on the same node, or the node can no longer retry joining an existing cluster.
To "fix" a VM that is in this failed state, the VM needs to be rebooted, and the state-disk wiped.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Change how `joinClient` and `initServer` are run
  - Both routines now have return values and are run in parallel
  - If any error occurs in `run()`, the VM is rebooted
- Adapt the flow of `joinClient` to more easily differentiate between transient and non recoverable errors
- In both `joinClient` and `initServer`, mark the state disk as not initialized if a non recoverable error occurs (any error after the VM was marked as initialized)
- Remove the ability to call `JoinClient.Start()` and `JoinClient.Stop()` idempotently
  - This was and is not required for the bootstrapper
  - This was unnecessarily complicating the set up and testing of the client

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/421

### Additional info
<!-- Remove items that do not apply -->
- [AB#3930](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3930)
- Why not use `systemd` native ways to restart the VM when `constelllation-bootstrapper.service` fails?
  - On debug images, the service is expected to fail until a bootstrapper is uploaded using `cdbg`. This makes using debug images impossible
- How to test?
  - This PR currently contains a commit marked with `[drop]` that returns an error in the `joinClient` which causes a fatal error and causes the VM to reboot. The state disk should then be marked as non initialized and be wiped again on start.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Run the E2E tests that are relevant to this PR's changes
  - [x] [e2e Test (Azure SNP) to make sure regular behavior is still as expected](https://github.com/edgelesssys/constellation/actions/runs/8187559867)
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
