### PR TITLE
disk-mapper: write to syslog

### DIFF
--- a/image/system/mkosi.conf
+++ b/image/system/mkosi.conf
@@ -13,7 +13,7 @@ Seed=0e9a6fe0-68f6-408c-bbeb-136054d20445
 SourceDateEpoch=0
 Bootable=yes
 Bootloader=uki
-KernelCommandLine=preempt=full rd.shell=0 rd.emergency=reboot loglevel=8 console=ttyS0
+KernelCommandLine=preempt=full rd.shell=0 rd.emergency=reboot loglevel=8
 RemoveFiles=/var/log
 RemoveFiles=/var/cache
 RemoveFiles=/etc/pki/ca-trust/extracted/java/cacerts

--- a/image/system/variants.bzl
+++ b/image/system/variants.bzl
@@ -55,6 +55,7 @@ base_cmdline = "selinux=1 enforcing=0 audit=0"
 csp_settings = {
     "aws": {
         "kernel_command_line_dict": {
+            "console": "ttyS0",
             "constel.csp": "aws",
             "idle": "poll",
             "mitigations": "auto",
@@ -62,20 +63,21 @@ csp_settings = {
     },
     "azure": {
         "kernel_command_line_dict": {
+            "console": "ttyS0",
             "constel.csp": "azure",
             "mitigations": "auto,nosmt",
         },
     },
     "gcp": {
         "kernel_command_line_dict": {
+            "console": "ttyS0",
             "constel.csp": "gcp",
             "mitigations": "auto,nosmt",
         },
     },
     "openstack": {
-        "kernel_command_line": "console=tty0 console=ttyS0",
+        "kernel_command_line": "console=tty0 console=ttyS0 console=ttyS1",
         "kernel_command_line_dict": {
-            "console": "tty0",
             "constel.csp": "openstack",
             "kvm_amd.sev": "1",
             "mem_encrypt": "on",
@@ -86,6 +88,7 @@ csp_settings = {
     "qemu": {
         "autologin": True,
         "kernel_command_line_dict": {
+            "console": "ttyS0",
             "constel.csp": "qemu",
             "mitigations": "auto,nosmt",
         },

--- a/internal/imagefetcher/imagefetcher.go
+++ b/internal/imagefetcher/imagefetcher.go
@@ -111,7 +111,7 @@ func buildMarketplaceImage(payload marketplaceImagePayload) (string, error) {
 		return "", fmt.Errorf("parsing image version: %w", err)
 	}
 
-	if sv.Prerelease() != "" {
+	if sv.Prerelease() != "" && payload.provider != cloudprovider.OpenStack {
 		return "", fmt.Errorf("marketplace images are not supported for prerelease versions")
 	}
 


### PR DESCRIPTION
### Context
<!-- Please add background information on why this PR is opened. -->

The disk-mapper can fail for various reasons. One that is hard to detect is currently the IMDS endpoint on OpenStack.
This change makes the error easily detectable using the serial console.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Write boot log to all serial consoles on OpenStack (ttyS1 was missing)
- Let disk mapper also write to syslog on failure (this is in addition to the log of the unit itself and makes the logging more robust across cloud providers / virtualization solutions)
- improve the error message in cases where the OpenStack imds API returns errors

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
