### PR TITLE
cli: retry auth handshake deadline exceeded errors in CLI and Terraform

### DIFF
--- a/internal/grpc/retry/retry_test.go
+++ b/internal/grpc/retry/retry_test.go
@@ -43,6 +43,10 @@ func TestServiceIsUnavailable(t *testing.T) {
 			err:             status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: read tcp error"`),
 			wantUnavailable: true,
 		},
+		"handshake deadline exceeded error": {
+			err:             status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: context deadline exceeded"`),
+			wantUnavailable: true,
+		},
 		"wrapped error": {
 			err:             fmt.Errorf("some wrapping: %w", status.Error(codes.Unavailable, "error")),
 			wantUnavailable: true,
@@ -80,6 +84,10 @@ func TestLoadbalancerIsNotReady(t *testing.T) {
 		},
 		"handshake read tcp error": {
 			err:          status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: read tcp error"`),
+			wantNotReady: true,
+		},
+		"handshake deadline exceeded error": {
+			err:          status.Error(codes.Unavailable, `connection error: desc = "transport: authentication handshake failed: context deadline exceeded"`),
 			wantNotReady: true,
 		},
 		"normal unavailable error": {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
CLI (and also our Terraform provider) uses gRPC to talk with different services on Constellation.
We have a retry logic for these calls that make sure transient errors don't cause the entire action to fail.
In the past we have observed "authentication handshake failed: context deadline exceeded" during these rpcs.

Since we do not set a deadline for some of our CLI commands (e.g. `constellation recover`) but we have observed these errors nonetheless, I believe that gRPC/Go TLS uses a custom deadline at some point during the handshake.
This deadline may be exceeded by transient connection errors and should be retried by our code.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add `authentication handshake failed: context deadline exceeded` to the list of retriable rpc errors

### Related issue
This PR may resolve the following issues, though we should keep them open and observe potential regressions:

- https://github.com/edgelesssys/issues/issues/110
- https://github.com/edgelesssys/issues/issues/424


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Run the E2E tests that are relevant to this PR's changes
  - [ ] [e2e sanity check](https://github.com/edgelesssys/constellation/actions/runs/8201979476)
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
