### PR TITLE
docs: remove steps for STACKIT credentials in config

### DIFF
--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -124,11 +124,7 @@ If you encounter any problem with the following steps, make sure to use the [lat
     To use Constellation on STACKIT, the cluster will use the User Access Token (UAT) that's generated [during the install step](./install.md).
     After creating the accounts, fill in the STACKIT details in `constellation-conf.yaml` under `provider.openstack`:
 
-    - `projectID`: OpenStack project id (can be found in `clouds.yaml` or `openrc` file of UAT)
-    - `projectName`: OpenStack project name (can be found in `clouds.yaml` or `openrc` file of UAT)
     - `stackitProjectID`: STACKIT project id (can be found after login on <https://portal.stackit.cloud>)
-    - `username`: username of the UAT
-    - `password`: password of the UAT
 
     </tabItem>
     </tabs>

--- a/docs/versioned_docs/version-2.16/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.16/getting-started/first-steps.md
@@ -124,11 +124,7 @@ If you encounter any problem with the following steps, make sure to use the [lat
     To use Constellation on STACKIT, the cluster will use the User Access Token (UAT) that's generated [during the install step](./install.md).
     After creating the accounts, fill in the STACKIT details in `constellation-conf.yaml` under `provider.openstack`:
 
-    - `projectID`: OpenStack project id (can be found in `clouds.yaml` or `openrc` file of UAT)
-    - `projectName`: OpenStack project name (can be found in `clouds.yaml` or `openrc` file of UAT)
     - `stackitProjectID`: STACKIT project id (can be found after login on <https://portal.stackit.cloud>)
-    - `username`: username of the UAT
-    - `password`: password of the UAT
 
     </tabItem>
     </tabs>


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

The OpenStack credentials (username and password) can now be retrieved from the "clouds.yaml" by the Constellation CLI and terraform code. This simplifies the configuration for end users.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- docs: remove steps for STACKIT credentials in config

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
