### PR TITLE
helm: manually retry uninstalling a failed release

### DIFF
--- a/internal/constellation/helm/actionfactory.go
+++ b/internal/constellation/helm/actionfactory.go
@@ -139,6 +139,9 @@ func (a actionFactory) appendNewAction(
 
 func (a actionFactory) newInstall(release release, timeout time.Duration) *installAction {
 	action := &installAction{helmAction: newHelmInstallAction(a.cfg, release, timeout), release: release, log: a.log}
+	if action.IsAtomic() {
+		action.uninstallAction = newHelmUninstallAction(a.cfg, timeout)
+	}
 	return action
 }
 


### PR DESCRIPTION
### Context

Helm installations can fail halfway through due to transient problems (e.g. edgelesssys/issues#30). If we're unlucky, the subsequent uninstall also fails, which makes future installation attempts fail because there is already an existing release.

### Proposed change(s)

- After a failure in `helm install`, check whether uninstalling worked and uninstall manually if not.

### Related issue

- Fixes edgelesssys/issues#367

### Manual Test

1. Created a cluster on Azure from `main` and applied up to excluding the `helm` phase.
2. Added an iptables rule to drop all etcd traffic.
3. Ran the `helm` phase, which expectedly failed with the symptoms of edgelesssys/issues#367.
4. Removed the iptables rule, confirmed that Kubernetes is serving again.
5. Re-ran the `helm` phase, expectedly observing the same failure.
6. Built from this PRs HEAD and ran the `helm` phase successfully.

### Checklist

- [x] Run the E2E tests that are relevant to this PR's changes
  * [x] [Azure TDX](https://github.com/edgelesssys/constellation/actions/runs/8271318869)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
