### PR TITLE
ci: query identity directly instead of searching in list

### DIFF
--- a/.github/actions/cdbg_deploy/action.yml
+++ b/.github/actions/cdbg_deploy/action.yml
@@ -42,6 +42,13 @@ runs:
       run: |
         UAMI=$(yq eval ".provider.azure.userAssignedIdentity | upcase" constellation-conf.yaml)
         PRINCIPAL_ID=$(az identity list | yq ".[] | select(.id | test(\"(?i)$UAMI\"; \"g\")) | .principalId")
+        if [ -z "$PRINCIPAL_ID" ]; then
+          echo "::error::PRINCIPAL_ID for $UAMI not found"
+          echo "::group::Available identities"
+          az identity list | yq ".[].id"
+          echo "::endgroup::"
+          exit 1
+        fi
         az role assignment create --role "Key Vault Secrets User" \
           --assignee "$PRINCIPAL_ID" \
           --scope /subscriptions/0d202bbb-4fa7-4af8-8125-58c269a05435/resourceGroups/e2e-test-creds/providers/Microsoft.KeyVault/vaults/opensearch-creds

--- a/.github/actions/cdbg_deploy/action.yml
+++ b/.github/actions/cdbg_deploy/action.yml
@@ -40,10 +40,10 @@ runs:
       if: inputs.cloudProvider == 'azure'
       shell: bash
       run: |
-        UAMI=$(yq eval ".provider.azure.userAssignedIdentity | upcase" constellation-conf.yaml)
-        PRINCIPAL_ID=$(az identity list | yq ".[] | select(.id | test(\"(?i)$UAMI\"; \"g\")) | .principalId")
+        UAMI=$(yq eval ".provider.azure.userAssignedIdentity" constellation-conf.yaml)
+        PRINCIPAL_ID=$(az identity show --ids "$UAMI" | yq ".principalId")
         if [ -z "$PRINCIPAL_ID" ]; then
-          echo "::error::PRINCIPAL_ID for $UAMI not found"
+          echo "::error::PRINCIPAL_ID for \"$UAMI\" not found"
           echo "::group::Available identities"
           az identity list | yq ".[].id"
           echo "::endgroup::"


### PR DESCRIPTION
### Context

Azure AD suffers from a propagation delay: a managed identity created in a far location may not show up in `az identity list` for a couple of minutes, which is long enough to break our tests, which assume read-after-write consistency. Using `az identity show` seems to circumvent the cache, and it also happens to be the cleaner solution.

### Proposed change(s)
- Use `az identity show` instead of `az identity list`.
- Add debugging information if the principal id is still not found.

### Related issue
- Fixes edgelesssys/issues#408

### Checklist

- [x] Run the E2E tests that are relevant to this PR's changes
  * [x] [Azure TDX](https://github.com/edgelesssys/constellation/actions/runs/8278654000/job/22651471429)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
