### PR TITLE
operator: escape dots in url

### DIFF
--- a/operators/constellation-node-operator/internal/cloud/gcp/client/disks.go
+++ b/operators/constellation-node-operator/internal/cloud/gcp/client/disks.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	diskSourceRegex = regexp.MustCompile(`^https://www.googleapis.com/compute/v1/projects/([^/]+)/zones/([^/]+)/disks/([^/]+)$`)
-	computeAPIBase  = regexp.MustCompile(`^https://www.googleapis.com/compute/v1/(.+)$`)
+	diskSourceRegex = regexp.MustCompile(`^https://www\.googleapis\.com/compute/v1/projects/([^/]+)/zones/([^/]+)/disks/([^/]+)$`)
+	computeAPIBase  = regexp.MustCompile(`^https://www\.googleapis\.com/compute/v1/(.+)$`)
 )
 
 // diskSourceToDiskReq converts a disk source URI to a disk request.

--- a/operators/constellation-node-operator/internal/cloud/gcp/client/disks_test.go
+++ b/operators/constellation-node-operator/internal/cloud/gcp/client/disks_test.go
@@ -36,6 +36,10 @@ func TestDiskSourceToDiskReq(t *testing.T) {
 			diskSource: "invalid://www.googleapis.com/compute/v1/projects/project/zones/zone/disks/disk",
 			wantErr:    true,
 		},
+		"url dots in regex are escaped": {
+			diskSource: "https://wwwAgoogleapisAcom/compute/v1/projects/project/zones/zone/disks/disk",
+			wantErr:    true,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -66,6 +70,10 @@ func TestURINormalize(t *testing.T) {
 		"normalized": {
 			imageURI:       "projects/project/global/images/image",
 			wantNormalized: "projects/project/global/images/image",
+		},
+		"url dots in regex are escaped": {
+			imageURI:       "https://wwwAgoogleapisAcom/compute/v1/projects/project/global/images/image",
+			wantNormalized: "https://wwwAgoogleapisAcom/compute/v1/projects/project/global/images/image",
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Since the regex is used for values that are provided by GCP's IMDS API they (and nobody else) has control over those values. Since they can provide arbitrary values for the disk information anyway, there's no threat.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- escape url dots in regex

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes: upgrade gcp e2e: https://github.com/edgelesssys/constellation/actions/runs/8299939426
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
