### PR TITLE
ci: fix pvc clean-up on non deletable namespaces

### DIFF
--- a/.github/actions/constellation_destroy/action.yml
+++ b/.github/actions/constellation_destroy/action.yml
@@ -24,6 +24,7 @@ runs:
     - name: Delete persistent volumes
       if: inputs.kubeconfig != ''
       shell: bash
+      continue-on-error: true
       env:
         KUBECONFIG: ${{ inputs.kubeconfig }}
         PV_DELETION_TIMEOUT: "120" # 2 minutes timeout for pv deletion

--- a/.github/actions/constellation_destroy/action.yml
+++ b/.github/actions/constellation_destroy/action.yml
@@ -34,6 +34,14 @@ runs:
         # Scrap namespaces that contain PVCs
         for namespace in `kubectl get namespace --no-headers=true -o custom-columns=":metadata.name"`; do
           if [[ `kubectl get pvc -n $namespace --no-headers=true -o custom-columns=":metadata.name" | wc -l` -gt 0 ]]; then
+            if [[ "${namespace}" == "default" ]]; then
+              kubectl delete all --all --namespace "default" --wait
+              continue
+            fi
+            if [[ "${namespace}" == "kube-system" ]]; then
+              kubectl delete pvc --all --namespace "kube-system" --wait
+              continue
+            fi
             kubectl delete namespace $namespace --wait
           fi
         done


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
"default" and "kube-system" are protected namespaces in Kubernetes and can't be deleted.
This causes problems if a PVC was create in one of those namespaces and the `constellation_destroy` action tries to clean up the cluster, since that action just tries to delete any namespace with a PVC in it.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Don't try to delete non deletable namespaces ("default", "kube-system")
  - Instead, just try to delete all pvcs in that namespace
- Don't abort the `constellation_destroy` action if pvc deletion fails
  - Lingering PVCs are annoying and costs money, but lingering clusters even more so

### Related issue
- See https://github.com/edgelesssys/issues/issues/465 for an e2e run that caused this failure
- Fixes https://github.com/edgelesssys/issues/issues/402

