### PR TITLE
ci: fix unwanted license checks for some e2e test configs

### DIFF
--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -90,7 +90,7 @@ inputs:
     description: "Set the force-flag on apply to ignore version mismatches."
     required: false
   encryptionSecret:
-    description: 'The secret to use for decrypting the artifact.'
+    description: "The secret to use for decrypting the artifact."
     required: true
 
 outputs:
@@ -169,8 +169,10 @@ runs:
         echo "$(pwd)" >> $GITHUB_PATH
         export PATH="$PATH:$(pwd)"
         constellation version
-        # Do not spam license server from pipeline
-        sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts'
+
+    - name: Disable license check
+      shell: bash
+      run: sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts'
 
     - name: Build Terraform provider binary
       if: inputs.clusterCreation == 'terraform' && inputs.cliVersion == ''

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -170,10 +170,6 @@ runs:
         export PATH="$PATH:$(pwd)"
         constellation version
 
-    - name: Disable license check
-      shell: bash
-      run: sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts'
-
     - name: Build Terraform provider binary
       if: inputs.clusterCreation == 'terraform' && inputs.cliVersion == ''
       uses: ./.github/actions/build_tf_provider

--- a/.github/workflows/e2e-test-provider-example.yml
+++ b/.github/workflows/e2e-test-provider-example.yml
@@ -312,6 +312,7 @@ jobs:
         working-directory: ${{ github.workspace }}/cluster
         shell: bash
         run: |
+          sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts'
           terraform init
           if [[ "${{ inputs.attestationVariant }}" == "azure-sev-snp" ]]; then
             terraform apply -target module.azure_iam -auto-approve
@@ -392,7 +393,7 @@ jobs:
           IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-latest-image.outputs.image }}
           KUBERNETES: ${{ inputs.toKubernetes }}
           MICROSERVICES: ${{ steps.build.outputs.build_version }}
-          WORKERNODES:  1
+          WORKERNODES: 1
           CONTROLNODES: 1
         run: |
           terraform output -raw kubeconfig > constellation-admin.conf
@@ -446,7 +447,7 @@ jobs:
           KUBECONFIG=${{ github.workspace }}/cluster/constellation-admin.conf bazel run //e2e/provider-upgrade:provider-upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --cli "${{ github.workspace }}/build/constellation" "$IMAGE_FLAG" "$KUBERNETES_FLAG" "$MICROSERVICES_FLAG"
 
       - name: Destroy Terraform Cluster
-      # outcome is part of the steps context (https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context)
+        # outcome is part of the steps context (https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context)
         if: always() && steps.apply_terraform.outcome != 'skipped'
         working-directory: ${{ github.workspace }}/cluster
         shell: bash

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -395,7 +395,7 @@ jobs:
           IMAGE: ${{ inputs.toImage && inputs.toImage || steps.find-image.outputs.output }}
           KUBERNETES: ${{ inputs.toKubernetes }}
           MICROSERVICES: ${{ inputs.toMicroservices }}
-          WORKERNODES:  ${{ needs.generate-input-parameters.outputs.workerNodes }}
+          WORKERNODES: ${{ needs.generate-input-parameters.outputs.workerNodes }}
           CONTROLNODES: ${{ needs.generate-input-parameters.outputs.controlPlaneNodes }}
         run: |
           echo "Image target: $IMAGE"
@@ -409,6 +409,7 @@ jobs:
             KUBERNETES_FLAG="--target-kubernetes=$KUBERNETES"
           fi
 
+          sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts'
           bazel run //e2e/internal/upgrade:upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --target-image "$IMAGE" "$KUBERNETES_FLAG" "$MICROSERVICES_FLAG"
 
       - name: Remove Terraform plugin cache


### PR DESCRIPTION
License check is supposed to be disabled for e2e tests, but it wasn't for some test configs, e.g., TF provider.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
