### PR TITLE
ci: disable license check for minicon e2e

### DIFF
--- a/e2e/miniconstellation/test-remote.sh
+++ b/e2e/miniconstellation/test-remote.sh
@@ -45,6 +45,8 @@ fi
 
 echo "Done waiting."
 
+echo '127.0.0.1 license.confidential.cloud' | sudo tee /etc/hosts > /dev/null
+
 ./constellation mini up --debug
 
 export KUBECONFIG="${PWD}/constellation-admin.conf"


### PR DESCRIPTION
missed this one in #3001

### Checklist
- [x] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
