### PR TITLE
bazel: patch Go SDK to increase tls maxHandshake size

### DIFF
--- a/3rdparty/bazel/org_golang/BUILD.bazel
+++ b/3rdparty/bazel/org_golang/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["go_tls_max_handshake_size.patch"])

--- a/3rdparty/bazel/org_golang/go_tls_max_handshake_size.patch
+++ b/3rdparty/bazel/org_golang/go_tls_max_handshake_size.patch
@@ -1,0 +1,11 @@
+--- src/crypto/tls/common.go
++++ src/crypto/tls/common.go
+@@ -62,7 +62,7 @@
+ 	maxCiphertext      = 16384 + 2048 // maximum ciphertext payload length
+ 	maxCiphertextTLS13 = 16384 + 256  // maximum ciphertext length in TLS 1.3
+ 	recordHeaderLen    = 5            // record header length
+-	maxHandshake       = 65536        // maximum handshake we support (protocol max is 16 MB)
++	maxHandshake       = 262144       // maximum handshake we support (protocol max is 16 MB)
+ 	maxUselessRecords  = 16           // maximum number of consecutive non-advancing records
+ )
+ 

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -165,11 +165,17 @@ load("//bazel/toolchains:go_module_deps.bzl", "go_dependencies")
 # gazelle:repository_macro bazel/toolchains/go_module_deps.bzl%go_dependencies
 go_dependencies()
 
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
+
+go_download_sdk(
+    name = "go_sdk",
+    patches = ["//3rdparty/bazel/org_golang:go_tls_max_handshake_size.patch"],
+    version = "1.22.1",
+)
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.22.1")
+go_register_toolchains()
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

Go has a very small default for the maximum handshake size in TLS (65536 bytes), while the protocol specifies a maximum of 16 MB.
Since aTLS adds a lot of additional data to TLS certificates, an increase of this handshake size is needed.
Currently, this requires a patch of the Go SDK.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- bazel: patch Go SDK to increase tls maxHandshake size

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- Upstream proposal for making this limit configurable: https://github.com/golang/go/issues/50773

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Run the E2E tests that are relevant to this PR's changes
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [x] Link to Milestone
