### PR TITLE
ci: bump `fromVersion` for e2e tests to v2.16.2

### DIFF
--- a/.github/workflows/e2e-test-release.yml
+++ b/.github/workflows/e2e-test-release.yml
@@ -339,7 +339,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        fromVersion: ["v2.16.0"]
+        fromVersion: ["v2.16.2"]
         attestationVariant: ["gcp-sev-es", "azure-sev-snp", "azure-tdx", "aws-sev-snp"]
     name: Run upgrade tests
     secrets: inherit

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -353,7 +353,7 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        fromVersion: ["v2.16.0"]
+        fromVersion: ["v2.16.2"]
         attestationVariant: ["gcp-sev-es", "azure-sev-snp", "azure-tdx", "aws-sev-snp"]
     name: Run upgrade tests
     secrets: inherit


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
New release, new default version for upgrade tests

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Bump `fromVersion` to v2.16.2`


### Additional info
<!-- Remove items that do not apply -->
- Wait for v2.16.2 release to finish before merging
  - https://github.com/edgelesssys/constellation/actions/runs/8570539093
