### PR TITLE
ci: add error handling to e2e windows liveness probe

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -14,6 +14,11 @@ jobs:
   build-cli:
     name: Build Windows CLI
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      checks: write
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -26,17 +31,26 @@ jobs:
           useCache: "true"
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
 
+      - name: Log in to the Container registry
+        uses: ./.github/actions/container_registry_login
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build CLI
         uses: ./.github/actions/build_cli
         with:
           targetOS: "windows"
           targetArch: "amd64"
           enterpriseCLI: true
+          outputPath: "build/constellation"
+          push: true
 
       - name: Upload CLI artifact
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          path: "bazel-bin/cli/cli_enterprise_windows_amd64"
+          path: build/constellation.exe
           name: "constell-exe"
 
   e2e-test:
@@ -57,7 +71,6 @@ jobs:
       - name: Check CLI version
         shell: pwsh
         run: |
-          Move-Item -Path .\cli_enterprise_windows_amd64 -Destination .\constellation.exe
           .\constellation.exe version
 
       - name: Login to Azure (IAM service principal)
@@ -68,8 +81,10 @@ jobs:
       - name: Create IAM configuration
         shell: pwsh
         run: |
+          $uid = Get-Random -Minimum 1000 -Maximum 9999
+          $rgName = "e2e-windows-${{ github.run_id }}-${{ github.run_attempt }}-$uid"
           .\constellation.exe config generate azure
-          .\constellation.exe iam create azure --region=westus --resourceGroup=e2eWindoewsRG --servicePrincipal=e2eWindoewsSP --update-config --debug -y
+          .\constellation.exe iam create azure --region=westus --resourceGroup=e2eWindoewsRG --servicePrincipal=$rgName --update-config --debug -y
 
       - name: Login to Azure (Cluster service principal)
         uses: ./.github/actions/login_azure
@@ -95,8 +110,11 @@ jobs:
               Write-Host "Retry ${retryCount}: Checking node status..."
 
               $nodesOutput = & kubectl get nodes --kubeconfig "$PWD\constellation-admin.conf"
+              $status = $?
 
-              if ($?) {
+              $nodesOutput
+
+              if ($status) {
                   $lines = $nodesOutput -split "`r?`n" | Select-Object -Skip 1
 
                   if ($lines.count -eq 4) {

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -98,8 +98,10 @@ jobs:
 
               if (-not $?) {
                   Write-Host "Execution of command 'kubectl' failed with exit code: $LASTEXITCODE"
-                  Write-Host "Retrying in $retryIntervalSeconds seconds..."
-                  Start-Sleep -Seconds $retryIntervalSeconds
+                  if ($retryCount -lt $maxRetries) {
+                      Write-Host "Retrying in $retryIntervalSeconds seconds..."
+                      Start-Sleep -Seconds $retryIntervalSeconds
+                  }
                   continue
               }
 
@@ -119,7 +121,7 @@ jobs:
                   }
               }
 
-              if (-not $allNodesReady) {
+              if (-not $allNodesReady -and $retryCount -lt $maxRetries) {
                   Write-Host "Retrying in $retryIntervalSeconds seconds..."
                   Start-Sleep -Seconds $retryIntervalSeconds
               }

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -72,6 +72,7 @@ jobs:
         shell: pwsh
         run: |
           .\constellation.exe version
+          Add-Content -Path $env:windir\System32\drivers\etc\hosts -Value "`n127.0.0.1`tlicense.confidential.cloud" -Force
 
       - name: Login to Azure (IAM service principal)
         uses: ./.github/actions/login_azure
@@ -82,9 +83,9 @@ jobs:
         shell: pwsh
         run: |
           $uid = Get-Random -Minimum 1000 -Maximum 9999
-          $rgName = "e2e-windows-${{ github.run_id }}-${{ github.run_attempt }}-$uid"
+          $rgName = "e2e-win-${{ github.run_id }}-${{ github.run_attempt }}-$uid"
           .\constellation.exe config generate azure
-          .\constellation.exe iam create azure --region=westus --resourceGroup=e2eWindoewsRG --servicePrincipal=$rgName --update-config --debug -y
+          .\constellation.exe iam create azure --region=westus --resourceGroup=$rgName-rg --servicePrincipal=$rgName-sp --update-config --debug -y
 
       - name: Login to Azure (Cluster service principal)
         uses: ./.github/actions/login_azure

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -96,6 +96,13 @@ jobs:
 
               $nodesOutput = & kubectl get nodes --kubeconfig "$PWD\constellation-admin.conf"
 
+              if (-not $?) {
+                  Write-Host "Execution of command 'kubectl' failed with exit code: $LASTEXITCODE"
+                  Write-Host "Retrying in $retryIntervalSeconds seconds..."
+                  Start-Sleep -Seconds $retryIntervalSeconds
+                  continue
+              }
+
               $lines = $nodesOutput -split "`r?`n" | Select-Object -Skip 1
 
               $allNodesReady = $true

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -96,28 +96,23 @@ jobs:
 
               $nodesOutput = & kubectl get nodes --kubeconfig "$PWD\constellation-admin.conf"
 
-              if (-not $?) {
-                  Write-Host "Execution of command 'kubectl' failed with exit code: $LASTEXITCODE"
-                  if ($retryCount -lt $maxRetries) {
-                      Write-Host "Retrying in $retryIntervalSeconds seconds..."
-                      Start-Sleep -Seconds $retryIntervalSeconds
-                  }
-                  continue
-              }
+              if ($?) {
+                  $lines = $nodesOutput -split "`r?`n" | Select-Object -Skip 1
 
-              $lines = $nodesOutput -split "`r?`n" | Select-Object -Skip 1
+                  if ($lines.count -eq 4) {
+                      $allNodesReady = $true
 
-              $allNodesReady = $true
+                      foreach ($line in $lines) {
+                          $columns = $line -split '\s+' | Where-Object { $_ -ne '' }
 
-              foreach ($line in $lines) {
-                  $columns = $line -split '\s+' | Where-Object { $_ -ne '' }
+                          $nodeName = $columns[0]
+                          $status = $columns[1]
 
-                  $nodeName = $columns[0]
-                  $status = $columns[1]
-
-                  if ($status -ne "Ready") {
-                      Write-Host "Node $nodeName is not ready!"
-                      $allNodesReady = $false
+                          if ($status -ne "Ready") {
+                              Write-Host "Node $nodeName is not ready!"
+                              $allNodesReady = $false
+                          }
+                      }
                   }
               }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The liveness probe should not print "All nodes are ready!" after an unsuccessful call to kubectl. Instead, it should retry the command after the specified time.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Check the exit status of kubectl command and continue the retry loop if the execution failed.
- Add check to not wait another 30 seconds after last retry has finished.

### Related issue
- https://github.com/edgelesssys/issues/issues/506

### Additional info
<!-- Remove items that do not apply -->
- [AB#4027](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4027)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [windows-e2e-test](https://github.com/edgelesssys/constellation/actions/runs/8616718469)
- [x] Is PR title adequate for changelog?
