### PR TITLE
ci: fix Windows e2e test not pushing required container images

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -95,8 +95,11 @@ jobs:
               Write-Host "Retry ${retryCount}: Checking node status..."
 
               $nodesOutput = & kubectl get nodes --kubeconfig "$PWD\constellation-admin.conf"
+              $status = $?
 
-              if ($?) {
+              $nodesOutput
+
+              if ($status) {
                   $lines = $nodesOutput -split "`r?`n" | Select-Object -Skip 1
 
                   if ($lines.count -eq 4) {

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -68,8 +68,10 @@ jobs:
       - name: Create IAM configuration
         shell: pwsh
         run: |
+          $uid = Get-Random -Minimum 1000 -Maximum 9999
+          $rgName = "e2e-windows-${{ github.run_id }}-${{ github.run_attempt }}-$uid"
           .\constellation.exe config generate azure
-          .\constellation.exe iam create azure --region=westus --resourceGroup=e2eWindoewsRG --servicePrincipal=e2eWindoewsSP --update-config --debug -y
+          .\constellation.exe iam create azure --region=westus --resourceGroup=e2eWindoewsRG --servicePrincipal=$rgName --update-config --debug -y
 
       - name: Login to Azure (Cluster service principal)
         uses: ./.github/actions/login_azure

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -14,6 +14,11 @@ jobs:
   build-cli:
     name: Build Windows CLI
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      checks: write
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -26,17 +31,26 @@ jobs:
           useCache: "true"
           buildBuddyApiKey: ${{ secrets.BUILDBUDDY_ORG_API_KEY }}
 
+      - name: Log in to the Container registry
+        uses: ./.github/actions/container_registry_login
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build CLI
         uses: ./.github/actions/build_cli
         with:
           targetOS: "windows"
           targetArch: "amd64"
           enterpriseCLI: true
+          outputPath: "build/constellation"
+          push: true
 
       - name: Upload CLI artifact
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
-          path: "bazel-bin/cli/cli_enterprise_windows_amd64"
+          path: build/constellation.exe
           name: "constell-exe"
 
   e2e-test:
@@ -57,7 +71,6 @@ jobs:
       - name: Check CLI version
         shell: pwsh
         run: |
-          Move-Item -Path .\cli_enterprise_windows_amd64 -Destination .\constellation.exe
           .\constellation.exe version
 
       - name: Login to Azure (IAM service principal)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The Windows e2e never uploaded the container images that were built for the CLI that is used in the test.
This causes the cluster to never fully come up.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Upload container images when building the CLI in the Windows e2e test
- Generate unique resource group names in Windows e2e test so more than one test can run in parallel
- Print the `kubectl` output when waiting for nodes to come up



### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [Windows e2e test](https://github.com/edgelesssys/constellation/actions/runs/8631320963/job/23659874252)
