### PR TITLE
helm: unbreak helm test after Cilium version bump

### DIFF
--- a/internal/constellation/helm/helm_test.go
+++ b/internal/constellation/helm/helm_test.go
@@ -198,7 +198,7 @@ func TestHelmApply(t *testing.T) {
 			if tc.clusterCertManagerVersion != nil {
 				certManagerVersion = *tc.clusterCertManagerVersion
 			}
-			helmListVersion(lister, "cilium", "v1.15.0-pre.3-edg.2")
+			helmListVersion(lister, "cilium", "v1.15.0-pre.3-edg.3")
 			helmListVersion(lister, "cert-manager", certManagerVersion)
 			helmListVersion(lister, "constellation-services", tc.clusterMicroServiceVersion)
 			helmListVersion(lister, "constellation-operators", tc.clusterMicroServiceVersion)


### PR DESCRIPTION
### Context

550798279a8bb625e3b0b34f2b3eefa1a76b4c32 broke the Helm tests because it updated the Cilium version without updating the expected version in the test.

### Proposed change(s)

- Bump version in test.

### Additional info

- [AB#4002](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4002)

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
