### PR TITLE
deps: auto-assign reviewer for deps PRs

### DIFF
--- a/.github/workflows/assign_reviewer.yml
+++ b/.github/workflows/assign_reviewer.yml
@@ -26,5 +26,5 @@ jobs:
           --method POST \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          "/repos/edgelesssys/constellation/pulls/$PR/requested_reviewers" \
-          -f "reviewers[]=$ASSIGNEE"
+          "/repos/edgelesssys/constellation/pulls/${PR}/requested_reviewers" \
+          -f "reviewers[]=${ASSIGNEE}"

--- a/.github/workflows/assign_reviewer.yml
+++ b/.github/workflows/assign_reviewer.yml
@@ -1,0 +1,30 @@
+name: Assign Reviewer
+
+on:
+  pull_request:
+    types: ["labeled"]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  specific_review_requested:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'dependencies'}}
+    steps:
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - name: Pick assignee
+      id: pick-assignee
+      uses: ./.github/actions/pick_assignee
+    - name: Assign reviewer
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR: ${{ github.event.pull_request.number }}
+        ASSIGNEE: ${{ steps.pick-assignee.outputs.assignee }}
+      run: |
+        gh api \
+          --method POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          /repos/edgelesssys/constellation/pulls/$PR/requested_reviewers \
+          -f "reviewers[]=$ASSIGNEE"

--- a/.github/workflows/assign_reviewer.yml
+++ b/.github/workflows/assign_reviewer.yml
@@ -26,5 +26,5 @@ jobs:
           --method POST \
           -H "Accept: application/vnd.github+json" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
-          /repos/edgelesssys/constellation/pulls/$PR/requested_reviewers \
+          "/repos/edgelesssys/constellation/pulls/$PR/requested_reviewers" \
           -f "reviewers[]=$ASSIGNEE"


### PR DESCRIPTION
### Context

Constellation receives a considerable amount of maintenance PRs, which are usually assigned to code owners for review. This is an attempt to increase fairness and distribute the review load.

### Proposed change(s)

- Assign one of the Constellation maintainers to dependecy PRs at random.

### Additional info

- [AB#4062](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4062)

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
