### PR TITLE
ci: tag resources created by e2e tests with the run name

### DIFF
--- a/.github/actions/constellation_iam_create/action.yml
+++ b/.github/actions/constellation_iam_create/action.yml
@@ -14,6 +14,10 @@ inputs:
   namePrefix:
     description: "Name prefix to use for resources."
     required: true
+  additionalTags:
+    description: "Additional resource tags that will be written into the constellation configuration."
+    default: ""
+    required: false
   #
   # AWS specific inputs
   #
@@ -49,7 +53,7 @@ runs:
         fi
 
         echo "flag=--update-config" | tee -a "$GITHUB_OUTPUT"
-        constellation config generate ${{ inputs.cloudProvider }} ${kubernetesFlag} --attestation ${{ inputs.attestationVariant }}
+        constellation config generate ${{ inputs.cloudProvider }} ${kubernetesFlag} --attestation ${{ inputs.attestationVariant }} --tags ${{ inputs.additionalTags }}
 
     - name: Constellation iam create aws
       shell: bash

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -126,8 +126,7 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.cosignPassword }}" == '' || "${{ inputs.cosignPrivateKey }}" == '' ]]; then
-          echo "::error::e2e test verify requires cosignPassword and cosignPrivateKey to be set."
-          exit 1
+          echo "::error::e2e test verify requires cosignPassword and cosignPrivateKey to be set." exit 1
         fi
 
     - name: Determine build target
@@ -258,6 +257,7 @@ runs:
         gcpProjectID: ${{ inputs.gcpProject }}
         gcpZone: ${{ inputs.regionZone || 'europe-west3-b' }}
         kubernetesVersion: ${{ inputs.kubernetesVersion }}
+        additionalTags: "run-name=${{ steps.create-prefix.outputs.prefix }}"
 
     - name: Login to GCP (Cluster service account)
       if: inputs.cloudProvider == 'gcp'

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -126,7 +126,7 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.cosignPassword }}" == '' || "${{ inputs.cosignPrivateKey }}" == '' ]]; then
-          echo "::error::e2e test verify requires cosignPassword and cosignPrivateKey to be set." 
+          echo "::error::e2e test verify requires cosignPassword and cosignPrivateKey to be set."
           exit 1
         fi
 

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -126,7 +126,8 @@ runs:
       shell: bash
       run: |
         if [[ "${{ inputs.cosignPassword }}" == '' || "${{ inputs.cosignPrivateKey }}" == '' ]]; then
-          echo "::error::e2e test verify requires cosignPassword and cosignPrivateKey to be set." exit 1
+          echo "::error::e2e test verify requires cosignPassword and cosignPrivateKey to be set." 
+          exit 1
         fi
 
     - name: Determine build target
@@ -257,7 +258,7 @@ runs:
         gcpProjectID: ${{ inputs.gcpProject }}
         gcpZone: ${{ inputs.regionZone || 'europe-west3-b' }}
         kubernetesVersion: ${{ inputs.kubernetesVersion }}
-        additionalTags: "run-name=${{ steps.create-prefix.outputs.prefix }}"
+        additionalTags: "workflow=${{ github.workflow }}"
 
     - name: Login to GCP (Cluster service account)
       if: inputs.cloudProvider == 'gcp'

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           $uid = Get-Random -Minimum 1000 -Maximum 9999
           $rgName = "e2e-win-${{ github.run_id }}-${{ github.run_attempt }}-$uid"
-          .\constellation.exe config generate azure -t "run-name=$rgName"
+          .\constellation.exe config generate azure -t "workflow=${{ github.workflow }}"
           .\constellation.exe iam create azure --region=westus --resourceGroup=$rgName-rg --servicePrincipal=$rgName-sp --update-config --debug -y
 
       - name: Login to Azure (Cluster service principal)

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           $uid = Get-Random -Minimum 1000 -Maximum 9999
           $rgName = "e2e-win-${{ github.run_id }}-${{ github.run_attempt }}-$uid"
-          .\constellation.exe config generate azure
+          .\constellation.exe config generate azure -t "run-name=$rgName"
           .\constellation.exe iam create azure --region=westus --resourceGroup=$rgName-rg --servicePrincipal=$rgName-sp --update-config --debug -y
 
       - name: Login to Azure (Cluster service principal)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
If cleanups fail, it should be easier to locate resources created by an e2e test.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add an input to `constellation_iam_create/action.yml` that allows the addition of additional tags.
- tag all resources created through `e2e_test/action.yml` with the generated prefix

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- Since windows e2e tests don't use `e2e_test/action.yml`, resources are tagged with the resource group name instead.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
