### PR TITLE
ci: add missing permission for e2e-windows test in weekly run

### DIFF
--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -464,6 +464,7 @@ jobs:
     name: Run Windows E2E test
     permissions:
       id-token: write
+      checks: write
       contents: read
       packages: write
     secrets: inherit


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
weekly runs were broken for 1.5 weeks due to a missing permission when calling the e2e-windows workflow

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add `check: write` permission when calling e2e-windows from weekly test


[e2e test](https://github.com/edgelesssys/constellation/actions/runs/8782453540)