### PR TITLE
ci: ensure `--tags` flag is only set if the CLI supports it

### DIFF
--- a/.github/actions/constellation_iam_create/action.yml
+++ b/.github/actions/constellation_iam_create/action.yml
@@ -53,7 +53,7 @@ runs:
         fi
 
         echo "flag=--update-config" | tee -a "$GITHUB_OUTPUT"
-        constellation config generate ${{ inputs.cloudProvider }} ${kubernetesFlag} --attestation ${{ inputs.attestationVariant }} --tags ${{ inputs.additionalTags }}
+        constellation config generate ${{ inputs.cloudProvider }} ${kubernetesFlag} --attestation ${{ inputs.attestationVariant }} --tags "${{ inputs.additionalTags }}"
 
     - name: Constellation iam create aws
       shell: bash

--- a/.github/actions/constellation_iam_create/action.yml
+++ b/.github/actions/constellation_iam_create/action.yml
@@ -52,8 +52,14 @@ runs:
           kubernetesFlag="--kubernetes=${{ inputs.kubernetesVersion }}"
         fi
 
+        # TODO(v2.17): Remove this fallback and always use --tags flag
+        tagsFlag=""
+        if constellation config generate --help | grep -q -- --tags; then
+          tagsFlag="--tags=\"${{ inputs.additionalTags }}\""
+        fi
+
         echo "flag=--update-config" | tee -a "$GITHUB_OUTPUT"
-        constellation config generate ${{ inputs.cloudProvider }} ${kubernetesFlag} --attestation ${{ inputs.attestationVariant }} --tags "${{ inputs.additionalTags }}"
+        constellation config generate ${{ inputs.cloudProvider }} ${kubernetesFlag} --attestation ${{ inputs.attestationVariant }} ${tagsFlag}
 
     - name: Constellation iam create aws
       shell: bash

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -258,7 +258,7 @@ runs:
         gcpProjectID: ${{ inputs.gcpProject }}
         gcpZone: ${{ inputs.regionZone || 'europe-west3-b' }}
         kubernetesVersion: ${{ inputs.kubernetesVersion }}
-        additionalTags: "workflow=${{ github.workflow }}"
+        additionalTags: "workflow=${{ github.run_id }}"
 
     - name: Login to GCP (Cluster service account)
       if: inputs.cloudProvider == 'gcp'

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -84,7 +84,7 @@ jobs:
         run: |
           $uid = Get-Random -Minimum 1000 -Maximum 9999
           $rgName = "e2e-win-${{ github.run_id }}-${{ github.run_attempt }}-$uid"
-          .\constellation.exe config generate azure -t "workflow=${{ github.workflow }}"
+          .\constellation.exe config generate azure -t "workflow=${{ github.run_id }}"
           .\constellation.exe iam create azure --region=westus --resourceGroup=$rgName-rg --servicePrincipal=$rgName-sp --update-config --debug -y
 
       - name: Login to Azure (Cluster service principal)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The new `--tags` flag was set unconditionally for all e2e runs, which breaks runs on stable releases or upgrade tests.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Only set `--tags` if the CLI supports it
- Use `github.run_id` instead of `github.workflow`
  - Tagging runs with the run ID was the intended behavior of the action

### Related issues
- Fixes https://github.com/edgelesssys/issues/issues/537
- Fixes https://github.com/edgelesssys/issues/issues/540


### e2e tests
- [Azure stable image](https://github.com/edgelesssys/constellation/actions/runs/8844438019)
- [Azure debug image](https://github.com/edgelesssys/constellation/actions/runs/8844430632)
