### PR TITLE
terraform: set empty default value for `additional_tags`

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -286,6 +286,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         uses: ./.github/actions/update_tfstate
         with:
-          name: terraform-state-${{ steps.e2e_test.outputs.namePrefix }} 
+          name: terraform-state-${{ steps.e2e_test.outputs.namePrefix }}
           runID: ${{ github.run_id }}
           encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}

--- a/terraform/infrastructure/aws/variables.tf
+++ b/terraform/infrastructure/aws/variables.tf
@@ -82,5 +82,6 @@ variable "enable_snp" {
 
 variable "additional_tags" {
   type        = map(any)
+  default     = {}
   description = "Additional tags that should be applied to created resources."
 }

--- a/terraform/infrastructure/azure/variables.tf
+++ b/terraform/infrastructure/azure/variables.tf
@@ -92,5 +92,6 @@ variable "marketplace_image" {
 
 variable "additional_tags" {
   type        = map(any)
+  default     = {}
   description = "Additional tags that should be applied to created resources."
 }

--- a/terraform/infrastructure/gcp/variables.tf
+++ b/terraform/infrastructure/gcp/variables.tf
@@ -72,5 +72,6 @@ variable "cc_technology" {
 
 variable "additional_labels" {
   type        = map(any)
+  default     = {}
   description = "Additional labels that should be given to created recources."
 }

--- a/terraform/infrastructure/openstack/variables.tf
+++ b/terraform/infrastructure/openstack/variables.tf
@@ -61,6 +61,7 @@ variable "floating_ip_pool_id" {
 
 variable "additional_tags" {
   type        = list(any)
+  default     = []
   description = "Additional tags that should be applied to created resources."
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Since no default value was given for `additional_tags` / `additional_labels`, Terraform interprets the variable as required, causing issues when running our Terraform provider example test, which calls the Terraform infrastructure files used by the CLI as a module:

```
│ Error: Missing required argument
│ 
│   on main.tf line 51, in module "azure_infrastructure":
│   51: module "azure_infrastructure" {
│ 
│ The argument "additional_tags" is required, but no definition was found.
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Provide default values (empty map) for the `additional_tags` field
  - I went with this option rather than setting a default in the example `main.tf`, since the additional tags are supposed to be optional. A user should not need to set any additional tags if they don't wish to do so

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/543

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [Azure](https://github.com/edgelesssys/constellation/actions/runs/8874927123)
  - [x] [AWS](https://github.com/edgelesssys/constellation/actions/runs/8875238826)
  - [x] [GCP](https://github.com/edgelesssys/constellation/actions/runs/8875235808)
