### PR TITLE
deps: upgrade to tink-go v2.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,11 +33,8 @@ replace (
 	k8s.io/sample-apiserver v0.0.0 => k8s.io/sample-apiserver v0.29.0
 )
 
-replace (
-	// TODO(daniel-weisse): revert after merging https://github.com/martinjungblut/go-cryptsetup/pull/16.
-	github.com/martinjungblut/go-cryptsetup => github.com/daniel-weisse/go-cryptsetup v0.0.0-20230705150314-d8c07bd1723c
-	github.com/tink-crypto/tink-go/v2 v2.0.0 => github.com/derpsteb/tink-go/v2 v2.0.0-20231002051717-a808e454eed6
-)
+// TODO(daniel-weisse): revert after merging https://github.com/martinjungblut/go-cryptsetup/pull/16.
+replace github.com/martinjungblut/go-cryptsetup => github.com/daniel-weisse/go-cryptsetup v0.0.0-20230705150314-d8c07bd1723c
 
 require (
 	cloud.google.com/go/compute v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ replace (
 )
 
 replace (
+	// TODO(daniel-weisse): revert after merging https://github.com/martinjungblut/go-cryptsetup/pull/16.
 	github.com/martinjungblut/go-cryptsetup => github.com/daniel-weisse/go-cryptsetup v0.0.0-20230705150314-d8c07bd1723c
 	github.com/tink-crypto/tink-go/v2 v2.0.0 => github.com/derpsteb/tink-go/v2 v2.0.0-20231002051717-a808e454eed6
 )


### PR DESCRIPTION
### Context

Constellation consumes some of its dependencies from edgeless-related forks. Inspecting these forks, some turned out not to be needed anymore:

* `tink-go` updated  Bazel visibility in v2.1.0
* (2024-06-11: the rest was resolved elsewhere)

### Proposed change(s)
- Upgrade `tink-go`.

### Additional info

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
