### PR TITLE
ci: enable gcp-sev-snp for daily tests

### DIFF
--- a/.github/actions/e2e_verify/action.yml
+++ b/.github/actions/e2e_verify/action.yml
@@ -66,12 +66,16 @@ runs:
           forwarderPID=$!
           sleep 5
 
-          if [[ ${{ inputs.attestationVariant }} == "azure-sev-snp" ]] || [[ ${{ inputs.attestationVariant }} == "aws-sev-snp" ]]; then
-            echo "Extracting TCB versions for API update"
-            constellation verify --cluster-id "${clusterID}" --node-endpoint localhost:9090 -o json > "snp-report-${node}.json"
-          else
-            constellation verify --cluster-id "${clusterID}" --node-endpoint localhost:9090
-          fi
+          case "${{ inputs.attestationVariant }}"
+          in
+            "azure-sev-snp"|"aws-sev-snp"|"gcp-sev-snp")
+              echo "Extracting TCB versions for API update"
+              constellation verify --cluster-id "${clusterID}" --node-endpoint localhost:9090 -o json > "snp-report-${node}.json"
+              ;;
+            *)
+              constellation verify --cluster-id "${clusterID}" --node-endpoint localhost:9090
+              ;;
+          esac
 
           kill $forwarderPID
         done
@@ -90,11 +94,6 @@ runs:
         COSIGN_PASSWORD: ${{ inputs.cosignPassword }}
         COSIGN_PRIVATE_KEY: ${{ inputs.cosignPrivateKey }}
       run: |
-        if [[ ${{ inputs.attestationVariant }} == "aws-sev-snp" ]] && constellation version | grep -q "v2.13."; then
-          echo "Skipping TCB upload for AWS on CLI v2.13"
-          exit 0
-        fi
-
         reports=(snp-report-*.json)
         if [ -z ${#reports[@]} ]; then
             exit 1

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -46,10 +46,15 @@ jobs:
       max-parallel: 5
       matrix:
         kubernetesVersion: ["1.28"] # should be default
-        # TODO(msanft): Enable GCP SEV-SNP once stable GCP SEV-SNP images exist.
-        attestationVariant: ["gcp-sev-es", "azure-sev-snp", "azure-tdx", "aws-sev-snp"]
+        attestationVariant: ["gcp-sev-es", "gcp-sev-snp", "azure-sev-snp", "azure-tdx", "aws-sev-snp"]
         refStream: ["ref/main/stream/debug/?", "ref/release/stream/stable/?"]
         test: ["sonobuoy quick"]
+        exclude:
+          # TODO(v2.18 msanft): Remove exclude rule for GCP SEV-SNP stable once images exist.
+          - kubernetesVersion: "1.28"
+            attestationVariant: "gcp-sev-snp"
+            refStream: "ref/release/stream/stable/?"
+            test: "sonobuoy quick"
     runs-on: ubuntu-22.04
     permissions:
       id-token: write
@@ -129,7 +134,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         uses: ./.github/actions/update_tfstate
         with:
-          name: terraform-state-${{ steps.e2e_test.outputs.namePrefix }} 
+          name: terraform-state-${{ steps.e2e_test.outputs.namePrefix }}
           runID: ${{ github.run_id }}
           encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
gcp-sev-snp was disabled on daily e2e tests since we currently don't have stable images for this variant.
However, we the test was disabled for both debug and stable images.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Enable gcp-sev-snp for daily test runs
  - Currently excludes stable images from the test
- Fix verify e2e test for gcp-sev-snp
  - Properly create the JSON file for gcp-sev-snp and upload it
  - Remove a check for backwards compatibility with old CLI versions (v2.13)
  - [e2e test](https://github.com/edgelesssys/constellation/actions/runs/8922428735/job/24504575569)

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/547

