### PR TITLE
ci: correctly clean up failed windows e2e tests

### DIFF
--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -156,7 +156,8 @@ jobs:
         if: always()
         shell: pwsh
         run: |
-          .\constellation.exe terminate --debug -y
+          # .\constellation.exe terminate --debug -y
+          exit 1
 
       - name: Login to Azure (IAM service principal)
         if: always()

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -172,7 +172,8 @@ jobs:
           .\constellation.exe iam destroy --debug -y
 
       - name: Clean up after failure
-        if: ${{ (failure() && (steps.terminate-cluster.conclusion == 'failure' || steps.delete-iam.conclusion == 'failure')) || cancelled() }} # run on a cleanup failure or if cancelled
+        # run on a cleanup failure or if cancelled
+        if: (failure() && (steps.terminate-cluster.conclusion == 'failure' || steps.delete-iam.conclusion == 'failure')) || cancelled()
         shell: pwsh
         run: |
           az group delete --name ${{ steps.iam-create.outputs.rgName }}-rg --yes

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -176,8 +176,8 @@ jobs:
         if: ${{ (failure() && (steps.terminate-cluster.conclusion == 'failure' || steps.delete-iam.conclusion == 'failure')) || cancelled() }} # run on a cleanup failure or if cancelled
         shell: pwsh
         run: |
-          az rg delete --name ${{ steps.iam-create.outputs.rgName }}-rg --yes
-          az rg delete --name ${{ steps.iam-create.outputs.rgName }}-sp --yes
+          az group delete --name ${{ steps.iam-create.outputs.rgName }}-rg --yes
+          az group delete --name ${{ steps.iam-create.outputs.rgName }}-sp --yes
 
   notify-failure:
     name: Notify about failure

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -178,7 +178,6 @@ jobs:
         run: |
           az group delete --name ${{ steps.iam-create.outputs.rgName }}-rg --yes
           az group delete --name ${{ steps.iam-create.outputs.rgName }}-rg-identity --yes
-          az group delete --name ${{ steps.iam-create.outputs.rgName }}-sp --yes
 
   notify-failure:
     name: Notify about failure

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           $uid = Get-Random -Minimum 1000 -Maximum 9999
           $rgName = "e2e-win-${{ github.run_id }}-${{ github.run_attempt }}-$uid"
-          Write-Output "rgName=$($rgName)" >> $Env::GITHUB_OUTPUT
+          "rgName=$($rgName)" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
           .\constellation.exe config generate azure -t "workflow=${{ github.run_id }}"
           .\constellation.exe iam create azure --region=westus --resourceGroup=$rgName-rg --servicePrincipal=$rgName-sp --update-config --debug -y
 

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -156,8 +156,7 @@ jobs:
         if: always()
         shell: pwsh
         run: |
-          # .\constellation.exe terminate --debug -y
-          exit 1
+          .\constellation.exe terminate --debug -y
 
       - name: Login to Azure (IAM service principal)
         if: always()
@@ -170,7 +169,8 @@ jobs:
         if: always()
         shell: pwsh
         run: |
-          .\constellation.exe iam destroy --debug -y
+          # .\constellation.exe iam destroy --debug -y
+          exit 1
 
       - name: Clean up after failure
         if: ${{ (failure() && (steps.terminate-cluster.conclusion == 'failure' || steps.delete-iam.conclusion == 'failure')) || cancelled() }} # run on a cleanup failure or if cancelled

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -169,8 +169,7 @@ jobs:
         if: always()
         shell: pwsh
         run: |
-          # .\constellation.exe iam destroy --debug -y
-          exit 1
+          .\constellation.exe iam destroy --debug -y
 
       - name: Clean up after failure
         if: ${{ (failure() && (steps.terminate-cluster.conclusion == 'failure' || steps.delete-iam.conclusion == 'failure')) || cancelled() }} # run on a cleanup failure or if cancelled

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -173,7 +173,7 @@ jobs:
           .\constellation.exe iam destroy --debug -y
 
       - name: Clean up after failure
-        if: ${{ (failure() && (steps.terminate-cluster.conclusion == 'failure' || steps.delete-iam.conclusion == 'failure') || cancelled() }} # run on a cleanup failure or if cancelled
+        if: ${{ (failure() && (steps.terminate-cluster.conclusion == 'failure' || steps.delete-iam.conclusion == 'failure')) || cancelled() }} # run on a cleanup failure or if cancelled
         shell: pwsh
         run: |
           az rg delete --name ${{ steps.iam-create.outputs.rgName }}-rg --yes

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -80,10 +80,12 @@ jobs:
           azure_credentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
 
       - name: Create IAM configuration
+        id: iam-create
         shell: pwsh
         run: |
           $uid = Get-Random -Minimum 1000 -Maximum 9999
           $rgName = "e2e-win-${{ github.run_id }}-${{ github.run_attempt }}-$uid"
+          Write-Output "rgName=$($rgName)" >> $Env::GITHUB_OUTPUT
           .\constellation.exe config generate azure -t "workflow=${{ github.run_id }}"
           .\constellation.exe iam create azure --region=westus --resourceGroup=$rgName-rg --servicePrincipal=$rgName-sp --update-config --debug -y
 
@@ -150,6 +152,7 @@ jobs:
           }
 
       - name: Terminate cluster
+        id: terminate-cluster
         if: always()
         shell: pwsh
         run: |
@@ -162,10 +165,18 @@ jobs:
           azure_credentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
 
       - name: Delete IAM configuration
+        id: delete-iam
         if: always()
         shell: pwsh
         run: |
           .\constellation.exe iam destroy --debug -y
+
+      - name: Clean up after failure
+        if: ${{ (failure() && (steps.terminate-cluster.conclusion == 'failure' || steps.delete-iam.conclusion == 'failure') || cancelled() }} # run on a cleanup failure or if cancelled
+        shell: pwsh
+        run: |
+          az rg delete --name ${{ steps.iam-create.outputs.rgName }}-rg --yes
+          az rg delete --name ${{ steps.iam-create.outputs.rgName }}-sp --yes
 
   notify-failure:
     name: Notify about failure
@@ -195,26 +206,4 @@ jobs:
           test: Windows E2E Test
           provider: Azure
           attestationVariant: "azure-sev-snp"
-
-  upload-tfstate:
-    name: Upload terraform state if it exists
-    runs-on: ubuntu-22.04
-    needs: e2e-test
-    if: always()
-    steps:
-      - name: Checkout
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          ref: ${{ !github.event.pull_request.head.repo.fork && github.head_ref || '' }}
-
-      - name: Upload tfstate
-        if: always()
-        env:
-          GH_TOKEN: ${{ github.token }}
-        uses: ./.github/actions/update_tfstate
-        with:
-          name: terraform-state-${{ github.run_id }} 
-          runID: ${{ github.run_id }}
-          encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
-          skipDeletion: "true"
 

--- a/.github/workflows/e2e-windows.yml
+++ b/.github/workflows/e2e-windows.yml
@@ -177,6 +177,7 @@ jobs:
         shell: pwsh
         run: |
           az group delete --name ${{ steps.iam-create.outputs.rgName }}-rg --yes
+          az group delete --name ${{ steps.iam-create.outputs.rgName }}-rg-identity --yes
           az group delete --name ${{ steps.iam-create.outputs.rgName }}-sp --yes
 
   notify-failure:


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Failed Windows E2E tests may not be cleaned up correctly.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- If termination of the cluster/destruction of the IAM configuration using terraform fails, delete all resource groups using the azure CLI

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional Info
- Clean up if `constellation terminate` fails: https://github.com/edgelesssys/constellation/actions/runs/8924646002/job/24511751671
- Clean up if `constellation iam destroy` fails: https://github.com/edgelesssys/constellation/actions/runs/8925134979/job/24513391935
- If neither `constellation terminate` nor `constellation iam destroy` fails: https://github.com/edgelesssys/constellation/actions/runs/8925624928

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
