### PR TITLE
terraform: Allow nodes to join the cluster when using a jump host by removing the `constellation-uid` tag

### DIFF
--- a/terraform/infrastructure/aws/main.tf
+++ b/terraform/infrastructure/aws/main.tf
@@ -213,5 +213,5 @@ module "jump_host" {
   ports                = [for port in local.load_balancer_ports : port.port]
   security_groups      = [aws_security_group.security_group.id]
   iam_instance_profile = var.iam_instance_profile_name_worker_nodes
-  additional_tags      = local.tags
+  additional_tags      = var.additional_tags
 }

--- a/terraform/infrastructure/aws/modules/jump_host/main.tf
+++ b/terraform/infrastructure/aws/modules/jump_host/main.tf
@@ -27,7 +27,8 @@ resource "aws_instance" "jump_host" {
   vpc_security_group_ids = var.security_groups
 
   tags = merge(var.additional_tags, {
-    "Name" = "${var.base_name}-jump-host"
+    "Name"               = "${var.base_name}-jump-host",
+    "constellation-role" = "jump-host",
   })
 
   user_data = <<EOF

--- a/terraform/infrastructure/aws/modules/jump_host/main.tf
+++ b/terraform/infrastructure/aws/modules/jump_host/main.tf
@@ -27,8 +27,7 @@ resource "aws_instance" "jump_host" {
   vpc_security_group_ids = var.security_groups
 
   tags = merge(var.additional_tags, {
-    "Name"               = "${var.base_name}-jump-host",
-    "constellation-role" = "jump-host",
+    "Name" = "${var.base_name}-jump-host",
   })
 
   user_data = <<EOF

--- a/terraform/infrastructure/azure/main.tf
+++ b/terraform/infrastructure/azure/main.tf
@@ -276,7 +276,7 @@ module "jump_host" {
   subnet_id      = azurerm_subnet.loadbalancer_subnet[0].id
   ports          = [for port in local.ports : port.port]
   lb_internal_ip = azurerm_lb.loadbalancer.frontend_ip_configuration[0].private_ip_address
-  tags           = local.tags
+  tags           = var.additional_tags
 }
 
 data "azurerm_subscription" "current" {

--- a/terraform/infrastructure/gcp/main.tf
+++ b/terraform/infrastructure/gcp/main.tf
@@ -240,7 +240,7 @@ module "jump_host" {
   base_name      = local.name
   zone           = var.zone
   subnetwork     = google_compute_subnetwork.vpc_subnetwork.id
-  labels         = local.labels
+  labels         = var.additional_labels
   lb_internal_ip = google_compute_address.loadbalancer_ip_internal[0].address
   ports          = [for port in local.control_plane_named_ports : port.port]
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

```
May 03 12:39:20 fedora bootstrapper[3378]: {"time":"2024-05-03T12:39:20.374587495Z","level":"ERROR","source":{"function":"github.com/edgelesssys/constellation/v2/bootstrapper/internal/joinclient.(*JoinClient).getControlPlaneIPs","file":"bootstrapper/internal/joinclient/joinclient.go","line":357},"msg":"Failed to list instances from metadata API","bootstrapper":{"join-client":{"error":"retrieving tag for instance i-03976588af8c28747: tag \"constellation-role\" not found"}}}
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove the `constellation-uid` tag from the jump host since the tag signals that the instance belongs to the Constellation cluster which the jump host does not.

Note that the jump host is only ever applied when using a load balancer and the debug mode.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
