### PR TITLE
deps: update to Go 1.22.3

### DIFF
--- a/.github/actions/versionsapi/Dockerfile
+++ b/.github/actions/versionsapi/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.2@sha256:c4fb952e712efd8f787bcd8e53fd66d1d83b7dc26adabc218e9eac1dbf776bdf as builder
+FROM golang:1.22.3@sha256:b1e05e2c918f52c59d39ce7d5844f73b2f4511f7734add8bb98c9ecdd4443365 as builder
 
 # Download project root dependencies
 WORKDIR /workspace

--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.22.2"
+          go-version: "1.22.3"
           cache: false
 
       - name: Install Crane

--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.22.2"
+          go-version: "1.22.3"
           cache: false
 
       - name: Determine version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.22.2"
+          go-version: "1.22.3"
           cache: false
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.22.2"
+          go-version: "1.22.3"
           cache: true
 
       - name: Build generateMeasurements tool

--- a/.github/workflows/test-operator-codegen.yml
+++ b/.github/workflows/test-operator-codegen.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
         with:
-          go-version: "1.22.2"
+          go-version: "1.22.3"
           cache: true
 
       - name: Run code generation

--- a/3rdparty/gcp-guest-agent/Dockerfile
+++ b/3rdparty/gcp-guest-agent/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
     git
 
 # Install Go
-ARG GO_VER=1.22.2
+ARG GO_VER=1.22.3
 RUN wget -q https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go${GO_VER}.linux-amd64.tar.gz && \
     rm go${GO_VER}.linux-amd64.tar.gz

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -170,7 +170,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchai
 go_download_sdk(
     name = "go_sdk",
     patches = ["//3rdparty/bazel/org_golang:go_tls_max_handshake_size.patch"],
-    version = "1.22.2",
+    version = "1.22.3",
 )
 
 go_rules_dependencies()

--- a/dev-docs/workflows/bump-go-version.md
+++ b/dev-docs/workflows/bump-go-version.md
@@ -1,4 +1,5 @@
 # Bump Go version
+
 `govulncheck` from the bazel `check` target will fail if our code is vulnerable, which is often the case when a patch version was released with security fixes.
 
 ## Steps
@@ -6,5 +7,13 @@
 Replace "1.xx.x" with the new version in [WORKSPACE.bazel](/WORKSPACE.bazel):
 
 ```starlark
-go_register_toolchains(version = "1.xx.x")
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_toolchains", "go_rules_dependencies")
+
+go_download_sdk(
+    name = "go_sdk",
+    patches = ["//3rdparty/bazel/org_golang:go_tls_max_handshake_size.patch"],
+    version = "1.xx.x", <--- Replace this one
+              ~~~~~~~~
+)
+
 ```

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.22.2
+go 1.22.3
 
-toolchain go1.22.2
+toolchain go1.22.3
 
 use (
 	.

--- a/renovate.json5
+++ b/renovate.json5
@@ -42,44 +42,44 @@
       "prPriority": -30,
     },
     {
-      "matchPackagePatterns": ["^k8s.io", "^sigs.k8s.io"],
+      "matchDepPatterns": ["^k8s.io", "^sigs.k8s.io"],
       "groupName": "K8s dependencies",
     },
     {
-      "matchPackagePatterns": ["^go.etcd.io/etcd"],
+      "matchDepPatterns": ["^go.etcd.io/etcd"],
       "groupName": "etcd dependencies",
     },
     {
-      "matchPackagePatterns": ["^github.com/hashicorp/go-kms-wrapping"],
+      "matchDepPatterns": ["^github.com/hashicorp/go-kms-wrapping"],
       "groupName": "github.com/hashicorp/go-kms-wrapping",
     },
     {
-      "matchPackagePatterns": ["^github.com/aws/aws-sdk-go-v2"],
+      "matchDepPatterns": ["^github.com/aws/aws-sdk-go-v2"],
       "groupName": "AWS SDK",
       "prPriority": -10,
     },
     {
-      "matchPackagePatterns": [
+      "matchDepPatterns": [
         "^github.com/Azure/",
         "^github.com/AzureAD/microsoft-authentication-library-for-go",
       ],
       "groupName": "Azure SDK",
     },
     {
-      "matchPackagePatterns": ["^cloud.google.com/go"],
+      "matchDepPatterns": ["^cloud.google.com/go"],
       "groupName": "Google SDK",
     },
     {
-      "matchPackagePatterns": ["^google.golang.org/genproto"],
+      "matchDepPatterns": ["^google.golang.org/genproto"],
       "prPriority": -10,
     },
     {
-      "matchPackagePatterns": ["^libvirt.org/go"],
+      "matchDepPatterns": ["^libvirt.org/go"],
       "groupName": "libvirt.org/go",
     },
     {
       "matchManagers": ["bazelisk", "bazel", "bazel-module"],
-      "matchPackageNames": ["bazel", "io_bazel_rules_go", "bazel_gazelle"],
+      "matchDepNames": ["bazel", "io_bazel_rules_go", "bazel_gazelle"],
       "groupName": "bazel (core)",
     },
     {
@@ -105,14 +105,14 @@
       ],
     },
     {
-      "matchPackageNames": ["kubernetes/kubernetes"],
+      "matchDepNames": ["kubernetes/kubernetes"],
       // example match: v1.2.3 (1.2 -> compatibility, 3 -> patch)
       "versioning": "regex:^(?<compatibility>v?\\d+\\.\\d+\\.)(?<patch>\\d+)$",
       "groupName": "Kubernetes versions",
       "prPriority": 15,
     },
     {
-      "matchPackageNames": [
+      "matchDepNames": [
         "registry.k8s.io/provider-aws/cloud-controller-manager",
       ],
       // example match: v1.2.3 (1.2 -> compatibility, 3 -> patch)
@@ -121,7 +121,7 @@
       "prPriority": 15,
     },
     {
-      "matchPackageNames": [
+      "matchDepNames": [
         "mcr.microsoft.com/oss/kubernetes/azure-cloud-controller-manager",
         "mcr.microsoft.com/oss/kubernetes/azure-cloud-node-manager",
       ],
@@ -131,7 +131,7 @@
       "prPriority": 15,
     },
     {
-      "matchPackageNames": [
+      "matchDepNames": [
         "docker.io/k8scloudprovider/openstack-cloud-controller-manager",
       ],
       // example match: v1.2.3 (1.2 -> compatibility, 3 -> patch)
@@ -140,14 +140,14 @@
       "prPriority": 15,
     },
     {
-      "matchPackageNames": ["registry.k8s.io/autoscaling/cluster-autoscaler"],
+      "matchDepNames": ["registry.k8s.io/autoscaling/cluster-autoscaler"],
       // example match: v1.2.3 (1.2 -> compatibility, 3 -> patch)
       "versioning": "regex:^(?<compatibility>v?\\d+\\.\\d+\\.)(?<patch>\\d+)$",
       "groupName": "K8s constrained GCP versions",
       "prPriority": 15,
     },
     {
-      "matchPackageNames": ["ghcr.io/edgelesssys/cloud-provider-gcp"],
+      "matchDepNames": ["ghcr.io/edgelesssys/cloud-provider-gcp"],
       // example match: v1.2.3 (1. -> compatibility, 2 -> minor, 3 -> patch)
       "versioning": "regex:^(?<compatibility>v\\d+\\.)(?<minor>\\d+)\\.(?<patch>\\d+)$",
       "groupName": "cloud-provider-gcp (K8s version constrained)",
@@ -166,7 +166,7 @@
       "prPriority": 20,
     },
     {
-      "matchPackageNames": [
+      "matchDepNames": [
         "registry.k8s.io/kas-network-proxy/proxy-agent",
         "registry.k8s.io/kas-network-proxy/proxy-server",
       ],
@@ -175,7 +175,7 @@
       "prPriority": 15,
     },
     {
-      "matchPackageNames": ["^k8s.io/client-go"],
+      "matchDepNames": ["^k8s.io/client-go"],
       "matchUpdateTypes": ["major"],
       "enabled": false,
     },
@@ -185,11 +185,11 @@
     },
     {
       "matchManagers": ["github-actions"],
-      "matchPackageNames": ["slsa-framework/slsa-github-generator"],
+      "matchDepNames": ["slsa-framework/slsa-github-generator"],
       "pinDigests": false,
     },
     {
-      "matchPackagePatterns": ["_(darwin|linux)_(arm64|amd64)$"],
+      "matchDepPatterns": ["_(darwin|linux)_(arm64|amd64)$"],
       "additionalBranchPrefix": "{{packageName}}-",
       "groupName": "{{packageName}}",
     },


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
New Go v1.22.3 released with v1.22.2 causing errors in `govulncheck`

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Update to Go 1.22.3
- Replace deprecated renovate syntax

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

