### PR TITLE
terraform: only set `confidential_instance_type` if `cc_technology` is `SEV_SNP`

### DIFF
--- a/terraform/infrastructure/gcp/modules/instance_group/main.tf
+++ b/terraform/infrastructure/gcp/modules/instance_group/main.tf
@@ -42,7 +42,7 @@ resource "google_compute_instance_template" "template" {
 
   confidential_instance_config {
     enable_confidential_compute = true
-    confidential_instance_type  = var.cc_technology
+    confidential_instance_type  = var.cc_technology == "SEV_SNP" ? "SEV_SNP" : null
   }
 
   # If SEV-SNP is used, we have to explicitly select a Milan processor, as per


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Upgrades of existing GCP SEV-ES clusters are failing because setting `confidential_instance_type` makes Terraform want to re-create the instance templates, which does not work because they are still in use by instances.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Only set `confidential_instance_type` if `cc_technology` is `SEV_SNP`
  - When this feature is introduced into the mainline GCP Terraform provider, we will likely have to introduce some form of migration, but I would hold of on that until the provider maintainers decide on how this will look like

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/545


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [GCP SEV-ES upgrade test](https://github.com/edgelesssys/constellation/actions/runs/9078683513)
  - [x] [GCP SEV-SNP test](https://github.com/edgelesssys/constellation/actions/runs/9064172448)