### PR TITLE
ci: only assign reviewer to bot PRs

### DIFF
--- a/.github/workflows/assign_reviewer.yml
+++ b/.github/workflows/assign_reviewer.yml
@@ -8,9 +8,9 @@ permissions:
   pull-requests: write
 
 jobs:
-  specific_review_requested:
+  assign_reviewer:
     runs-on: ubuntu-latest
-    if: ${{ github.event.label.name == 'dependencies'}}
+    if: github.event.label.name == 'dependencies' && github.event.pull_request.user.login == 'app/renovate'
     steps:
     - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
     - name: Pick assignee


### PR DESCRIPTION
### Context

CI currently assigns reviewers to all PRs with the `dependencies` label. The label can and should be used by humans, though, where manual reviewer assignment is preferrable. This also avoids the assignment failing if author == reviewer.

### Proposed change(s)

- Only assign a reviewer automatically to renovate PRs.

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
