### PR TITLE
ci: explicitly set bazel test timeout to four hours for e2e tests

### DIFF
--- a/.github/actions/e2e_lb/action.yml
+++ b/.github/actions/e2e_lb/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         kubectl apply -f ns.yml
         kubectl apply -f lb.yml
-        bazel run //e2e/internal/lb:lb_test
+        bazel run --test_timeout=14400 //e2e/internal/lb:lb_test
 
     - name: Test AWS Ingress
       if: inputs.cloudProvider == 'aws'

--- a/.github/actions/e2e_malicious_join/action.yml
+++ b/.github/actions/e2e_malicious_join/action.yml
@@ -32,7 +32,7 @@ runs:
         KUBECONFIG: ${{ inputs.kubeconfig }}
       working-directory: e2e/malicious-join
       run: |
-        bazel run //e2e/malicious-join:stamp_and_push
+        bazel run --test_timeout=14400 //e2e/malicious-join:stamp_and_push
         yq eval -i "(.spec.template.spec.containers[0].command) = \
           [ \"/malicious-join_bin\", \
           \"--js-endpoint=join-service.kube-system:9090\", \

--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -43,4 +43,4 @@ runs:
         ARM_SUBSCRIPTION_ID: ${{ inputs.azureSubscriptionID }}
         ARM_TENANT_ID: ${{ inputs.azureTenantID }}
       run: |
-        bazel run //e2e/miniconstellation:push_remote_test
+        bazel run --test_timeout=14400 //e2e/miniconstellation:push_remote_test

--- a/.github/workflows/e2e-test-provider-example.yml
+++ b/.github/workflows/e2e-test-provider-example.yml
@@ -453,7 +453,7 @@ jobs:
             yq e '.nodeGroups.control_plane_default.zone = "eu-central-1a"' -i constellation-conf.yaml
             yq e '.nodeGroups.worker_default.zone = "eu-central-1a"' -i constellation-conf.yaml
           fi
-          KUBECONFIG=${{ github.workspace }}/cluster/constellation-admin.conf bazel run //e2e/provider-upgrade:provider-upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --cli "${{ github.workspace }}/build/constellation" "$IMAGE_FLAG" "$KUBERNETES_FLAG" "$MICROSERVICES_FLAG"
+          KUBECONFIG=${{ github.workspace }}/cluster/constellation-admin.conf bazel run --test_timeout=14400 //e2e/provider-upgrade:provider-upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --cli "${{ github.workspace }}/build/constellation" "$IMAGE_FLAG" "$KUBERNETES_FLAG" "$MICROSERVICES_FLAG"
 
       - name: Destroy Terraform Cluster
         # outcome is part of the steps context (https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context)

--- a/.github/workflows/e2e-upgrade.yml
+++ b/.github/workflows/e2e-upgrade.yml
@@ -402,7 +402,7 @@ jobs:
           fi
 
           sudo sh -c 'echo "127.0.0.1 license.confidential.cloud" >> /etc/hosts'
-          bazel run //e2e/internal/upgrade:upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --target-image "$IMAGE" "$KUBERNETES_FLAG" "$MICROSERVICES_FLAG"
+          bazel run --test_timeout=14400 //e2e/internal/upgrade:upgrade_test -- --want-worker "$WORKERNODES" --want-control "$CONTROLNODES" --target-image "$IMAGE" "$KUBERNETES_FLAG" "$MICROSERVICES_FLAG"
 
       - name: Remove Terraform plugin cache
         if: always()


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

The default test timeout was five minutes. Due to an upgrade of rules_go, this timeout is now enforced.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- ci: explicitly set bazel test timeout to four hours for e2e tests

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->
