### PR TITLE
s3proxy: commit image version on release, too

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
           yq eval -i ".version = \"$WITHOUT_V\"" s3proxy/deploy/s3proxy/Chart.yaml
           yq eval -i ".image = \"ghcr.io/edgelesssys/constellation/s3proxy:$VERSION\"" s3proxy/deploy/s3proxy/values.yaml
 
-          git add s3proxy/deploy/s3proxy/Chart.yaml
+          git add s3proxy/deploy/s3proxy/Chart.yaml s3proxy/deploy/s3proxy/values.yaml
 
       - name: Commit
         run: |


### PR DESCRIPTION
### Context

On release, we modify the Helm chart, package it and update the source tree with the new versions. We forgot to commit `values.yaml`, though.

Note: this is not an issue in released Helm charts, because they are packaged from the dirty working tree.

### Proposed change(s)

- Also commit `values.yaml`.

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
