### PR TITLE
renovate: group all Terraform dependency updates into one PR

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -58,6 +58,21 @@
       ],
     },
     {
+      // Group update of Terraform dependencies.
+      "groupName": "Terraform dependencies",
+      "matchManagers": ["terraform"],
+      "matchUpdateTypes": [
+        "bump",
+        "digest",
+        "lockFileMaintenance",
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "rollback",
+      ],
+    },
+    {
       "matchManagers": ["bazelisk", "bazel", "bazel-module"],
       "matchDepNames": ["bazel", "io_bazel_rules_go", "bazel_gazelle"],
       "groupName": "bazel (core)",


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Trying to keep our dependencies up to date, I noticed that Terraform dependencies are not grouped, taking up most of the space in our renovate dashboard.
Lets group the updates for easier maintenance.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Group all Terraform dependecy updates in one PR
