### PR TITLE
deps: remove obsolete Go replace to upgrade go-sev-guest

### DIFF
--- a/bazel/toolchains/go_module_deps.bzl
+++ b/bazel/toolchains/go_module_deps.bzl
@@ -2197,9 +2197,8 @@ def go_dependencies():
         build_file_generation = "on",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/google/go-sev-guest",
-        replace = "github.com/google/go-sev-guest",
-        sum = "h1:6o4Z/vQqNUH+cEagfx1Ez5ElK70iZulEXZwmLnRo44I=",
-        version = "v0.0.0-20230928233922-2dcbba0a4b9d",
+        sum = "h1:gnww4U8fHV5DCPz4gykr1s8SEX1fFNcxCBy+vvXN24k=",
+        version = "v0.11.1",
     )
     go_repository(
         name = "com_github_google_go_tdx_guest",

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,6 @@ replace (
 )
 
 replace (
-	github.com/google/go-sev-guest => github.com/google/go-sev-guest v0.0.0-20230928233922-2dcbba0a4b9d
 	github.com/martinjungblut/go-cryptsetup => github.com/daniel-weisse/go-cryptsetup v0.0.0-20230705150314-d8c07bd1723c
 	github.com/tink-crypto/tink-go/v2 v2.0.0 => github.com/derpsteb/tink-go/v2 v2.0.0-20231002051717-a808e454eed6
 )

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/google/go-configfs-tsm v0.2.2 h1:YnJ9rXIOj5BYD7/0DNnzs8AOp7UcvjfTvt21
 github.com/google/go-configfs-tsm v0.2.2/go.mod h1:EL1GTDFMb5PZQWDviGfZV9n87WeGTR/JUg13RfwkgRo=
 github.com/google/go-containerregistry v0.19.0 h1:uIsMRBV7m/HDkDxE/nXMnv1q+lOOSPlQ/ywc5JbB8Ic=
 github.com/google/go-containerregistry v0.19.0/go.mod h1:u0qB2l7mvtWVR5kNcbFIhFY1hLbf8eeGapA+vbFDCtQ=
-github.com/google/go-sev-guest v0.0.0-20230928233922-2dcbba0a4b9d h1:6o4Z/vQqNUH+cEagfx1Ez5ElK70iZulEXZwmLnRo44I=
-github.com/google/go-sev-guest v0.0.0-20230928233922-2dcbba0a4b9d/go.mod h1:hc1R4R6f8+NcJwITs0L90fYWTsBpd1Ix+Gur15sqHDs=
+github.com/google/go-sev-guest v0.11.1 h1:gnww4U8fHV5DCPz4gykr1s8SEX1fFNcxCBy+vvXN24k=
+github.com/google/go-sev-guest v0.11.1/go.mod h1:qBOfb+JmgsUI3aUyzQoGC13Kpp9zwLeWvuyXmA9q77w=
 github.com/google/go-tdx-guest v0.3.1 h1:gl0KvjdsD4RrJzyLefDOvFOUH3NAJri/3qvaL5m83Iw=
 github.com/google/go-tdx-guest v0.3.1/go.mod h1:/rc3d7rnPykOPuY8U9saMyEps0PZDThLk/RygXm04nE=
 github.com/google/go-tpm v0.9.1-0.20240510201744-5c2f0887e003 h1:gfGQAIxsEEAuYuFvjCGpDnTwisMJOz+rUfJMkk4yTmc=

--- a/internal/attestation/aws/snp/BUILD.bazel
+++ b/internal/attestation/aws/snp/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//internal/attestation/vtpm",
         "//internal/config",
         "@com_github_google_go_sev_guest//abi",
-        "@com_github_google_go_sev_guest//client",
         "@com_github_google_go_sev_guest//kds",
         "@com_github_google_go_sev_guest//proto/sevsnp",
         "@com_github_google_go_sev_guest//validate",

--- a/internal/attestation/aws/snp/issuer.go
+++ b/internal/attestation/aws/snp/issuer.go
@@ -21,7 +21,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/attestation/vtpm"
 
 	"github.com/google/go-sev-guest/abi"
-	sevclient "github.com/google/go-sev-guest/client"
 	"github.com/google/go-tpm-tools/client"
 	tpmclient "github.com/google/go-tpm-tools/client"
 )
@@ -70,13 +69,7 @@ func getInstanceInfo(_ context.Context, tpm io.ReadWriteCloser, _ []byte) ([]byt
 
 	akDigest := sha512.Sum512(encoded)
 
-	device, err := sevclient.OpenDevice()
-	if err != nil {
-		return nil, fmt.Errorf("opening sev device: %w", err)
-	}
-	defer device.Close()
-
-	report, certs, err := sevclient.GetRawExtendedReportAtVmpl(device, akDigest, 0)
+	report, certs, err := snp.GetExtendedReport(akDigest)
 	if err != nil {
 		return nil, fmt.Errorf("getting extended report: %w", err)
 	}

--- a/internal/attestation/azure/snp/validator_test.go
+++ b/internal/attestation/azure/snp/validator_test.go
@@ -368,7 +368,7 @@ func TestTrustedKeyFromSNP(t *testing.T) {
 			),
 			wantErr: true,
 			assertion: func(assert *assert.Assertions, err error) {
-				assert.ErrorContains(err, "could not interpret VCEK DER bytes: x509: malformed certificate")
+				assert.ErrorContains(err, "x509: malformed certificate")
 			},
 		},
 		"invalid certchain fall back to embedded": {

--- a/internal/attestation/gcp/snp/BUILD.bazel
+++ b/internal/attestation/gcp/snp/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//internal/attestation/vtpm",
         "//internal/config",
         "@com_github_google_go_sev_guest//abi",
-        "@com_github_google_go_sev_guest//client",
         "@com_github_google_go_sev_guest//kds",
         "@com_github_google_go_sev_guest//proto/sevsnp",
         "@com_github_google_go_sev_guest//validate",

--- a/internal/attestation/gcp/snp/issuer.go
+++ b/internal/attestation/gcp/snp/issuer.go
@@ -21,7 +21,6 @@ import (
 	"github.com/edgelesssys/constellation/v2/internal/attestation/vtpm"
 
 	"github.com/google/go-sev-guest/abi"
-	sevclient "github.com/google/go-sev-guest/client"
 	"github.com/google/go-tpm-tools/client"
 	tpmclient "github.com/google/go-tpm-tools/client"
 	"github.com/google/go-tpm-tools/proto/attest"
@@ -65,13 +64,7 @@ func getInstanceInfo(_ context.Context, _ io.ReadWriteCloser, extraData []byte) 
 	var extraData64 [64]byte
 	copy(extraData64[:], extraData)
 
-	device, err := sevclient.OpenDevice()
-	if err != nil {
-		return nil, fmt.Errorf("opening sev device: %w", err)
-	}
-	defer device.Close()
-
-	report, certs, err := sevclient.GetRawExtendedReportAtVmpl(device, extraData64, 0)
+	report, certs, err := snp.GetExtendedReport(extraData64)
 	if err != nil {
 		return nil, fmt.Errorf("getting extended report: %w", err)
 	}

--- a/internal/attestation/snp/BUILD.bazel
+++ b/internal/attestation/snp/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//internal/attestation",
         "@com_github_google_go_sev_guest//abi",
+        "@com_github_google_go_sev_guest//client",
         "@com_github_google_go_sev_guest//kds",
         "@com_github_google_go_sev_guest//proto/sevsnp",
         "@com_github_google_go_sev_guest//verify/trust",

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -131,7 +131,7 @@ func getCertChain(cfg config.AttestationCfg) ([]byte, error) {
 	}
 
 	if awsCfg.AMDSigningKey.Equal(config.Certificate{}) {
-		certs, err := trust.GetProductChain(kds.ProductString(snp.Product()), abi.VlekReportSigner, trust.DefaultHTTPSGetter())
+		certs, err := trust.GetProductChain(kds.ProductLine(snp.Product()), abi.VlekReportSigner, trust.DefaultHTTPSGetter())
 		if err != nil {
 			return nil, fmt.Errorf("getting product certificate chain: %w", err)
 		}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Our `go.mod` file had a replace statement for `github.com/google/go-sev-guest` which prevented us from actually upgrading the dependency

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove the replace statement and replace usage of deprecated functions

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/583


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [AWS SEV-SNP](https://github.com/edgelesssys/constellation/actions/runs/9112897702)
  - [x] [GCP SEV-SNP](https://github.com/edgelesssys/constellation/actions/runs/9112901815)
