### PR TITLE
ci: clean up failed miniconstellation e2e tests

### DIFF
--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -47,9 +47,7 @@ runs:
         ARM_SUBSCRIPTION_ID: ${{ inputs.azureSubscriptionID }}
         ARM_TENANT_ID: ${{ inputs.azureTenantID }}
       run: |
-        tfdir=$(mktemp -d)
-        TF_DIR="$tfdir" bazel run --test_timeout=14400 //e2e/miniconstellation:push_remote_test
-        echo "terraform-dir=$tfdir" >> $GITHUB_OUTPUT
+        bazel run --test_timeout=14400 //e2e/miniconstellation:push_remote_test
 
     - name: Log in to azure
       # only log in if e2e test failed or if the run was cancelled
@@ -63,8 +61,6 @@ runs:
       # clean up if e2e test failed or if the run was cancelled
       if: (failure() && steps.e2e-test.conclusion == 'failure') || cancelled()
       run: |
-        cd ${{ steps.e2e-test.outputs.terraform-dir }}
-        terraform init
-        rg_name=$(terraform output -raw rg_name)
+        rg_name=${{ steps.e2e-test.outputs.rgname}}
         echo "[*] Deleting resource group $rg_name"
         az group delete -y --resource-group "$rg_name"

--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -46,11 +46,17 @@ runs:
       run: |
         bazel run --test_timeout=14400 //e2e/miniconstellation:push_remote_test
 
+    - name: Log in to azure
+      # only log in if e2e test failed or if the run was cancelled
+      if: (failure() && steps.e2e-test.conclusion == 'failure') || cancelled()
+      uses: ./.github/actions/login_azure
+      with:
+        azure_credentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+
     - name: Clean up after failure
       shell: bash
       # clean up if e2e test failed or if the run was cancelled
       if: (failure() && steps.e2e-test.conclusion == 'failure') || cancelled()
       run: |
         cd e2e/miniconstellation
-        terraform init
-        terraform destroy -auto-approve
+        echo $(terraform output -raw rg_name) | xargs az group delete -y --resource-group

--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -11,6 +11,9 @@ inputs:
   azureTenantID:
     description: "Azure tenant to use for login with OIDC"
     required: true
+  azureIAMCredentials:
+    description: "Azure IAM credentials used for cleaning up resources"
+    required: true
   registry:
     description: "Container registry to use"
     required: true
@@ -51,7 +54,7 @@ runs:
       if: (failure() && steps.e2e-test.conclusion == 'failure') || cancelled()
       uses: ./.github/actions/login_azure
       with:
-        azure_credentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
+        azure_credentials: ${{ inputs.azureIAMCredentials }}
 
     - name: Clean up after failure
       shell: bash

--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -61,6 +61,6 @@ runs:
       # clean up if e2e test failed or if the run was cancelled
       if: (failure() && steps.e2e-test.conclusion == 'failure') || cancelled()
       run: |
-        rg_name=${{ steps.e2e-test.outputs.rgname}}
+        rg_name=${{ steps.e2e-test.outputs.rgname }}
         echo "[*] Deleting resource group $rg_name"
         az group delete -y --resource-group "$rg_name"

--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -48,8 +48,7 @@ runs:
         ARM_TENANT_ID: ${{ inputs.azureTenantID }}
       run: |
         bazel run --test_timeout=14400 //e2e/miniconstellation:push_remote_test
-        # TODO: Replace and test with BUILD_WORKING_DIRECTORY
-        echo "bazel-workspace-dir=$BUILD_WORKSPACE_DIRECTORY" >> $GITHUB_OUTPUT
+        echo "bazel-workspace-dir=$BUILD_WORKING_DIRECTORY" >> $GITHUB_OUTPUT
 
     - name: Log in to azure
       # only log in if e2e test failed or if the run was cancelled

--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -51,4 +51,5 @@ runs:
       # clean up if e2e test failed or if the run was cancelled
       if: (failure() && steps.e2e-test.conclusion == 'failure') || cancelled()
       run: |
+        cd e2e/miniconstellation
         terraform destroy -auto-approve

--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -47,8 +47,9 @@ runs:
         ARM_SUBSCRIPTION_ID: ${{ inputs.azureSubscriptionID }}
         ARM_TENANT_ID: ${{ inputs.azureTenantID }}
       run: |
-        bazel run --test_timeout=14400 //e2e/miniconstellation:push_remote_test
-        echo "bazel-workspace-dir=$BUILD_WORKING_DIRECTORY" >> $GITHUB_OUTPUT
+        tfdir=$(mktemp -d)
+        TF_DIR="$tfdir" bazel run --test_timeout=14400 //e2e/miniconstellation:push_remote_test
+        echo "terraform-dir=$tfdir" >> $GITHUB_OUTPUT
 
     - name: Log in to azure
       # only log in if e2e test failed or if the run was cancelled
@@ -62,7 +63,7 @@ runs:
       # clean up if e2e test failed or if the run was cancelled
       if: (failure() && steps.e2e-test.conclusion == 'failure') || cancelled()
       run: |
-        cd ${{ steps.e2e-test.outputs.bazel-workspace-dir }}/e2e/miniconstellation
+        cd ${{ steps.e2e-test.outputs.terraform-dir }}
         terraform init
         rg_name=$(terraform output -raw rg_name)
         echo "[*] Deleting resource group $rg_name"

--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -52,4 +52,5 @@ runs:
       if: (failure() && steps.e2e-test.conclusion == 'failure') || cancelled()
       run: |
         cd e2e/miniconstellation
+        terraform init
         terraform destroy -auto-approve

--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -48,6 +48,8 @@ runs:
         ARM_TENANT_ID: ${{ inputs.azureTenantID }}
       run: |
         bazel run --test_timeout=14400 //e2e/miniconstellation:push_remote_test
+        # TODO: Replace and test with BUILD_WORKING_DIRECTORY
+        echo "bazel-workspace-dir=$BUILD_WORKSPACE_DIRECTORY" >> $GITHUB_OUTPUT
 
     - name: Log in to azure
       # only log in if e2e test failed or if the run was cancelled
@@ -61,7 +63,7 @@ runs:
       # clean up if e2e test failed or if the run was cancelled
       if: (failure() && steps.e2e-test.conclusion == 'failure') || cancelled()
       run: |
-        cd e2e/miniconstellation
+        cd ${{ steps.e2e-test.outputs.bazel-workspace-dir }}/e2e/miniconstellation
         terraform init
         rg_name=$(terraform output -raw rg_name)
         echo "[*] Deleting resource group $rg_name"

--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -38,9 +38,17 @@ runs:
 
     - name: MiniConstellation E2E
       shell: bash
+      id: e2e-test
       env:
         ARM_CLIENT_ID: ${{ inputs.azureClientID }}
         ARM_SUBSCRIPTION_ID: ${{ inputs.azureSubscriptionID }}
         ARM_TENANT_ID: ${{ inputs.azureTenantID }}
       run: |
         bazel run --test_timeout=14400 //e2e/miniconstellation:push_remote_test
+
+    - name: Clean up after failure
+      shell: bash
+      # clean up if e2e test failed or if the run was cancelled
+      if: (failure() && steps.e2e-test.conclusion == 'failure') || cancelled()
+      run: |
+        terraform destroy -auto-approve

--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -62,4 +62,7 @@ runs:
       if: (failure() && steps.e2e-test.conclusion == 'failure') || cancelled()
       run: |
         cd e2e/miniconstellation
-        echo $(terraform output -raw rg_name) | xargs az group delete -y --resource-group
+        terraform init
+        rg_name=$(terraform output -raw rg_name)
+        echo "[*] Deleting resource group $rg_name"
+        az group delete -y --resource-group "$rg_name"

--- a/.github/workflows/e2e-mini.yml
+++ b/.github/workflows/e2e-mini.yml
@@ -46,5 +46,6 @@ jobs:
           azureClientID: ${{ secrets.AZURE_E2E_MINI_CLIENT_ID }}
           azureSubscriptionID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azureTenantID: ${{ secrets.AZURE_TENANT_ID }}
+          azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -181,6 +181,7 @@ jobs:
           azureClientID: ${{ secrets.AZURE_E2E_MINI_CLIENT_ID }}
           azureSubscriptionID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azureTenantID: ${{ secrets.AZURE_TENANT_ID }}
+          azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -455,6 +455,7 @@ jobs:
           azureClientID: ${{ secrets.AZURE_E2E_MINI_CLIENT_ID }}
           azureSubscriptionID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           azureTenantID: ${{ secrets.AZURE_TENANT_ID }}
+          azureIAMCredentials: ${{ secrets.AZURE_E2E_IAM_CREDENTIALS }}
           registry: ghcr.io
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 

--- a/e2e/miniconstellation/main.sh.in
+++ b/e2e/miniconstellation/main.sh.in
@@ -4,6 +4,7 @@ clean_up() {
   echo "::group::Terminate"
 
   # terraform destroy -auto-approve
+  popd
   exit 1
 
   echo "::endgroup::"
@@ -23,6 +24,14 @@ registerExitHandler clean_up
 cd e2e/miniconstellation
 
 echo "::group::Terraform"
+
+if [[ -z "$TF_DIR" ]]; then
+  TF_DIR="."
+fi
+
+cp -n -r * "$TF_DIR"
+
+pushd "$TF_DIR"
 
 terraform init
 terraform apply -auto-approve

--- a/e2e/miniconstellation/main.sh.in
+++ b/e2e/miniconstellation/main.sh.in
@@ -3,7 +3,8 @@
 clean_up() {
   echo "::group::Terminate"
 
-  terraform destroy -auto-approve
+  # terraform destroy -auto-approve
+  exit 1
 
   echo "::endgroup::"
 }

--- a/e2e/miniconstellation/main.sh.in
+++ b/e2e/miniconstellation/main.sh.in
@@ -3,8 +3,7 @@
 clean_up() {
   echo "::group::Terminate"
 
-  # terraform destroy -auto-approve
-  exit 1
+  terraform destroy -auto-approve
 
   echo "::endgroup::"
 }

--- a/e2e/miniconstellation/main.sh.in
+++ b/e2e/miniconstellation/main.sh.in
@@ -29,7 +29,7 @@ terraform output -raw ssh_private_key > id_rsa
 chmod 600 id_rsa
 
 rg_name=$(terraform output -raw rg_name)
-echo "rgname=$rg_name" >> "$GITHUB_OUTPUT"
+echo "rgname=$rg_name" >> "${GITHUB_OUTPUT:-/dev/null}"
 
 azure_vm_ip=$(terraform output -raw public_ip)
 

--- a/e2e/miniconstellation/main.sh.in
+++ b/e2e/miniconstellation/main.sh.in
@@ -29,7 +29,7 @@ terraform output -raw ssh_private_key > id_rsa
 chmod 600 id_rsa
 
 rg_name=$(terraform output -raw rg_name)
-echo "rgname=$rg_name" >> $GITHUB_OUTPUT
+echo "rgname=$rg_name" >> "$GITHUB_OUTPUT"
 
 azure_vm_ip=$(terraform output -raw public_ip)
 

--- a/e2e/miniconstellation/main.sh.in
+++ b/e2e/miniconstellation/main.sh.in
@@ -4,7 +4,6 @@ clean_up() {
   echo "::group::Terminate"
 
   # terraform destroy -auto-approve
-  popd
   exit 1
 
   echo "::endgroup::"
@@ -25,18 +24,13 @@ cd e2e/miniconstellation
 
 echo "::group::Terraform"
 
-if [[ -z "$TF_DIR" ]]; then
-  TF_DIR="."
-fi
-
-cp -n -r * "$TF_DIR"
-
-pushd "$TF_DIR"
-
 terraform init
 terraform apply -auto-approve
 terraform output -raw ssh_private_key > id_rsa
 chmod 600 id_rsa
+
+rg_name=$(terraform output -raw rg_name)
+echo "rgname=$rg_name" >> $GITHUB_OUTPUT
 
 azure_vm_ip=$(terraform output -raw public_ip)
 

--- a/e2e/miniconstellation/output.tf
+++ b/e2e/miniconstellation/output.tf
@@ -11,7 +11,7 @@ output "ssh_private_key" {
 }
 
 output "rg_name" {
-  value = "e2e-mini-${random_string.suffix.result}"
-  sensitive = false
+  value      = "e2e-mini-${random_string.suffix.result}"
+  sensitive  = false
   depends_on = [random_string.suffix]
 }

--- a/e2e/miniconstellation/output.tf
+++ b/e2e/miniconstellation/output.tf
@@ -9,3 +9,9 @@ output "ssh_private_key" {
   sensitive  = true
   depends_on = [tls_private_key.ssh_key]
 }
+
+output "rg_name" {
+  value = "e2e-mini-${random_string.suffix.result}"
+  sensitive = false
+  depends_on = [random_string.suffix]
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Currently, if a QEMU/miniconstellation e2e test fails or is cancelled, the created resources won't be cleaned up automatically.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- If a test fails or is cancelled, delete the created resource group using the azure CLI.

### Additional Info
- A successful run can be seen [here](https://github.com/edgelesssys/constellation/actions/runs/9113876753/job/25056476083) (The cleanup happens at the very bottom of "Run e2e MiniConstellation")

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
