### PR TITLE
ci: ignore missing files when creating archive

### DIFF
--- a/.github/actions/artifact_download/action.yml
+++ b/.github/actions/artifact_download/action.yml
@@ -37,4 +37,4 @@ runs:
       shell: bash
       run: |
         mkdir -p ${{ inputs.path }}
-        7zz x -p'${{ inputs.encryptionSecret }}' -t7z -o"${{ inputs.path }}" ${{ steps.tempdir.outputs.directory }}/archive.7z
+        7zz x -p'${{ inputs.encryptionSecret }}' -bso0 -bsp0 -t7z -o"${{ inputs.path }}" ${{ steps.tempdir.outputs.directory }}/archive.7z

--- a/.github/actions/artifact_upload/action.yml
+++ b/.github/actions/artifact_upload/action.yml
@@ -47,6 +47,7 @@ runs:
             something_exists=true
           fi
         done
+
         # Create an archive if files exist.
         # Don't create an archive file if no files are found
         # and warn.
@@ -55,11 +56,15 @@ runs:
           echo "::warning:: No files/directories found with the provided path(s): ${paths}. No artifact will be uploaded."
           exit 0
         fi
+
         for target in ${paths}
         do
-          pushd "$(dirname "${target}")" || exit 1
-          7zz a -p'${{ inputs.encryptionSecret }}' -bso0 -bsp0 -t7z -ms=on -mhe=on "${{ steps.tempdir.outputs.directory }}/archive.7z" "$(basename "${target}")"
-          popd || exit 1
+          if [[ -f "${target}" ]]
+          then
+            pushd "$(dirname "${target}")" || exit 1
+            7zz a -p'${{ inputs.encryptionSecret }}' -bso0 -bsp0 -t7z -ms=on -mhe=on "${{ steps.tempdir.outputs.directory }}/archive.7z" "$(basename "${target}")"
+            popd || exit 1
+          fi
         done
 
     - name: Upload archive as artifact

--- a/.github/actions/artifact_upload/action.yml
+++ b/.github/actions/artifact_upload/action.yml
@@ -58,7 +58,7 @@ runs:
         for target in ${paths}
         do
           pushd "$(dirname "${target}")" || exit 1
-          7zz a -p'${{ inputs.encryptionSecret }}' -t7z -ms=on -mhe=on "${{ steps.tempdir.outputs.directory }}/archive.7z" "$(basename "${target}")"
+          7zz a -p'${{ inputs.encryptionSecret }}' -bso0 -bsp0 -t7z -ms=on -mhe=on "${{ steps.tempdir.outputs.directory }}/archive.7z" "$(basename "${target}")"
           popd || exit 1
         done
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
During our e2e tests, we have a pre-configured list of files we plan to upload.
If some of these files don't exist, our artifact upload action fails, and we never upload an archive.
This can happen if the CLI fails during creation of the infrastructure, and then fails to clean up said infrastructure.
In this case, no `constellation-mastersecret.json` was ever created and the archive creation fails.
This causes problems for the clean-up action of the upgrade test.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Only add files to the archive if they actually exist
- Reduce noise of archive creation and extraction
