### PR TITLE
ci: check for pattern completion instead of file when creating archive

### DIFF
--- a/.github/actions/artifact_upload/action.yml
+++ b/.github/actions/artifact_upload/action.yml
@@ -59,7 +59,7 @@ runs:
 
         for target in ${paths}
         do
-          if [[ -f "${target}" ]]
+          if compgen -G "${target}" > /dev/null
           then
             pushd "$(dirname "${target}")" || exit 1
             7zz a -p'${{ inputs.encryptionSecret }}' -bso0 -bsp0 -t7z -ms=on -mhe=on "${{ steps.tempdir.outputs.directory }}/archive.7z" "$(basename "${target}")"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Upload action accepts files, directories, or patterns as input.
This is a problem if we only check for file existence when creating the archive.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Check for pattern completion instead of file existence

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/618
