### PR TITLE
bootstrapper: disable gRPC logging

### DIFF
--- a/bootstrapper/cmd/bootstrapper/main.go
+++ b/bootstrapper/cmd/bootstrapper/main.go
@@ -43,22 +43,14 @@ const (
 )
 
 func main() {
-	debug := flag.Bool("debug", false, "Enable debug logging")
-	gRPCDebug := flag.Bool("grpc-debug", false, "Enable gRPC debug logging")
 	verbosity := flag.Int("v", 0, logger.CmdLineVerbosityDescription)
 	flag.Parse()
 	log := logger.NewJSONLogger(logger.VerbosityFromInt(*verbosity)).WithGroup("bootstrapper")
-
-	level := slog.LevelWarn
-	if *debug {
-		level = slog.LevelDebug
-	}
-
-	if *gRPCDebug {
-		logger.ReplaceGRPCLogger(log.WithGroup("gRPC"))
-	} else {
-		logger.ReplaceGRPCLogger(slog.New(logger.NewLevelHandler(level, log.Handler())).WithGroup("gRPC"))
-	}
+	logger.ReplaceGRPCLogger(
+		slog.New(
+			logger.NewLevelHandler(logger.VerbosityFromInt(*verbosity), log.Handler()),
+		).WithGroup("gRPC"),
+	)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/bootstrapper/cmd/bootstrapper/main.go
+++ b/bootstrapper/cmd/bootstrapper/main.go
@@ -43,15 +43,21 @@ const (
 )
 
 func main() {
-	gRPCDebug := flag.Bool("debug", false, "Enable gRPC debug logging")
+	debug := flag.Bool("debug", false, "Enable debug logging")
+	gRPCDebug := flag.Bool("grpc-debug", false, "Enable gRPC debug logging")
 	verbosity := flag.Int("v", 0, logger.CmdLineVerbosityDescription)
 	flag.Parse()
 	log := logger.NewJSONLogger(logger.VerbosityFromInt(*verbosity)).WithGroup("bootstrapper")
 
+	level := slog.LevelWarn
+	if *debug {
+		level = slog.LevelDebug
+	}
+
 	if *gRPCDebug {
 		logger.ReplaceGRPCLogger(log.WithGroup("gRPC"))
 	} else {
-		logger.ReplaceGRPCLogger(slog.New(logger.NewLevelHandler(slog.LevelWarn, log.Handler())).WithGroup("gRPC"))
+		logger.ReplaceGRPCLogger(slog.New(logger.NewLevelHandler(level, log.Handler())).WithGroup("gRPC"))
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/image/base/mkosi.skeleton/usr/lib/systemd/system/constellation-bootstrapper.service
+++ b/image/base/mkosi.skeleton/usr/lib/systemd/system/constellation-bootstrapper.service
@@ -10,7 +10,7 @@ RemainAfterExit=yes
 Restart=on-failure
 EnvironmentFile=/run/constellation.env
 Environment=PATH=/run/state/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-ExecStart=/usr/bin/bootstrapper $CONSTELLATION_DEBUG_FLAGS
+ExecStart=/usr/bin/bootstrapper
 
 [Install]
 WantedBy=multi-user.target

--- a/image/base/mkosi.skeleton/usr/lib/systemd/system/constellation-upgrade-agent.service
+++ b/image/base/mkosi.skeleton/usr/lib/systemd/system/constellation-upgrade-agent.service
@@ -8,7 +8,7 @@ RemainAfterExit=yes
 Restart=on-failure
 EnvironmentFile=/run/constellation.env
 Environment=PATH=/run/state/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
-ExecStart=/usr/bin/upgrade-agent $CONSTELLATION_DEBUG_FLAGS
+ExecStart=/usr/bin/upgrade-agent
 
 [Install]
 WantedBy=multi-user.target

--- a/upgrade-agent/cmd/main.go
+++ b/upgrade-agent/cmd/main.go
@@ -23,17 +23,14 @@ const (
 )
 
 func main() {
-	gRPCDebug := flag.Bool("debug", false, "Enable gRPC debug logging")
 	verbosity := flag.Int("v", 0, logger.CmdLineVerbosityDescription)
 	flag.Parse()
-
-	log := logger.NewJSONLogger(logger.VerbosityFromInt(*verbosity)).WithGroup("bootstrapper")
-
-	if *gRPCDebug {
-		logger.ReplaceGRPCLogger(log.WithGroup("gRPC"))
-	} else {
-		logger.ReplaceGRPCLogger(slog.New(logger.NewLevelHandler(slog.LevelWarn, log.Handler())).WithGroup("gRPC"))
-	}
+	log := logger.NewJSONLogger(logger.VerbosityFromInt(*verbosity)).WithGroup("upgrade-agent")
+	logger.ReplaceGRPCLogger(
+		slog.New(
+			logger.NewLevelHandler(logger.VerbosityFromInt(*verbosity), log.Handler()),
+		).WithGroup("gRPC"),
+	)
 
 	handler := file.NewHandler(afero.NewOsFs())
 	server, err := server.New(log, handler)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The bootstrapper vomits out a whole lot of gRPC debug logs, which don't seem very useful.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove the `debug` flag.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
