### PR TITLE
Update conditions on when to pick reviewer

### DIFF
--- a/.github/workflows/assign_reviewer.yml
+++ b/.github/workflows/assign_reviewer.yml
@@ -2,7 +2,12 @@ name: Assign Reviewer
 
 on:
   pull_request:
-    types: ["labeled"]
+    types:
+      - opened
+      - reopened
+      - edited
+      - review_request_removed
+      - labeled
 
 permissions:
   pull-requests: write
@@ -10,7 +15,7 @@ permissions:
 jobs:
   assign_reviewer:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'dependencies' && github.event.pull_request.user.login == 'app/renovate'
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies') && github.event.pull_request.user.login == 'app/renovate' && github.event.pull_request.requested_reviewers == null
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - name: Pick assignee

--- a/.github/workflows/assign_reviewer.yml
+++ b/.github/workflows/assign_reviewer.yml
@@ -15,7 +15,7 @@ permissions:
 jobs:
   assign_reviewer:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'dependencies') && github.event.pull_request.user.login == 'app/renovate' && github.event.pull_request.requested_reviewers == null
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies') && github.event.pull_request.requested_reviewers == null && (github.event.pull_request.user.login == 'renovate[bot]')
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - name: Pick assignee

--- a/.github/workflows/assign_reviewer.yml
+++ b/.github/workflows/assign_reviewer.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - reopened
       - edited
+      - synchronize
       - review_request_removed
       - labeled
 
@@ -15,7 +16,7 @@ permissions:
 jobs:
   assign_reviewer:
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'dependencies') && github.event.pull_request.requested_reviewers == null && (github.event.pull_request.user.login == 'renovate[bot]')
+    if: contains(github.event.pull_request.labels.*.name, 'dependencies') && toJson(github.event.pull_request.requested_reviewers) == '[]' &&  github.event.pull_request.user.login == 'renovate[bot]'
     steps:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
     - name: Pick assignee


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Lots of dependency PRs don't get assigned a reviewer.
I hope this PR fixes some of the cases where the review assignment  is skipped.

### Proposed change(s)


- Add more triggers to the assign_reviewer workflow
- Only run the workflow if no reviewers are assigned
- Update the name we check against to `renovate[bot]` following this comment: https://github.com/renovatebot/renovate/discussions/13704#discussioncomment-7079564

