### PR TITLE
flake: pin bazel to 7.1.2

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,13 +18,29 @@
         "type": "github"
       }
     },
-    "nixpkgsUnstable": {
+    "nixpkgsBazel": {
       "locked": {
-        "lastModified": 1715161350,
-        "narHash": "sha256-5ZU8DVwHO0gjw2sKoKkToYOXMJFRBpRsa17Ebm8fgj0=",
+        "lastModified": 1717414489,
+        "narHash": "sha256-fhvJv8hkJwotkqxhoSQfvh6UfKG+sTYIQ3hchariEDk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c4200cb341ee794775185ecd4105fbbfb5ca73a0",
+        "rev": "c429fa2ffa21229eeadbe37c11a47aff35f53ce0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c429fa2ffa21229eeadbe37c11a47aff35f53ce0",
+        "type": "github"
+      }
+    },
+    "nixpkgsUnstable": {
+      "locked": {
+        "lastModified": 1717399147,
+        "narHash": "sha256-eCWaE/q1VItpFAxxLVt171MdtDcjEnwi6QB/yuF73JU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4a4ecb0ab415c9fccfb005567a215e6a9564cdf5",
         "type": "github"
       },
       "original": {
@@ -37,6 +53,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nixpkgsBazel": "nixpkgsBazel",
         "nixpkgsUnstable": "nixpkgsUnstable",
         "uplosi": "uplosi"
       }
@@ -66,11 +83,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714468720,
-        "narHash": "sha256-i/RVCoeQLeOaPaEtJS/l+42CVohMucA6cBBt0mdJ4uE=",
+        "lastModified": 1715947971,
+        "narHash": "sha256-1YpxN5R3lEQnOUg94B2B/Ah2WDABUQTZ6kpyQMPt/xI=",
         "owner": "edgelesssys",
         "repo": "uplosi",
-        "rev": "7c881351a2f7c664d04c4e235562e5b427b167f2",
+        "rev": "73b6208ac21603bb69e8079fa8be821e590de286",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,11 @@
     nixpkgsUnstable = {
       url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     };
+    # TODO(msanft): Remove once https://github.com/NixOS/nixpkgs/commit/c429fa2ffa21229eeadbe37c11a47aff35f53ce0
+    # lands in nixpkgs-unstable.
+    nixpkgsBazel = {
+      url = "github:NixOS/nixpkgs/c429fa2ffa21229eeadbe37c11a47aff35f53ce0";
+    };
     flake-utils = {
       url = "github:numtide/flake-utils";
     };
@@ -18,12 +23,15 @@
   outputs =
     { self
     , nixpkgsUnstable
+    , nixpkgsBazel
     , flake-utils
     , uplosi
     }:
     flake-utils.lib.eachDefaultSystem (system:
     let
       pkgsUnstable = import nixpkgsUnstable { inherit system; };
+
+      bazelPkgsUnstable = import nixpkgsBazel { inherit system; };
 
       callPackage = pkgsUnstable.callPackage;
 
@@ -55,7 +63,7 @@
 
       openssl-static = pkgsUnstable.openssl.override { static = true; };
 
-      bazel_7 = callPackage ./nix/packages/bazel.nix { pkgs = pkgsUnstable; nixpkgs = nixpkgsUnstable; };
+      bazel_7 = bazelPkgsUnstable.callPackage ./nix/packages/bazel.nix { pkgs = bazelPkgsUnstable; nixpkgs = nixpkgsBazel; };
 
     in
     {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We updated Bazel to v7.1.2 in #3136, but Bazel is still on v7.1.0 in `nixpkgs-unstable`, where we source it from. Therefore, we need to pin the nixpkgs version against the exact commit that updated Bazel to v7.1.2 in nixpkgs, until that commit lands in `nixpkgs-unstable`.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Source Bazel from a pinned nixpkgs.
- Update the Nix flake.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
