### PR TITLE
bazel: use go_bin_for_host for all CI scripts

### DIFF
--- a/bazel/ci/BUILD.bazel
+++ b/bazel/ci/BUILD.bazel
@@ -57,10 +57,10 @@ sh_template(
 sh_template(
     name = "go_mod_tidy",
     data = [
-        "@io_bazel_rules_go//go",
+        ":go_bin_for_host",
     ],
     substitutions = {
-        "@@GO@@": "$(rootpath @io_bazel_rules_go//go)",
+        "@@GO@@": "$(rootpath :go_bin_for_host)",
     },
     template = "go_tidy.sh.in",
 )
@@ -234,10 +234,10 @@ sh_template(
     name = "golangci_lint",
     data = [
         ":com_github_golangci_golangci_lint",
-        "@io_bazel_rules_go//go",
+        ":go_bin_for_host",
     ],
     substitutions = {
-        "@@GO@@": "$(rootpath @io_bazel_rules_go//go)",
+        "@@GO@@": "$(rootpath :go_bin_for_host)",
         "@@GOLANGCI-LINT@@": "$(rootpath :com_github_golangci_golangci_lint)",
     },
     template = "golangci_lint.sh.in",
@@ -267,11 +267,11 @@ sh_template(
 sh_template(
     name = "golicenses_check",
     data = [
+        ":go_bin_for_host",
         "@com_github_google_go_licenses//:go-licenses",
-        "@io_bazel_rules_go//go",
     ],
     substitutions = {
-        "@@GO@@": "$(rootpath @io_bazel_rules_go//go)",
+        "@@GO@@": "$(rootpath :go_bin_for_host)",
         "@@GO_LICENSES@@": "$(rootpath @com_github_google_go_licenses//:go-licenses)",
     },
     template = "golicenses.sh.in",
@@ -287,11 +287,11 @@ sh_template(
 sh_template(
     name = "govulncheck",
     data = [
-        "@io_bazel_rules_go//go",
+        ":go_bin_for_host",
         "@org_golang_x_vuln//cmd/govulncheck",
     ],
     substitutions = {
-        "@@GO@@": "$(rootpath @io_bazel_rules_go//go)",
+        "@@GO@@": "$(rootpath :go_bin_for_host)",
         "@@GOVULNCHECK@@": "$(rootpath @org_golang_x_vuln//cmd/govulncheck:govulncheck)",
     },
     template = "govulncheck.sh.in",
@@ -322,15 +322,15 @@ sh_template(
     data = [
         ":com_github_helm_helm",
         ":com_github_siderolabs_talos_hack_docgen",
+        ":go_bin_for_host",
         "//internal/attestation/measurements/measurement-generator",
         "//internal/versions/hash-generator",
-        "@io_bazel_rules_go//go",
         "@org_golang_x_tools//cmd/stringer",
         "@yq_toolchains//:resolved_toolchain",
     ],
     substitutions = {
         "@@DOCGEN@@": "$(rootpath :com_github_siderolabs_talos_hack_docgen)",
-        "@@GO@@": "$(rootpath @io_bazel_rules_go//go)",
+        "@@GO@@": "$(rootpath :go_bin_for_host)",
         "@@HASH_GENERATOR@@": "$(rootpath //internal/versions/hash-generator:hash-generator)",
         "@@HELM@@": "$(rootpath :com_github_helm_helm)",
         "@@MEASUREMENT_GENERATOR@@": "$(rootpath //internal/attestation/measurements/measurement-generator:measurement-generator)",


### PR DESCRIPTION
### Context

Since we introduced bzlmod, using `@io_bazel_rules_go//go` as Go binary for CI scripts does not work anymore. Example:

```raw
$ bazel run //bazel/ci:govulncheck
Starting local Bazel server and connecting to it...
INFO: Analyzed target //bazel/ci:govulncheck (146 packages loaded, 12854 targets configured).
INFO: Found 1 target...
Target //bazel/ci:govulncheck up-to-date:
  bazel-bin/bazel/ci/govulncheck-script.bash
  bazel-bin/bazel/ci/govulncheck
INFO: Elapsed time: 4.579s, Critical Path: 0.44s
INFO: 6 processes: 6 internal.
INFO: Build completed successfully, 6 total actions
INFO: Running command line: bazel-bin/bazel/ci/govulncheck
2024/06/05 14:13:47 runfiles: no runfiles found
ERROR: /home/burger/.cache/bazel/_bazel_burger/71bc3bb25a3aa4f6aac591d8b4f36d9e/execroot/_main/bazel-out/k8-opt/bin/bazel/ci/govulncheck: 'submodules=$(${go} list -f '{{.Dir}}' -m)' failed at line 23
ERROR: /home/burger/.cache/bazel/_bazel_burger/71bc3bb25a3aa4f6aac591d8b4f36d9e/execroot/_main/bazel-out/k8-opt/bin/bazel/ci/govulncheck: exit status 1
```

The `//bazel/ci:check` target still works because the `gocoverage_diff` target uses `go_bin_for_host`, and that seems to provide the right runfiles for the other invocations, too.

### Proposed change(s)
- Switch the go binary to `go_bin_for_host` for all scripts.

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
