### PR TITLE
ci: don't filter output of govulncheck

### DIFF
--- a/bazel/ci/govulncheck.sh.in
+++ b/bazel/ci/govulncheck.sh.in
@@ -27,16 +27,11 @@ PATH=$(dirname "${go}"):${PATH}
 check() {
   err=0
 
-  echo "Scanning Go vulnerability DB for knwon vulnerabilities in modules:"
+  echo "Scanning Go vulnerability DB for known vulnerabilities in modules:"
   for mod in ${submodules}; do
     echo "  ${mod}"
     echo -n "  "
-    CGO_ENABLED=0 ${govulncheck} -C "${mod}" "./..." |
-      tail -n 2 | # Providing some nice output...
-      tr '\n' ' ' |
-      sed s/" your code and"// &&
-      printf "\n" ||
-      err=$?
+    CGO_ENABLED=0 ${govulncheck} -C "${mod}" "./..." || err=$?
   done
 
   exit "${err}"


### PR DESCRIPTION
### Context

We have a unix pipeline for filtering the output of govulncheck. It seems like the output format changed since it was introduced, because the filtered output does not make much sense at the moment.

### Proposed change(s)
- Don't filter the output, trading in beauty for lower maintenance effort.

### Additional info
- Example output: https://github.com/edgelesssys/constellation/actions/runs/9383762951/job/25838113072#step:12:196

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
