### PR TITLE
debugd: remove `--debug` flag from bootstrapper service created by debugd

### DIFF
--- a/debugd/internal/debugd/deploy/service.go
+++ b/debugd/internal/debugd/deploy/service.go
@@ -172,7 +172,7 @@ func (s *ServiceManager) OverrideServiceUnitExecStart(ctx context.Context, unitN
 	if strings.Contains(execStart, "\n") || strings.Contains(execStart, "\r") {
 		return fmt.Errorf("execStart must not contain newlines")
 	}
-	overrideUnitContents := fmt.Sprintf("[Service]\nExecStart=\nExecStart=%s $CONSTELLATION_DEBUG_FLAGS\n", execStart)
+	overrideUnitContents := fmt.Sprintf("[Service]\nExecStart=\nExecStart=%s\n", execStart)
 	s.systemdUnitFilewriteLock.Lock()
 	defer s.systemdUnitFilewriteLock.Unlock()
 	path := filepath.Join(systemdUnitFolder, unitName+".service.d", "override.conf")

--- a/debugd/internal/debugd/deploy/service_test.go
+++ b/debugd/internal/debugd/deploy/service_test.go
@@ -218,7 +218,7 @@ func TestOverrideServiceUnitExecStart(t *testing.T) {
 			},
 			unitName:         "test",
 			execStart:        "/run/state/bin/test",
-			wantFileContents: "[Service]\nExecStart=\nExecStart=/run/state/bin/test $CONSTELLATION_DEBUG_FLAGS\n",
+			wantFileContents: "[Service]\nExecStart=\nExecStart=/run/state/bin/test\n",
 			wantActionCalls: []dbusConnActionInput{
 				{name: "test.service", mode: "replace"},
 			},
@@ -264,7 +264,7 @@ func TestOverrideServiceUnitExecStart(t *testing.T) {
 			},
 			unitName:         "test",
 			execStart:        "/run/state/bin/test",
-			wantFileContents: "[Service]\nExecStart=\nExecStart=/run/state/bin/test $CONSTELLATION_DEBUG_FLAGS\n",
+			wantFileContents: "[Service]\nExecStart=\nExecStart=/run/state/bin/test\n",
 			wantActionCalls: []dbusConnActionInput{
 				{name: "test.service", mode: "replace"},
 			},


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The `--debug` flag was removed from the bootstrapper, yet the debugd still sets it when creating the service unit.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- remove `--debug` from the service created by debugd

### Related issue
- https://github.com/edgelesssys/issues/issues/658

### Additional info
<!-- Remove items that do not apply -->
- Will built a new debug image once this is merged to main

