### PR TITLE
docs: adjust MAA updating

### DIFF
--- a/docs/docs/getting-started/install.md
+++ b/docs/docs/getting-started/install.md
@@ -188,7 +188,7 @@ Follow Amazon's guide on [understanding](https://docs.aws.amazon.com/IAM/latest/
 
 The following [resource providers need to be registered](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider) in your subscription:
 
-* `Microsoft.Attestation` \[2]
+* `Microsoft.Attestation`
 * `Microsoft.Compute`
 * `Microsoft.Insights`
 * `Microsoft.ManagedIdentity`
@@ -208,7 +208,7 @@ The built-in `Owner` role is a superset of these permissions.
 
 To [create a Constellation cluster](../workflows/create.md), you need the following permissions:
 
-* `Microsoft.Attestation/attestationProviders/*` \[2]
+* `Microsoft.Attestation/attestationProviders/*`
 * `Microsoft.Compute/virtualMachineScaleSets/*`
 * `Microsoft.Insights/components/*`
 * `Microsoft.ManagedIdentity/userAssignedIdentities/*`
@@ -225,8 +225,6 @@ The built-in `Contributor` role is a superset of these permissions.
 Follow Microsoft's guide on [understanding](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions) and [assigning roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments).
 
 1: You can omit `*/register/Action` if the resource providers mentioned above are already registered and the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable is set to `true` when creating the IAM configuration.
-
-2: You can omit `Microsoft.Attestation/attestationProviders/*` and the registration of `Microsoft.Attestation` if `EnforceIDKeyDigest` isn't set to `MAAFallback` in the [config file](../workflows/config.md#configure-your-cluster).
 
 </tabItem>
 <tabItem value="gcp" label="GCP">

--- a/docs/docs/workflows/create.md
+++ b/docs/docs/workflows/create.md
@@ -56,7 +56,7 @@ management tooling of your choice. You need to keep the essential functionality 
 
 :::info
 
-  On Azure, if the enforcement policy is set to `MAAFallback` in `constellation-config.yaml`, a manual update to the MAA provider's policy is necessary.
+  On Azure, a manual update to the MAA provider's policy is necessary.
   You can apply the update with the following command after creating the infrastructure, with `<URL>` being the URL of the MAA provider (i.e., `$(terraform output attestation_url | jq -r)`, when using the minimal Terraform configuration).
 
   ```bash

--- a/docs/versioned_docs/version-2.10/getting-started/install.md
+++ b/docs/versioned_docs/version-2.10/getting-started/install.md
@@ -109,7 +109,7 @@ If you don't have a cloud subscription, you can also set up a [local Constellati
 <tabItem value="azure" label="Azure">
 
 The following [resource providers need to be registered](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider) in your subscription:
-* `Microsoft.Attestation` \[2]
+* `Microsoft.Attestation`
 * `Microsoft.Compute`
 * `Microsoft.Insights`
 * `Microsoft.ManagedIdentity`
@@ -127,7 +127,7 @@ To [create the IAM configuration](../workflows/config.md#creating-an-iam-configu
 The built-in `Owner` role is a superset of these permissions.
 
 To [create a Constellation cluster](../workflows/create.md#the-create-step), you need the following permissions:
-* `Microsoft.Attestation/attestationProviders/*` \[2]
+* `Microsoft.Attestation/attestationProviders/*`
 * `Microsoft.Compute/virtualMachineScaleSets/*`
 * `Microsoft.Insights/components/*`
 * `Microsoft.ManagedIdentity/userAssignedIdentities/*`
@@ -144,8 +144,6 @@ The built-in `Contributor` role is a superset of these permissions.
 Follow Microsoft's guide on [understanding](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions) and [assigning roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments).
 
 1: You can omit `*/register/Action` if the resource providers mentioned above are already registered and the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable is set to `true` when creating the IAM configuration.
-
-2: You can omit `Microsoft.Attestation/attestationProviders/*` and the registration of `Microsoft.Attestation` if `EnforceIDKeyDigest` isn't set to `MAAFallback` in the [config file](../workflows/config.md#configure-your-cluster).
 
 </tabItem>
 <tabItem value="gcp" label="GCP">

--- a/docs/versioned_docs/version-2.11/getting-started/install.md
+++ b/docs/versioned_docs/version-2.11/getting-started/install.md
@@ -127,7 +127,7 @@ To [create the IAM configuration](../workflows/config.md#creating-an-iam-configu
 The built-in `Owner` role is a superset of these permissions.
 
 To [create a Constellation cluster](../workflows/create.md#the-create-step), you need the following permissions:
-* `Microsoft.Attestation/attestationProviders/*` \[2]
+* `Microsoft.Attestation/attestationProviders/*`
 * `Microsoft.Compute/virtualMachineScaleSets/*`
 * `Microsoft.Insights/components/*`
 * `Microsoft.ManagedIdentity/userAssignedIdentities/*`
@@ -144,8 +144,6 @@ The built-in `Contributor` role is a superset of these permissions.
 Follow Microsoft's guide on [understanding](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions) and [assigning roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments).
 
 1: You can omit `*/register/Action` if the resource providers mentioned above are already registered and the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable is set to `true` when creating the IAM configuration.
-
-2: You can omit `Microsoft.Attestation/attestationProviders/*` and the registration of `Microsoft.Attestation` if `EnforceIDKeyDigest` isn't set to `MAAFallback` in the [config file](../workflows/config.md#configure-your-cluster).
 
 </tabItem>
 <tabItem value="gcp" label="GCP">

--- a/docs/versioned_docs/version-2.12/getting-started/install.md
+++ b/docs/versioned_docs/version-2.12/getting-started/install.md
@@ -109,7 +109,7 @@ If you don't have a cloud subscription, you can also set up a [local Constellati
 <tabItem value="azure" label="Azure">
 
 The following [resource providers need to be registered](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider) in your subscription:
-* `Microsoft.Attestation` \[2]
+* `Microsoft.Attestation`
 * `Microsoft.Compute`
 * `Microsoft.Insights`
 * `Microsoft.ManagedIdentity`
@@ -127,7 +127,7 @@ To [create the IAM configuration](../workflows/config.md#creating-an-iam-configu
 The built-in `Owner` role is a superset of these permissions.
 
 To [create a Constellation cluster](../workflows/create.md#the-create-step), you need the following permissions:
-* `Microsoft.Attestation/attestationProviders/*` \[2]
+* `Microsoft.Attestation/attestationProviders/*`
 * `Microsoft.Compute/virtualMachineScaleSets/*`
 * `Microsoft.Insights/components/*`
 * `Microsoft.ManagedIdentity/userAssignedIdentities/*`
@@ -144,8 +144,6 @@ The built-in `Contributor` role is a superset of these permissions.
 Follow Microsoft's guide on [understanding](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions) and [assigning roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments).
 
 1: You can omit `*/register/Action` if the resource providers mentioned above are already registered and the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable is set to `true` when creating the IAM configuration.
-
-2: You can omit `Microsoft.Attestation/attestationProviders/*` and the registration of `Microsoft.Attestation` if `EnforceIDKeyDigest` isn't set to `MAAFallback` in the [config file](../workflows/config.md#configure-your-cluster).
 
 </tabItem>
 <tabItem value="gcp" label="GCP">

--- a/docs/versioned_docs/version-2.13/getting-started/install.md
+++ b/docs/versioned_docs/version-2.13/getting-started/install.md
@@ -109,7 +109,7 @@ If you don't have a cloud subscription, you can also set up a [local Constellati
 <tabItem value="azure" label="Azure">
 
 The following [resource providers need to be registered](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider) in your subscription:
-* `Microsoft.Attestation` \[2]
+* `Microsoft.Attestation`
 * `Microsoft.Compute`
 * `Microsoft.Insights`
 * `Microsoft.ManagedIdentity`
@@ -127,7 +127,7 @@ To [create the IAM configuration](../workflows/config.md#creating-an-iam-configu
 The built-in `Owner` role is a superset of these permissions.
 
 To [create a Constellation cluster](../workflows/create.md#the-create-step), you need the following permissions:
-* `Microsoft.Attestation/attestationProviders/*` \[2]
+* `Microsoft.Attestation/attestationProviders/*`
 * `Microsoft.Compute/virtualMachineScaleSets/*`
 * `Microsoft.Insights/components/*`
 * `Microsoft.ManagedIdentity/userAssignedIdentities/*`
@@ -144,8 +144,6 @@ The built-in `Contributor` role is a superset of these permissions.
 Follow Microsoft's guide on [understanding](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions) and [assigning roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments).
 
 1: You can omit `*/register/Action` if the resource providers mentioned above are already registered and the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable is set to `true` when creating the IAM configuration.
-
-2: You can omit `Microsoft.Attestation/attestationProviders/*` and the registration of `Microsoft.Attestation` if `EnforceIDKeyDigest` isn't set to `MAAFallback` in the [config file](../workflows/config.md#configure-your-cluster).
 
 </tabItem>
 <tabItem value="gcp" label="GCP">

--- a/docs/versioned_docs/version-2.13/workflows/create.md
+++ b/docs/versioned_docs/version-2.13/workflows/create.md
@@ -55,7 +55,7 @@ management tooling of your choice. You need to keep the essential functionality 
 
 :::info
 
-  On Azure, if the enforcement policy is set to `MAAFallback` in `constellation-config.yaml`, a manual update to the MAA provider's policy is necessary.
+  On Azure, a manual update to the MAA provider's policy is necessary.
   You can apply the update with the following command after creating the infrastructure, with `<URL>` being the URL of the MAA provider (i.e., `$(terraform output attestationURL | jq -r)`, when using the minimal Terraform configuration).
 
   ```bash

--- a/docs/versioned_docs/version-2.14/getting-started/install.md
+++ b/docs/versioned_docs/version-2.14/getting-started/install.md
@@ -114,7 +114,7 @@ If you don't have a cloud subscription, you can also set up a [local Constellati
 
 The following [resource providers need to be registered](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider) in your subscription:
 
-* `Microsoft.Attestation` \[2]
+* `Microsoft.Attestation`
 * `Microsoft.Compute`
 * `Microsoft.Insights`
 * `Microsoft.ManagedIdentity`
@@ -134,7 +134,7 @@ The built-in `Owner` role is a superset of these permissions.
 
 To [create a Constellation cluster](../workflows/create.md), you need the following permissions:
 
-* `Microsoft.Attestation/attestationProviders/*` \[2]
+* `Microsoft.Attestation/attestationProviders/*`
 * `Microsoft.Compute/virtualMachineScaleSets/*`
 * `Microsoft.Insights/components/*`
 * `Microsoft.ManagedIdentity/userAssignedIdentities/*`
@@ -151,8 +151,6 @@ The built-in `Contributor` role is a superset of these permissions.
 Follow Microsoft's guide on [understanding](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions) and [assigning roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments).
 
 1: You can omit `*/register/Action` if the resource providers mentioned above are already registered and the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable is set to `true` when creating the IAM configuration.
-
-2: You can omit `Microsoft.Attestation/attestationProviders/*` and the registration of `Microsoft.Attestation` if `EnforceIDKeyDigest` isn't set to `MAAFallback` in the [config file](../workflows/config.md#configure-your-cluster).
 
 </tabItem>
 <tabItem value="gcp" label="GCP">

--- a/docs/versioned_docs/version-2.14/workflows/create.md
+++ b/docs/versioned_docs/version-2.14/workflows/create.md
@@ -56,7 +56,7 @@ management tooling of your choice. You need to keep the essential functionality 
 
 :::info
 
-  On Azure, if the enforcement policy is set to `MAAFallback` in `constellation-config.yaml`, a manual update to the MAA provider's policy is necessary.
+  On Azure, a manual update to the MAA provider's policy is necessary.
   You can apply the update with the following command after creating the infrastructure, with `<URL>` being the URL of the MAA provider (i.e., `$(terraform output attestation_url | jq -r)`, when using the minimal Terraform configuration).
 
   ```bash

--- a/docs/versioned_docs/version-2.15/getting-started/install.md
+++ b/docs/versioned_docs/version-2.15/getting-started/install.md
@@ -114,7 +114,7 @@ If you don't have a cloud subscription, you can also set up a [local Constellati
 
 The following [resource providers need to be registered](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider) in your subscription:
 
-* `Microsoft.Attestation` \[2]
+* `Microsoft.Attestation`
 * `Microsoft.Compute`
 * `Microsoft.Insights`
 * `Microsoft.ManagedIdentity`
@@ -134,7 +134,7 @@ The built-in `Owner` role is a superset of these permissions.
 
 To [create a Constellation cluster](../workflows/create.md), you need the following permissions:
 
-* `Microsoft.Attestation/attestationProviders/*` \[2]
+* `Microsoft.Attestation/attestationProviders/*`
 * `Microsoft.Compute/virtualMachineScaleSets/*`
 * `Microsoft.Insights/components/*`
 * `Microsoft.ManagedIdentity/userAssignedIdentities/*`
@@ -151,8 +151,6 @@ The built-in `Contributor` role is a superset of these permissions.
 Follow Microsoft's guide on [understanding](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions) and [assigning roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments).
 
 1: You can omit `*/register/Action` if the resource providers mentioned above are already registered and the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable is set to `true` when creating the IAM configuration.
-
-2: You can omit `Microsoft.Attestation/attestationProviders/*` and the registration of `Microsoft.Attestation` if `EnforceIDKeyDigest` isn't set to `MAAFallback` in the [config file](../workflows/config.md#configure-your-cluster).
 
 </tabItem>
 <tabItem value="gcp" label="GCP">

--- a/docs/versioned_docs/version-2.15/workflows/create.md
+++ b/docs/versioned_docs/version-2.15/workflows/create.md
@@ -56,7 +56,7 @@ management tooling of your choice. You need to keep the essential functionality 
 
 :::info
 
-  On Azure, if the enforcement policy is set to `MAAFallback` in `constellation-config.yaml`, a manual update to the MAA provider's policy is necessary.
+  On Azure, a manual update to the MAA provider's policy is necessary.
   You can apply the update with the following command after creating the infrastructure, with `<URL>` being the URL of the MAA provider (i.e., `$(terraform output attestation_url | jq -r)`, when using the minimal Terraform configuration).
 
   ```bash

--- a/docs/versioned_docs/version-2.16/getting-started/install.md
+++ b/docs/versioned_docs/version-2.16/getting-started/install.md
@@ -188,7 +188,7 @@ Follow Amazon's guide on [understanding](https://docs.aws.amazon.com/IAM/latest/
 
 The following [resource providers need to be registered](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider) in your subscription:
 
-* `Microsoft.Attestation` \[2]
+* `Microsoft.Attestation`
 * `Microsoft.Compute`
 * `Microsoft.Insights`
 * `Microsoft.ManagedIdentity`
@@ -208,7 +208,7 @@ The built-in `Owner` role is a superset of these permissions.
 
 To [create a Constellation cluster](../workflows/create.md), you need the following permissions:
 
-* `Microsoft.Attestation/attestationProviders/*` \[2]
+* `Microsoft.Attestation/attestationProviders/*`
 * `Microsoft.Compute/virtualMachineScaleSets/*`
 * `Microsoft.Insights/components/*`
 * `Microsoft.ManagedIdentity/userAssignedIdentities/*`
@@ -225,8 +225,6 @@ The built-in `Contributor` role is a superset of these permissions.
 Follow Microsoft's guide on [understanding](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions) and [assigning roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments).
 
 1: You can omit `*/register/Action` if the resource providers mentioned above are already registered and the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable is set to `true` when creating the IAM configuration.
-
-2: You can omit `Microsoft.Attestation/attestationProviders/*` and the registration of `Microsoft.Attestation` if `EnforceIDKeyDigest` isn't set to `MAAFallback` in the [config file](../workflows/config.md#configure-your-cluster).
 
 </tabItem>
 <tabItem value="gcp" label="GCP">

--- a/docs/versioned_docs/version-2.16/workflows/create.md
+++ b/docs/versioned_docs/version-2.16/workflows/create.md
@@ -56,7 +56,7 @@ management tooling of your choice. You need to keep the essential functionality 
 
 :::info
 
-  On Azure, if the enforcement policy is set to `MAAFallback` in `constellation-config.yaml`, a manual update to the MAA provider's policy is necessary.
+  On Azure, a manual update to the MAA provider's policy is necessary.
   You can apply the update with the following command after creating the infrastructure, with `<URL>` being the URL of the MAA provider (i.e., `$(terraform output attestation_url | jq -r)`, when using the minimal Terraform configuration).
 
   ```bash

--- a/docs/versioned_docs/version-2.7/getting-started/install.md
+++ b/docs/versioned_docs/version-2.7/getting-started/install.md
@@ -109,7 +109,7 @@ If you don't have a cloud subscription, you can try [MiniConstellation](first-st
 <tabItem value="azure" label="Azure">
 
 The following [resource providers need to be registered](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider) in your subscription:
-* `Microsoft.Attestation` \[2]
+* `Microsoft.Attestation`
 * `Microsoft.Compute`
 * `Microsoft.Insights`
 * `Microsoft.ManagedIdentity`
@@ -127,7 +127,7 @@ To [create the IAM configuration](../workflows/config.md#creating-an-iam-configu
 The built-in `Owner` role is a superset of these permissions.
 
 To [create a Constellation cluster](../workflows/create.md#the-create-step), you need the following permissions:
-* `Microsoft.Attestation/attestationProviders/*` \[2]
+* `Microsoft.Attestation/attestationProviders/*`
 * `Microsoft.Compute/virtualMachineScaleSets/*`
 * `Microsoft.Insights/components/*`
 * `Microsoft.ManagedIdentity/userAssignedIdentities/*`
@@ -143,8 +143,6 @@ The built-in `Contributor` role is a superset of these permissions.
 Follow Microsoft's guide on [understanding](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions) and [assigning roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments).
 
 1: You can omit `*/register/Action` if the resource providers mentioned above are already registered and the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable is set to `true` when creating the IAM configuration.
-
-2: You can omit `Microsoft.Attestation/attestationProviders/*` and the registration of `Microsoft.Attestation` if `EnforceIDKeyDigest` isn't set to `MAAFallback` in the [config file](../workflows/config.md#configure-your-cluster).
 
 </tabItem>
 <tabItem value="gcp" label="GCP">

--- a/docs/versioned_docs/version-2.8/getting-started/install.md
+++ b/docs/versioned_docs/version-2.8/getting-started/install.md
@@ -109,7 +109,7 @@ If you don't have a cloud subscription, you can also set up a [local Constellati
 <tabItem value="azure" label="Azure">
 
 The following [resource providers need to be registered](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider) in your subscription:
-* `Microsoft.Attestation` \[2]
+* `Microsoft.Attestation`
 * `Microsoft.Compute`
 * `Microsoft.Insights`
 * `Microsoft.ManagedIdentity`
@@ -127,7 +127,7 @@ To [create the IAM configuration](../workflows/config.md#creating-an-iam-configu
 The built-in `Owner` role is a superset of these permissions.
 
 To [create a Constellation cluster](../workflows/create.md#the-create-step), you need the following permissions:
-* `Microsoft.Attestation/attestationProviders/*` \[2]
+* `Microsoft.Attestation/attestationProviders/*`
 * `Microsoft.Compute/virtualMachineScaleSets/*`
 * `Microsoft.Insights/components/*`
 * `Microsoft.ManagedIdentity/userAssignedIdentities/*`
@@ -144,8 +144,6 @@ The built-in `Contributor` role is a superset of these permissions.
 Follow Microsoft's guide on [understanding](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions) and [assigning roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments).
 
 1: You can omit `*/register/Action` if the resource providers mentioned above are already registered and the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable is set to `true` when creating the IAM configuration.
-
-2: You can omit `Microsoft.Attestation/attestationProviders/*` and the registration of `Microsoft.Attestation` if `EnforceIDKeyDigest` isn't set to `MAAFallback` in the [config file](../workflows/config.md#configure-your-cluster).
 
 </tabItem>
 <tabItem value="gcp" label="GCP">

--- a/docs/versioned_docs/version-2.9/getting-started/install.md
+++ b/docs/versioned_docs/version-2.9/getting-started/install.md
@@ -109,7 +109,7 @@ If you don't have a cloud subscription, you can also set up a [local Constellati
 <tabItem value="azure" label="Azure">
 
 The following [resource providers need to be registered](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/resource-providers-and-types#register-resource-provider) in your subscription:
-* `Microsoft.Attestation` \[2]
+* `Microsoft.Attestation`
 * `Microsoft.Compute`
 * `Microsoft.Insights`
 * `Microsoft.ManagedIdentity`
@@ -127,7 +127,7 @@ To [create the IAM configuration](../workflows/config.md#creating-an-iam-configu
 The built-in `Owner` role is a superset of these permissions.
 
 To [create a Constellation cluster](../workflows/create.md#the-create-step), you need the following permissions:
-* `Microsoft.Attestation/attestationProviders/*` \[2]
+* `Microsoft.Attestation/attestationProviders/*`
 * `Microsoft.Compute/virtualMachineScaleSets/*`
 * `Microsoft.Insights/components/*`
 * `Microsoft.ManagedIdentity/userAssignedIdentities/*`
@@ -144,8 +144,6 @@ The built-in `Contributor` role is a superset of these permissions.
 Follow Microsoft's guide on [understanding](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions) and [assigning roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments).
 
 1: You can omit `*/register/Action` if the resource providers mentioned above are already registered and the `ARM_SKIP_PROVIDER_REGISTRATION` environment variable is set to `true` when creating the IAM configuration.
-
-2: You can omit `Microsoft.Attestation/attestationProviders/*` and the registration of `Microsoft.Attestation` if `EnforceIDKeyDigest` isn't set to `MAAFallback` in the [config file](../workflows/config.md#configure-your-cluster).
 
 </tabItem>
 <tabItem value="gcp" label="GCP">


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The docs said that the permissions for updating the MAA policy are only required if the enforcement policy is set to use the MAA. However, this does not reflect our current code, which creates and patches the MAA unconditionally. This is necessary to ensure that a cluster created without using the MAA can switch to using the MAA later on.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove the parts of the docs saying that the MAA-related permissions are only necessary if the enforcement policy is set to `MAAFallback`.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
