### PR TITLE
cli: return a more helpful error message on MAA patch failure

### DIFF
--- a/internal/maa/patch.go
+++ b/internal/maa/patch.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/profiles/latest/attestation/attestation"
@@ -55,10 +56,14 @@ func (p AzurePolicyPatcher) Patch(ctx context.Context, attestationURL string) er
 	if err != nil {
 		return fmt.Errorf("sending request: %w", err)
 	}
-	resp.Body.Close()
+	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("updating attestation policy: unexpected status code: %s", resp.Status)
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("updating attestation policy: unexpected status code: %s\nread response body: %w", resp.Status, err)
+		}
+		return fmt.Errorf("updating attestation policy: unexpected status code: %s\nresponse body: %s", resp.Status, string(body))
 	}
 
 	return nil

--- a/internal/maa/patch.go
+++ b/internal/maa/patch.go
@@ -59,11 +59,8 @@ func (p AzurePolicyPatcher) Patch(ctx context.Context, attestationURL string) er
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("updating attestation policy: unexpected status code: %s\nread response body: %w", resp.Status, err)
-		}
-		return fmt.Errorf("updating attestation policy: unexpected status code: %s\nresponse body: %s", resp.Status, string(body))
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("updating attestation policy: unexpected status code: %s: %s", resp.Status, string(body))
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The updating of the MAA policy is not done via Terraform, hence failures cannot be debugged through the Terraform logs. We only return the status code currently, which is not very helpful for users running into a failure here. The response body should inform the user about which permissions are missing, hence it should also be shown to the user.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Return both status code and response body in case of a policy patching failure.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
