### PR TITLE
fix: let `artifact_upload` fail if a bash command errors

### DIFF
--- a/.github/actions/artifact_upload/action.yml
+++ b/.github/actions/artifact_upload/action.yml
@@ -36,6 +36,7 @@ runs:
     - name: Create archive
       shell: bash
       run: |
+        set -euo pipefail
         shopt -s extglob
         paths="${{ inputs.path }}"
         paths=${paths%$'\n'} # Remove trailing newline
@@ -61,9 +62,9 @@ runs:
         do
           if compgen -G "${target}" > /dev/null
           then
-            pushd "$(dirname "${target}")" || exit 1
+            pushd "$(dirname "${target}")"
             7zz a -p'${{ inputs.encryptionSecret }}' -bso0 -bsp0 -t7z -ms=on -mhe=on "${{ steps.tempdir.outputs.directory }}/archive.7z" "$(basename "${target}")"
-            popd || exit 1
+            popd
           fi
         done
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Currently, the `artifact_upload` CI action does not necessarily fail if an executed command fails. This PR fixes that behaviour.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add `set -euo pipefail` in the `artifact_upload` action

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [link to e2e run](https://github.com/edgelesssys/constellation/actions/runs/9415759017)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
