### PR TITLE
debugd: return systemd logs if restarting a unit fails

### DIFF
--- a/debugd/internal/debugd/deploy/service_test.go
+++ b/debugd/internal/debugd/deploy/service_test.go
@@ -104,6 +104,7 @@ func TestSystemdAction(t *testing.T) {
 			manager := ServiceManager{
 				log:                      logger.NewTest(t),
 				dbus:                     &tc.dbus,
+				journal:                  &stubJournalReader{},
 				fs:                       fs,
 				systemdUnitFilewriteLock: sync.Mutex{},
 			}
@@ -183,6 +184,7 @@ func TestWriteSystemdUnitFile(t *testing.T) {
 			manager := ServiceManager{
 				log:                      logger.NewTest(t),
 				dbus:                     &tc.dbus,
+				journal:                  &stubJournalReader{},
 				fs:                       fs,
 				systemdUnitFilewriteLock: sync.Mutex{},
 			}
@@ -296,6 +298,7 @@ func TestOverrideServiceUnitExecStart(t *testing.T) {
 			manager := ServiceManager{
 				log:                      logger.NewTest(t),
 				dbus:                     &tc.dbus,
+				journal:                  &stubJournalReader{},
 				fs:                       fs,
 				systemdUnitFilewriteLock: sync.Mutex{},
 			}
@@ -367,3 +370,9 @@ func (c *fakeDbusConn) ReloadContext(_ context.Context) error {
 }
 
 func (c *fakeDbusConn) Close() {}
+
+type stubJournalReader struct{}
+
+func (s *stubJournalReader) readJournal(_ string) string {
+	return ""
+}

--- a/debugd/internal/debugd/deploy/wrappers.go
+++ b/debugd/internal/debugd/deploy/wrappers.go
@@ -58,6 +58,9 @@ func (j *journalctlWrapper) readJournal(unit string) string {
 }
 
 /*
+// Preferably, we would use the systemd journal API directly.
+// However, this requires linking against systemd libraries, so we go with the easier journalctl command for now.
+
 type sdJournalWrapper struct{}
 
 // readJournal reads the journal for a specific unit.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
We have observed multiple cases of `debugd` failing when the `bootstrapper` unit should be restarted.
This is tracked in https://github.com/edgelesssys/issues/issues/609
Since this happens rather early in the deployment process, we don't have any logs pushed to OpenSearch at this point

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Read and return systemd logs of the unit that failed to be restarted on failure
- Wait until logcollection containers are running before continuing
  - This doesn't really solve the issue of no logs being pushed to OpenSearch since logs are not pushed on creation, but aggregated every 30 seconds and then pushed to OpenSearch, but I think its a good practice regardless
