### PR TITLE
attetstation: enable Azure TDX CRL checking

### DIFF
--- a/internal/attestation/azure/tdx/validator.go
+++ b/internal/attestation/azure/tdx/validator.go
@@ -93,11 +93,10 @@ func (v *Validator) validateQuote(tdxQuote *tdx.QuoteV4) error {
 	roots.AddCert((*x509.Certificate)(&v.cfg.IntelRootKey))
 
 	if err := verify.TdxQuote(tdxQuote, &verify.Options{
-		// TODO: Re-enable CRL checking once issues on Azure's side are resolved.
-		// CheckRevocations: true,
-		// GetCollateral:    true,
-		TrustedRoots: roots,
-		Getter:       v.getter,
+		CheckRevocations: true,
+		GetCollateral:    true,
+		TrustedRoots:     roots,
+		Getter:           v.getter,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Azure updated their Intel TDX firmware, so its now actually compatible with the TCB info returned by Intel's PCS.
This means we can use the PCS to perform CRL checks on the TDX certificates.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Enable collateral retrieval and CRL checking for Azure TDX

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [Azure TDX e2e test](https://github.com/edgelesssys/constellation/actions/runs/9462669036)
