### PR TITLE
cli: enable JSON output for `constellation verify` on Azure TDX

### DIFF
--- a/cli/internal/cmd/BUILD.bazel
+++ b/cli/internal/cmd/BUILD.bazel
@@ -111,6 +111,9 @@ go_library(
         "@io_k8s_sigs_yaml//:yaml",
         "@org_golang_x_mod//semver",
         "@org_golang_google_grpc//:grpc",
+        "@com_github_google_go_tdx_guest//abi",
+        "@com_github_google_go_tdx_guest//proto/tdx",
+        "//internal/attestation/azure/tdx",
     ] + select({
         "@io_bazel_rules_go//go/platform:android_amd64": [
             "@org_golang_x_sys//unix",

--- a/internal/attestation/azure/tdx/issuer.go
+++ b/internal/attestation/azure/tdx/issuer.go
@@ -90,7 +90,7 @@ func (i *Issuer) getInstanceInfo(ctx context.Context, tpm io.ReadWriteCloser, _ 
 		return nil, fmt.Errorf("getting quote: %w", err)
 	}
 
-	instanceInfo := instanceInfo{
+	instanceInfo := InstanceInfo{
 		AttestationReport: quote,
 		RuntimeData:       runtimeData,
 	}

--- a/internal/attestation/azure/tdx/tdx.go
+++ b/internal/attestation/azure/tdx/tdx.go
@@ -19,7 +19,8 @@ More specifically:
 */
 package tdx
 
-type instanceInfo struct {
+// InstanceInfo wraps the TDX report with additional Azure specific runtime data.
+type InstanceInfo struct {
 	AttestationReport []byte
 	RuntimeData       []byte
 }

--- a/internal/attestation/azure/tdx/validator.go
+++ b/internal/attestation/azure/tdx/validator.go
@@ -58,7 +58,7 @@ func NewValidator(cfg *config.AzureTDX, log attestation.Logger) *Validator {
 }
 
 func (v *Validator) getTrustedTPMKey(_ context.Context, attDoc vtpm.AttestationDocument, _ []byte) (crypto.PublicKey, error) {
-	var instanceInfo instanceInfo
+	var instanceInfo InstanceInfo
 	if err := json.Unmarshal(attDoc.InstanceInfo, &instanceInfo); err != nil {
 		return nil, err
 	}

--- a/internal/verify/verify.go
+++ b/internal/verify/verify.go
@@ -157,7 +157,7 @@ func getCertChain(cfg config.AttestationCfg) ([]byte, error) {
 	return certChain, nil
 }
 
-// FormatString builds a string representation of a report that is inteded for console output.
+// FormatString builds a string representation of a report that is intended for console output.
 func (r *Report) FormatString(b *strings.Builder) (string, error) {
 	if len(r.ReportSigner) != 1 {
 		return "", fmt.Errorf("expected exactly one report signing certificate, found %d", len(r.ReportSigner))


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Our CI parses the JSON output of `constellation verify` in order to upload the latest CC claims to Constellation's CDN.
For now, this was only enabled for SEV-SNP attestation variants.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Enabled JSON output for Azure TDX
  - The TDX library we use also handles JSON marshalling of the quote, so I didn't implement any extra methods, unlike we did for SNP. This means we won't have pretty formatted text output for TDX variants, but this can always be added at a later date since it doesn't have high priority: [AB#4266](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/4266)
- Simplify the `constellation verify` code a bit by removing the formatter factory

### Additional info
<!-- Remove items that do not apply -->
- [AB#3798](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/3798)

