### PR TITLE
ci: make cdbg deploy errors easier to spot

### DIFF
--- a/.github/actions/cdbg_deploy/action.yml
+++ b/.github/actions/cdbg_deploy/action.yml
@@ -112,4 +112,8 @@ runs:
           --info logcollect.deployment-type="debugd" \
           --verbosity=-1 \
           --force
+          if [[ $? -ne 0 ]]; then
+            echo "::error::cdbg deploy failed"
+            exit 1
+          fi
         echo "::endgroup::"


### PR DESCRIPTION
### Context

We had a couple of failed `cdbg deploy` steps recently, which are incredibly hard to spot in the logs because they are hidden in the log group. Adding an explicit `::error::` should highlight them. 

### Proposed change(s)

- Write an error message if `cdbg deploy` failed.


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] https://github.com/edgelesssys/constellation/actions/runs/9512506797
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
