### PR TITLE
ci: don't assign 3u13r for e2e failures

### DIFF
--- a/.github/actions/pick_assignee/action.yml
+++ b/.github/actions/pick_assignee/action.yml
@@ -15,7 +15,6 @@ runs:
       run: |
         possibleAssignees=(
           "elchead"
-          "3u13r"
           "daniel-weisse"
           "msanft"
           "burgerdev"


### PR DESCRIPTION


### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
