### PR TITLE
ci: better fence around tidy-check-generate summary

### DIFF
--- a/.github/workflows/test-tidy.yml
+++ b/.github/workflows/test-tidy.yml
@@ -98,10 +98,11 @@ jobs:
             exit 0
           fi
 
+          # Use quadruple backticks to escape triple backticks in diff'ed files.
           cat << EOF >> "${GITHUB_STEP_SUMMARY}"
-          \`\`\`diff
+          \`\`\`\`diff
           ${diff}
-          \`\`\`
+          \`\`\`\`
           EOF
 
           if [[ "${{ steps.untidy.outputs.untidy }}" == "true" ]] &&


### PR DESCRIPTION
### Context

The Github step summary for tidy-check-generate renders badly if there are code fences in the diff: https://github.com/edgelesssys/constellation/actions/runs/9578991258.

### Proposed change(s)

- Use quadruple fences ([docs](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-and-highlighting-code-blocks#fenced-code-blocks)).

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
