### PR TITLE
ci: fix GCP CCM findvers.sh script

### DIFF
--- a/.github/actions/gcpccm_vers_to_build/findvers.sh
+++ b/.github/actions/gcpccm_vers_to_build/findvers.sh
@@ -82,4 +82,4 @@ for major in "${allMajorVersions[@]}"; do
 done
 
 # Print one elem per line | quote elems | create array | remove empty elems and print compact.
-printf '%s' "${versionsToBuild[@]}" | jq -R | jq -s | jq -c 'map(select(length > 0))'
+printf '%s\n' "${versionsToBuild[@]}" | jq -R | jq -s | jq -c 'map(select(length > 0))'


### PR DESCRIPTION
### Context

Due to a small mistake in the script, it only ever worked correctly if there were 0 or 1 images to build. Last week saw 3 new tags published on the repo, which triggered the failure: https://github.com/edgelesssys/constellation/actions/runs/9582767025/job/26422530403.

### Proposed change(s)

- Print one tag per line before handling with `jq`.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] Test run: https://github.com/edgelesssys/constellation/actions/runs/9583316014
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
