### PR TITLE
ci: fix cdbg_deploy error reporting

### DIFF
--- a/.github/actions/cdbg_deploy/action.yml
+++ b/.github/actions/cdbg_deploy/action.yml
@@ -91,6 +91,11 @@ runs:
       shell: bash
       run: |
         echo "::group::cdbg deploy"
+        on_error() {
+          echo "::error::cdbg deploy failed"
+        }
+        trap on_error ERR
+        
         chmod +x $GITHUB_WORKSPACE/build/cdbg
         cdbg deploy \
           --bootstrapper "${{ github.workspace }}/build/bootstrapper" \
@@ -112,8 +117,4 @@ runs:
           --info logcollect.deployment-type="debugd" \
           --verbosity=-1 \
           --force
-          if [[ $? -ne 0 ]]; then
-            echo "::error::cdbg deploy failed"
-            exit 1
-          fi
         echo "::endgroup::"


### PR DESCRIPTION
### Context

The attempted fix of error logging in #3168 is incomplete, because the shell (started with `-e`) exits before it even reaches the return code check: https://github.com/edgelesssys/constellation/actions/runs/9590976869/job/26447189061#step:4:3609.

### Proposed change(s)

- Use an `ERR` trap to report the error.

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
