### PR TITLE
debugd: reset unit failed status before restarting

### DIFF
--- a/debugd/internal/debugd/deploy/service_test.go
+++ b/debugd/internal/debugd/deploy/service_test.go
@@ -356,6 +356,10 @@ func (c *fakeDbusConn) StopUnitContext(_ context.Context, name string, mode stri
 	return c.jobID, c.actionErr
 }
 
+func (c *fakeDbusConn) ResetFailedUnitContext(_ context.Context, _ string) error {
+	return nil
+}
+
 func (c *fakeDbusConn) RestartUnitContext(_ context.Context, name string, mode string, ch chan<- string) (int, error) {
 	c.inputs = append(c.inputs, dbusConnActionInput{name: name, mode: mode})
 	ch <- c.result

--- a/debugd/internal/debugd/deploy/wrappers.go
+++ b/debugd/internal/debugd/deploy/wrappers.go
@@ -38,6 +38,10 @@ func (c *dbusConnWrapper) StopUnitContext(ctx context.Context, name string, mode
 	return c.conn.StopUnitContext(ctx, name, mode, ch)
 }
 
+func (c *dbusConnWrapper) ResetFailedUnitContext(ctx context.Context, name string) error {
+	return c.conn.ResetFailedUnitContext(ctx, name)
+}
+
 func (c *dbusConnWrapper) RestartUnitContext(ctx context.Context, name string, mode string, ch chan<- string) (int, error) {
 	return c.conn.RestartUnitContext(ctx, name, mode, ch)
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
On debug images, our bootstrapper and upgrade-agent systemd units continuously fail until the binaries are uploaded using `cdbg deploy`.
Once this is done, the `debugd` issues a `systemctl restart` command to those units.
Under some circumstances, this restart can fall into the timeout period from our units being rate limited in restarting by systemd.
We can use `systemctl reset-failed` to reset the failed counter and by this way bypass the timeout.

See https://bugzilla.redhat.com/show_bug.cgi?id=1016548 for some more details about the issue.
See [the man page](https://www.freedesktop.org/software/systemd/man/latest/systemctl.html#reset-failed%20%5BPATTERN%E2%80%A6%5D) for `systemctl reset-failed`.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Run `systemctl reset-failed` before restarting a unit in `debugd`

### Related issue
- (should) fix https://github.com/edgelesssys/issues/issues/609


### Additional info
- debug image to test: `ref/fix-debugd-unit-restarting/stream/debug/v2.17.0-pre.0.20240620090724-9385e634a613`

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [e2e test](https://github.com/edgelesssys/constellation/actions/runs/9593987352)
