### PR TITLE
cli: fix `constellation verify` depending on an initialized `constellation-state.yaml` file

### DIFF
--- a/cli/internal/cmd/verify.go
+++ b/cli/internal/cmd/verify.go
@@ -138,10 +138,7 @@ func (c *verifyCmd) verify(cmd *cobra.Command, verifyClient verifyClient, config
 
 	stateFile, err := state.ReadFromFile(c.fileHandler, constants.StateFilename)
 	if err != nil {
-		return fmt.Errorf("reading state file: %w", err)
-	}
-	if err := stateFile.Validate(state.PostInit, conf.GetAttestationConfig().GetVariant()); err != nil {
-		return fmt.Errorf("validating state file: %w", err)
+		stateFile = state.New() // A state file is only required if the user has not provided IP or ID flags
 	}
 
 	ownerID, clusterID, err := c.validateIDFlags(cmd, stateFile)

--- a/cli/internal/cmd/verify_test.go
+++ b/cli/internal/cmd/verify_test.go
@@ -167,6 +167,18 @@ func TestVerify(t *testing.T) {
 			stateFile:        defaultStateFile(cloudprovider.Azure),
 			wantErr:          true,
 		},
+		"state file is not required if flags are given": {
+			provider:         cloudprovider.Azure,
+			nodeEndpointFlag: "192.0.2.1:1234",
+			clusterIDFlag:    zeroBase64,
+			protoClient:      &stubVerifyClient{},
+			wantEndpoint:     "192.0.2.1:1234",
+		},
+		"no state file and no flags": {
+			provider:    cloudprovider.Azure,
+			protoClient: &stubVerifyClient{},
+			wantErr:     true,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -183,7 +195,9 @@ func TestVerify(t *testing.T) {
 				cfg := defaultConfigWithExpectedMeasurements(t, config.Default(), tc.provider)
 				require.NoError(fileHandler.WriteYAML(constants.ConfigFilename, cfg))
 			}
-			require.NoError(tc.stateFile.WriteToFile(fileHandler, constants.StateFilename))
+			if tc.stateFile != nil {
+				require.NoError(tc.stateFile.WriteToFile(fileHandler, constants.StateFilename))
+			}
 
 			v := &verifyCmd{
 				fileHandler: fileHandler,

--- a/docs/docs/workflows/verify-cluster.md
+++ b/docs/docs/workflows/verify-cluster.md
@@ -88,6 +88,7 @@ The `verify` command also allows you to verify any Constellation deployment that
 
 * The IP address of a running Constellation cluster's [VerificationService](../architecture/microservices.md#verificationservice). The `VerificationService` is exposed via a `NodePort` service using the external IP address of your cluster. Run `kubectl get nodes -o wide` and look for `EXTERNAL-IP`.
 * The cluster's *clusterID*. See [cluster identity](../architecture/keys.md#cluster-identity) for more details.
+* A `constellation-conf.yaml` file with the expected measurements of the cluster in your working directory.
 
 For example:
 

--- a/docs/versioned_docs/version-2.15/workflows/verify-cluster.md
+++ b/docs/versioned_docs/version-2.15/workflows/verify-cluster.md
@@ -88,6 +88,7 @@ The `verify` command also allows you to verify any Constellation deployment that
 
 * The IP address of a running Constellation cluster's [VerificationService](../architecture/microservices.md#verificationservice). The `VerificationService` is exposed via a `NodePort` service using the external IP address of your cluster. Run `kubectl get nodes -o wide` and look for `EXTERNAL-IP`.
 * The cluster's *clusterID*. See [cluster identity](../architecture/keys.md#cluster-identity) for more details.
+* A `constellation-conf.yaml` file with the expected measurements of the cluster in your working directory.
 
 For example:
 

--- a/docs/versioned_docs/version-2.16/workflows/verify-cluster.md
+++ b/docs/versioned_docs/version-2.16/workflows/verify-cluster.md
@@ -88,6 +88,7 @@ The `verify` command also allows you to verify any Constellation deployment that
 
 * The IP address of a running Constellation cluster's [VerificationService](../architecture/microservices.md#verificationservice). The `VerificationService` is exposed via a `NodePort` service using the external IP address of your cluster. Run `kubectl get nodes -o wide` and look for `EXTERNAL-IP`.
 * The cluster's *clusterID*. See [cluster identity](../architecture/keys.md#cluster-identity) for more details.
+* A `constellation-conf.yaml` file with the expected measurements of the cluster in your working directory.
 
 For example:
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
`constellation verify` should be usable with only a config file, the IP of the service, and the cluster ID of a Constellation cluster

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove dependency on an initialized `constellation-state.yaml` when executing `constellation verify` with `--endpoint` and `--cluster-id` flags set
- More prominently mention requirement for `constellation-conf.yaml` for `constellation verify` in our docs

### Related issue
- fixes https://github.com/edgelesssys/constellation/issues/3181

