### PR TITLE
ci: make bazel generate more stable

### DIFF
--- a/bazel/ci/BUILD.bazel
+++ b/bazel/ci/BUILD.bazel
@@ -541,16 +541,34 @@ multirun(
 )
 
 multirun(
-    name = "generate",
+    name = "generate_files",
     commands = [
         ":terraform_gen",
         "//3rdparty/bazel/com_github_medik8s_node_maintainance_operator:pull_files",
         ":go_generate",
         ":proto_generate",
-        ":cli_docgen",
-        ":terraform_docgen",
-        ":version_info_gen",
     ],
     jobs = 0,  # execute concurrently
+    visibility = ["//visibility:public"],
+)
+
+multirun(
+    name = "generate_docs",
+    commands = [
+        ":cli_docgen",
+        ":terraform_docgen",
+    ],
+    jobs = 0,  # execute concurrently
+    visibility = ["//visibility:public"],
+)
+
+multirun(
+    name = "generate",
+    commands = [
+        ":generate_files",
+        ":generate_docs",
+        ":version_info_gen",
+    ],
+    jobs = 1,  # execute sequentially
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Our CI occasionally failed when running `bazel run //:generate` because some sub commands of the target could interfere with each other. 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Ensure more stable `bazel run //:generate` by not running all commands in parallel

