### PR TITLE
operator: fix gRPC dialing over UDS

### DIFF
--- a/operators/constellation-node-operator/internal/upgrade/BUILD.bazel
+++ b/operators/constellation-node-operator/internal/upgrade/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//bazel/go:go_test.bzl", "go_test")
 
 go_library(
     name = "upgrade",
@@ -11,5 +12,17 @@ go_library(
         "//upgrade-agent/upgradeproto",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//credentials/insecure",
+    ],
+)
+
+go_test(
+    name = "upgrade_test",
+    srcs = ["upgrade_test.go"],
+    embed = [":upgrade"],
+    deps = [
+        "//internal/versions/components",
+        "//upgrade-agent/upgradeproto",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/operators/constellation-node-operator/internal/upgrade/upgrade_test.go
+++ b/operators/constellation-node-operator/internal/upgrade/upgrade_test.go
@@ -1,0 +1,46 @@
+package upgrade
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/edgelesssys/constellation/v2/internal/versions/components"
+	"github.com/edgelesssys/constellation/v2/upgrade-agent/upgradeproto"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+)
+
+// TestGRPCDialer is a regression test to ensure the upgrade client can connect to a UDS.
+func TestGRPCDialer(t *testing.T) {
+	require := require.New(t)
+
+	dir := t.TempDir()
+	sockAddr := filepath.Join(dir, "test.socket")
+
+	upgradeAgent := &fakeUpgradeAgent{}
+	grpcServer := grpc.NewServer()
+	upgradeproto.RegisterUpdateServer(grpcServer, upgradeAgent)
+
+	listener, err := net.Listen("unix", sockAddr)
+	require.NoError(err)
+	go grpcServer.Serve(listener)
+	t.Cleanup(grpcServer.Stop)
+
+	fileInfo, err := os.Stat(sockAddr)
+	require.NoError(err)
+	require.Equal(os.ModeSocket, fileInfo.Mode()&os.ModeType)
+
+	upgradeClient := newClientWithAddress(sockAddr)
+	require.NoError(upgradeClient.Upgrade(context.Background(), []*components.Component{}, "v1.29.6"))
+}
+
+type fakeUpgradeAgent struct {
+	upgradeproto.UnimplementedUpdateServer
+}
+
+func (s *fakeUpgradeAgent) ExecuteUpdate(_ context.Context, _ *upgradeproto.ExecuteUpdateRequest) (*upgradeproto.ExecuteUpdateResponse, error) {
+	return &upgradeproto.ExecuteUpdateResponse{}, nil
+}

--- a/operators/constellation-node-operator/internal/upgrade/upgrade_test.go
+++ b/operators/constellation-node-operator/internal/upgrade/upgrade_test.go
@@ -1,3 +1,9 @@
+/*
+Copyright (c) Edgeless Systems GmbH
+
+SPDX-License-Identifier: AGPL-3.0-only
+*/
+
 package upgrade
 
 import (


### PR DESCRIPTION
### Context

`grpc.NewClient` uses DNS as default resolver. This does not work for UDS, so we need to specify the resolver explicitly.

### Proposed change(s)

- Dial UDS with `unix:` prefix (see https://github.com/grpc/grpc/blob/master/doc/naming.md).

### Related issue
- Fixes edgelesssys/issues#711

### Checklist

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
