### PR TITLE
debugd: use runc as podman runtime

### DIFF
--- a/debugd/filebeat/Dockerfile
+++ b/debugd/filebeat/Dockerfile
@@ -2,6 +2,8 @@ FROM fedora:40@sha256:5ce8497aeea599bf6b54ab3979133923d82aaa4f6ca5ced1812611b197
 
 RUN dnf install -y https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-8.6.2-x86_64.rpm
 
+RUN dnf install -y systemd-libs
+
 COPY debugd/filebeat/templates/ /usr/share/constellogs/templates/
 
 ENTRYPOINT ["/usr/share/filebeat/bin/filebeat", "-e", "--path.home", "/usr/share/filebeat", "--path.data", "/usr/share/filebeat/data"]


### PR DESCRIPTION
### Context

The logcollection deployed by debugd is not working since ~2024-06-08. Investigating a debug cluster, it turns out that `podman`  commands fail because of an absent `crun` runtime. A change in defaults might have been introduced by 0a3f77e92634fd9b3434172000e13fc2f23129d7.

### Proposed change(s)

- Explicitly use `runc` runtime.

### Related issue
- Fixes edgelesssys/issues#700

### Checklist

- [ ] Run the E2E tests that are relevant to this PR's changes
  - [ ] https://github.com/edgelesssys/constellation/actions/runs/9691695039
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
