### PR TITLE
ci: reduce max parallel attestationconfig e2e tests back to 1 for stability

### DIFF
--- a/.github/workflows/e2e-attestationconfigapi.yml
+++ b/.github/workflows/e2e-attestationconfigapi.yml
@@ -15,7 +15,7 @@ jobs:
   e2e-api:
     strategy:
       fail-fast: false
-      max-parallel: 2
+      max-parallel: 1
       matrix:
         attestationVariant: ["azure-sev-snp", "azure-tdx", "aws-sev-snp", "gcp-sev-snp"]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
I originally increased it to 2 during testing and did not experience any issues.
However, the test just failed after merging a PR. Lets decrease it back to 1 for stability reasons

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Reduce max parallel to 1

### Related issue
- https://github.com/edgelesssys/constellation/actions/runs/9692223251/attempts/1

