### PR TITLE
renovate: allow major version upgrades of GitHub action dependencies

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -89,6 +89,7 @@
       "matchManagers": ["github-actions"],
       "groupName": "GitHub action dependencies",
       "matchUpdateTypes": [
+        "major",
         "minor",
         "patch",
         "pin",


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Some action dependencies are not upgrade as frequently as they should be because our renovate config does not group updates to major versions with other action dependencies

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Allow major version upgrades for the GitHub action dependency group
