### PR TITLE
ci: add missing permissions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,6 +278,7 @@ jobs:
       packages: write
       id-token: write
       contents: read
+      actions: write
     secrets: inherit
     with:
       ref: ${{ needs.verify-inputs.outputs.WORKING_BRANCH }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Since https://github.com/edgelesssys/constellation/commit/0c0d87aa4cdfee0c862b03818ad1d45cf31db600, the E2E tests requires `actions: write`. The aforementioned PR only added it to the upgrade test invocation.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add `actions: write` to the E2E test called from the release pipeline.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
