### PR TITLE
deps: bump Go version to v1.22.5

### DIFF
--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: "1.22.4"
+          go-version: "1.22.5"
           cache: false
 
       - name: Install Crane

--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: "1.22.4"
+          go-version: "1.22.5"
           cache: false
 
       - name: Determine version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: "1.22.4"
+          go-version: "1.22.5"
           cache: false
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: "1.22.4"
+          go-version: "1.22.5"
           cache: true
 
       - name: Build generateMeasurements tool

--- a/.github/workflows/test-operator-codegen.yml
+++ b/.github/workflows/test-operator-codegen.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@cdcb36043654635271a94b9a6d1392de5bb323a7 # v5.0.1
         with:
-          go-version: "1.22.4"
+          go-version: "1.22.5"
           cache: true
 
       - name: Run code generation

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,7 +16,7 @@ go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_sdk",
     patches = ["//3rdparty/bazel/org_golang:go_tls_max_handshake_size.patch"],
-    version = "1.22.4",
+    version = "1.22.5",
 )
 
 # the use_repo rule needs to list all top-level go dependencies

--- a/dev-docs/workflows/bump-go-version.md
+++ b/dev-docs/workflows/bump-go-version.md
@@ -24,6 +24,8 @@ You can use the following command to find replace all instances of `go-version: 
 OLD_VERSION="1.xx.x"
 NEW_VERSION="1.xx.y"
 find .github -type f -exec sed -i "s/go-version: \"${OLD_VERSION}\"/go-version: \"${NEW_VERSION}\"/g" {} \;
+sed -i "s/go ${OLD_VERSION}/go ${NEW_VERSION}/g" go.mod
+sed -i "s/${OLD_VERSION}/${NEW_VERSION}/g" go.work
 ```
 
 Or manually:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelesssys/constellation/v2
 
-go 1.22.4
+go 1.22.5
 
 // TODO(daniel-weisse): revert after merging https://github.com/martinjungblut/go-cryptsetup/pull/16.
 replace github.com/martinjungblut/go-cryptsetup => github.com/daniel-weisse/go-cryptsetup v0.0.0-20230705150314-d8c07bd1723c

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.22.4
+go 1.22.5
 
-toolchain go1.22.4
+toolchain go1.22.5
 
 use (
 	.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
A new Go version was released which addresses https://pkg.go.dev/vuln/GO-2024-2963

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Bump Go version to v1.22.5
- Add instructions to update version in `go.mod` and `go.work` files

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Run the E2E tests that are relevant to this PR's changes
  - [ ] [e2e test](https://github.com/edgelesssys/constellation/actions/runs/9773255994)
