### PR TITLE
ci: add conformance test to weekly

### DIFF
--- a/.github/actions/constellation_create/action.yml
+++ b/.github/actions/constellation_create/action.yml
@@ -192,6 +192,13 @@ runs:
       run: |
         echo "flag=--force" | tee -a $GITHUB_OUTPUT
 
+    - name: Set conformance flag
+      id: set-conformance-flag
+      if: inputs.test == 'sonobuoy conformance'
+      shell: bash
+      run: |
+        echo "flag=--conformance" | tee -a $GITHUB_OUTPUT
+
     - name: Constellation apply (Terraform)
       id: constellation-apply-terraform
       if: inputs.clusterCreation == 'terraform'
@@ -204,7 +211,7 @@ runs:
       if: inputs.clusterCreation != 'terraform'
       shell: bash
       run: |
-        constellation apply --skip-phases=infrastructure --debug ${{ steps.set-force-flag.outputs.flag }}
+        constellation apply --skip-phases=infrastructure --debug ${{ steps.set-force-flag.outputs.flag }} ${{ steps.set-conformance-flag.outputs.flag }}
 
     - name: Get kubeconfig
       id: get-kubeconfig

--- a/.github/actions/e2e_sonobuoy/action.yml
+++ b/.github/actions/e2e_sonobuoy/action.yml
@@ -48,6 +48,12 @@ runs:
         sonobuoy results *_sonobuoy_*.tar.gz
         sonobuoy results *_sonobuoy_*.tar.gz --mode detailed | jq 'select(.status!="passed")' | jq 'select(.status!="skipped")' || true
 
+    - name: Cleanup sonobuoy deployment
+      env:
+        KUBECONFIG: ${{ inputs.kubeconfig }}
+      shell: bash
+      run: sonobuoy delete --wait
+
     - name: Upload test results
       if: always() && !env.ACT
       uses: ./.github/actions/artifact_upload

--- a/.github/actions/e2e_sonobuoy/action.yml
+++ b/.github/actions/e2e_sonobuoy/action.yml
@@ -48,12 +48,6 @@ runs:
         sonobuoy results *_sonobuoy_*.tar.gz
         sonobuoy results *_sonobuoy_*.tar.gz --mode detailed | jq 'select(.status!="passed")' | jq 'select(.status!="skipped")' || true
 
-    - name: Cleanup sonobuoy deployment
-      env:
-        KUBECONFIG: ${{ inputs.kubeconfig }}
-      shell: bash
-      run: sonobuoy delete --wait
-
     - name: Upload test results
       if: always() && !env.ACT
       uses: ./.github/actions/artifact_upload

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -352,7 +352,7 @@ runs:
       if: inputs.test == 'sonobuoy conformance'
       uses: ./.github/actions/e2e_sonobuoy
       with:
-        sonobuoyTestSuiteCmd: "--mode certified-conformance"
+        sonobuoyTestSuiteCmd: "--plugin e2e --mode certified-conformance"
         kubeconfig: ${{ steps.constellation-create.outputs.kubeconfig }}
         artifactNameSuffix: ${{ steps.create-prefix.outputs.prefix }}
         encryptionSecret: ${{ inputs.encryptionSecret }}

--- a/.github/actions/e2e_test/action.yml
+++ b/.github/actions/e2e_test/action.yml
@@ -53,7 +53,7 @@ inputs:
     description: "Azure credentials authorized to create an IAM configuration."
     required: true
   test:
-    description: "The test to run. Can currently be one of [sonobuoy full, sonobuoy quick, autoscaling, lb, perf-bench, verify, recover, malicious join, nop, upgrade]."
+    description: "The test to run. Can currently be one of [sonobuoy full, sonobuoy quick, sonobuoy conformance, autoscaling, lb, perf-bench, verify, recover, malicious join, nop, upgrade]."
     required: true
   sonobuoyTestSuiteCmd:
     description: "The sonobuoy test suite to run."
@@ -103,7 +103,7 @@ runs:
   using: "composite"
   steps:
     - name: Check input
-      if: (!contains(fromJson('["sonobuoy full", "sonobuoy quick", "autoscaling", "perf-bench", "verify", "lb", "recover", "malicious join", "s3proxy", "nop", "upgrade"]'), inputs.test))
+      if: (!contains(fromJson('["sonobuoy full", "sonobuoy quick", "sonobuoy conformance", "autoscaling", "perf-bench", "verify", "lb", "recover", "malicious join", "s3proxy", "nop", "upgrade"]'), inputs.test))
       shell: bash
       run: |
         echo "::error::Invalid input for test field: ${{ inputs.test }}"
@@ -344,6 +344,15 @@ runs:
       with:
         # TODO(3u13r): Remove E2E_SKIP once AB#2174 is resolved
         sonobuoyTestSuiteCmd: '--plugin e2e --plugin-env e2e.E2E_FOCUS="\[Conformance\]" --plugin-env e2e.E2E_SKIP="for service with type clusterIP|HostPort validates that there is no conflict between pods with same hostPort but different hostIP and protocol|Services should serve endpoints on same port and different protocols" --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/102cd62a4091f80a795189f64ccc20738f931ef0/cis-benchmarks/kube-bench-plugin.yaml --plugin https://raw.githubusercontent.com/vmware-tanzu/sonobuoy-plugins/102cd62a4091f80a795189f64ccc20738f931ef0/cis-benchmarks/kube-bench-master-plugin.yaml'
+        kubeconfig: ${{ steps.constellation-create.outputs.kubeconfig }}
+        artifactNameSuffix: ${{ steps.create-prefix.outputs.prefix }}
+        encryptionSecret: ${{ inputs.encryptionSecret }}
+
+    - name: Run sonobuoy conformance
+      if: inputs.test == 'sonobuoy conformance'
+      uses: ./.github/actions/e2e_sonobuoy
+      with:
+        sonobuoyTestSuiteCmd: "--mode certified-conformance"
         kubeconfig: ${{ steps.constellation-create.outputs.kubeconfig }}
         artifactNameSuffix: ${{ steps.create-prefix.outputs.prefix }}
         encryptionSecret: ${{ inputs.encryptionSecret }}

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -82,7 +82,7 @@ jobs:
           - test: "sonobuoy conformance"
             refStream: "ref/main/stream/debug/?"
             attestationVariant: "gcp-sev-snp"
-            kubernetes-version: "v1.28"
+            kubernetes-version: "v1.30"
             clusterCreation: "cli"
 
           # Sonobuoy quick test on all but the latest k8s versions

--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -78,6 +78,13 @@ jobs:
             kubernetes-version: "v1.30"
             clusterCreation: "cli"
 
+          # Sonobuoy conformance test
+          - test: "sonobuoy conformance"
+            refStream: "ref/main/stream/debug/?"
+            attestationVariant: "gcp-sev-snp"
+            kubernetes-version: "v1.28"
+            clusterCreation: "cli"
+
           # Sonobuoy quick test on all but the latest k8s versions
           - test: "sonobuoy quick"
             refStream: "ref/main/stream/debug/?"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -26,7 +26,7 @@ on:
           - "macos-12"
         default: "ubuntu-22.04"
       test:
-        description: "The test to run."
+        description: "The test to run. The conformance test is only supported for clusterCreation=cli."
         type: choice
         options:
           - "sonobuoy quick"
@@ -83,7 +83,7 @@ on:
         type: string
         required: true
       test:
-        description: "The test to run."
+        description: "The test to run. The conformance test is only supported for clusterCreation=cli."
         type: string
         required: true
       kubernetesVersion:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -31,6 +31,7 @@ on:
         options:
           - "sonobuoy quick"
           - "sonobuoy full"
+          - "sonobuoy conformance"
           - "autoscaling"
           - "lb"
           - "perf-bench"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We want to periodically test the conformance mode to stay compliant.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- add 'sonobuoy conformance' to test options
- add to weekly tests

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#4145](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4145)

This was the last manual run for comparison: 
https://github.com/cncf/k8s-conformance/pull/3200

[Successful run](https://github.com/edgelesssys/constellation/actions/runs/10091432763/job/27903156084)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Run the E2E tests that are relevant to this PR's changes
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [ ] Add labels (e.g., for changelog category)
- [ ] Is PR title adequate for changelog?
- [ ] Link to Milestone
