### PR TITLE
dev-docs: set an MTU on the VPN route

### DIFF
--- a/dev-docs/howto/vpn/helm/templates/_helpers.tpl
+++ b/dev-docs/howto/vpn/helm/templates/_helpers.tpl
@@ -39,4 +39,6 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   value: {{ .Values.serviceCIDR | quote }}
 - name: VPN_FRONTEND_POD
   value: {{ include "..fullname" . }}-frontend-0
+- name: VPN_MTU
+  value: {{ .Values.mtu | quote }}
 {{- end }}

--- a/dev-docs/howto/vpn/helm/values.yaml
+++ b/dev-docs/howto/vpn/helm/values.yaml
@@ -8,6 +8,10 @@ serviceCIDR: "10.96.0.0/12"
 # on-prem IP ranges to expose to Constellation. Must contain at least one CIDR.
 peerCIDRs: []
 
+# MTU to set on the VPN route. Leave empty if path MTU discovery is supported end-to-end.
+# See also https://docs.strongswan.org/docs/5.9/howtos/forwarding.html#_mtumss_issues.
+mtu: 1300
+
 # IPSec configuration
 ipsec:
   # pre-shared key used for authentication
@@ -15,4 +19,4 @@ ipsec:
   # Address of the peer's gateway router.
   peer: ""
 
-image: "ghcr.io/edgelesssys/constellation/vpn@sha256:34e28ced172d04dfdadaadbefb1a53b5857cb24fb24e275fbbc537f3639a789e"
+image: "ghcr.io/edgelesssys/constellation/vpn@sha256:88b6a0265052cb0a68d20d9b20e0d42ef15e7a80e5f71201ecf32e004de2356e"

--- a/nix/container/vpn/sidecar.sh
+++ b/nix/container/vpn/sidecar.sh
@@ -30,10 +30,17 @@ reconcile_sip_verification() {
   fi
 }
 
+optional_mtu() {
+  if [ -n "${VPN_MTU}" ]; then
+    printf "mtu %s" "${VPN_MTU}"
+  fi
+}
+
 # Set up the route from the node network namespace to the VPN pod.
 reconcile_route() {
   for cidr in ${VPN_PEER_CIDRS}; do
-    nsenter -t 1 -n ip route replace "${cidr}" via "$(myip)"
+    # shellcheck disable=SC2046 # Word splitting is intentional here.
+    nsenter -t 1 -n ip route replace "${cidr}" via "$(myip)" $(optional_mtu)
   done
 }
 


### PR DESCRIPTION
### Context

In a test setup with Constellation on GCP and a VM on Azure, I observed failures when trying to connect via TLS from the VM to the API server. The issue turned out to be packets dropped in XFRM, because they were too large for the 1500 MTU of the tunnel connection. 


### Proposed change(s)

Enabling path MTU over the GCP load balancer is likely impossible, so I'm adding a config knob to set the MTU manually. The conservative default setting should be enough to work with MTU 1500.

### Additional info
<!-- Remove items that do not apply -->
- [AB#4384](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4384)


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] tested manually on standard 1.29 cluster.
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
