### PR TITLE
docs: move compute benchmarks to own page

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Encrypting your K8s is good for:
 
 * High availability with multi-master architecture and stacked etcd topology
 * Dynamic cluster autoscaling with verification and secure bootstrapping of new nodes
-* Competitive performance ([see K-Bench comparison with AKS and GKE][performance])
+* Competitive [performance]
 
 ### 🧩 Easy to use and integrate
 

--- a/docs/docs/overview/performance/compute.md
+++ b/docs/docs/overview/performance/compute.md
@@ -1,0 +1,11 @@
+# Impact of runtime encryption on compute performance
+
+All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
+
+## AMD and Azure benchmarking
+
+AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
+
+## AMD and Google benchmarking
+
+Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.

--- a/docs/docs/overview/performance/performance.md
+++ b/docs/docs/overview/performance/performance.md
@@ -1,18 +1,10 @@
 # Performance analysis of Constellation
 
-This section provides a comprehensive examination of the performance characteristics of Constellation, encompassing various aspects, including runtime encryption, I/O benchmarks, and real-world applications.
+This section provides a comprehensive examination of the performance characteristics of Constellation.
 
-## Impact of runtime encryption on performance
+## Runtime encryption
 
-All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
-
-### AMD and Azure benchmarking
-
-AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
-
-### AMD and Google benchmarking
-
-Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.
+Runtime encryption affects compute performance. [Benchmarks by Azure and Google](compute.md) show that the performance degradation of Confidential VMs (CVMs) is small, ranging from 2% to 8% for compute-intensive workloads.
 
 ## I/O performance benchmarks
 

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -57,6 +57,11 @@ const sidebars = {
           items: [
             {
               type: 'doc',
+              label: 'Compute benchmarks',
+              id: 'overview/performance/compute',
+            },
+            {
+              type: 'doc',
               label: 'I/O benchmarks',
               id: 'overview/performance/io',
             },

--- a/docs/versioned_docs/version-2.10/overview/performance/compute.md
+++ b/docs/versioned_docs/version-2.10/overview/performance/compute.md
@@ -1,0 +1,11 @@
+# Impact of runtime encryption on compute performance
+
+All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
+
+## AMD and Azure benchmarking
+
+AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
+
+## AMD and Google benchmarking
+
+Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.

--- a/docs/versioned_docs/version-2.10/overview/performance/performance.md
+++ b/docs/versioned_docs/version-2.10/overview/performance/performance.md
@@ -1,18 +1,10 @@
 # Performance analysis of Constellation
 
-This section provides a comprehensive examination of the performance characteristics of Constellation, encompassing various aspects, including runtime encryption, I/O benchmarks, and real-world applications.
+This section provides a comprehensive examination of the performance characteristics of Constellation.
 
-## Impact of runtime encryption on performance
+## Runtime encryption
 
-All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
-
-### AMD and Azure benchmarking
-
-AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
-
-### AMD and Google benchmarking
-
-Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.
+Runtime encryption affects compute performance. [Benchmarks by Azure and Google](compute.md) show that the performance degradation of Confidential VMs (CVMs) is small, ranging from 2% to 8% for compute-intensive workloads.
 
 ## I/O performance benchmarks
 

--- a/docs/versioned_docs/version-2.10/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.10/workflows/verify-cli.md
@@ -33,6 +33,10 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
+:::info
+This guide assumes Linux on an amd64 processor. The exact steps for other platforms differ slightly.
+:::
+
 First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session

--- a/docs/versioned_docs/version-2.11/overview/performance/compute.md
+++ b/docs/versioned_docs/version-2.11/overview/performance/compute.md
@@ -1,0 +1,11 @@
+# Impact of runtime encryption on compute performance
+
+All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
+
+## AMD and Azure benchmarking
+
+AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
+
+## AMD and Google benchmarking
+
+Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.

--- a/docs/versioned_docs/version-2.11/overview/performance/performance.md
+++ b/docs/versioned_docs/version-2.11/overview/performance/performance.md
@@ -1,18 +1,10 @@
 # Performance analysis of Constellation
 
-This section provides a comprehensive examination of the performance characteristics of Constellation, encompassing various aspects, including runtime encryption, I/O benchmarks, and real-world applications.
+This section provides a comprehensive examination of the performance characteristics of Constellation.
 
-## Impact of runtime encryption on performance
+## Runtime encryption
 
-All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
-
-### AMD and Azure benchmarking
-
-AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
-
-### AMD and Google benchmarking
-
-Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.
+Runtime encryption affects compute performance. [Benchmarks by Azure and Google](compute.md) show that the performance degradation of Confidential VMs (CVMs) is small, ranging from 2% to 8% for compute-intensive workloads.
 
 ## I/O performance benchmarks
 

--- a/docs/versioned_docs/version-2.11/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.11/workflows/verify-cli.md
@@ -33,6 +33,10 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
+:::info
+This guide assumes Linux on an amd64 processor. The exact steps for other platforms differ slightly.
+:::
+
 First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session

--- a/docs/versioned_docs/version-2.12/overview/performance/compute.md
+++ b/docs/versioned_docs/version-2.12/overview/performance/compute.md
@@ -1,0 +1,11 @@
+# Impact of runtime encryption on compute performance
+
+All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
+
+## AMD and Azure benchmarking
+
+AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
+
+## AMD and Google benchmarking
+
+Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.

--- a/docs/versioned_docs/version-2.12/overview/performance/performance.md
+++ b/docs/versioned_docs/version-2.12/overview/performance/performance.md
@@ -1,18 +1,10 @@
 # Performance analysis of Constellation
 
-This section provides a comprehensive examination of the performance characteristics of Constellation, encompassing various aspects, including runtime encryption, I/O benchmarks, and real-world applications.
+This section provides a comprehensive examination of the performance characteristics of Constellation.
 
-## Impact of runtime encryption on performance
+## Runtime encryption
 
-All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
-
-### AMD and Azure benchmarking
-
-AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
-
-### AMD and Google benchmarking
-
-Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.
+Runtime encryption affects compute performance. [Benchmarks by Azure and Google](compute.md) show that the performance degradation of Confidential VMs (CVMs) is small, ranging from 2% to 8% for compute-intensive workloads.
 
 ## I/O performance benchmarks
 

--- a/docs/versioned_docs/version-2.12/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.12/workflows/verify-cli.md
@@ -33,6 +33,10 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
+:::info
+This guide assumes Linux on an amd64 processor. The exact steps for other platforms differ slightly.
+:::
+
 First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session

--- a/docs/versioned_docs/version-2.13/overview/performance/compute.md
+++ b/docs/versioned_docs/version-2.13/overview/performance/compute.md
@@ -1,0 +1,11 @@
+# Impact of runtime encryption on compute performance
+
+All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
+
+## AMD and Azure benchmarking
+
+AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
+
+## AMD and Google benchmarking
+
+Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.

--- a/docs/versioned_docs/version-2.13/overview/performance/performance.md
+++ b/docs/versioned_docs/version-2.13/overview/performance/performance.md
@@ -1,18 +1,10 @@
 # Performance analysis of Constellation
 
-This section provides a comprehensive examination of the performance characteristics of Constellation, encompassing various aspects, including runtime encryption, I/O benchmarks, and real-world applications.
+This section provides a comprehensive examination of the performance characteristics of Constellation.
 
-## Impact of runtime encryption on performance
+## Runtime encryption
 
-All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
-
-### AMD and Azure benchmarking
-
-AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
-
-### AMD and Google benchmarking
-
-Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.
+Runtime encryption affects compute performance. [Benchmarks by Azure and Google](compute.md) show that the performance degradation of Confidential VMs (CVMs) is small, ranging from 2% to 8% for compute-intensive workloads.
 
 ## I/O performance benchmarks
 

--- a/docs/versioned_docs/version-2.13/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.13/workflows/verify-cli.md
@@ -33,6 +33,10 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
+:::info
+This guide assumes Linux on an amd64 processor. The exact steps for other platforms differ slightly.
+:::
+
 First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session

--- a/docs/versioned_docs/version-2.14/overview/performance/compute.md
+++ b/docs/versioned_docs/version-2.14/overview/performance/compute.md
@@ -1,0 +1,11 @@
+# Impact of runtime encryption on compute performance
+
+All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
+
+## AMD and Azure benchmarking
+
+AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
+
+## AMD and Google benchmarking
+
+Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.

--- a/docs/versioned_docs/version-2.14/overview/performance/performance.md
+++ b/docs/versioned_docs/version-2.14/overview/performance/performance.md
@@ -1,18 +1,10 @@
 # Performance analysis of Constellation
 
-This section provides a comprehensive examination of the performance characteristics of Constellation, encompassing various aspects, including runtime encryption, I/O benchmarks, and real-world applications.
+This section provides a comprehensive examination of the performance characteristics of Constellation.
 
-## Impact of runtime encryption on performance
+## Runtime encryption
 
-All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
-
-### AMD and Azure benchmarking
-
-AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
-
-### AMD and Google benchmarking
-
-Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.
+Runtime encryption affects compute performance. [Benchmarks by Azure and Google](compute.md) show that the performance degradation of Confidential VMs (CVMs) is small, ranging from 2% to 8% for compute-intensive workloads.
 
 ## I/O performance benchmarks
 

--- a/docs/versioned_docs/version-2.14/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.14/workflows/verify-cli.md
@@ -33,6 +33,10 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
+:::info
+This guide assumes Linux on an amd64 processor. The exact steps for other platforms differ slightly.
+:::
+
 First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session

--- a/docs/versioned_docs/version-2.15/overview/performance/compute.md
+++ b/docs/versioned_docs/version-2.15/overview/performance/compute.md
@@ -1,0 +1,11 @@
+# Impact of runtime encryption on compute performance
+
+All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
+
+## AMD and Azure benchmarking
+
+AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
+
+## AMD and Google benchmarking
+
+Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.

--- a/docs/versioned_docs/version-2.15/overview/performance/performance.md
+++ b/docs/versioned_docs/version-2.15/overview/performance/performance.md
@@ -1,18 +1,10 @@
 # Performance analysis of Constellation
 
-This section provides a comprehensive examination of the performance characteristics of Constellation, encompassing various aspects, including runtime encryption, I/O benchmarks, and real-world applications.
+This section provides a comprehensive examination of the performance characteristics of Constellation.
 
-## Impact of runtime encryption on performance
+## Runtime encryption
 
-All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
-
-### AMD and Azure benchmarking
-
-AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
-
-### AMD and Google benchmarking
-
-Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.
+Runtime encryption affects compute performance. [Benchmarks by Azure and Google](compute.md) show that the performance degradation of Confidential VMs (CVMs) is small, ranging from 2% to 8% for compute-intensive workloads.
 
 ## I/O performance benchmarks
 

--- a/docs/versioned_docs/version-2.15/workflows/verify-cli.md
+++ b/docs/versioned_docs/version-2.15/workflows/verify-cli.md
@@ -33,6 +33,10 @@ You don't need to verify the Constellation node images. This is done automatical
 
 ## Verify the signature
 
+:::info
+This guide assumes Linux on an amd64 processor. The exact steps for other platforms differ slightly.
+:::
+
 First, [install the Cosign CLI](https://docs.sigstore.dev/system_config/installation). Next, [download](https://github.com/edgelesssys/constellation/releases) and verify the signature that accompanies your CLI executable, for example:
 
 ```shell-session

--- a/docs/versioned_docs/version-2.16/overview/performance/compute.md
+++ b/docs/versioned_docs/version-2.16/overview/performance/compute.md
@@ -1,0 +1,11 @@
+# Impact of runtime encryption on compute performance
+
+All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
+
+## AMD and Azure benchmarking
+
+AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
+
+## AMD and Google benchmarking
+
+Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.

--- a/docs/versioned_docs/version-2.16/overview/performance/performance.md
+++ b/docs/versioned_docs/version-2.16/overview/performance/performance.md
@@ -1,18 +1,10 @@
 # Performance analysis of Constellation
 
-This section provides a comprehensive examination of the performance characteristics of Constellation, encompassing various aspects, including runtime encryption, I/O benchmarks, and real-world applications.
+This section provides a comprehensive examination of the performance characteristics of Constellation.
 
-## Impact of runtime encryption on performance
+## Runtime encryption
 
-All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
-
-### AMD and Azure benchmarking
-
-AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
-
-### AMD and Google benchmarking
-
-Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.
+Runtime encryption affects compute performance. [Benchmarks by Azure and Google](compute.md) show that the performance degradation of Confidential VMs (CVMs) is small, ranging from 2% to 8% for compute-intensive workloads.
 
 ## I/O performance benchmarks
 

--- a/docs/versioned_docs/version-2.16/workflows/lb.md
+++ b/docs/versioned_docs/version-2.16/workflows/lb.md
@@ -4,12 +4,25 @@ Constellation integrates the native load balancers of each CSP. Therefore, to ex
 
 ## Internet-facing LB service on AWS
 
-To expose your application service externally you might want to use a Kubernetes Service of type `LoadBalancer`. On AWS, load-balancing is achieved through the [AWS Load Balancing Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller) as in the managed EKS.
+To expose your application service externally you might want to use a Kubernetes Service of type `LoadBalancer`. On AWS, load-balancing is achieved through the [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller) as in the managed EKS.
 
-Since recent versions, the controller deploy an internal LB by default requiring to set an annotation `service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing` to have an internet-facing LB. For more details, see the [official docs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.2/guide/service/nlb/).
+Since recent versions, the controller deploy an internal LB by default requiring to set an annotation `service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing` to have an internet-facing LB. For more details, see the [official docs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.7/guide/service/nlb/).
 
 For general information on LB with AWS see [Network load balancing on Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/network-load-balancing.html).
 
 :::caution
 Before terminating the cluster, all LB backed services should be deleted, so that the controller can cleanup the related resources.
+:::
+
+## Ingress on AWS
+
+The AWS Load Balancer Controller also provisions `Ingress` resources of class `alb`.
+AWS Application Load Balancers (ALBs) can be configured with a [`target-type`](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.7/guide/ingress/annotations/#target-type).
+The target type `ip` requires using the EKS container network solution, which makes it incompatible with Constellation.
+If a service can be exposed on a `NodePort`, the target type `instance` can be used.
+
+See [Application load balancing on Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html) for more information.
+
+:::caution
+Ingress handlers backed by AWS ALBs reside outside the Constellation cluster, so they shouldn't be handling sensitive traffic!
 :::

--- a/docs/versioned_docs/version-2.17/overview/performance/compute.md
+++ b/docs/versioned_docs/version-2.17/overview/performance/compute.md
@@ -1,0 +1,11 @@
+# Impact of runtime encryption on compute performance
+
+All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
+
+## AMD and Azure benchmarking
+
+AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
+
+## AMD and Google benchmarking
+
+Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.

--- a/docs/versioned_docs/version-2.17/overview/performance/performance.md
+++ b/docs/versioned_docs/version-2.17/overview/performance/performance.md
@@ -1,18 +1,10 @@
 # Performance analysis of Constellation
 
-This section provides a comprehensive examination of the performance characteristics of Constellation, encompassing various aspects, including runtime encryption, I/O benchmarks, and real-world applications.
+This section provides a comprehensive examination of the performance characteristics of Constellation.
 
-## Impact of runtime encryption on performance
+## Runtime encryption
 
-All nodes in a Constellation cluster are executed inside Confidential VMs (CVMs). Consequently, the performance of Constellation is inherently linked to the performance of these CVMs.
-
-### AMD and Azure benchmarking
-
-AMD and Azure have collectively released a [performance benchmark](https://community.amd.com/t5/business/microsoft-azure-confidential-computing-powered-by-3rd-gen-epyc/ba-p/497796) for CVMs that utilize 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. This benchmark, which included a variety of mostly compute-intensive tests such as SPEC CPU 2017 and CoreMark, demonstrated that CVMs experience only minor performance degradation (ranging from 2% to 8%) when compared to standard VMs. Such results are indicative of the performance that can be expected from compute-intensive workloads running with Constellation on Azure.
-
-### AMD and Google benchmarking
-
-Similarly, AMD and Google have jointly released a [performance benchmark](https://www.amd.com/system/files/documents/3rd-gen-epyc-gcp-c2d-conf-compute-perf-brief.pdf) for CVMs employing 3rd Gen AMD EPYC processors (Milan) with SEV-SNP. With high-performance computing workloads such as WRF, NAMD, Ansys CFS, and Ansys LS_DYNA, they observed analogous findings, with only minor performance degradation (between 2% and 4%) compared to standard VMs. These outcomes are reflective of the performance that can be expected for compute-intensive workloads running with Constellation on GCP.
+Runtime encryption affects compute performance. [Benchmarks by Azure and Google](compute.md) show that the performance degradation of Confidential VMs (CVMs) is small, ranging from 2% to 8% for compute-intensive workloads.
 
 ## I/O performance benchmarks
 

--- a/docs/versioned_sidebars/version-2.10-sidebars.json
+++ b/docs/versioned_sidebars/version-2.10-sidebars.json
@@ -42,6 +42,11 @@
           "items": [
             {
               "type": "doc",
+              "label": "Compute benchmarks",
+              "id": "overview/performance/compute"
+            },
+            {
+              "type": "doc",
               "label": "I/O benchmarks",
               "id": "overview/performance/io"
             },

--- a/docs/versioned_sidebars/version-2.11-sidebars.json
+++ b/docs/versioned_sidebars/version-2.11-sidebars.json
@@ -42,6 +42,11 @@
           "items": [
             {
               "type": "doc",
+              "label": "Compute benchmarks",
+              "id": "overview/performance/compute"
+            },
+            {
+              "type": "doc",
               "label": "I/O benchmarks",
               "id": "overview/performance/io"
             },

--- a/docs/versioned_sidebars/version-2.12-sidebars.json
+++ b/docs/versioned_sidebars/version-2.12-sidebars.json
@@ -42,6 +42,11 @@
           "items": [
             {
               "type": "doc",
+              "label": "Compute benchmarks",
+              "id": "overview/performance/compute"
+            },
+            {
+              "type": "doc",
               "label": "I/O benchmarks",
               "id": "overview/performance/io"
             },

--- a/docs/versioned_sidebars/version-2.13-sidebars.json
+++ b/docs/versioned_sidebars/version-2.13-sidebars.json
@@ -42,6 +42,11 @@
           "items": [
             {
               "type": "doc",
+              "label": "Compute benchmarks",
+              "id": "overview/performance/compute"
+            },
+            {
+              "type": "doc",
               "label": "I/O benchmarks",
               "id": "overview/performance/io"
             },

--- a/docs/versioned_sidebars/version-2.14-sidebars.json
+++ b/docs/versioned_sidebars/version-2.14-sidebars.json
@@ -42,6 +42,11 @@
           "items": [
             {
               "type": "doc",
+              "label": "Compute benchmarks",
+              "id": "overview/performance/compute"
+            },
+            {
+              "type": "doc",
               "label": "I/O benchmarks",
               "id": "overview/performance/io"
             },

--- a/docs/versioned_sidebars/version-2.15-sidebars.json
+++ b/docs/versioned_sidebars/version-2.15-sidebars.json
@@ -42,6 +42,11 @@
           "items": [
             {
               "type": "doc",
+              "label": "Compute benchmarks",
+              "id": "overview/performance/compute"
+            },
+            {
+              "type": "doc",
               "label": "I/O benchmarks",
               "id": "overview/performance/io"
             },

--- a/docs/versioned_sidebars/version-2.16-sidebars.json
+++ b/docs/versioned_sidebars/version-2.16-sidebars.json
@@ -42,6 +42,11 @@
           "items": [
             {
               "type": "doc",
+              "label": "Compute benchmarks",
+              "id": "overview/performance/compute"
+            },
+            {
+              "type": "doc",
               "label": "I/O benchmarks",
               "id": "overview/performance/io"
             },

--- a/docs/versioned_sidebars/version-2.17-sidebars.json
+++ b/docs/versioned_sidebars/version-2.17-sidebars.json
@@ -42,6 +42,11 @@
           "items": [
             {
               "type": "doc",
+              "label": "Compute benchmarks",
+              "id": "overview/performance/compute"
+            },
+            {
+              "type": "doc",
               "label": "I/O benchmarks",
               "id": "overview/performance/io"
             },


### PR DESCRIPTION
### Context
A category page should only provide a summary of the pages of that category because it can easily be overlooked.

### Proposed change(s)
- move compute benchmark to its own page and provide a summary on the category page

### Checklist
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
