### PR TITLE
ci: fix relative paths for verify e2e test

### DIFF
--- a/.github/actions/e2e_verify/action.yml
+++ b/.github/actions/e2e_verify/action.yml
@@ -96,7 +96,14 @@ runs:
       run: |
         reports=attestation-report-*.json
 
-        report=$(bazel run //internal/api/attestationconfigapi/cli -- compare ${{ inputs.attestationVariant }} ${reports})
+        # bazel run changes the working directory
+        # convert the relative paths to absolute paths to avoid issues
+        absolute_reports=""
+        for report in ${reports}; do
+          absolute_reports="${absolute_reports} $(realpath "${report}")"
+        done
+
+        report=$(bazel run //internal/api/attestationconfigapi/cli -- compare ${{ inputs.attestationVariant }} ${absolute_reports})
 
         path=$(realpath "${report}")
         cat "${path}"

--- a/internal/api/attestationconfigapi/cli/compare.go
+++ b/internal/api/attestationconfigapi/cli/compare.go
@@ -66,13 +66,13 @@ func compareVersions(attestationVariant variant.Variant, files []string, fs file
 	lowestVersion := files[0]
 	lowestReport, err := readReport(files[0], fs)
 	if err != nil {
-		return "", fmt.Errorf("reading tdx report: %w", err)
+		return "", fmt.Errorf("reading report: %w", err)
 	}
 
 	for _, file := range files[1:] {
 		report, err := readReport(file, fs)
 		if err != nil {
-			return "", fmt.Errorf("reading tdx report: %w", err)
+			return "", fmt.Errorf("reading report: %w", err)
 		}
 
 		if client.IsInputNewerThanOtherVersion(attestationVariant, lowestReport, report) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
`bazel run` changes working directory, so relative paths as input parameters result in issues

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use absolute paths for the reports passed to the attestationconfig CLI invoked using `bazel run`
- Fix error message in attestationconfig CLI mentioning TDX when it shouldn't

<!-- (uncomment if applicable)
### Related issue
- Fixes https://github.com/edgelesssys/constellation/actions/runs/9890950326/job/27320484010#step:6:7593
