### PR TITLE
renovate: exclude stackit from Terraform group

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -71,6 +71,7 @@
         "pinDigest",
         "rollback",
       ],
+      // stackit is excluded from the group so that we can ignore v0.24.1: https://github.com/stackitcloud/terraform-provider-stackit/issues/464.
       "excludeDepNames": ["stackit"],
     },
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -71,6 +71,7 @@
         "pinDigest",
         "rollback",
       ],
+      "excludeDepNames": ["stackit"],
     },
     {
       "matchManagers": ["bazelisk", "bazel", "bazel-module"],


### PR DESCRIPTION
### Context

The stackit provider introduced a bug in `v0.24.0` and we'd like to avoid renovate bundling this version with the other Terraform providers. Excluding it from the group should result in a dedicated upgrade PR, which we can then ignore.

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
