### PR TITLE
Allow upgrades on azure without Terraform changes on LBs created from within Kubernetes

### DIFF
--- a/docs/docs/reference/migration.md
+++ b/docs/docs/reference/migration.md
@@ -9,9 +9,9 @@ Use [`constellation config migrate`](./cli.md#constellation-config-migrate) to a
 ### Azure
 
 * To allow seamless upgrades on Azure when Kubernetes services of type `LoadBalancer` are deployed, the target  
- load balancer in which the `cloud-controller-maanger` created the load balancing rules was changed. Instead of using the load balancer, 
- created and maintained by the CLI's Terraform code, the `cloud-controller-mananger` now creates its own load balancer in Azure.  
- If inside your Constellation there are services of type `LoadBalancer`, please remove them before the upgrade and re-apply them  
+ load balancer in which the `cloud-controller-manager` creates load balancing rules was changed. Instead of using the load balancer
+ created and maintained by the CLI's Terraform code, the `cloud-controller-manager` now creates its own load balancer in Azure.
+ If your Constellation has services of type `LoadBalancer`, please remove them before the upgrade and re-apply them
  afterward. 
 
 

--- a/docs/docs/reference/migration.md
+++ b/docs/docs/reference/migration.md
@@ -3,7 +3,19 @@
 This document describes breaking changes and migrations between Constellation releases.
 Use [`constellation config migrate`](./cli.md#constellation-config-migrate) to automatically update an old config file to a new format.
 
-## Migrating from Azure's service principal authentication to managed identity authentication
+
+## Migrations to v2.19.0
+
+### Azure
+
+* To allow seamless upgrades on Azure when Kubernetes services of type `LoadBalancer` are deployed, we changed the target
+ load balancer in which the `cloud-controller-maanger` create the load balancing rules. Instead of using the load balancer we
+ create and maintain in the CLI's Terraform code, the `cloud-controller-mananger` now creates its own load balancer in Azure.
+ If inside your Constellation there are services of type `LoadBalancer`, please remove them before the upgrade and re-apply them
+ afterwards. 
+
+
+## Migrating from Azure's service principal authentication to managed identity authentication (during the upgrade to Constellation v2.8.0)
 
 - The `provider.azure.appClientID` and `provider.azure.appClientSecret` fields are no longer supported and should be removed.
 - To keep using an existing UAMI, add the `Owner` permission with the scope of your `resourceGroup`.

--- a/docs/docs/reference/migration.md
+++ b/docs/docs/reference/migration.md
@@ -8,11 +8,11 @@ Use [`constellation config migrate`](./cli.md#constellation-config-migrate) to a
 
 ### Azure
 
-* To allow seamless upgrades on Azure when Kubernetes services of type `LoadBalancer` are deployed, we changed the target
- load balancer in which the `cloud-controller-maanger` create the load balancing rules. Instead of using the load balancer we
- create and maintain in the CLI's Terraform code, the `cloud-controller-mananger` now creates its own load balancer in Azure.
- If inside your Constellation there are services of type `LoadBalancer`, please remove them before the upgrade and re-apply them
- afterwards. 
+* To allow seamless upgrades on Azure when Kubernetes services of type `LoadBalancer` are deployed, the target  
+ load balancer in which the `cloud-controller-maanger` created the load balancing rules was changed. Instead of using the load balancer, 
+ created and maintained by the CLI's Terraform code, the `cloud-controller-mananger` now creates its own load balancer in Azure.  
+ If inside your Constellation there are services of type `LoadBalancer`, please remove them before the upgrade and re-apply them  
+ afterward. 
 
 
 ## Migrating from Azure's service principal authentication to managed identity authentication (during the upgrade to Constellation v2.8.0)

--- a/internal/constellation/helm/overrides.go
+++ b/internal/constellation/helm/overrides.go
@@ -243,7 +243,7 @@ func getCCMConfig(azureState state.Azure, serviceAccURI string) ([]byte, error) 
 		ResourceGroup:               azureState.ResourceGroup,
 		LoadBalancerSku:             "standard",
 		SecurityGroupName:           azureState.NetworkSecurityGroupName,
-		LoadBalancerName:            azureState.LoadBalancerName,
+		LoadBalancerName:            "kubernetes-lb",
 		UseInstanceMetadata:         true,
 		VMType:                      "vmss",
 		Location:                    creds.Location,

--- a/terraform/infrastructure/aws/main.tf
+++ b/terraform/infrastructure/aws/main.tf
@@ -55,6 +55,13 @@ locals {
 
   in_cluster_endpoint     = aws_lb.front_end.dns_name
   out_of_cluster_endpoint = var.internal_load_balancer && var.debug ? module.jump_host[0].ip : local.in_cluster_endpoint
+  revision                = 1
+}
+
+# A way to force replacement of resources if the provider does not want to replace them
+# see: https://developer.hashicorp.com/terraform/language/resources/terraform-data#example-usage-data-for-replace_triggered_by
+resource "terraform_data" "replacement" {
+  input = local.revision
 }
 
 resource "random_id" "uid" {

--- a/terraform/infrastructure/azure/main.tf
+++ b/terraform/infrastructure/azure/main.tf
@@ -52,6 +52,13 @@ locals {
 
   in_cluster_endpoint     = var.internal_load_balancer ? azurerm_lb.loadbalancer.frontend_ip_configuration[0].private_ip_address : azurerm_public_ip.loadbalancer_ip[0].ip_address
   out_of_cluster_endpoint = var.debug && var.internal_load_balancer ? module.jump_host[0].ip : local.in_cluster_endpoint
+  revision                = 1
+}
+
+# A way to force replacement of resources if the provider does not want to replace them
+# see: https://developer.hashicorp.com/terraform/language/resources/terraform-data#example-usage-data-for-replace_triggered_by
+resource "terraform_data" "replacement" {
+  input = local.revision
 }
 
 resource "random_id" "uid" {

--- a/terraform/infrastructure/azure/modules/scale_set/main.tf
+++ b/terraform/infrastructure/azure/modules/scale_set/main.tf
@@ -122,6 +122,7 @@ resource "azurerm_linux_virtual_machine_scale_set" "scale_set" {
       instances,              # required. autoscaling modifies the instance count externally
       source_image_id,        # required. update procedure modifies the image id externally
       source_image_reference, # required. update procedure modifies the image reference externally
+      network_interface[0].ip_configuration[0].load_balancer_backend_address_pool_ids
     ]
   }
 }

--- a/terraform/infrastructure/gcp/main.tf
+++ b/terraform/infrastructure/gcp/main.tf
@@ -60,6 +60,13 @@ locals {
   ]
   in_cluster_endpoint     = var.internal_load_balancer ? google_compute_address.loadbalancer_ip_internal[0].address : google_compute_global_address.loadbalancer_ip[0].address
   out_of_cluster_endpoint = var.debug && var.internal_load_balancer ? module.jump_host[0].ip : local.in_cluster_endpoint
+  revision                = 1
+}
+
+# A way to force replacement of resources if the provider does not want to replace them
+# see: https://developer.hashicorp.com/terraform/language/resources/terraform-data#example-usage-data-for-replace_triggered_by
+resource "terraform_data" "replacement" {
+  input = local.revision
 }
 
 resource "random_id" "uid" {

--- a/terraform/infrastructure/openstack/main.tf
+++ b/terraform/infrastructure/openstack/main.tf
@@ -59,6 +59,13 @@ locals {
   cloudsyaml_path       = length(var.openstack_clouds_yaml_path) > 0 ? var.openstack_clouds_yaml_path : "~/.config/openstack/clouds.yaml"
   cloudsyaml            = yamldecode(file(pathexpand(local.cloudsyaml_path)))
   cloudyaml             = local.cloudsyaml.clouds[var.cloud]
+  revision              = 1
+}
+
+# A way to force replacement of resources if the provider does not want to replace them
+# see: https://developer.hashicorp.com/terraform/language/resources/terraform-data#example-usage-data-for-replace_triggered_by
+resource "terraform_data" "replacement" {
+  input = local.revision
 }
 
 resource "random_id" "uid" {

--- a/terraform/infrastructure/qemu/main.tf
+++ b/terraform/infrastructure/qemu/main.tf
@@ -23,6 +23,13 @@ locals {
   cidr_vpc_subnet_nodes          = "10.42.0.0/22"
   cidr_vpc_subnet_control_planes = "10.42.1.0/24"
   cidr_vpc_subnet_worker         = "10.42.2.0/24"
+  revision                       = 1
+}
+
+# A way to force replacement of resources if the provider does not want to replace them
+# see: https://developer.hashicorp.com/terraform/language/resources/terraform-data#example-usage-data-for-replace_triggered_by
+resource "terraform_data" "replacement" {
+  input = local.revision
 }
 
 resource "random_password" "init_secret" {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove worker nodes from any existing load balancer backend, since any VM NIC can only be attached to one backend group. Also the worker backends were unused anyway.
- Let the cloud-controller-manager create a separate "kubernetes-lb" to create LBs for Kubernetes services.
- Don't inline (most) of the network security rules
  - Sadly, we cannot fix the upgrade process in one go, as we need 2 state changes on the same resource. So the upgrade to this release still removes the network security rules added by the cloud controller manager, but which should heal itself in the upgrade process one it's restarted. After we execute the instructions mentioned in the TODO, there will finally be no terraform changes after "constellation create" -> "create LB svc" -> "terraform plan". 

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

Azure, snp, 1:2, lb: https://github.com/edgelesssys/constellation/actions/runs/11220341955
Azure, snp, 1:2, upgrade: https://github.com/edgelesssys/constellation/actions/runs/11220359763

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
