### PR TITLE
ci: run performance e2e tests using nightly image

### DIFF
--- a/.github/workflows/e2e-test-weekly.yml
+++ b/.github/workflows/e2e-test-weekly.yml
@@ -243,27 +243,27 @@ jobs:
 
           # perf-bench test on latest k8s version
           - test: "perf-bench"
-            refStream: "ref/main/stream/debug/?"
+            refStream: "ref/main/stream/nightly/?"
             attestationVariant: "gcp-sev-es"
             kubernetes-version: "v1.30"
             clusterCreation: "cli"
           - test: "perf-bench"
-            refStream: "ref/main/stream/debug/?"
+            refStream: "ref/main/stream/nightly/?"
             attestationVariant: "gcp-sev-snp"
             kubernetes-version: "v1.30"
             clusterCreation: "cli"
           - test: "perf-bench"
-            refStream: "ref/main/stream/debug/?"
+            refStream: "ref/main/stream/nightly/?"
             attestationVariant: "azure-sev-snp"
             kubernetes-version: "v1.30"
             clusterCreation: "cli"
           - test: "perf-bench"
-            refStream: "ref/main/stream/debug/?"
+            refStream: "ref/main/stream/nightly/?"
             attestationVariant: "azure-tdx"
             kubernetes-version: "v1.30"
             clusterCreation: "cli"
           - test: "perf-bench"
-            refStream: "ref/main/stream/debug/?"
+            refStream: "ref/main/stream/nightly/?"
             attestationVariant: "aws-sev-snp"
             kubernetes-version: "v1.30"
             clusterCreation: "cli"
@@ -338,7 +338,7 @@ jobs:
           controlNodesCount: "3"
           cloudProvider: ${{ steps.split-attestationVariant.outputs.cloudProvider }}
           attestationVariant: ${{ matrix.attestationVariant }}
-          osImage: ${{ matrix.refStream == 'ref/release/stream/stable/?' && needs.find-latest-image.outputs.image-release-stable || needs.find-latest-image.outputs.image-main-debug }}
+          osImage: ${{ matrix.refStream == 'ref/release/stream/stable/?' && needs.find-latest-image.outputs.image-release-stable || matrix.refStream == 'ref/main/stream/nightly/?' && needs.find-latest-image.outputs.image-main-nightly || needs.find-latest-image.outputs.image-main-debug }}
           isDebugImage: ${{ matrix.refStream == 'ref/main/stream/debug/?' }}
           cliVersion: ${{ matrix.refStream == 'ref/release/stream/stable/?' && needs.find-latest-image.outputs.image-release-stable || '' }}
           kubernetesVersion: ${{ matrix.kubernetes-version }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Since debug images deploy additional software before the cluster is started which might impact performance, performance e2e tests should use our nightly images to better reflect the actual performance of our Constellation cluster.
I thought there was more to be done to enable this, but seems like we already implemented most things to use nightly images.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Run performance e2e tests using nightly images

### Additional info
<!-- Remove items that do not apply -->
- [AB#4392](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4392)
- Fixes https://github.com/edgelesssys/issues/issues/707

