### PR TITLE
ci: correctly fetch image on nightly image ref

### DIFF
--- a/.github/actions/select_image/action.yml
+++ b/.github/actions/select_image/action.yml
@@ -3,15 +3,15 @@ description: Resolve string presets and shortpaths to shortpaths only
 
 inputs:
   osImage:
-    description: "Shortpath or main-debug or release-stable"
+    description: "Shortpath, main-debug, main-nightly, or release-stable"
     required: true
 
 outputs:
   osImage:
-    description: "Shortpath of for input string, original input if that was already a shortpath"
+    description: "Shortpath of input string, original input if that was already a shortpath"
     value: ${{ steps.set-output.outputs.osImage }}
   isDebugImage:
-    description: "Input represents a debug image or not"
+    description: "Input is a debug image or not"
     value: ${{ steps.set-output.outputs.isDebugImage }}
 
 runs:
@@ -27,7 +27,7 @@ runs:
       id: input-is-preset
       shell: bash
       run: |
-        if [[ "${{ inputs.osImage }}" == "ref/main/stream/debug/?" || "${{ inputs.osImage }}" == "ref/release/stream/stable/?" ]]; then
+        if [[ "${{ inputs.osImage }}" == "ref/main/stream/debug/?" || "${{ inputs.osImage }}" == "ref/main/stream/nightly/?" || "${{ inputs.osImage }}" == "ref/release/stream/stable/?" ]]; then
           echo "result=true" | tee -a "$GITHUB_OUTPUT"
         else
           echo "result=false" | tee -a "$GITHUB_OUTPUT"


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
I thought I tested this correctly, but turns out weekly and daily e2e tests use a different action to select their image than the manual e2e test.
That action did not recognize `ref/main/stream/nightly/?` as refStream, instead assuming it was a full os image shortpath.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Correctly fetch the latest nightly image when `refStream==ref/main/stream/nightly/?`

### Related issue
- https://github.com/edgelesssys/issues/issues/776
