### PR TITLE
renovate: group non-core bazel dependency updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -80,6 +80,28 @@
       "groupName": "bazel (core)",
     },
     {
+      "matchManagers": ["bazel"],
+      "matchDepNames": [
+        "!bazel",
+        "!io_bazel_rules_go",
+        "!bazel_gazelle",
+        "!rules_go",
+        "!gazelle",
+      ]
+      "groupName": "bazel (plugins)",
+    },
+    {
+      "matchManagers": ["bazel-module"],
+      "matchDepNames": [
+        "!bazel",
+        "!io_bazel_rules_go",
+        "!bazel_gazelle",
+        "!rules_go",
+        "!gazelle",
+      ]
+      "groupName": "bazel (modules)",
+    },
+    {
       "matchDatasources": ["golang-version"],
       "allowedVersions": "1.22",
     },


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
We already grouped core bazel dependency updates into one renovate PR.
To reduce the load of dependency PRs we want to group other dependencies tracked through bazel as well.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Group non-core dependency updates for `bazel` and `bazel-module`

