### PR TITLE
renovate: schedule dependency updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -72,8 +72,6 @@
         "pinDigest",
         "rollback",
       ],
-      // stackit is excluded from the group so that we can ignore v0.24.1: https://github.com/stackitcloud/terraform-provider-stackit/issues/464.
-      "excludeDepNames": ["stackit"],
       "schedule": ["before 8am on wednesday"],
     },
     {

--- a/renovate.json5
+++ b/renovate.json5
@@ -56,6 +56,7 @@
         "pinDigest",
         "rollback",
       ],
+      "schedule": ["before 8am on monday"],
     },
     {
       // Group update of Terraform dependencies.
@@ -73,6 +74,7 @@
       ],
       // stackit is excluded from the group so that we can ignore v0.24.1: https://github.com/stackitcloud/terraform-provider-stackit/issues/464.
       "excludeDepNames": ["stackit"],
+      "schedule": ["before 8am on wednesday"],
     },
     {
       "matchManagers": ["bazelisk", "bazel", "bazel-module"],
@@ -123,6 +125,7 @@
         "rollback",
         "bump",
       ],
+      "schedule": ["before 8am on tuesday"],
     },
     {
       "matchDepNames": ["kubernetes/kubernetes"],

--- a/renovate.json5
+++ b/renovate.json5
@@ -185,6 +185,7 @@
       "ignoreUnstable": false,
       "groupName": "Constellation containers",
       "prPriority": 20,
+      "schedule": ["before 8am on thursday"],
     },
     {
       "matchDepNames": [


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Keeping our dependencies up to date is not easy.
Putting updates of our larger dependency groups on a schedule should help once we get the pending PR list down

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Put Go, GitHub actions, Terraform, and Constellation container updates on a schedule
- Stop ignoring StackIT Terraform updates since the issues in `v0.24.1` have been resolved upstream
