### PR TITLE
terraform-provider-constellation: make kubeconfig output fine-grained

### DIFF
--- a/terraform-provider-constellation/docs/resources/cluster.md
+++ b/terraform-provider-constellation/docs/resources/cluster.md
@@ -90,8 +90,12 @@ See the [full list of CSPs](https://docs.edgeless.systems/constellation/overview
 
 ### Read-Only
 
+- `client_certificate` (String) The client certificate of the cluster.
+- `client_key` (String, Sensitive) The client key of the cluster.
+- `cluster_ca_certificate` (String) The cluster CA certificate of the cluster.
 - `cluster_id` (String) The cluster ID of the cluster.
-- `kubeconfig` (String, Sensitive) The kubeconfig of the cluster.
+- `host` (String) The host of the cluster.
+- `kubeconfig` (String, Sensitive) The kubeconfig (file) of the cluster.
 - `owner_id` (String) The owner ID of the cluster.
 
 <a id="nestedatt--attestation"></a>

--- a/terraform-provider-constellation/internal/provider/BUILD.bazel
+++ b/terraform-provider-constellation/internal/provider/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "@com_github_hashicorp_terraform_plugin_framework_validators//stringvalidator",
         "@com_github_hashicorp_terraform_plugin_log//tflog",
         "@com_github_spf13_afero//:afero",
+        "@io_k8s_client_go//tools/clientcmd",
     ],
 )
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
To directly plug in the Constellation Terraform provider into the `kubernetes` and `helm` providers, we need fine-grained outputs for cluster address, client certificate, key, etc.

To test this, consider the following Terraform snippet, which can be plugged into the AWS Terraform example configuration:

```hcl
provider "kubernetes" {
  host = constellation_cluster.aws_example.host

  client_certificate     = constellation_cluster.aws_example.client_certificate
  client_key             = constellation_cluster.aws_example.client_key
  cluster_ca_certificate = constellation_cluster.aws_example.cluster_ca_certificate
}

data "kubernetes_nodes" "example" {}

output "node-ids" {
  value = [for node in data.kubernetes_nodes.example.nodes : node.spec.0.provider_id]
}
```

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Parse the kubeconfig returned through the init RPC and extract the respective values, making them available as outputs of the `constellation_cluster` resource.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#4604](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4604)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
