### PR TITLE
treewide: update Go toolchain to 1.22.7

### DIFF
--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.22.5"
+          go-version: "1.22.7"
           cache: false
 
       - name: Install Crane

--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.22.5"
+          go-version: "1.22.7"
           cache: false
 
       - name: Determine version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.22.5"
+          go-version: "1.22.7"
           cache: false
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.22.5"
+          go-version: "1.22.7"
           cache: true
 
       - name: Build generateMeasurements tool

--- a/.github/workflows/test-operator-codegen.yml
+++ b/.github/workflows/test-operator-codegen.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.22.5"
+          go-version: "1.22.7"
           cache: true
 
       - name: Run code generation

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -21,7 +21,7 @@ go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_sdk",
     patches = ["//3rdparty/bazel/org_golang:go_tls_max_handshake_size.patch"],
-    version = "1.22.5",
+    version = "1.22.7",
 )
 
 # the use_repo rule needs to list all top-level go dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelesssys/constellation/v2
 
-go 1.22.5
+go 1.22.7
 
 // TODO(daniel-weisse): revert after merging https://github.com/martinjungblut/go-cryptsetup/pull/16.
 replace github.com/martinjungblut/go-cryptsetup => github.com/daniel-weisse/go-cryptsetup v0.0.0-20230705150314-d8c07bd1723c

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.22.5
+go 1.22.7
 
-toolchain go1.22.5
+toolchain go1.22.7
 
 use (
 	.


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Changelog: https://go.dev/doc/devel/release#go1.22.0

> go1.22.7 (released 2024-09-05) includes security fixes to the encoding/gob, go/build/constraint, and go/parser packages, as well as bug fixes to the fix command and the runtime. See the [Go 1.22.7 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.22.7+label%3ACherryPickApproved) on our issue tracker for details.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Update the Go toolchain to v1.22.7

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
