### PR TITLE
helm: cilium: allow multiple default routes

### DIFF
--- a/internal/constellation/helm/charts/cilium/templates/cilium-agent/daemonset.yaml
+++ b/internal/constellation/helm/charts/cilium/templates/cilium-agent/daemonset.yaml
@@ -764,13 +764,14 @@ spec:
         - -exc
         - |
           pref=32
-          interface=$(ip route | awk '/^default/ { print $5 }')
-          tc qdisc add dev "${interface}" clsact || true
-          tc filter del dev "${interface}" ingress pref "${pref}" 2>/dev/null || true
-          handle=0
-          for cidr in ${POD_CIDRS}; do
-            handle=$((handle + 1))
-            tc filter replace dev "${interface}" ingress pref "${pref}" handle "${handle}" protocol ip flower dst_ip "${cidr}" action drop
+          for interface in $(ip route | awk '/^default/ { print $5 }'); do
+            tc qdisc add dev "${interface}" clsact || true
+            tc filter del dev "${interface}" ingress pref "${pref}" 2>/dev/null || true
+            handle=0
+            for cidr in ${POD_CIDRS}; do
+              handle=$((handle + 1))
+              tc filter replace dev "${interface}" ingress pref "${pref}" handle "${handle}" protocol ip flower dst_ip "${cidr}" action drop
+            done
           done
         env:
         - name: POD_CIDRS

--- a/internal/constellation/helm/cilium.patch
+++ b/internal/constellation/helm/cilium.patch
@@ -1,5 +1,5 @@
 diff --git a/install/kubernetes/cilium/Chart.yaml b/install/kubernetes/cilium/Chart.yaml
-index 256a79542..3f3fc714b 100644
+index 4df10f166b..9f079933b2 100644
 --- a/install/kubernetes/cilium/Chart.yaml
 +++ b/install/kubernetes/cilium/Chart.yaml
 @@ -2,8 +2,8 @@ apiVersion: v2
@@ -13,4 +13,29 @@ index 256a79542..3f3fc714b 100644
  kubeVersion: ">= 1.16.0-0"
  icon: https://cdn.jsdelivr.net/gh/cilium/cilium@v1.15/Documentation/images/logo-solo.svg
  description: eBPF-based Networking, Security, and Observability
- 
+diff --git a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+index ffd5935ba1..e2b8ccff6c 100644
+--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
++++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+@@ -764,13 +764,14 @@ spec:
+         - -exc
+         - |
+           pref=32
+-          interface=$(ip route | awk '/^default/ { print $5 }')
+-          tc qdisc add dev "${interface}" clsact || true
+-          tc filter del dev "${interface}" ingress pref "${pref}" 2>/dev/null || true
+-          handle=0
+-          for cidr in ${POD_CIDRS}; do
+-            handle=$((handle + 1))
+-            tc filter replace dev "${interface}" ingress pref "${pref}" handle "${handle}" protocol ip flower dst_ip "${cidr}" action drop
++          for interface in $(ip route | awk '/^default/ { print $5 }'); do
++            tc qdisc add dev "${interface}" clsact || true
++            tc filter del dev "${interface}" ingress pref "${pref}" 2>/dev/null || true
++            handle=0
++            for cidr in ${POD_CIDRS}; do
++              handle=$((handle + 1))
++              tc filter replace dev "${interface}" ingress pref "${pref}" handle "${handle}" protocol ip flower dst_ip "${cidr}" action drop
++            done
+           done
+         env:
+         - name: POD_CIDRS


### PR DESCRIPTION
### Context

Our Cilium hardening scripts assume that there is only one default route configured on the host. However, this turned out to be wrong for some environments, breaking Cilium.

### Proposed change(s)

- Apply [hardening](https://github.com/edgelesssys/constellation/blob/0aeda78089905d87dccbfa5e2c2ef0a02725df3f/internal/constellation/helm/charts/cilium/templates/cilium-agent/daemonset.yaml#L766-L774) to all interfaces used for default routes.


### Related issue
- Fixes #3294 

### Checklist
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [Azure](https://github.com/edgelesssys/constellation/actions/runs/10788840090)
  - [x] [GCP](https://github.com/edgelesssys/constellation/actions/runs/10789922092)
  - [x] [AWS](https://github.com/edgelesssys/constellation/actions/runs/10789933106)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
