### PR TITLE
e2e: remove immediate node status printing

### DIFF
--- a/e2e/internal/upgrade/upgrade.go
+++ b/e2e/internal/upgrade/upgrade.go
@@ -142,7 +142,6 @@ func testNodesEventuallyHaveVersion(t *testing.T, k *kubernetes.Clientset, targe
 					if key == "constellation.edgeless.systems/node-image" {
 						if !strings.EqualFold(value, targetVersions.ImageRef) {
 							log.Printf("\t%s: Image %s, want %s\n", node.Name, value, targetVersions.ImageRef)
-							fmt.Printf("\tP: %s: Image %s, want %s\n", node.Name, value, targetVersions.ImageRef)
 							allUpdated = false
 						}
 					}


### PR DESCRIPTION
### Context
The upgrade test interleaves stdout messages and test logs, making the output harder to read than necessary.

https://github.com/edgelesssys/constellation/actions/runs/10791721941/job/29952302050#step:19:20029

### Proposed change(s)
- Don't print to stdout, only to log.

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
