### PR TITLE
helm: fix kubeadm bugs caused by CoreDNS installation

### DIFF
--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -428,6 +428,9 @@ func (a *applyCmd) apply(
 		if err := a.runHelmApply(cmd, conf, stateFile, upgradeDir); err != nil {
 			return err
 		}
+		if err := a.applier.CleanupCoreDNSResources(cmd.Context()); err != nil {
+			return fmt.Errorf("cleaning up CoreDNS: %w", err)
+		}
 	}
 
 	// Upgrade node image
@@ -847,6 +850,7 @@ type applier interface {
 	// methods required to install/upgrade Helm charts
 
 	AnnotateCoreDNSResources(context.Context) error
+	CleanupCoreDNSResources(context.Context) error
 	PrepareHelmCharts(
 		flags helm.Options, state *state.State, serviceAccURI string, masterSecret uri.MasterSecret,
 	) (helm.Applier, bool, error)

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -554,6 +554,7 @@ func (s *stubConstellApplier) Init(context.Context, atls.Validator, *state.State
 
 type helmApplier interface {
 	AnnotateCoreDNSResources(context.Context) error
+	CleanupCoreDNSResources(ctx context.Context) error
 	PrepareHelmCharts(
 		flags helm.Options, stateFile *state.State, serviceAccURI string, masterSecret uri.MasterSecret,
 	) (

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -282,6 +282,10 @@ func (s stubHelmApplier) AnnotateCoreDNSResources(_ context.Context) error {
 	return nil
 }
 
+func (s stubHelmApplier) CleanupCoreDNSResources(_ context.Context) error {
+	return nil
+}
+
 func (s stubHelmApplier) PrepareHelmCharts(
 	_ helm.Options, _ *state.State, _ string, _ uri.MasterSecret,
 ) (helm.Applier, bool, error) {

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -379,6 +379,10 @@ func (m *mockApplier) AnnotateCoreDNSResources(_ context.Context) error {
 	return nil
 }
 
+func (s *mockApplier) CleanupCoreDNSResources(_ context.Context) error {
+	return nil
+}
+
 func (m *mockApplier) PrepareHelmCharts(
 	helmOpts helm.Options, stateFile *state.State, str string, masterSecret uri.MasterSecret,
 ) (helm.Applier, bool, error) {

--- a/cli/internal/cmd/upgradeapply_test.go
+++ b/cli/internal/cmd/upgradeapply_test.go
@@ -379,7 +379,7 @@ func (m *mockApplier) AnnotateCoreDNSResources(_ context.Context) error {
 	return nil
 }
 
-func (s *mockApplier) CleanupCoreDNSResources(_ context.Context) error {
+func (m *mockApplier) CleanupCoreDNSResources(_ context.Context) error {
 	return nil
 }
 

--- a/internal/constellation/helm.go
+++ b/internal/constellation/helm.go
@@ -60,6 +60,21 @@ func (a *Applier) AnnotateCoreDNSResources(ctx context.Context) error {
 	return nil
 }
 
+// CleanupCoreDNSResources removes CoreDNS resources that are not managed by Helm.
+//
+// This is only required when CoreDNS was installed by kubeadm directly.
+// TODO(burgerdev): remove after v2.19 is released.
+func (a *Applier) CleanupCoreDNSResources(ctx context.Context) error {
+	err := a.dynamicClient.
+		Resource(schema.GroupVersionResource{Group: "", Version: "v1", Resource: "configmaps"}).
+		Namespace("kube-system").
+		Delete(ctx, "coredns", v1.DeleteOptions{})
+	if !k8serrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
 // PrepareHelmCharts loads Helm charts for Constellation and returns an executor to apply them.
 func (a *Applier) PrepareHelmCharts(
 	flags helm.Options, state *state.State, serviceAccURI string, masterSecret uri.MasterSecret,

--- a/internal/constellation/helm/charts/coredns/templates/configmap.yaml
+++ b/internal/constellation/helm/charts/coredns/templates/configmap.yaml
@@ -1,9 +1,4 @@
-
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: coredns
-  namespace: kube-system
 data:
   Corefile: |
     .:53 {
@@ -26,3 +21,8 @@ data:
         reload
         loadbalance
     }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: edg-coredns
+  namespace: kube-system

--- a/internal/constellation/helm/charts/coredns/templates/deployment.yaml
+++ b/internal/constellation/helm/charts/coredns/templates/deployment.yaml
@@ -104,6 +104,6 @@ spec:
           items:
           - key: Corefile
             path: Corefile
-          name: coredns
+          name: edg-coredns
         name: config-volume
 status: {}

--- a/terraform-provider-constellation/internal/provider/cluster_resource.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource.go
@@ -1311,6 +1311,11 @@ func (r *ClusterResource) applyHelmCharts(ctx context.Context, applier *constell
 		diags.AddError("Applying Helm charts", err.Error())
 		return diags
 	}
+
+	if err := applier.CleanupCoreDNSResources(ctx); err != nil {
+		diags.AddError("Cleaning up CoreDNS resources", err.Error())
+		return diags
+	}
 	return diags
 }
 

--- a/upgrade-agent/internal/server/server.go
+++ b/upgrade-agent/internal/server/server.go
@@ -111,12 +111,18 @@ func (s *Server) ExecuteUpdate(ctx context.Context, updateRequest *upgradeproto.
 		return nil, status.Errorf(codes.Internal, "unable to install the kubeadm binary: %s", err)
 	}
 
-	upgradeCmd := exec.CommandContext(ctx, "kubeadm", "upgrade", "plan", updateRequest.WantedKubernetesVersion)
+	// CoreDNS addon status is checked even though we did not install it.
+	// TODO(burgerdev): Use kubeadm phases once supported: https://github.com/kubernetes/kubeadm/issues/1318.
+	commonArgs := []string{"--ignore-preflight-errors", "CoreDNSMigration,CoreDNSUnsupportedPlugins", updateRequest.WantedKubernetesVersion}
+	planArgs := append([]string{"upgrade", "plan"}, commonArgs...)
+	applyArgs := append([]string{"upgrade", "apply", "--yes", "--patches", constants.KubeadmPatchDir}, commonArgs...)
+
+	upgradeCmd := exec.CommandContext(ctx, "kubeadm", planArgs...)
 	if out, err := upgradeCmd.CombinedOutput(); err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to execute kubeadm upgrade plan %s: %s: %s", updateRequest.WantedKubernetesVersion, err, string(out))
 	}
 
-	applyCmd := exec.CommandContext(ctx, "kubeadm", "upgrade", "apply", "--yes", "--patches", constants.KubeadmPatchDir, updateRequest.WantedKubernetesVersion)
+	applyCmd := exec.CommandContext(ctx, "kubeadm", applyArgs...)
 	if out, err := applyCmd.CombinedOutput(); err != nil {
 		return nil, status.Errorf(codes.Internal, "unable to execute kubeadm upgrade apply: %s: %s", err, string(out))
 	}


### PR DESCRIPTION
### Context

Putting the CoreDNS deployment under Helm management (#3236) introduced two bugs:

1. The `kubeadm upgrade` preflight checks started to fail because the version can't be parsed from the pinned image (see kubernetes/kubernetes#122967).
2. `kubeadm upgrade` overwrites the Helm chart resources because there's no way to skip the addon phase (see kubernetes/kubeadm#1318).

Both of these issues arise because Helm charts are installed before the Kubernetes upgrade, and both issues have not been caught because the upgrade process ignores errors from kubeadm (see edgelesssys/issues#134).

### Proposed change(s)

- Ignore CoreDNS-related preflight errors.
- Rename the CoreDNS ConfigMap during upgrades. This is working around the missing kubeadm phase feature: if there's no `kube-system/coredns` ConfigMap, kubeadm does not try to manage CoreDNS. This is more temporary code that will be deleted as soon as all eligible upgrade origin versions have Helm-managed CoreDNS (>2.19). 

### Additional info
<!-- Remove items that do not apply -->
- [AB#4654](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4654)


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] Azure e2e
  - [x] Azure upgrade
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
