### PR TITLE
image: re-enable autologin for debug and console images

### DIFF
--- a/bazel/mkosi/mkosi_image.bzl
+++ b/bazel/mkosi/mkosi_image.bzl
@@ -70,8 +70,6 @@ def _mkosi_image_impl(ctx):
         args.add("--kernel-command-line", ctx.attr.kernel_command_line)
     for key, value in ctx.attr.kernel_command_line_dict.items():
         args.add("--kernel-command-line", "{}={}".format(key, value))
-    if ctx.attr.autologin:
-        args.add("--autologin", "yes")
 
     info = ctx.toolchains["@constellation//bazel/mkosi:toolchain_type"].mkosi
     if not info.valid:
@@ -110,7 +108,6 @@ mkosi_image = rule(
     implementation = _mkosi_image_impl,
     attrs = {
         "architecture": attr.string(),
-        "autologin": attr.bool(),
         "base_trees": attr.label_list(allow_files = True),
         "distribution": attr.string(),
         "env": attr.string_dict(),

--- a/image/sysroot-tree/usr/lib/systemd/system-preset/20-constellation-base.preset
+++ b/image/sysroot-tree/usr/lib/systemd/system-preset/20-constellation-base.preset
@@ -2,6 +2,7 @@ enable systemd-timesyncd.service
 enable systemd-networkd.service
 enable systemd-networkd-wait-online.service
 enable configure-constel-csp.service
+enable serial-getty@tty0.service
 enable dbus.service
 enable dbus-broker.service
 enable dbus-daemon.service

--- a/image/sysroot-tree/usr/lib/systemd/system/serial-getty@ttyS0.service.d/autologin.conf
+++ b/image/sysroot-tree/usr/lib/systemd/system/serial-getty@ttyS0.service.d/autologin.conf
@@ -1,0 +1,12 @@
+[Unit]
+Description=autologin
+ConditionPathExists=/proc/cmdline
+ConditionKernelCommandLine=|constellation.console
+ConditionKernelCommandLine=|constellation.debug
+
+[Service]
+ExecStart=
+ExecStart=-/sbin/agetty -o '-p -f -- \\u' --keep-baud --autologin root 115200,57600,38400,9600 - $TERM
+
+[Install]
+WantedBy=multi-user.target

--- a/image/system/BUILD.bazel
+++ b/image/system/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//bazel/mkosi:mkosi_image.bzl", "mkosi_image")
 load("//bazel/osimage:upload_os_images.bzl", "upload_os_images")
-load(":variants.bzl", "CSPS", "STREAMS", "VARIANTS", "autologin", "base_image", "constellation_packages", "images_for_csp", "images_for_csp_and_stream", "images_for_stream", "kernel_command_line", "kernel_command_line_dict")
+load(":variants.bzl", "CSPS", "STREAMS", "VARIANTS", "base_image", "constellation_packages", "images_for_csp", "images_for_csp_and_stream", "images_for_stream", "kernel_command_line", "kernel_command_line_dict")
 
 [
     mkosi_image(
@@ -10,11 +10,6 @@ load(":variants.bzl", "CSPS", "STREAMS", "VARIANTS", "autologin", "base_image", 
         ] + glob([
             "mkosi.repart/**",
         ]),
-        autologin = autologin(
-            variant["csp"],
-            variant["attestation_variant"],
-            stream,
-        ),
         base_trees = [
             base_image(
                 variant["csp"],

--- a/image/system/variants.bzl
+++ b/image/system/variants.bzl
@@ -86,7 +86,6 @@ csp_settings = {
         },
     },
     "qemu": {
-        "autologin": True,
         "kernel_command_line_dict": {
             "console": "ttyS0",
             "constel.csp": "qemu",
@@ -136,10 +135,8 @@ attestation_variant_settings = {
 
 stream_settings = {
     "console": {
-        "autologin": True,
     },
     "debug": {
-        "autologin": True,
         "kernel_command_line": "constellation.debug",
     },
     "nightly": {},
@@ -180,26 +177,6 @@ def constellation_packages(stream):
         "//upgrade-agent/cmd:upgrade-agent-package",
         "//bootstrapper/cmd/bootstrapper:bootstrapper-package",
     ] + base_packages
-
-def autologin(csp, attestation_variant, stream):
-    """Generates a boolean indicating whether autologin should be enabled for the given csp, attestation_variant and stream.
-
-    Args:
-      csp: The cloud service provider to use.
-      attestation_variant: The attestation variant to use.
-      stream: The stream to use.
-
-    Returns:
-        A boolean indicating whether autologin should be enabled.
-    """
-    out = None
-    for settings in from_settings(csp, attestation_variant, stream):
-        if not "autologin" in settings:
-            continue
-        if out != None and out != settings["autologin"]:
-            fail("Inconsistent autologin settings")
-        out = settings["autologin"]
-    return out
 
 def kernel_command_line(csp, attestation_variant, stream):
     cmdline = base_cmdline

--- a/image/system/variants.bzl
+++ b/image/system/variants.bzl
@@ -86,6 +86,7 @@ csp_settings = {
         },
     },
     "qemu": {
+        "kernel_command_line": "constellation.console",  # All qemu images have console enabled independent of stream
         "kernel_command_line_dict": {
             "console": "ttyS0",
             "constel.csp": "qemu",
@@ -135,6 +136,7 @@ attestation_variant_settings = {
 
 stream_settings = {
     "console": {
+        "kernel_command_line": "constellation.console",
     },
     "debug": {
         "kernel_command_line": "constellation.debug",


### PR DESCRIPTION
In mkosi v24 --autologin no longer works for ttyS consoles. Since the CSPs use those exclusively for their serial consoles, we need to replace this with another solution. Since it seems the simplest, I just created the systemd unit myself and made it conditional on the kernel cmdline.

Console:
~https://github.com/edgelesssys/constellation/actions/runs/10856407864~
~https://github.com/edgelesssys/constellation/actions/runs/10874367218~
~https://github.com/edgelesssys/constellation/actions/runs/10874697856~
https://github.com/edgelesssys/constellation/actions/runs/10892773346

Debug:
~https://github.com/edgelesssys/constellation/actions/runs/10856416476~
~https://github.com/edgelesssys/constellation/actions/runs/10874954823~
https://github.com/edgelesssys/constellation/actions/runs/10892782667

Sanity Check / nightly:
~https://github.com/edgelesssys/constellation/actions/runs/10856431020~
~https://github.com/edgelesssys/constellation/actions/runs/10874956962~
https://github.com/edgelesssys/constellation/actions/runs/10892766154

~I have not yet tested the images, but if the console still isn't there I might have missed `enable serial-getty@tty0.service` in `20-constellation-base.preset`~ Tested all 3 images now. Feel free to re-test.

Just to be extra sure, I think we should add a manual serial console enabled check for the next release in the release steps. What do you think?

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
