### PR TITLE
terraform: allow GCP console access without opening debugd port

### DIFF
--- a/terraform-provider-constellation/examples/full/gcp/main.tf
+++ b/terraform-provider-constellation/examples/full/gcp/main.tf
@@ -76,6 +76,7 @@ module "gcp_infrastructure" {
   }
   image_id               = data.constellation_image.bar.image.reference
   debug                  = false
+  console_access         = false
   zone                   = local.zone
   region                 = local.region
   project                = local.project_id

--- a/terraform/infrastructure/gcp/main.tf
+++ b/terraform/infrastructure/gcp/main.tf
@@ -183,6 +183,7 @@ module "instance_group" {
   alias_ip_range_name = google_compute_subnetwork.vpc_subnetwork.secondary_ip_range[0].range_name
   kube_env            = local.kube_env
   debug               = var.debug
+  console_access      = var.console_access
   named_ports         = each.value.role == "control-plane" ? local.control_plane_named_ports : []
   labels              = local.labels
   init_secret_hash    = local.init_secret_hash

--- a/terraform/infrastructure/gcp/modules/instance_group/main.tf
+++ b/terraform/infrastructure/gcp/modules/instance_group/main.tf
@@ -70,7 +70,7 @@ resource "google_compute_instance_template" "template" {
   metadata = {
     kube-env                       = var.kube_env
     constellation-init-secret-hash = var.init_secret_hash
-    serial-port-enable             = var.debug ? "TRUE" : "FALSE"
+    serial-port-enable             = (var.debug || var.console_access) ? "TRUE" : "FALSE"
   }
 
   network_interface {

--- a/terraform/infrastructure/gcp/modules/instance_group/variables.tf
+++ b/terraform/infrastructure/gcp/modules/instance_group/variables.tf
@@ -85,6 +85,11 @@ variable "debug" {
   description = "DO NOT USE IN PRODUCTION. Enable debug mode. This opens up a debugd port that can be used to deploy a custom bootstrapper."
 }
 
+variable "console_access" {
+  type        = bool
+  description = "Enable serial console access to OS images that expose a serial console. This will be shadowed by `debug` (i.e. if `debug` is enabled, console access will be enabled)."
+}
+
 variable "alias_ip_range_name" {
   type        = string
   description = "Name of the alias IP range to use."

--- a/terraform/infrastructure/gcp/variables.tf
+++ b/terraform/infrastructure/gcp/variables.tf
@@ -32,6 +32,12 @@ variable "debug" {
   description = "DO NOT USE IN PRODUCTION. Enable debug mode. This opens up a debugd port that can be used to deploy a custom bootstrapper."
 }
 
+variable "console_access" {
+  type        = bool
+  default     = false
+  description = "Enable serial console access to OS images that expose a serial console. This will be shadowed by `debug` (i.e. if `debug` is enabled, console access will be enabled)."
+}
+
 variable "custom_endpoint" {
   type        = string
   default     = ""


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
On GCP, access to the serial console needs to be enabled via a metadata attribute. Previously, this has always been set to the `debug` variable, that also opens up the debugd port, which is unnecessary and potentially security-relevant for non-debug images, where arbitrary other services could bind to the debugd port by accident.
 
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a separate flag to enable serial console access without opening the debugd port.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
