### PR TITLE
terraform: enable serial console by default

### DIFF
--- a/terraform/infrastructure/azure/modules/jump_host/main.tf
+++ b/terraform/infrastructure/azure/modules/jump_host/main.tf
@@ -29,7 +29,7 @@ resource "azurerm_linux_virtual_machine" "jump_host" {
   }
 
   boot_diagnostics {
-
+    storage_account_uri = null
   }
 
   user_data = base64encode(<<EOF

--- a/terraform/infrastructure/azure/modules/scale_set/main.tf
+++ b/terraform/infrastructure/azure/modules/scale_set/main.tf
@@ -57,7 +57,9 @@ resource "azurerm_linux_virtual_machine_scale_set" "scale_set" {
     identity_ids = [var.user_assigned_identity]
   }
 
-  boot_diagnostics {}
+  boot_diagnostics {
+    storage_account_uri = null
+  }
 
   dynamic "os_disk" {
     for_each = var.confidential_vm ? [1] : [] # if confidential_vm is true

--- a/terraform/infrastructure/gcp/modules/instance_group/main.tf
+++ b/terraform/infrastructure/gcp/modules/instance_group/main.tf
@@ -70,7 +70,7 @@ resource "google_compute_instance_template" "template" {
   metadata = {
     kube-env                       = var.kube_env
     constellation-init-secret-hash = var.init_secret_hash
-    serial-port-enable             = var.debug ? "TRUE" : "FALSE"
+    serial-port-enable             = "TRUE"
   }
 
   network_interface {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Enabling the serial console by default improves DX while no security issues arise, as no login is possible either way in non-debug-images, and CSPs can access serial consoles either way.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Enable serial console by default for VMs created by the Constellation Terraform modules.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- AB#4670

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
