### PR TITLE
ci: check if CLI version supports `--subscriptionID` flag before using it

### DIFF
--- a/.github/actions/constellation_iam_create/action.yml
+++ b/.github/actions/constellation_iam_create/action.yml
@@ -79,14 +79,19 @@ runs:
       shell: bash
       if: inputs.cloudProvider == 'azure'
       run: |
+        extraFlags=""
+
+        if [[ $(constellation iam create azure --help | grep -c -- --subscriptionID) -ne 0 ]]; then
+          extraFlags="--subscriptionID=${{ inputs.azureSubscriptionID }}"
+        fi
+
         constellation iam create azure \
-          --subscriptionID="${{ inputs.azureSubscriptionID }}" \
           --region="${{ inputs.azureRegion }}" \
           --resourceGroup="${{ inputs.namePrefix }}-rg" \
           --servicePrincipal="${{ inputs.namePrefix }}-sp" \
           --update-config \
           --tf-log=DEBUG \
-          --yes
+          --yes ${extraFlags}
 
     - name: Constellation iam create gcp
       shell: bash


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
https://github.com/edgelesssys/constellation/pull/3328 added a new flag to `constellation iam create azure` and enabled use of it in our e2e tests. However, our stable releases do not yet support this flag. This is currently causing our ci workflows to fail for stable releases.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Check if the CLI supports the `--subscriptionID` flag before using it

### Related issue
- fixes https://github.com/edgelesssys/issues/issues/872

