### PR TITLE
ci: update incorrect variable naming in mini e2e test

### DIFF
--- a/.github/actions/e2e_mini/action.yml
+++ b/.github/actions/e2e_mini/action.yml
@@ -61,6 +61,5 @@ runs:
       # clean up if e2e test failed or if the run was cancelled
       if: (failure() && steps.e2e-test.conclusion == 'failure') || cancelled()
       run: |
-        rg_name=${{ steps.e2e-test.outputs.rgname }}
-        echo "[*] Deleting resource group $rg_name"
-        az group delete -y --resource-group "$rg_name"
+        echo "[*] Deleting resource group ${{ steps.e2e-test.outputs.rgname }}"
+        az group delete -y --resource-group "${{ steps.e2e-test.outputs.rgname }}"

--- a/e2e/miniconstellation/.terraform.lock.hcl
+++ b/e2e/miniconstellation/.terraform.lock.hcl
@@ -55,36 +55,6 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.6.2"
-  constraints = "3.6.2"
-  hashes = [
-    "h1:5lstwe/L8AZS/CP0lil2nPvmbbjAu8kCaU/ogSGNbxk=",
-    "h1:Gd3WitYIzSYo/Suo+PMxpZpIGpRPrwl0JU0+DhxycFM=",
-    "h1:J9EOvuE7qCS/S0lqMX6DNqsh/wq2uhwxE2bOpSn0/hc=",
-    "h1:R5qdQjKzOU16TziCN1vR3Exr/B+8WGK80glLTT4ZCPk=",
-    "h1:UQlmHGddu39vVzG8kruMsde4GHlG+1S7OLqFApbJvtc=",
-    "h1:VYBb5/CQ1tPhV92eUsfxSZ4Ta2OCfNggYwE+Qo+yCD0=",
-    "h1:VavG5unYCa3SYISMKF9pzc3718M0bhPlcbUZZGl7wuo=",
-    "h1:jke+2u84Hrc7szJKevP1BKFn1o3pfxYhYtity2RPCS8=",
-    "h1:m/7/S7a6RzGgeRAJJCsDza2kbaNmFpQDDd849RxD2FE=",
-    "h1:uOP0uuF8PKF98YlLqgtjdHBELJLI4BMOOHYXQMYhdlI=",
-    "h1:wmG0QFjQ2OfyPy6BB7mQ57WtoZZGGV07uAPQeDmIrAE=",
-    "zh:0ef01a4f81147b32c1bea3429974d4d104bbc4be2ba3cfa667031a8183ef88ec",
-    "zh:1bcd2d8161e89e39886119965ef0f37fcce2da9c1aca34263dd3002ba05fcb53",
-    "zh:37c75d15e9514556a5f4ed02e1548aaa95c0ecd6ff9af1119ac905144c70c114",
-    "zh:4210550a767226976bc7e57d988b9ce48f4411fa8a60cd74a6b246baf7589dad",
-    "zh:562007382520cd4baa7320f35e1370ffe84e46ed4e2071fdc7e4b1a9b1f8ae9b",
-    "zh:5efb9da90f665e43f22c2e13e0ce48e86cae2d960aaf1abf721b497f32025916",
-    "zh:6f71257a6b1218d02a573fc9bff0657410404fb2ef23bc66ae8cd968f98d5ff6",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:9647e18f221380a85f2f0ab387c68fdafd58af6193a932417299cdcae4710150",
-    "zh:bb6297ce412c3c2fa9fec726114e5e0508dd2638cad6a0cb433194930c97a544",
-    "zh:f83e925ed73ff8a5ef6e3608ad9225baa5376446349572c2449c0c0b3cf184b7",
-    "zh:fbef0781cb64de76b1df1ca11078aecba7800d82fd4a956302734999cfd9a4af",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/tls" {
   version     = "4.0.5"
   constraints = "4.0.5"

--- a/e2e/miniconstellation/BUILD.bazel
+++ b/e2e/miniconstellation/BUILD.bazel
@@ -9,6 +9,7 @@ filegroup(
         "main.tf",
         "output.tf",
         "test-remote.sh",
+        "variables.tf",
     ],
 )
 

--- a/e2e/miniconstellation/main.sh.in
+++ b/e2e/miniconstellation/main.sh.in
@@ -23,13 +23,15 @@ cd e2e/miniconstellation
 
 echo "::group::Terraform"
 
+random_string=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 6)
+rg_name="e2e-mini-${random_string}"
+echo "rgname=${rg_name}" >> "${GITHUB_OUTPUT:-/dev/null}"
+echo "resource_name = \"${rg_name}\"" > terraform.tfvars
+
 terraform init
 terraform apply -auto-approve
 terraform output -raw ssh_private_key > id_rsa
 chmod 600 id_rsa
-
-rg_name=$(terraform output -raw rg_name)
-echo "rgname=$rg_name" >> "${GITHUB_OUTPUT:-/dev/null}"
 
 azure_vm_ip=$(terraform output -raw public_ip)
 

--- a/e2e/miniconstellation/main.tf
+++ b/e2e/miniconstellation/main.tf
@@ -4,10 +4,6 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "4.1.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.6.2"
-    }
     tls = {
       source  = "hashicorp/tls"
       version = "4.0.5"
@@ -29,11 +25,6 @@ provider "azurerm" {
 
 provider "tls" {}
 
-resource "random_string" "suffix" {
-  length  = 6
-  special = false
-}
-
 resource "tls_private_key" "ssh_key" {
   algorithm = "RSA"
   rsa_bits  = 2048
@@ -50,26 +41,26 @@ data "cloudinit_config" "cloud_init" {
 }
 
 resource "azurerm_resource_group" "main" {
-  name     = "e2e-mini-${random_string.suffix.result}"
+  name     = var.resource_name
   location = "North Europe"
 }
 
 resource "azurerm_virtual_network" "main" {
-  name                = "e2e-mini-${random_string.suffix.result}"
+  name                = var.resource_name
   address_space       = ["10.0.0.0/16"]
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
 }
 
 resource "azurerm_subnet" "main" {
-  name                 = "e2e-mini-${random_string.suffix.result}"
+  name                 = var.resource_name
   resource_group_name  = azurerm_resource_group.main.name
   virtual_network_name = azurerm_virtual_network.main.name
   address_prefixes     = ["10.0.2.0/24"]
 }
 
 resource "azurerm_public_ip" "main" {
-  name                = "e2e-mini-${random_string.suffix.result}"
+  name                = var.resource_name
   location            = azurerm_resource_group.main.location
   resource_group_name = azurerm_resource_group.main.name
   allocation_method   = "Static"
@@ -77,7 +68,7 @@ resource "azurerm_public_ip" "main" {
 }
 
 resource "azurerm_network_interface" "main" {
-  name                = "e2e-mini-${random_string.suffix.result}"
+  name                = var.resource_name
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
 
@@ -90,7 +81,7 @@ resource "azurerm_network_interface" "main" {
 }
 
 resource "azurerm_network_security_group" "ssh" {
-  name                = "e2e-mini-${random_string.suffix.result}"
+  name                = var.resource_name
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
 
@@ -113,7 +104,7 @@ resource "azurerm_subnet_network_security_group_association" "ssh" {
 }
 
 resource "azurerm_linux_virtual_machine" "main" {
-  name                = "e2e-mini-${random_string.suffix.result}"
+  name                = var.resource_name
   resource_group_name = azurerm_resource_group.main.name
   location            = azurerm_resource_group.main.location
 

--- a/e2e/miniconstellation/main.tf
+++ b/e2e/miniconstellation/main.tf
@@ -42,7 +42,7 @@ data "cloudinit_config" "cloud_init" {
 
 resource "azurerm_resource_group" "main" {
   name     = var.resource_name
-  location = "North Europe"
+  location = "West Europe"
 }
 
 resource "azurerm_virtual_network" "main" {

--- a/e2e/miniconstellation/output.tf
+++ b/e2e/miniconstellation/output.tf
@@ -9,9 +9,3 @@ output "ssh_private_key" {
   sensitive  = true
   depends_on = [tls_private_key.ssh_key]
 }
-
-output "rg_name" {
-  value      = "e2e-mini-${random_string.suffix.result}"
-  sensitive  = false
-  depends_on = [random_string.suffix]
-}

--- a/e2e/miniconstellation/variables.tf
+++ b/e2e/miniconstellation/variables.tf
@@ -1,0 +1,4 @@
+variable "resource_name" {
+  type        = string
+  description = "name for resources to create"
+}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The `rgname` variable set by `e2e/miniconstellation/main.sh.in` is not parsed back to the GitHub workflow if `terraform apply` failed

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Define resource group name outside of terraform to ensure there is always a valid value, even if `terraform apply` fails
- Only run tests in West Europe to get around potential quota issues

### Additional info
- Resource group is now [correctly set](https://github.com/edgelesssys/constellation/actions/runs/11008951631/job/30567585420#step:5:2918) on delete
- [e2e test](https://github.com/edgelesssys/constellation/actions/runs/11010915855/job/30573868498)
- Fixes https://github.com/edgelesssys/issues/issues/888

