### PR TITLE
openstack: Fix a crash in the bootstrapper during node join discovery

### DIFF
--- a/internal/cloud/openstack/imds.go
+++ b/internal/cloud/openstack/imds.go
@@ -172,6 +172,20 @@ func (c *imdsClient) userDomainName(ctx context.Context) (string, error) {
 	return c.userDataCache.UserDomainName, nil
 }
 
+func (c *imdsClient) regionName(ctx context.Context) (string, error) {
+	if c.timeForUpdate(c.cacheTime) || c.userDataCache.RegionName == "" {
+		if err := c.update(ctx); err != nil {
+			return "", err
+		}
+	}
+
+	if c.userDataCache.RegionName == "" {
+		return "", errors.New("unable to get user domain name")
+	}
+
+	return c.userDataCache.RegionName, nil
+}
+
 func (c *imdsClient) username(ctx context.Context) (string, error) {
 	if c.timeForUpdate(c.cacheTime) || c.userDataCache.Username == "" {
 		if err := c.update(ctx); err != nil {
@@ -295,6 +309,7 @@ type metadataTags struct {
 type userDataResponse struct {
 	AuthURL              string `json:"openstack-auth-url,omitempty"`
 	UserDomainName       string `json:"openstack-user-domain-name,omitempty"`
+	RegionName           string `json:"openstack-region-name,omitempty"`
 	Username             string `json:"openstack-username,omitempty"`
 	Password             string `json:"openstack-password,omitempty"`
 	LoadBalancerEndpoint string `json:"openstack-load-balancer-endpoint,omitempty"`

--- a/internal/cloud/openstack/openstack.go
+++ b/internal/cloud/openstack/openstack.go
@@ -54,6 +54,10 @@ func New(ctx context.Context) (*MetadataClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("getting user domain name: %w", err)
 	}
+	regionName, err := imds.regionName(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("getting region name: %w", err)
+	}
 
 	clientOpts := &clientconfig.ClientOpts{
 		AuthType: clientconfig.AuthV3Password,
@@ -63,6 +67,7 @@ func New(ctx context.Context) (*MetadataClient, error) {
 			Username:       username,
 			Password:       password,
 		},
+		RegionName: regionName,
 	}
 
 	serversClient, err := clientconfig.NewServiceClient(ctx, "compute", clientOpts)

--- a/terraform/infrastructure/openstack/main.tf
+++ b/terraform/infrastructure/openstack/main.tf
@@ -242,6 +242,7 @@ module "instance_group" {
   openstack_username               = local.cloudyaml["auth"]["username"]
   openstack_password               = local.cloudyaml["auth"]["password"]
   openstack_user_domain_name       = local.cloudyaml["auth"]["user_domain_name"]
+  openstack_region_name            = local.cloudyaml["region_name"]
   openstack_load_balancer_endpoint = openstack_networking_floatingip_v2.public_ip.address
 }
 

--- a/terraform/infrastructure/openstack/modules/instance_group/main.tf
+++ b/terraform/infrastructure/openstack/modules/instance_group/main.tf
@@ -80,6 +80,7 @@ resource "openstack_compute_instance_v2" "instance_group_member" {
     openstack-username               = var.openstack_username
     openstack-password               = var.openstack_password
     openstack-user-domain-name       = var.openstack_user_domain_name
+    openstack-region-name            = var.openstack_region_name
     openstack-load-balancer-endpoint = var.openstack_load_balancer_endpoint
   })
   availability_zone_hints = length(var.availability_zone) > 0 ? var.availability_zone : null

--- a/terraform/infrastructure/openstack/modules/instance_group/variables.tf
+++ b/terraform/infrastructure/openstack/modules/instance_group/variables.tf
@@ -97,6 +97,11 @@ variable "openstack_password" {
   description = "OpenStack password."
 }
 
+variable "openstack_region_name" {
+  type        = string
+  description = "OpenStack region name."
+}
+
 variable "openstack_load_balancer_endpoint" {
   type        = string
   description = "OpenStack load balancer endpoint."


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The bootstrapper still likes to query any nodes in addition to the LB endpoint when searching for join endpoints.

Openstack has a catalog discovery feature that gets URL endpoints during authentication (see: https://github.com/jtopjian/gophercloud/blob/master/openstack/endpoint_location.go#L63). Since we did not set the region we received more endpoints than expected and some even invalid ones.



### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Passthrough openstack region name via IMDS to instance to use it in the cloud API client.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->

- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
