### PR TITLE
image: improve AWS performance by retiring idle=poll option

### DIFF
--- a/image/system/variants.bzl
+++ b/image/system/variants.bzl
@@ -57,8 +57,7 @@ csp_settings = {
         "kernel_command_line_dict": {
             "console": "ttyS0",
             "constel.csp": "aws",
-            "idle": "poll",
-            "mitigations": "auto",
+            "mitigations": "auto,nosmt",
         },
     },
     "azure": {


### PR DESCRIPTION
### Context

The Linux command line parameter `idle=poll` was introduced mid-2023 to work around a hypervisor issue at AWS. This issue has been fixed since end of 2023.

`idle=poll` has some negative consequences, see the kernel docs linked below. For example, it basically prevents the CPU from going idle at all under light load, resulting in the symptoms explained in #3383. I took these measurements on `m6a.xlarge` machines before and after the change proposed here:

```shell-session
/ # cat /proc/cmdline
roothash=de436e547b918bf0411d9738485c431918e068a051241db88bc099c0782da5e4 preempt=full rd.shell=0 rd.emergency=reboot loglevel=8 selinux=1 enforcing=0 audit=0 constellation.debug console=ttyS0 constel.csp=aws idle=poll mitigations=auto constel.attestation-variant=aws-sev-snp
/ # sysbench --threads=1 cpu run | grep -F "events per second"
    events per second:  1124.96
/ # sysbench --threads=2 cpu run | grep -F "events per second"
    events per second:  2187.34
/ # sysbench --threads=4 cpu run | grep -F "events per second"
    events per second:  2716.90
/ # iostat -c
Linux 6.6.30-100.constellation.fc40.x86_64 (b360f3f934b9)       10/04/24        _x86_64_        (4 CPU)

avg-cpu:  %user   %nice %system %iowait  %steal   %idle
           2.06    0.00   71.65    5.77    0.15   20.38
```

```shell-session
/ # cat /proc/cmdline 
roothash=91c73aa9caf458e8b15537ae608a1690a0f0f852e7835ebc49b5e3be1d5d1068 preempt=full rd.shell=0 rd.emergency=reboot loglevel=8 selinux=1 enforcing=0 audit=0 constellation.debug console=ttyS0 constel.csp=aws mitigations=auto,nosmt constel.attestation-variant=aws-sev-snp
/ # sysbench --threads=1 cpu run | grep -F "events per second"
    events per second:  1877.43
/ # sysbench --threads=2 cpu run | grep -F "events per second"
    events per second:  3364.97
/ # sysbench --threads=4 cpu run | grep -F "events per second"
    events per second:  3403.21
/ # iostat -c
Linux 6.6.30-100.constellation.fc40.x86_64 (490e83bc2711)       10/04/24        _x86_64_        (4 CPU)

avg-cpu:  %user   %nice %system %iowait  %steal   %idle
           0.75    0.00    7.68    4.75    0.03   86.79
```

### Proposed change(s)
- Remove `idle=poll`
- Align the mitigations to other CSPs: `mitigations=auto,nosmt`

### Related issue
- Fixes #3383 

### Additional info
- https://www.kernel.org/doc/html/latest/admin-guide/pm/cpuidle.html#idle-states-control-via-kernel-command-line

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] https://github.com/edgelesssys/constellation/actions/runs/11180739050
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
