### PR TITLE
dev-docs: link to docs website instead of to local files

### DIFF
--- a/dev-docs/security-overview.md
+++ b/dev-docs/security-overview.md
@@ -26,7 +26,7 @@ The purpose and source of the measurements are described in the [next section](#
 In addition to the measurements, the attestation config contains expected patch levels for the CPU microcode and the X.509 certificate of the CPU vendor's remote attestation infrastructure.
 An example of an attestation config is given [below](#attestation-config).
 
-In case a different version of the node image is to be used, the corresponding measurements can be fetched using the CLI's ["config fetch-measurements" command](reference/cli#constellation-config-fetch-measurements).
+In case a different version of the node image is to be used, the corresponding measurements can be fetched using the CLI's ["config fetch-measurements" command](https://docs.edgeless.systems/constellation/reference/cli#constellation-config-fetch-measurements).
 This command downloads the measurements and the corresponding signature from Edgeless Systems from https://cdn.confidential.cloud.
 See for example the following files corresponding to node image v2.16.3:
 * [Measurements](https://cdn.confidential.cloud/constellation/v2/ref/-/stream/stable/v2.16.3/image/measurements.json)
@@ -53,7 +53,7 @@ Based on the remote-attestation statement, the CLI and the Bootstrapper running 
 We refer to this type of connection as "attested TLS" (aTLS).
 This connection is mainly used for three things (see the the [interface definition](https://github.com/edgelesssys/constellation/blob/main/bootstrapper/initproto/init.proto) for a comprehensive list of exchanged data):
 1. The CLI sends the hashes of the expected Kubernetes binaries to the first node.
-2. The CLI generates the [master secret](../architecture/keys.md#master-secret) of the to-be-created cluster and sends it to the first node.
+2. The CLI generates the [master secret](https://docs.edgeless.systems/constellation/architecture/keys#master-secret) of the to-be-created cluster and sends it to the first node.
 3. The first node generates a [kubeconfig file](https://www.redhat.com/sysadmin/kubeconfig) and sends it to the CLI.
 The kubeconfig file contains Kubernetes credentials for the CLI and the Kubernetes cluster's public key, among others.
 
@@ -132,7 +132,7 @@ The CLI uses this connection for two essential operations at the Kubernetes leve
 1. It executes the [hardcoded Helm charts](#cli-root-of-trust), which, most notably, install the three core services KeyService, JoinService, and VerificationService, the [constellation-node-operator](https://github.com/edgelesssys/constellation/tree/main/operators/constellation-node-operator), and a small number of standard services like Cilium and cert-manager.
 
 The latter causes the first node to download, verify, and run the containers defined in the Helm charts.
-The containers that are specific to  Constellation are hosted at https://ghcr.io/edgelesssys.
+The containers that are specific to  Constellation are hosted at `ghcr.io/edgelesssys`.
 
 After this, the Constellation cluster is operational on the first node.
 

--- a/dev-docs/workflows/github-actions.md
+++ b/dev-docs/workflows/github-actions.md
@@ -24,7 +24,7 @@ Here are some examples for test suites you might want to run. Values for `sonobu
 * `--mode certified-conformance`
   * For K8s conformance certification test suite
 
-Check [Sonobuoy docs](https://sonobuoy.io/docs/latest/e2eplugin/) for more examples.
+Check [Sonobuoy docs](https://sonobuoy.io/docs/v0.57.1/e2eplugin/) for more examples.
 
 When using `--mode` be aware that `--e2e-focus` and `e2e-skip` will be overwritten. [Check in the source code](https://github.com/vmware-tanzu/sonobuoy/blob/e709787426316423a4821927b1749d5bcc90cb8c/cmd/sonobuoy/app/modes.go#L130) what the different modes do.
 

--- a/dev-docs/workflows/qemu.md
+++ b/dev-docs/workflows/qemu.md
@@ -20,7 +20,7 @@ Follow the steps in our [libvirt readme](../../nix/container/README.md) if you w
 
 ### Install required packages
 
-[General reference](https://ubuntu.com/server/docs/virtualization-libvirt)
+[General reference](https://documentation.ubuntu.com/server/how-to/virtualisation/libvirt/)
 
 ```shell-session
 sudo apt install qemu-kvm libvirt-daemon-system xsltproc


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Link to the website hosting the docs instead of using local links
- Link to new libvirt docs URL

See CI failures: https://github.com/edgelesssys/constellation/actions/runs/11218452983/job/31182252488?pr=3257#step:3:9549

The CI still fails because of sonobuoy. This should be fixed when https://github.com/vmware-tanzu/sonobuoy/pull/1987 is merged, but the PR is already 4 weeks old so we might link against v0.57.1 instead of latest.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
