### PR TITLE
CODEOWNERS: move ownership of Helm charts to burgerdev

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,7 +34,7 @@
 /internal/compatibility @derpsteb
 /internal/config @derpsteb
 /internal/constellation/featureset @thomasten
-/internal/constellation/helm @derpsteb
+/internal/constellation/helm @burgerdev
 /internal/constellation/kubecmd @daniel-weisse
 /internal/constellation/state @elchead
 /internal/containerimage @burgerdev


### PR DESCRIPTION
### Context

The Helm chart directory frequently gets PRs from renovate. Renovate PRs are auto-assigned unless they have requested assignee, so PRs may only be assigned to CODEOWNERS. 

### Proposed change(s)
- Move ownership of `/internal/constellation/helm` to @burgerdev. 

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
