### PR TITLE
ci: ignore GO-2024-3166 in govulncheck

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -4,6 +4,7 @@ bazel_dep(name = "aspect_bazel_lib", version = "2.9.0")
 
 bazel_lib = use_extension("@aspect_bazel_lib//lib:extensions.bzl", "toolchains")
 bazel_lib.yq()
+use_repo(bazel_lib, "jq_toolchains")
 use_repo(bazel_lib, "yq_toolchains")
 
 bazel_dep(name = "bazel_skylib", version = "1.7.1")

--- a/bazel/ci/BUILD.bazel
+++ b/bazel/ci/BUILD.bazel
@@ -288,11 +288,13 @@ sh_template(
     name = "govulncheck",
     data = [
         ":go_bin_for_host",
+        "@jq_toolchains//:resolved_toolchain",
         "@org_golang_x_vuln//cmd/govulncheck",
     ],
     substitutions = {
         "@@GO@@": "$(rootpath :go_bin_for_host)",
         "@@GOVULNCHECK@@": "$(rootpath @org_golang_x_vuln//cmd/govulncheck:govulncheck)",
+        "@@JQ@@": "$(rootpath @jq_toolchains//:resolved_toolchain)",
     },
     template = "govulncheck.sh.in",
 )

--- a/bazel/ci/govulncheck.sh.in
+++ b/bazel/ci/govulncheck.sh.in
@@ -15,6 +15,8 @@ go=$(realpath @@GO@@)
 stat "${go}" >> /dev/null
 govulncheck=$(realpath @@GOVULNCHECK@@)
 stat "${govulncheck}" >> /dev/null
+jq=$(realpath @@JQ@@)
+stat "${jq}" >> /dev/null
 
 cd "${BUILD_WORKSPACE_DIRECTORY}"
 
@@ -25,8 +27,9 @@ submodules=$(${go} list -f '{{.Dir}}' -m)
 PATH=$(dirname "${go}"):${PATH}
 
 check_module() {
+  # shellcheck disable=SC2016 # The $ sign in the single quoted string is correct.
   CGO_ENABLED=0 ${govulncheck} -C "$1" -format json "./..." |
-    jq -sr '
+    "${jq}" -sr '
         (map(select(.osv) | {"key": .osv.id, "value": .osv.summary}) | from_entries) as $osvs | 
         map(select( .finding and .finding.osv != "GO-2024-3166" ) | .finding | select( .trace[-1].module | startswith("github.com/edgelesssys/") )) |
         group_by(.osv) | 

--- a/bazel/ci/govulncheck.sh.in
+++ b/bazel/ci/govulncheck.sh.in
@@ -25,8 +25,8 @@ submodules=$(${go} list -f '{{.Dir}}' -m)
 PATH=$(dirname "${go}"):${PATH}
 
 check_module() {
-    CGO_ENABLED=0 ${govulncheck} -C "$1" -format json "./..." |
-      jq -sr '
+  CGO_ENABLED=0 ${govulncheck} -C "$1" -format json "./..." |
+    jq -sr '
         (map(select(.osv) | {"key": .osv.id, "value": .osv.summary}) | from_entries) as $osvs | 
         map(select( .finding and .finding.osv != "GO-2024-3166" ) | .finding | select( .trace[-1].module | startswith("github.com/edgelesssys/") )) |
         group_by(.osv) | 

--- a/bazel/ci/govulncheck.sh.in
+++ b/bazel/ci/govulncheck.sh.in
@@ -24,6 +24,17 @@ submodules=$(${go} list -f '{{.Dir}}' -m)
 
 PATH=$(dirname "${go}"):${PATH}
 
+check_module() {
+    CGO_ENABLED=0 ${govulncheck} -C "$1" -format json "./..." |
+      jq -sr '
+        (map(select(.osv) | {"key": .osv.id, "value": .osv.summary}) | from_entries) as $osvs | 
+        map(select( .finding and .finding.osv != "GO-2024-3166" ) | .finding | select( .trace[-1].module | startswith("github.com/edgelesssys/") )) |
+        group_by(.osv) | 
+        map( {"osv": .[0].osv, "summary": $osvs[.[0].osv], "traces": [.[] | [.trace[] | .module]]} ) |
+        if length > 0 then halt_error(1) else .[] end'
+
+}
+
 check() {
   err=0
 
@@ -31,7 +42,7 @@ check() {
   for mod in ${submodules}; do
     echo "  ${mod}"
     echo -n "  "
-    CGO_ENABLED=0 ${govulncheck} -C "${mod}" "./..." || err=$?
+    check_module "${mod}"
   done
 
   exit "${err}"


### PR DESCRIPTION
### Context

`govulncheck` shows a finding in a transitive dependency of `sigstore/rekor`. According to https://github.com/sigstore/rekor/issues/2237, this is a false-positive. Unfortunately, `govulncheck` does not support ignoring findings. 

### Proposed change(s)

- Parse the findings manually from JSON output, ignoring known false-positives.

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
