### PR TITLE
treewide: upgrade to Go 1.23.2

### DIFF
--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.22.7"
+          go-version: "1.23.2"
           cache: false
 
       - name: Install Crane

--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.22.7"
+          go-version: "1.23.2"
           cache: false
 
       - name: Determine version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.22.7"
+          go-version: "1.23.2"
           cache: false
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,7 +233,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.22.7"
+          go-version: "1.23.2"
           cache: true
 
       - name: Build generateMeasurements tool

--- a/.github/workflows/test-operator-codegen.yml
+++ b/.github/workflows/test-operator-codegen.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: "1.22.7"
+          go-version: "1.23.2"
           cache: true
 
       - name: Run code generation

--- a/3rdparty/bazel/org_golang/go_tls_max_handshake_size.patch
+++ b/3rdparty/bazel/org_golang/go_tls_max_handshake_size.patch
@@ -1,11 +1,11 @@
 --- src/crypto/tls/common.go
 +++ src/crypto/tls/common.go
-@@ -62,7 +62,7 @@
- 	maxCiphertext      = 16384 + 2048 // maximum ciphertext payload length
- 	maxCiphertextTLS13 = 16384 + 256  // maximum ciphertext length in TLS 1.3
- 	recordHeaderLen    = 5            // record header length
--	maxHandshake       = 65536        // maximum handshake we support (protocol max is 16 MB)
-+	maxHandshake       = 262144       // maximum handshake we support (protocol max is 16 MB)
- 	maxUselessRecords  = 16           // maximum number of consecutive non-advancing records
+@@ -64,7 +64,7 @@ const (
+ 	maxCiphertext              = 16384 + 2048 // maximum ciphertext payload length
+ 	maxCiphertextTLS13         = 16384 + 256  // maximum ciphertext length in TLS 1.3
+ 	recordHeaderLen            = 5            // record header length
+-	maxHandshake               = 65536        // maximum handshake we support (protocol max is 16 MB)
++	maxHandshake               = 262144        // maximum handshake we support (protocol max is 16 MB)
+ 	maxHandshakeCertificateMsg = 262144       // maximum certificate message size (256 KiB)
+ 	maxUselessRecords          = 16           // maximum number of consecutive non-advancing records
  )
- 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_sdk",
     patches = ["//3rdparty/bazel/org_golang:go_tls_max_handshake_size.patch"],
-    version = "1.22.7",
+    version = "1.23.2",
 )
 
 # the use_repo rule needs to list all top-level go dependencies

--- a/bazel/toolchains/ci_deps.bzl
+++ b/bazel/toolchains/ci_deps.bzl
@@ -223,45 +223,45 @@ def _golangci_lint_deps():
         name = "com_github_golangci_golangci_lint_linux_amd64",
         build_file = "//bazel/toolchains:BUILD.golangci.bazel",
         urls = [
-            "https://cdn.confidential.cloud/constellation/cas/sha256/c30696f1292cff8778a495400745f0f9c0406a3f38d8bb12cef48d599f6c7791",
+            "https://cdn.confidential.cloud/constellation/cas/sha256/77cb0af99379d9a21d5dc8c38364d060e864a01bd2f3e30b5e8cc550c3a54111",
             "https://github.com/golangci/golangci-lint/releases/download/v1.61.0/golangci-lint-1.61.0-linux-amd64.tar.gz",
         ],
         strip_prefix = "golangci-lint-1.61.0-linux-amd64",
         type = "tar.gz",
-        sha256 = "c30696f1292cff8778a495400745f0f9c0406a3f38d8bb12cef48d599f6c7791",
+        sha256 = "77cb0af99379d9a21d5dc8c38364d060e864a01bd2f3e30b5e8cc550c3a54111",
     )
     http_archive(
         name = "com_github_golangci_golangci_lint_linux_arm64",
         build_file = "//bazel/toolchains:BUILD.golangci.bazel",
         urls = [
-            "https://cdn.confidential.cloud/constellation/cas/sha256/8264507b560ae89dd080d5a0c7198ca5198e2b45f937a1f7fd873a8baa8e0b8f",
+            "https://cdn.confidential.cloud/constellation/cas/sha256/af60ac05566d9351615cb31b4cc070185c25bf8cbd9b09c1873aa5ec6f3cc17e",
             "https://github.com/golangci/golangci-lint/releases/download/v1.61.0/golangci-lint-1.61.0-linux-arm64.tar.gz",
         ],
         strip_prefix = "golangci-lint-1.61.0-linux-arm64",
         type = "tar.gz",
-        sha256 = "8264507b560ae89dd080d5a0c7198ca5198e2b45f937a1f7fd873a8baa8e0b8f",
+        sha256 = "af60ac05566d9351615cb31b4cc070185c25bf8cbd9b09c1873aa5ec6f3cc17e",
     )
     http_archive(
         name = "com_github_golangci_golangci_lint_darwin_amd64",
         build_file = "//bazel/toolchains:BUILD.golangci.bazel",
         urls = [
-            "https://cdn.confidential.cloud/constellation/cas/sha256/2f945063394a489c0037f0369c0ce21bc007565c08f90b924a35f4c04721cbc0",
+            "https://cdn.confidential.cloud/constellation/cas/sha256/5c280ef3284f80c54fd90d73dc39ca276953949da1db03eb9dd0fbf868cc6e55",
             "https://github.com/golangci/golangci-lint/releases/download/v1.61.0/golangci-lint-1.61.0-darwin-amd64.tar.gz",
         ],
         strip_prefix = "golangci-lint-1.61.0-darwin-amd64",
         type = "tar.gz",
-        sha256 = "2f945063394a489c0037f0369c0ce21bc007565c08f90b924a35f4c04721cbc0",
+        sha256 = "5c280ef3284f80c54fd90d73dc39ca276953949da1db03eb9dd0fbf868cc6e55",
     )
     http_archive(
         name = "com_github_golangci_golangci_lint_darwin_arm64",
         build_file = "//bazel/toolchains:BUILD.golangci.bazel",
         urls = [
-            "https://cdn.confidential.cloud/constellation/cas/sha256/16ec8a86974ddebd466a5cc071bb9f44d06d2a1f4bf93d13fbcb59e1704edb39",
+            "https://cdn.confidential.cloud/constellation/cas/sha256/544334890701e4e04a6e574bc010bea8945205c08c44cced73745a6378012d36",
             "https://github.com/golangci/golangci-lint/releases/download/v1.61.0/golangci-lint-1.61.0-darwin-arm64.tar.gz",
         ],
         strip_prefix = "golangci-lint-1.61.0-darwin-arm64",
         type = "tar.gz",
-        sha256 = "16ec8a86974ddebd466a5cc071bb9f44d06d2a1f4bf93d13fbcb59e1704edb39",
+        sha256 = "544334890701e4e04a6e574bc010bea8945205c08c44cced73745a6378012d36",
     )
 
 def _buf_deps():

--- a/bazel/toolchains/ci_deps.bzl
+++ b/bazel/toolchains/ci_deps.bzl
@@ -224,9 +224,9 @@ def _golangci_lint_deps():
         build_file = "//bazel/toolchains:BUILD.golangci.bazel",
         urls = [
             "https://cdn.confidential.cloud/constellation/cas/sha256/c30696f1292cff8778a495400745f0f9c0406a3f38d8bb12cef48d599f6c7791",
-            "https://github.com/golangci/golangci-lint/releases/download/v1.59.1/golangci-lint-1.59.1-linux-amd64.tar.gz",
+            "https://github.com/golangci/golangci-lint/releases/download/v1.61.0/golangci-lint-1.61.0-linux-amd64.tar.gz",
         ],
-        strip_prefix = "golangci-lint-1.59.1-linux-amd64",
+        strip_prefix = "golangci-lint-1.61.0-linux-amd64",
         type = "tar.gz",
         sha256 = "c30696f1292cff8778a495400745f0f9c0406a3f38d8bb12cef48d599f6c7791",
     )
@@ -235,9 +235,9 @@ def _golangci_lint_deps():
         build_file = "//bazel/toolchains:BUILD.golangci.bazel",
         urls = [
             "https://cdn.confidential.cloud/constellation/cas/sha256/8264507b560ae89dd080d5a0c7198ca5198e2b45f937a1f7fd873a8baa8e0b8f",
-            "https://github.com/golangci/golangci-lint/releases/download/v1.59.1/golangci-lint-1.59.1-linux-arm64.tar.gz",
+            "https://github.com/golangci/golangci-lint/releases/download/v1.61.0/golangci-lint-1.61.0-linux-arm64.tar.gz",
         ],
-        strip_prefix = "golangci-lint-1.59.1-linux-arm64",
+        strip_prefix = "golangci-lint-1.61.0-linux-arm64",
         type = "tar.gz",
         sha256 = "8264507b560ae89dd080d5a0c7198ca5198e2b45f937a1f7fd873a8baa8e0b8f",
     )
@@ -246,9 +246,9 @@ def _golangci_lint_deps():
         build_file = "//bazel/toolchains:BUILD.golangci.bazel",
         urls = [
             "https://cdn.confidential.cloud/constellation/cas/sha256/2f945063394a489c0037f0369c0ce21bc007565c08f90b924a35f4c04721cbc0",
-            "https://github.com/golangci/golangci-lint/releases/download/v1.59.1/golangci-lint-1.59.1-darwin-amd64.tar.gz",
+            "https://github.com/golangci/golangci-lint/releases/download/v1.61.0/golangci-lint-1.61.0-darwin-amd64.tar.gz",
         ],
-        strip_prefix = "golangci-lint-1.59.1-darwin-amd64",
+        strip_prefix = "golangci-lint-1.61.0-darwin-amd64",
         type = "tar.gz",
         sha256 = "2f945063394a489c0037f0369c0ce21bc007565c08f90b924a35f4c04721cbc0",
     )
@@ -257,9 +257,9 @@ def _golangci_lint_deps():
         build_file = "//bazel/toolchains:BUILD.golangci.bazel",
         urls = [
             "https://cdn.confidential.cloud/constellation/cas/sha256/16ec8a86974ddebd466a5cc071bb9f44d06d2a1f4bf93d13fbcb59e1704edb39",
-            "https://github.com/golangci/golangci-lint/releases/download/v1.59.1/golangci-lint-1.59.1-darwin-arm64.tar.gz",
+            "https://github.com/golangci/golangci-lint/releases/download/v1.61.0/golangci-lint-1.61.0-darwin-arm64.tar.gz",
         ],
-        strip_prefix = "golangci-lint-1.59.1-darwin-arm64",
+        strip_prefix = "golangci-lint-1.61.0-darwin-arm64",
         type = "tar.gz",
         sha256 = "16ec8a86974ddebd466a5cc071bb9f44d06d2a1f4bf93d13fbcb59e1704edb39",
     )

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelesssys/constellation/v2
 
-go 1.22.7
+go 1.23.2
 
 // TODO(daniel-weisse): revert after merging https://github.com/martinjungblut/go-cryptsetup/pull/16.
 replace github.com/martinjungblut/go-cryptsetup => github.com/daniel-weisse/go-cryptsetup v0.0.0-20230705150314-d8c07bd1723c

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.22.7
+go 1.23.2
 
-toolchain go1.22.7
+toolchain go1.23.2
 
 use (
 	.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelesssys/constellation/v2/hack/tools
 
-go 1.22
+go 1.23.2
 
 require (
 	github.com/google/go-licenses v1.6.0

--- a/renovate.json5
+++ b/renovate.json5
@@ -103,7 +103,7 @@
     },
     {
       "matchDatasources": ["golang-version"],
-      "allowedVersions": "1.22",
+      "allowedVersions": "1.23",
     },
     {
       "matchManagers": ["pip_requirements"],


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Go 1.23 is a requirement for keep-sorted, blocking our Go dependency bump. 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Upgrade to Go 1.23.2.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#4757](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4757)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
