### PR TITLE
e2e: fix malicious join test

### DIFF
--- a/e2e/malicious-join/malicious-join.go
+++ b/e2e/malicious-join/malicious-join.go
@@ -172,10 +172,10 @@ func (j *maliciousJoiner) join(ctx context.Context) (*joinproto.IssueJoinTicketR
 		IsControlPlane:     false,
 	}
 	res, err := protoClient.IssueJoinTicket(ctx, req)
-	j.logger.Debug("Got join ticket response", "apiServerEndpoint", res.ApiServerEndpoint, "kubernetesVersion", res.KubernetesVersion)
 	if err != nil {
 		return nil, fmt.Errorf("issuing join ticket: %w", err)
 	}
+	j.logger.Debug("Got join ticket response", "apiServerEndpoint", res.ApiServerEndpoint, "kubernetesVersion", res.KubernetesVersion)
 
 	return res, nil
 }


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
For some reason, the `IssueJoinTicket` returns a `nil` response now in a failure case, while it seemed not to do so a while ago(?). 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Only log after getting the response, where `(res != nil) == true`.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#4773](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4773)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Run the E2E tests that are relevant to this PR's changes
  - [Malicious join](https://github.com/edgelesssys/constellation/actions/runs/11383992071) 
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
