### PR TITLE
terraform: upgrade hashicorp/google to 6.7.0

### DIFF
--- a/terraform/infrastructure/gcp/.terraform.lock.hcl
+++ b/terraform/infrastructure/gcp/.terraform.lock.hcl
@@ -2,61 +2,25 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/google" {
-  version     = "5.37.0"
-  constraints = "5.37.0"
+  version     = "6.7.0"
+  constraints = "6.7.0"
   hashes = [
-    "h1:+0FfxQm8+OxXM6tDF8UCA2ir59Gel4oSnLoJoKkGCpc=",
-    "h1:+WQTQ1s/MhzXNDaCp4OvTY46DB4/e2GyvpCH41kA5pY=",
-    "h1:/4KB6HjJ0ByYamKdb/3BjQlVrqtqkWygh8XINuwHwLg=",
-    "h1:0mhHpFpgMtiw0vhuKlMtst7bhiaO4aa0/qb0SS5e3ns=",
-    "h1:ECJCeUsjARe6GHI1yLQKdsx1GW1CFqgww/dzooBe/xk=",
-    "h1:MXuNmywxH/QrtJqzQBEo5fPlcYGIvy0OxlE5ZPA37wE=",
-    "h1:RefrtlcP4AXprPTHHmUNuHZEOgTld4JeDOTeo4zWiJA=",
-    "h1:UuDnLkrIGy1u1gmwyQ7JIaI7Hax8Rvn/gxSBbg9oRWI=",
-    "h1:lP9wJfnhHJj1FcpKRKEweqSnVWwvMtts6+Yypyfpfpw=",
-    "h1:lfzk7MUYSJG4nwsdX6DLZth3BePTuhWW9W6xM9buOMU=",
-    "h1:wUeVrQ1ss9vQbb6HP+hSgtQ7efSliSdHRef1/TRef6k=",
-    "zh:00754c426ec8c2416d54904b25ebf3d831b5af4f02a20336d0a60d91897497d7",
-    "zh:0b4128affc12ace78d9cbd8aac308b992cc1829effba0ac761b4c3e9e37a36e2",
-    "zh:46afda4cdadc242b0a27acb181967b7a37768aa084c84593506490483fbdefd6",
-    "zh:4ad56e9d5ed5e05184bd0a23e17b6eb985c28e7ce23ce29fdf50daa5594ead69",
-    "zh:557b021f77bd97462b20519148f454158e6cf89eba5461ae6016568b317e1c87",
-    "zh:6552bb5e901e9fbcd95dc95b4e017dfd7c1eca465dd749f9c8afdc4ae2bf3213",
-    "zh:687347e31e69f2c4518abc057ad157ed4fd2b78e399b3a172bcab4277f7a235b",
-    "zh:a66bfc55856693fe82a81554abf7fd72b8ca2d56a08cb59c4769c15b1a1acea5",
-    "zh:a8b242c5aab000f2a27e934930a75656efb4a96fdb06a419b22ae0daffa6fba3",
-    "zh:da9e9b40d632f218a3e0bb88b8cf95b91485cee1eb2fd2a384d45c2619c36da4",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fda7bd1578e4b40e9e2d0298c77b0ad9f4486abee8ad38755299dd4b06be54c7",
-  ]
-}
-
-provider "registry.terraform.io/hashicorp/google-beta" {
-  version     = "5.37.0"
-  constraints = "5.37.0"
-  hashes = [
-    "h1:7KgxMd/i1rO/cSlbM2t0D6nB4Ib2ZEtWVtjeShp2D2c=",
-    "h1:965SYhz47hz+CmD4RVrGdy4XM9cDxUaAjqcNyEpWriw=",
-    "h1:Ey+JiF+0gvMdsPraA5D4Ia7f10gBIkMYRTvsfruHxw4=",
-    "h1:FBXp+od4ba3e9xDRSC8EDqjaFgGFGOQN2/7jf2tt6BA=",
-    "h1:HBlMZCUjS8wwrckbw3otzFLoyn1DooTP+fT6sJCaIoM=",
-    "h1:P/LLB5QFyBr99ex16Ba2Lkw327sBpcgcwblwGnNmiAg=",
-    "h1:PbPuajB/eQ9ta/l2AlKRfcfdmCs16cbVkiqKgRv+lOo=",
-    "h1:WZX+8D3Uj2Zulgtju8JpPZUNtNMS0VY4lBrE2iW606c=",
-    "h1:pr0HowX8labbBVVd4b0ljpXINgPGQo+2Z/zqDjcPL3E=",
-    "h1:yIknB3Xwv+hXDQP1PBRYxAOMn9BluPI2+uOd26iPqGo=",
-    "h1:zkVNOR/I98jO9a9G/OiFnnxETw8ScDQRlgbXNkw2LMo=",
-    "zh:01467c4b9c7169ed6326697064c1f7d449cde88f03a328af4bc475b258c21148",
-    "zh:0486a06cd78e816e38af10cd1c3b8cc09ef4f9d200a04814828f11ad38d41854",
-    "zh:0b59125a577f87f704429bb16779d1df032b271c5a7ea9b128cb14f190fb6747",
-    "zh:2f3a11b564184f245bb78e2914dde40091cd9e6e856da4477344b2e4c7a13eed",
-    "zh:7527aba218a0cdc865dbd8b5ca9a19a424c63bba7cbf036f7a8aac4b2b1dc491",
-    "zh:7821cfb469a8bd11461e8b7d45f026da6867d7caf9c511512f2677cd7c0a588c",
-    "zh:9aeed6e46cc632bd0dd8c8de63fe12e9e306437e68de7e556a05732ef8389a15",
-    "zh:9d6b7609b3832c8ee96c52a8c23741f7df0f79370f37ba684c11b1fc2f5a42bd",
-    "zh:d8c58b6bca74141ca8409af9959f0d54e4e941bfa637261dc1e2fc5fe523102a",
-    "zh:daa69120aff4356594c9fc811c9fe1297a321a4445f8d0ec1b95871bc618d410",
-    "zh:e3c56d0cbccb02fa17162eda3d85c74fe1e78d075db43f7d66f9878c80b8aa83",
+    "h1:2R/lqkaJ6+JzXLvMjV9RpS800/D+JBVJdUr5cMTCtqA=",
+    "h1:LEFMDSgj/Om4bqo2mgrcgXPBvhFyKkq/Z01//4SsWgw=",
+    "h1:LsOV33issuNApAMJrT8el7CKBtN0gqox0jehtBT3yjs=",
+    "h1:N0Jt+y4xXGLJvkrq0ocp+tEMgYpmtDCFu21CwPc9lyA=",
+    "h1:sMGHFZFZKvUr8FB1Ocm5612HsMeO4umUu6UW1UAgTds=",
+    "zh:16ac63e56986916015637bdc26a93e375aa84f22381d37dea51b227bc8fd58e3",
+    "zh:3d27c11cfd55394e247b01dc5d8bf4b892940ac0b66785cf565fbbabe8b8363b",
+    "zh:40011688dd3d5294f92bc0d85f30f26c427adc9a0e5c5053ca71a66f322e6edd",
+    "zh:84f2b94480c0979fbef001bc040dcaa5ac7b7d3cb47edc24ef612f6ede8ecb84",
+    "zh:9350b88bfeedf91176ed8447e368a980b0f5c9ad5f6bc0eff62e8889888a60df",
+    "zh:a0aba100e12c1a4e45ed9c66a95edb6c1f51d4f88ac4a38e0f64ee057128b23d",
+    "zh:cc5b520ea5806b967559f6f7fa07e7f0e9fe380bfb68d2f8b5afc1c94e99cd70",
+    "zh:d1eaea3ed952dff0337930938ae031841175725a6da1a512d8dfd649b1e2a83f",
+    "zh:d9deed8a673ce1d1f9ebcb6186ee4068933720d0d97ef7b627d7d0f819b67eed",
+    "zh:df342d4ab9cd3d1e26bd338bc4a2f0fd136c96f8861ce0ab63a7e6e41f62254b",
+    "zh:f0438dbdacdcfc2727b09752f682c96f5f575fdb3282b6fb1721756d83b390c7",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/terraform/infrastructure/gcp/main.tf
+++ b/terraform/infrastructure/gcp/main.tf
@@ -2,12 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.37.0"
-    }
-
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "5.37.0"
+      version = "6.7.0"
     }
 
     random = {
@@ -18,12 +13,6 @@ terraform {
 }
 
 provider "google" {
-  project = var.project
-  region  = var.region
-  zone    = var.zone
-}
-
-provider "google-beta" {
   project = var.project
   region  = var.region
   zone    = var.zone
@@ -91,12 +80,10 @@ resource "google_compute_subnetwork" "vpc_subnetwork" {
   description   = "Constellation VPC subnetwork"
   network       = google_compute_network.vpc_network.id
   ip_cidr_range = local.cidr_vpc_subnet_nodes
-  secondary_ip_range = [
-    {
-      range_name    = local.name,
-      ip_cidr_range = local.cidr_vpc_subnet_pods,
-    }
-  ]
+  secondary_ip_range {
+    range_name    = local.name
+    ip_cidr_range = local.cidr_vpc_subnet_pods
+  }
 }
 
 resource "google_compute_subnetwork" "proxy_subnet" {

--- a/terraform/infrastructure/gcp/modules/instance_group/main.tf
+++ b/terraform/infrastructure/gcp/modules/instance_group/main.tf
@@ -2,12 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.37.0"
-    }
-
-    google-beta = {
-      source  = "hashicorp/google-beta"
-      version = "5.37.0"
+      version = "6.7.0"
     }
 
     random = {
@@ -28,10 +23,6 @@ resource "random_id" "uid" {
 }
 
 resource "google_compute_instance_template" "template" {
-  # Beta provider is necessary to set confidential instance types.
-  # TODO(msanft): Remove beta provider once confidential instance type setting is in GA.
-  provider = google-beta
-
   name         = local.name
   machine_type = var.instance_type
   tags         = ["constellation-${var.uid}"] // Note that this is also applied as a label

--- a/terraform/infrastructure/gcp/modules/internal_load_balancer/main.tf
+++ b/terraform/infrastructure/gcp/modules/internal_load_balancer/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.37.0"
+      version = "6.7.0"
     }
   }
 }

--- a/terraform/infrastructure/gcp/modules/jump_host/main.tf
+++ b/terraform/infrastructure/gcp/modules/jump_host/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.37.0"
+      version = "6.7.0"
     }
   }
 }

--- a/terraform/infrastructure/gcp/modules/loadbalancer/main.tf
+++ b/terraform/infrastructure/gcp/modules/loadbalancer/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.37.0"
+      version = "6.7.0"
     }
   }
 }

--- a/terraform/infrastructure/iam/gcp/.terraform.lock.hcl
+++ b/terraform/infrastructure/iam/gcp/.terraform.lock.hcl
@@ -2,54 +2,48 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/google" {
-  version     = "5.37.0"
-  constraints = "5.37.0"
+  version     = "6.7.0"
+  constraints = "6.7.0"
   hashes = [
-    "h1:+0FfxQm8+OxXM6tDF8UCA2ir59Gel4oSnLoJoKkGCpc=",
-    "h1:+WQTQ1s/MhzXNDaCp4OvTY46DB4/e2GyvpCH41kA5pY=",
-    "h1:/4KB6HjJ0ByYamKdb/3BjQlVrqtqkWygh8XINuwHwLg=",
-    "h1:0mhHpFpgMtiw0vhuKlMtst7bhiaO4aa0/qb0SS5e3ns=",
-    "h1:ECJCeUsjARe6GHI1yLQKdsx1GW1CFqgww/dzooBe/xk=",
-    "h1:MXuNmywxH/QrtJqzQBEo5fPlcYGIvy0OxlE5ZPA37wE=",
-    "h1:RefrtlcP4AXprPTHHmUNuHZEOgTld4JeDOTeo4zWiJA=",
-    "h1:UuDnLkrIGy1u1gmwyQ7JIaI7Hax8Rvn/gxSBbg9oRWI=",
-    "h1:lP9wJfnhHJj1FcpKRKEweqSnVWwvMtts6+Yypyfpfpw=",
-    "h1:lfzk7MUYSJG4nwsdX6DLZth3BePTuhWW9W6xM9buOMU=",
-    "h1:wUeVrQ1ss9vQbb6HP+hSgtQ7efSliSdHRef1/TRef6k=",
-    "zh:00754c426ec8c2416d54904b25ebf3d831b5af4f02a20336d0a60d91897497d7",
-    "zh:0b4128affc12ace78d9cbd8aac308b992cc1829effba0ac761b4c3e9e37a36e2",
-    "zh:46afda4cdadc242b0a27acb181967b7a37768aa084c84593506490483fbdefd6",
-    "zh:4ad56e9d5ed5e05184bd0a23e17b6eb985c28e7ce23ce29fdf50daa5594ead69",
-    "zh:557b021f77bd97462b20519148f454158e6cf89eba5461ae6016568b317e1c87",
-    "zh:6552bb5e901e9fbcd95dc95b4e017dfd7c1eca465dd749f9c8afdc4ae2bf3213",
-    "zh:687347e31e69f2c4518abc057ad157ed4fd2b78e399b3a172bcab4277f7a235b",
-    "zh:a66bfc55856693fe82a81554abf7fd72b8ca2d56a08cb59c4769c15b1a1acea5",
-    "zh:a8b242c5aab000f2a27e934930a75656efb4a96fdb06a419b22ae0daffa6fba3",
-    "zh:da9e9b40d632f218a3e0bb88b8cf95b91485cee1eb2fd2a384d45c2619c36da4",
+    "h1:2R/lqkaJ6+JzXLvMjV9RpS800/D+JBVJdUr5cMTCtqA=",
+    "h1:LEFMDSgj/Om4bqo2mgrcgXPBvhFyKkq/Z01//4SsWgw=",
+    "h1:LsOV33issuNApAMJrT8el7CKBtN0gqox0jehtBT3yjs=",
+    "h1:N0Jt+y4xXGLJvkrq0ocp+tEMgYpmtDCFu21CwPc9lyA=",
+    "h1:sMGHFZFZKvUr8FB1Ocm5612HsMeO4umUu6UW1UAgTds=",
+    "zh:16ac63e56986916015637bdc26a93e375aa84f22381d37dea51b227bc8fd58e3",
+    "zh:3d27c11cfd55394e247b01dc5d8bf4b892940ac0b66785cf565fbbabe8b8363b",
+    "zh:40011688dd3d5294f92bc0d85f30f26c427adc9a0e5c5053ca71a66f322e6edd",
+    "zh:84f2b94480c0979fbef001bc040dcaa5ac7b7d3cb47edc24ef612f6ede8ecb84",
+    "zh:9350b88bfeedf91176ed8447e368a980b0f5c9ad5f6bc0eff62e8889888a60df",
+    "zh:a0aba100e12c1a4e45ed9c66a95edb6c1f51d4f88ac4a38e0f64ee057128b23d",
+    "zh:cc5b520ea5806b967559f6f7fa07e7f0e9fe380bfb68d2f8b5afc1c94e99cd70",
+    "zh:d1eaea3ed952dff0337930938ae031841175725a6da1a512d8dfd649b1e2a83f",
+    "zh:d9deed8a673ce1d1f9ebcb6186ee4068933720d0d97ef7b627d7d0f819b67eed",
+    "zh:df342d4ab9cd3d1e26bd338bc4a2f0fd136c96f8861ce0ab63a7e6e41f62254b",
+    "zh:f0438dbdacdcfc2727b09752f682c96f5f575fdb3282b6fb1721756d83b390c7",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-    "zh:fda7bd1578e4b40e9e2d0298c77b0ad9f4486abee8ad38755299dd4b06be54c7",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/null" {
-  version = "3.2.2"
+  version = "3.2.3"
   hashes = [
-    "h1:Gef5VGfobY5uokA5nV/zFvWeMNR2Pmq79DH94QnNZPM=",
-    "h1:IMVAUHKoydFrlPrl9OzasDnw/8ntZFerCC9iXw1rXQY=",
-    "h1:m467k2tZ9cdFFgHW7LPBK2GLPH43LC6wc3ppxr8yvoE=",
-    "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
-    "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
-    "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",
-    "zh:32b1aaa1c3013d33c245493f4a65465eab9436b454d250102729321a44c8ab9a",
-    "zh:38eff7e470acb48f66380a73a5c7cdd76cc9b9c9ba9a7249c7991488abe22fe3",
-    "zh:4c2f1faee67af104f5f9e711c4574ff4d298afaa8a420680b0cb55d7bbc65606",
-    "zh:544b33b757c0b954dbb87db83a5ad921edd61f02f1dc86c6186a5ea86465b546",
-    "zh:696cf785090e1e8cf1587499516b0494f47413b43cb99877ad97f5d0de3dc539",
-    "zh:6e301f34757b5d265ae44467d95306d61bef5e41930be1365f5a8dcf80f59452",
+    "h1:+AnORRgFbRO6qqcfaQyeX80W0eX3VmjadjnUFUJTiXo=",
+    "h1:I0Um8UkrMUb81Fxq/dxbr3HLP2cecTH2WMJiwKSrwQY=",
+    "h1:nKUqWEza6Lcv3xRlzeiRQrHtqvzX1BhIzjaOVXRYQXQ=",
+    "h1:obXguGZUWtNAO09f1f9Cb7hsPCOGXuGdN8bn/ohKRBQ=",
+    "h1:zxoDtu918XPWJ/Y6s4aFrZydn6SfqkRc5Ax1ZLnC6Ew=",
+    "zh:22d062e5278d872fe7aed834f5577ba0a5afe34a3bdac2b81f828d8d3e6706d2",
+    "zh:23dead00493ad863729495dc212fd6c29b8293e707b055ce5ba21ee453ce552d",
+    "zh:28299accf21763ca1ca144d8f660688d7c2ad0b105b7202554ca60b02a3856d3",
+    "zh:55c9e8a9ac25a7652df8c51a8a9a422bd67d784061b1de2dc9fe6c3cb4e77f2f",
+    "zh:756586535d11698a216291c06b9ed8a5cc6a4ec43eee1ee09ecd5c6a9e297ac1",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:913a929070c819e59e94bb37a2a253c228f83921136ff4a7aa1a178c7cce5422",
-    "zh:aa9015926cd152425dbf86d1abdbc74bfe0e1ba3d26b3db35051d7b9ca9f72ae",
-    "zh:bb04798b016e1e1d49bcc76d62c53b56c88c63d6f2dfe38821afef17c416a0e1",
-    "zh:c23084e1b23577de22603cff752e59128d83cfecc2e6819edadd8cf7a10af11e",
+    "zh:9d5eea62fdb587eeb96a8c4d782459f4e6b73baeece4d04b4a40e44faaee9301",
+    "zh:a6355f596a3fb8fc85c2fb054ab14e722991533f87f928e7169a486462c74670",
+    "zh:b5a65a789cff4ada58a5baffc76cb9767dc26ec6b45c00d2ec8b1b027f6db4ed",
+    "zh:db5ab669cf11d0e9f81dc380a6fdfcac437aea3d69109c7aef1a5426639d2d65",
+    "zh:de655d251c470197bcbb5ac45d289595295acb8f829f6c781d4a75c8c8b7c7dd",
+    "zh:f5c68199f2e6076bce92a12230434782bf768103a427e9bb9abee99b116af7b5",
   ]
 }

--- a/terraform/infrastructure/iam/gcp/main.tf
+++ b/terraform/infrastructure/iam/gcp/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "5.37.0"
+      version = "6.7.0"
     }
   }
 }


### PR DESCRIPTION
### Context

CI jobs have been running into GCP IAM inconsistencies, which are caused by a bad waiting condition in the Google Terraform provider. The issue has been fixed, but not backported to 5.x.

### Proposed change(s)
- Upgrade major version of Terraform provider

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/635

### Additional info
<!-- Remove items that do not apply -->
- [AB#4686](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4686)

### Checklist
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [Install](https://github.com/edgelesssys/constellation/actions/runs/11384990124)
  - [x] [Upgrade](https://github.com/edgelesssys/constellation/actions/runs/11401709210)
  - [x] [Terraform](https://github.com/edgelesssys/constellation/actions/runs/11385047425)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
