### PR TITLE
helm: allow namespace handling for node-maintenance-operator

### DIFF
--- a/internal/constellation/helm/charts/edgeless/operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
+++ b/internal/constellation/helm/charts/edgeless/operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
@@ -12,7 +12,13 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
+  - delete
   - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/constellation/helm/testdata/AWS/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
+++ b/internal/constellation/helm/testdata/AWS/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
@@ -15,7 +15,13 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
+  - delete
   - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/constellation/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
+++ b/internal/constellation/helm/testdata/Azure/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
@@ -15,7 +15,13 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
+  - delete
   - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/constellation/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
+++ b/internal/constellation/helm/testdata/GCP/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
@@ -15,7 +15,13 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
+  - delete
   - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/constellation/helm/testdata/OpenStack/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
+++ b/internal/constellation/helm/testdata/OpenStack/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
@@ -15,7 +15,13 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
+  - delete
   - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/constellation/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
+++ b/internal/constellation/helm/testdata/QEMU/constellation-operators/charts/node-maintenance-operator/templates/manager-rbac.yaml
@@ -15,7 +15,13 @@ rules:
   resources:
   - namespaces
   verbs:
+  - create
+  - delete
   - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
https://github.com/edgelesssys/constellation/pull/3425 broke the node-maintenance-operator by not updating the Helm chart accordingly. The operator now wants to handle namespaces, for which its clusterRole was missing the required permissions for.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add the new required permissions to the Helm chart.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#4791](https://dev.azure.com/Edgeless/Edgeless/_workitems/edit/4791)
- Needs to be backported into v2.19.0

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
