### PR TITLE
ci: use GOPROXY fallbacks

### DIFF
--- a/bazel/bazelrc/ci.bazelrc
+++ b/bazel/bazelrc/ci.bazelrc
@@ -62,6 +62,10 @@ build --remote_local_fallback
 # Docs: https://bazel.build/reference/command-line-reference#flag--grpc_keepalive_time
 build --grpc_keepalive_time=30s
 
+# Use fallbacks in case proxy.golang.org is not reachable.
+# Docs: https://go.dev/ref/mod#goproxy-protocol
+common '--repo_env=GOPROXY=https://proxy.golang.org|https://goproxy.io|direct'
+
 
 ######################################
 # Edgeless specific                  #


### PR DESCRIPTION
### Context

Golang builds use a module proxy to fetch dependencies. The default configuration is `GOPROXY=https://proxy.golang.org,direct`, which means "always use proxy.golang.org, and fall back to direct if the result is a 404". If the proxy fails differently (network disconnect, 502, ...), fetching fails.

### Proposed change(s)

- Use fallbacks on all proxy errors (this is done by using `|` instead of `,`).
- Add goproxy.io as additional fallback.

### Related issue
- Fixes edgelesssys/issues#1004

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
