### PR TITLE
cli: also log applier debug messages to debug log file

### DIFF
--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -227,7 +227,7 @@ func runApply(cmd *cobra.Command, _ []string) error {
 	}
 
 	fileHandler := file.NewHandler(afero.NewOsFs())
-	logger, err := newDebugFileLogger(cmd, fileHandler)
+	debugLogger, err := newDebugFileLogger(cmd, fileHandler)
 	if err != nil {
 		return err
 	}
@@ -250,12 +250,12 @@ func runApply(cmd *cobra.Command, _ []string) error {
 		)
 	}
 
-	applier := constellation.NewApplier(log, spinner, constellation.ApplyContextCLI, newDialer)
+	applier := constellation.NewApplier(debugLogger, spinner, constellation.ApplyContextCLI, newDialer)
 
 	apply := &applyCmd{
 		fileHandler:     fileHandler,
 		flags:           flags,
-		log:             logger,
+		log:             debugLogger,
 		wLog:            &warnLogger{cmd: cmd, log: log},
 		spinner:         spinner,
 		merger:          &kubeconfigMerger{log: log},

--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -211,10 +211,6 @@ func (f *applyFlags) parse(flags *pflag.FlagSet) error {
 
 // runApply sets up the apply command and runs it.
 func runApply(cmd *cobra.Command, _ []string) error {
-	log, err := newCLILogger(cmd)
-	if err != nil {
-		return fmt.Errorf("creating logger: %w", err)
-	}
 	spinner, err := newSpinnerOrStderr(cmd)
 	if err != nil {
 		return err
@@ -256,9 +252,9 @@ func runApply(cmd *cobra.Command, _ []string) error {
 		fileHandler:     fileHandler,
 		flags:           flags,
 		log:             debugLogger,
-		wLog:            &warnLogger{cmd: cmd, log: log},
+		wLog:            &warnLogger{cmd: cmd, log: debugLogger},
 		spinner:         spinner,
-		merger:          &kubeconfigMerger{log: log},
+		merger:          &kubeconfigMerger{log: debugLogger},
 		newInfraApplier: newInfraApplier,
 		imageFetcher:    imagefetcher.New(),
 		applier:         applier,
@@ -826,6 +822,7 @@ func (wl warnLogger) Info(msg string, args ...any) {
 // Warn prints a formatted warning from the validator.
 func (wl warnLogger) Warn(msg string, args ...any) {
 	wl.cmd.PrintErrf("Warning: %s %s\n", msg, fmt.Sprint(args...))
+	wl.log.Debug(msg, args...)
 }
 
 type warnLog interface {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Currenlty, when the coordinator is not reachable, the last log line is

```
{"time":"2024-10-18T11:59:38.778068783+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/cli/internal/cmd.(*applyCmd).runInit","file":"cli/internal/cmd/applyinit.go","line":38},"msg":"Running init RPC"}

<nothing else here, next line only if init is successful>

{"time":"2024-10-18T12:01:08.364242086+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/cli/internal/cmd.(*applyCmd).runInit","file":"cli/internal/cmd/applyinit.go","line":77},"msg":"Initialization request successful"}
```


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Use existing debugLogger, that logs both to a file and to stderr, in the applier that makes the init call to the coordinator. 


Now the logs also containt he following messages each time the CLI tries to init (those were previously only available directly in the cli output but not in the constellation-debug.log file)

```
{"time":"2024-10-24T11:57:16.602504601+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/cli/internal/cmd.(*applyCmd).runInit","file":"cli/internal/cmd/applyinit.go","line":38},"msg":"Running init RPC"}
{"time":"2024-10-24T11:57:16.602531232+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/constellation.(*Applier).GenerateMasterSecret","file":"internal/constellation/apply.go","line":125},"msg":"Generating master secret"}
{"time":"2024-10-24T11:57:16.602556592+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/constellation.(*Applier).GenerateMasterSecret","file":"internal/constellation/apply.go","line":138},"msg":"Generated master secret key and salt values"}
{"time":"2024-10-24T11:57:16.602652653+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/constellation.(*Applier).GenerateMeasurementSalt","file":"internal/constellation/apply.go","line":144},"msg":"Generating measurement salt"}
{"time":"2024-10-24T11:57:16.602675503+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/constellation.(*Applier).GenerateMeasurementSalt","file":"internal/constellation/apply.go","line":149},"msg":"Generated measurement salt"}
{"time":"2024-10-24T11:57:16.602700083+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/constellation.(*Applier).Init","file":"internal/constellation/applyinit.go","line":93},"msg":"Initialization call","endpoint":"34.117.169.242:9000"}
{"time":"2024-10-24T11:57:16.602804065+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/constellation.(*initDoer).Do","file":"internal/constellation/applyinit.go","line":191},"msg":"Created protoClient"}
{"time":"2024-10-24T11:57:16.602855575+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/grpc/grpclog.LogStateChangesUntilReady.func1","file":"internal/grpc/grpclog/grpclog.go","line":34},"msg":"Connection state started as \"IDLE\""}
{"time":"2024-10-24T11:57:16.602976596+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/grpc/grpclog.LogStateChangesUntilReady.func1","file":"internal/grpc/grpclog/grpclog.go","line":36},"msg":"Connection state changed to \"IDLE\""}
{"time":"2024-10-24T11:57:16.619469197+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/grpc/grpclog.LogStateChangesUntilReady.func1","file":"internal/grpc/grpclog/grpclog.go","line":36},"msg":"Connection state changed to \"CONNECTING\""}
{"time":"2024-10-24T11:57:16.619528677+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/grpc/grpclog.LogStateChangesUntilReady.func1","file":"internal/grpc/grpclog/grpclog.go","line":42},"msg":"Connection state ended with \"TRANSIENT_FAILURE\""}
{"time":"2024-10-24T11:57:16.619659429+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/constellation.(*Applier).Init.func1","file":"internal/constellation/applyinit.go","line":88},"msg":"Encountered error (retriable: true): \"init call: rpc error: code = Unavailable desc = connection error: desc = \\\"transport: authentication handshake failed: EOF\\\"\""}
{"time":"2024-10-24T11:57:46.606037431+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/constellation.(*initDoer).Do","file":"internal/constellation/applyinit.go","line":191},"msg":"Created protoClient"}
{"time":"2024-10-24T11:57:46.606093582+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/grpc/grpclog.LogStateChangesUntilReady.func1","file":"internal/grpc/grpclog/grpclog.go","line":34},"msg":"Connection state started as \"IDLE\""}
{"time":"2024-10-24T11:57:46.606321074+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/grpc/grpclog.LogStateChangesUntilReady.func1","file":"internal/grpc/grpclog/grpclog.go","line":36},"msg":"Connection state changed to \"IDLE\""}
{"time":"2024-10-24T11:57:46.623866876+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/grpc/grpclog.LogStateChangesUntilReady.func1","file":"internal/grpc/grpclog/grpclog.go","line":36},"msg":"Connection state changed to \"CONNECTING\""}
{"time":"2024-10-24T11:57:46.623954387+02:00","level":"DEBUG","source":{"function":"github.com/edgelesssys/constellation/v2/internal/grpc/grpclog.LogStateChangesUntilReady.func1","file":"internal/grpc/grpclog/grpclog.go","line":42},"msg":"Connection state ended with \"TRANSIENT_FAILURE\""}
```

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Link to Milestone
