### PR TITLE
ci: report failure in scheduled Terraform provider tests on cancel

### DIFF
--- a/.github/workflows/e2e-test-provider-example.yml
+++ b/.github/workflows/e2e-test-provider-example.yml
@@ -479,7 +479,7 @@ jobs:
 
       - name: Notify about failure
         if: |
-          failure() &&
+          (failure() || cancelled()) &&
           github.ref == 'refs/heads/main' &&
           github.event_name == 'schedule'
         continue-on-error: true


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
The weekly Terraform provider test failed multiple times without reporting a failure.
This was due to the provider being unable to complete the `apply` step, causing GitHub to cancel the workflow after 6 hours.
Terraform does not support running `apply` with a timeout itself, therefore we need another solution to report these failures.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Also report a failure on cancelled runs
  - Since failures are only reported for scheduled runs on main, they should never be cancelled by a user. If they were cancelled, it was most likely the GitHub CI itself, which we should be notified about

### Related issue
See 
* https://github.com/edgelesssys/constellation/actions/runs/11528371745/job/32095423964
* https://github.com/edgelesssys/constellation/actions/runs/11414034720/job/31762412086
* https://github.com/edgelesssys/constellation/actions/runs/11302173192/job/31437635434
