### PR TITLE
image: unset password reset date to ensure reprodicibility

### DIFF
--- a/image/base/BUILD.bazel
+++ b/image/base/BUILD.bazel
@@ -30,6 +30,7 @@ copy_to_directory(
     mkosi_image(
         name = "base_" + kernel_variant,
         srcs = [
+            "mkosi.finalize",
             "mkosi.postinst",
             "mkosi.prepare",
         ] + glob([

--- a/image/base/mkosi.finalize
+++ b/image/base/mkosi.finalize
@@ -4,5 +4,5 @@ set -euxo pipefail
 # Disable password age for Constellation sysusers.
 tmp=$(mktemp)
 cp -a "${BUILDROOT}/etc/shadow-" "${tmp}"
-mkosi-chroot chage -d "20014" etcd
+mkosi-chroot chage -d "" etcd
 cp -a "${tmp}" "${BUILDROOT}/etc/shadow-"

--- a/image/base/mkosi.finalize
+++ b/image/base/mkosi.finalize
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# Disable password age for Constellation sysusers.
+# For some reason yet unknown, SourceDateEpoch is not applied correctly to the
+# users added by systemd-sysusers. This has only been observed in our mkosi
+# flake so far, not in an upstream mkosi configuration.
+# TODO(burgerdev): wait for a couple of Nix package upgrades and try again?
+
+# Strategy: unset the "last password change" date without leaving a trace in
+# /etc/shadow-.
 tmp=$(mktemp)
 cp -a "${BUILDROOT}/etc/shadow-" "${tmp}"
 mkosi-chroot chage -d "" etcd

--- a/image/base/mkosi.finalize
+++ b/image/base/mkosi.finalize
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Disable password age for Constellation sysusers.
+tmp=$(mktemp)
+cp -a "${BUILDROOT}/etc/shadow-" "${tmp}"
+mkosi-chroot chage -d "20014" etcd
+cp -a "${tmp}" "${BUILDROOT}/etc/shadow-"


### PR DESCRIPTION
### Context

As part of our `mkosi` build, we add a system user `etcd` using the `systemctl-sysusers` mechanism. The tool [should understand `SOURCE_DATE_EPOCH`](https://github.com/systemd/systemd/commit/3fa8a1148a46b40b2a7ebac4007a95b4d0abab17), but does not apply it for some reason ~(maybe missing env propagation in mkosi)~. 

### Proposed change(s)

- Manually reset the "last changed" date in a finalize step.


### Related issue
- #3465 

### Additional info

- [AB#4815](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/4815)


### Checklist

- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [Image build](https://github.com/edgelesssys/constellation/actions/runs/11596498848) @ https://github.com/edgelesssys/constellation/commit/4cc5e08f53c2ec732ba7ddd8658139dc71141281
  - [x] [Image build](https://github.com/edgelesssys/constellation/actions/runs/11608302241) @ https://github.com/edgelesssys/constellation/commit/4fdbb198148f2d13dbe29ebe0bca63e964a40289
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
