### PR TITLE
Remove mention of Cilium's IPSec key rotation

### DIFF
--- a/docs/docs/architecture/keys.md
+++ b/docs/docs/architecture/keys.md
@@ -42,7 +42,6 @@ Each node creates its own [Curve25519](http://cr.yp.to/ecdh.html) encryption key
 A node uses another node's public key to decrypt and encrypt traffic from and to Cilium-managed endpoints running on that node.
 Connections are always encrypted peer-to-peer using [ChaCha20](http://cr.yp.to/chacha.html) with [Poly1305](http://cr.yp.to/mac.html).
 WireGuard implements [forward secrecy with key rotation every 2 minutes](https://lists.zx2c4.com/pipermail/wireguard/2017-December/002141.html).
-Cilium supports [key rotation](https://docs.cilium.io/en/stable/security/network/encryption-ipsec/#key-rotation) for the long-term node keys via Kubernetes secrets.
 
 ## Storage encryption
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Cilium does not support the rotation of the long term WireGuard keys in the same way as IPSec.
For Constellation the WireGuard long term keys are "rotated" when the nodes are replaced which happens on every Constellation upgrade.


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- remove mention of IPSec key rotation


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
