### PR TITLE
bootstrapper: only err if no control plane IPs available

### DIFF
--- a/bootstrapper/internal/joinclient/joinclient.go
+++ b/bootstrapper/internal/joinclient/joinclient.go
@@ -173,13 +173,13 @@ func (c *JoinClient) tryJoinWithAvailableServices() (ticket *joinproto.IssueJoin
 
 	endpoint, _, err := c.metadataAPI.GetLoadBalancerEndpoint(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get load balancer endpoint: %w", err)
+		c.log.Warn("Failed to get load balancer endpoint", "err", err)
 	}
 	endpoints = append(endpoints, endpoint)
 
 	ips, err := c.getControlPlaneIPs(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get control plane IPs: %w", err)
+		c.log.Warn("Failed to get control plane IPs", "err", err)
 	}
 	endpoints = append(endpoints, ips...)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Previously we errored out of the entire join if retrieval of either LB IP or control plane public IP failed. This resulted in the entire "use either IP" logic not working as intended.

This also fixes the problem encountered by STACKIT folks, where public IP retrieval fails and thus no nodes can join the cluster.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Log a warning only if the IP retrievals fail, and only errors out of the join if no IP can be found at all.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
