### PR TITLE
ci: run memory intensive `check` targets sequentially

### DIFF
--- a/bazel/ci/BUILD.bazel
+++ b/bazel/ci/BUILD.bazel
@@ -514,16 +514,14 @@ multirun(
 )
 
 multirun(
-    name = "check",
+    name = "parallel_checks",
     testonly = True,
     commands = [
         ":gazelle_check",
         ":buildifier_check",
-        ":golangci_lint",
         ":terraform_check",
         ":golicenses_check",
         ":license_header_check",
-        ":govulncheck",
         ":deps_mirror_check",
         ":proto_targets_check",
         ":unused_gh_actions",
@@ -538,6 +536,19 @@ multirun(
         ],
     }),
     jobs = 0,  # execute concurrently
+    stop_on_error = False,
+    visibility = ["//visibility:public"],
+)
+
+multirun(
+    name = "check",
+    testonly = True,
+    commands = [
+        ":parallel_checks",
+        ":golangci_lint",
+        ":govulncheck",
+    ],
+    jobs = 1,  # execute sequentially to avoid running into memory issues on our CI runners
     stop_on_error = False,
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Our tidy/check/generate CI job fails intermittently during `bazel run //:check` due to memory constraints on our CI runners, when more than one job runs at the same time on our cluster.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Run the two most memory intensive targets of `check` sequentially to avoid issues with single jobs taking up more than 20GB of RAM
  - `govulncheck` requires around 12GB of RAM on my local machine
  - `golang-ci-lint` requires 8-10GB on my local machine

