### PR TITLE
constellation-node-operator: don't bail out on listing errors

### DIFF
--- a/operators/constellation-node-operator/internal/cloud/gcp/client/scalinggroup_test.go
+++ b/operators/constellation-node-operator/internal/cloud/gcp/client/scalinggroup_test.go
@@ -427,8 +427,11 @@ func TestListScalingGroups(t *testing.T) {
 			templateLabels: map[string]string{
 				"label": "value",
 			},
+			wantErr: true,
 		},
-		"invalid instance group manager": {},
+		"invalid instance group manager": {
+			wantErr: true,
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
If the GCP project has scaling groups for which our checks can't be performed (which is the case for regional scaling groups, as they "don't exist" for the operator, if deployed in another region) . In that case, we should not bail out directly but go on with the next group. An error should only be thrown if there are no matching groups at all.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Don't error directly, but only if no scaling groups are found.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [E2E](https://github.com/edgelesssys/constellation/actions/runs/12135753706)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
