### PR TITLE
ci: exclude CoreDNS chart from renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,6 +14,7 @@
   "prConcurrentLimit": 4,
   "ignorePaths": [
     "internal/constellation/helm/charts/cilium/**",
+    "internal/constellation/helm/charts/coredns/**",
     "internal/constellation/helm/charts/edgeless/csi/charts/aws-csi-driver/**",
     "internal/constellation/helm/charts/edgeless/csi/charts/azuredisk-csi-driver/**",
     "internal/constellation/helm/charts/edgeless/csi/charts/gcp-compute-persistent-disk-csi-driver/**",


### PR DESCRIPTION
### Context

The CoreDNS Helm chart is synthesised from and updated with Kubernetes source dependencies, so we don't want automated upgrades of the CoreDNS image. 

### Proposed change(s)
- Ignore the CoreDNS Helm chart for renovation.

### Checklist
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
