### PR TITLE
image: use uplosi from nixpkgs-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,8 +37,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgsUnstable": "nixpkgsUnstable",
-        "uplosi": "uplosi"
+        "nixpkgsUnstable": "nixpkgsUnstable"
       }
     },
     "systems": {
@@ -53,29 +52,6 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
-        "type": "github"
-      }
-    },
-    "uplosi": {
-      "inputs": {
-        "flake-utils": [
-          "flake-utils"
-        ],
-        "nixpkgs": [
-          "nixpkgsUnstable"
-        ]
-      },
-      "locked": {
-        "lastModified": 1733317519,
-        "narHash": "sha256-Q/qCh655Cga1nKs4qMF+2JYLxy+mLvFofKxukoREZ3Q=",
-        "owner": "edgelesssys",
-        "repo": "uplosi",
-        "rev": "137f7b6557087fc198e919b2ef8c167ecbe94f91",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edgelesssys",
-        "repo": "uplosi",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -8,11 +8,6 @@
     flake-utils = {
       url = "github:numtide/flake-utils";
     };
-    uplosi = {
-      url = "github:edgelesssys/uplosi";
-      inputs.nixpkgs.follows = "nixpkgsUnstable";
-      inputs.flake-utils.follows = "flake-utils";
-    };
   };
 
   outputs =
@@ -20,7 +15,6 @@
       self,
       nixpkgsUnstable,
       flake-utils,
-      uplosi,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
@@ -56,13 +50,11 @@
               ]);
           })
         );
-
-        uplosiDev = uplosi.outputs.packages."${system}".uplosi;
       in
       {
         packages.mkosi = mkosiDev;
 
-        packages.uplosi = uplosiDev;
+        packages.uplosi = pkgsUnstable.uplosi;
 
         packages.openssl = callPackage ./nix/cc/openssl.nix { pkgs = pkgsUnstable; };
 

--- a/internal/osimage/uplosi/uplosi.conf.in
+++ b/internal/osimage/uplosi/uplosi.conf.in
@@ -12,6 +12,7 @@ subscriptionID = "0d202bbb-4fa7-4af8-8125-58c269a05435"
 location = "northeurope"
 resourceGroup = "constellation-images"
 sharingNamePrefix = "constellation"
+sharingProfile = "community"
 sku = "constellation"
 publisher = "edgelesssys"
 


### PR DESCRIPTION
### Context

uplosi on main tightened checks, which our image build setup fails. While this is being reverted (https://github.com/edgelesssys/uplosi/pull/102), we should not depend on an unreleased uplosi here.

### Proposed change(s)

- Use uplosi from nixpkgs-unstable.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [image build](https://github.com/edgelesssys/constellation/actions/runs/12273686522)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
