### PR TITLE
docs: correct STACKIT IDs

### DIFF
--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -117,6 +117,12 @@ If you encounter any problem with the following steps, make sure to use the [lat
 
     * `stackitProjectID`: STACKIT project id (can be found after login on the [STACKIT portal](https://portal.stackit.cloud))
 
+    :::caution
+
+    `stackitProjectID` refers to the ID of your STACKIT project. The STACKIT portal also shows the OpenStack ID that's associated with your project in some places. Make sure you insert the STACKIT project ID in the `constellation-conf.yaml` file. It's of the format `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`.
+
+    :::
+
     </TabItem>
     </Tabs>
 

--- a/docs/docs/getting-started/install.md
+++ b/docs/docs/getting-started/install.md
@@ -408,7 +408,7 @@ You need to authenticate with the infrastructure API (OpenStack) and create a se
                 auth_url: https://keystone.api.iaas.eu01.stackit.cloud/v3
                 username: REPLACE_WITH_UAT_USERNAME
                 password: REPLACE_WITH_UAT_PASSWORD
-                project_id: REPLACE_WITH_STACKIT_PROJECT_ID
+                project_id: REPLACE_WITH_OPENSTACK_PROJECT_ID
                 project_name: REPLACE_WITH_STACKIT_PROJECT_NAME
                 user_domain_name: portal_mvp
                 project_domain_name: portal_mvp
@@ -418,7 +418,7 @@ You need to authenticate with the infrastructure API (OpenStack) and create a se
 
 :::caution
 
-`project_id` refers to the ID of your STACKIT project. The STACKIT portal also shows the OpenStack ID that's associated with your project in some places. Make sure you insert the STACKIT project ID in the `clouds.yaml` file. It's of the format XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX.
+`project_id` refers to the ID of your OpenStack project. The STACKIT portal also shows the STACKIT ID that's associated with your project in some places. Make sure you insert the OpenStack project ID in the `clouds.yaml` file.
 
 :::
 

--- a/docs/versioned_docs/version-2.19/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.19/getting-started/first-steps.md
@@ -117,6 +117,12 @@ If you encounter any problem with the following steps, make sure to use the [lat
 
     * `stackitProjectID`: STACKIT project id (can be found after login on the [STACKIT portal](https://portal.stackit.cloud))
 
+    :::caution
+
+    `stackitProjectID` refers to the ID of your STACKIT project. The STACKIT portal also shows the OpenStack ID that's associated with your project in some places. Make sure you insert the STACKIT project ID in the `constellation-conf.yaml` file. It's of the format `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`.
+
+    :::
+
     </TabItem>
     </Tabs>
 

--- a/docs/versioned_docs/version-2.19/getting-started/install.md
+++ b/docs/versioned_docs/version-2.19/getting-started/install.md
@@ -418,7 +418,7 @@ You need to authenticate with the infrastructure API (OpenStack) and create a se
 
 :::caution
 
-`project_id` refers to the ID of your STACKIT project. The STACKIT portal also shows the OpenStack ID that's associated with your project in some places. Make sure you insert the STACKIT project ID in the `clouds.yaml` file. It's of the format "XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX".
+`project_id` refers to the ID of your OpenStack project. The STACKIT portal also shows the STACKIT ID that's associated with your project in some places. Make sure you insert the OpenStack project ID in the `clouds.yaml` file.
 
 :::
 

--- a/docs/versioned_docs/version-2.20/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.20/getting-started/first-steps.md
@@ -117,6 +117,12 @@ If you encounter any problem with the following steps, make sure to use the [lat
 
     * `stackitProjectID`: STACKIT project id (can be found after login on the [STACKIT portal](https://portal.stackit.cloud))
 
+    :::caution
+
+    `stackitProjectID` refers to the ID of your STACKIT project. The STACKIT portal also shows the OpenStack ID that's associated with your project in some places. Make sure you insert the STACKIT project ID in the `constellation-conf.yaml` file. It's of the format `XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`.
+
+    :::
+
     </TabItem>
     </Tabs>
 

--- a/docs/versioned_docs/version-2.20/getting-started/install.md
+++ b/docs/versioned_docs/version-2.20/getting-started/install.md
@@ -418,7 +418,7 @@ You need to authenticate with the infrastructure API (OpenStack) and create a se
 
 :::caution
 
-`project_id` refers to the ID of your STACKIT project. The STACKIT portal also shows the OpenStack ID that's associated with your project in some places. Make sure you insert the STACKIT project ID in the `clouds.yaml` file. It's of the format XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX.
+`project_id` refers to the ID of your OpenStack project. The STACKIT portal also shows the STACKIT ID that's associated with your project in some places. Make sure you insert the OpenStack project ID in the `clouds.yaml` file.
 
 :::
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We got OpenStack and STACKIT IDs mixed up in our documentation previously. The OpenStack project ID is required in the `clouds.yaml` file [^1], while the STACKIT project ID is required in the Constellation config [^2]. This fixes the warning for the OpenStack project ID in `clouds.yaml`, and adds an additional warning for the STACKIT project ID in the configuration section.

[^1]: https://github.com/edgelesssys/wiki/blob/master/documentation/constellation/stackit.md#cloudsyaml
[^2]: https://github.com/edgelesssys/wiki/blob/master/documentation/constellation/stackit.md#constellation-confyaml

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Fix OpenStack project ID warning (said STACKIT previously).
- Add an additional warning for the STACKIT project ID.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
