### PR TITLE
image: include files from git reproducibly

### DIFF
--- a/image/BUILD.bazel
+++ b/image/BUILD.bazel
@@ -1,16 +1,12 @@
 load("@aspect_bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@rules_pkg//pkg:mappings.bzl", "pkg_files", "strip_prefix")
-
-filegroup(
-    name = "sysroot_tree",
-    srcs = glob(["sysroot-tree/**"]),
-)
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files", "strip_prefix")
 
 pkg_files(
     name = "sysroot",
-    srcs = [":sysroot_tree"],
-    strip_prefix = strip_prefix.from_pkg() + "sysroot-tree",
+    srcs = glob(["sysroot-tree/**"]),
+    attributes = pkg_attributes(mode = "0555"),
+    strip_prefix = strip_prefix.from_pkg("sysroot-tree"),
     visibility = ["//visibility:public"],
 )
 

--- a/image/base/BUILD.bazel
+++ b/image/base/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@aspect_bazel_lib//lib:copy_to_directory.bzl", "copy_to_directory")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files", "strip_prefix")
 load("//bazel/mkosi:mkosi_image.bzl", "mkosi_image")
 
 copy_to_directory(
@@ -33,9 +34,7 @@ copy_to_directory(
             "mkosi.finalize",
             "mkosi.postinst",
             "mkosi.prepare",
-        ] + glob([
-            "mkosi.skeleton/**",
-        ]),
+        ],
         outs = [
             kernel_variant,
             kernel_variant + ".tar",
@@ -46,6 +45,7 @@ copy_to_directory(
             kernel_variant + "-rpmdb.sqlite-wal",
         ],
         extra_trees = [
+            ":skeleton",
             "//image:sysroot_tar",
             "//image:cryptsetup_closure",
         ],
@@ -85,4 +85,16 @@ pkg_tar(
     },
     tags = ["manual"],
     visibility = ["//visibility:public"],
+)
+
+pkg_files(
+    name = "skeleton_files",
+    srcs = glob(["mkosi.skeleton/**"]),
+    attributes = pkg_attributes(mode = "0555"),
+    strip_prefix = strip_prefix.from_pkg("mkosi.skeleton"),
+)
+
+pkg_tar(
+    name = "skeleton",
+    srcs = [":skeleton_files"],
 )

--- a/image/initrd/BUILD.bazel
+++ b/image/initrd/BUILD.bazel
@@ -1,17 +1,18 @@
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files", "strip_prefix")
 load("//bazel/mkosi:mkosi_image.bzl", "mkosi_image")
 
 mkosi_image(
     name = "initrd",
     srcs = [
         "mkosi.postinst",
-    ] + glob([
-        "mkosi.skeleton/**",
-    ]),
+    ],
     outs = [
         "image",
         "image.cpio.zst",
     ],
     extra_trees = [
+        ":skeleton",
         "//image:sysroot_tar",
         "//image:cryptsetup_closure",
         "//disk-mapper/cmd:disk-mapper-package.tar",
@@ -23,4 +24,16 @@ mkosi_image(
         "no-cache",
     ],
     visibility = ["//visibility:public"],
+)
+
+pkg_files(
+    name = "skeleton_files",
+    srcs = glob(["mkosi.skeleton/**"]),
+    attributes = pkg_attributes(mode = "0555"),
+    strip_prefix = strip_prefix.from_pkg("mkosi.skeleton"),
+)
+
+pkg_tar(
+    name = "skeleton",
+    srcs = [":skeleton_files"],
 )


### PR DESCRIPTION
### Context

Our image build includes source files from git. Since git respects the users `umask`, the files in the image might have different permissions depending on the system executing the build.

### Proposed change(s)

- Add a new Bazel rule `reproducible_tar` that normalizes git subtrees for image inclusion.


### Additional info

The added rule depends on gnutar and is unlikely to work on vanilla darwin (cc @elchead). This trades off portability for correctness of the rootfs. Some alternatives:

* Use[ `pkg_tar`](https://github.com/bazelbuild/rules_pkg/blob/main/docs/1.0.1/reference.md#pkg_tar) with a mode `0555`. Downside: our config files are now executable.
* Split sources for inclusion into two subtrees by desired permission bits. Downside: more rules, unintuitive layout.
* Explicitly list the files that should be executable in `pkg_tar(modes={})`. Downside: need to maintain names in two places.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - ~[ ] [sonobuoy-quick with fresh image on GCP](https://github.com/edgelesssys/constellation/actions/runs/12390246173)~
  - [x] [sonobuoy-quick with fresh image on GCP](https://github.com/edgelesssys/constellation/actions/runs/12413147620)
  - [x] [reproducible builds](https://github.com/edgelesssys/constellation/actions/runs/12413171970)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
