### PR TITLE
ci: only write STACKIT configuration if STACKIT test runs

### DIFF
--- a/.github/actions/constellation_iam_create/action.yml
+++ b/.github/actions/constellation_iam_create/action.yml
@@ -116,6 +116,7 @@ runs:
 
     - name: Set STACKIT-specific configuration
       shell: bash
+      if: inputs.cloudProvider == 'stackit'
       env:
         STACKIT_PROJECT_ID: ${{ inputs.stackitProjectID }}
       run: |


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
In #3556, we unconditionally write the STACKIT configuration to the config file used to create the cluster in the e2e tests. This causes all non-STACKIT tests to fail, as 2 CSPs will be defined in the configuration. An example can be seen [here](https://github.com/edgelesssys/constellation/actions/runs/12424824871).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Only write the STACKIT configuration if a STACKIT test should run.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [E2E test daily](https://github.com/edgelesssys/constellation/actions/runs/12427595179)
- [E2E test STACKIT](https://github.com/edgelesssys/constellation/actions/runs/12427597422)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
