### PR TITLE
renovate: match dl.k8s.io for K8s releases

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -235,9 +235,9 @@
       "fileMatch": ["(^|\\/)versions.go$"],
       "matchStrings": [
         // Match kubernetes releases.
-        // example match:'  "https://storage.googleapis.com/kubernetes-release/release/v1.2.3/foo" // renovate:kubernetes-release'
+        // example match:'  "https://dl.k8s.io/v1.2.3/foo" // renovate:kubernetes-release'
         // (v1.2.3 -> currentValue)
-        " \"https:\\/\\/storage\\.googleapis\\.com\\/kubernetes-release\\/release\\/(?<currentValue>[^\\/\\s\"]+)\\/[^\"]+\"[^\\n]+\\/\\/ renovate:kubernetes-release",
+        " \"https:\\/\\/dl\\.k8s\\.io\\/(?<currentValue>[^\\/\\s\"]+)\\/[^\"]+\"[^\\n]+\\/\\/ renovate:kubernetes-release",
         // Match kubernetes releases.
         // example match:' " "v1.2.3" // renovate:kubernetes-release"'
         // (v1.2.3 -> currentValue)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We have a version mismatch in our Kubernetes (e.g. `kubadm`) versions and the versions the CLI expects to have right now, as the Renovate rule didn't match the `dl.k8s.io` URLs introduced in https://github.com/edgelesssys/constellation/commit/c1714aaf92ed04f6795bf52002256a9cb4fdba76. This fixes the issue by adjusting the Regex. Updates should work again when the versions are back in sync.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Adjust the regex to match `dl.k8s.io/<version>/foo`.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- AB#5089

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
