### PR TITLE
ci: allow unrestricted user namespaces in image builds

### DIFF
--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -167,6 +167,12 @@ jobs:
         with:
           clouds_yaml: ${{ secrets.STACKIT_IMAGE_UPLOAD_CLOUDS_YAML }}
 
+      - name: Allow unrestricted user namespaces
+        shell: bash
+        run: |
+          sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_unconfined=0
+          sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_userns=0
+          
       - name: Build and upload
         id: build
         shell: bash


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Since Ubuntu 23.10, creating namespaces, e.g. via `unshare`, requires privileges. Since `unshare` is used by `mkosi` in our image build pipeline, we need to re-enable them explicitly here before building the image, aligning with the behavior before Ubuntu 23.10.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Explicitly enable unprivileged user namespaces in the image build action.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [Action before this update](https://github.com/edgelesssys/constellation/actions/runs/12818102529)
- [Action after this update](https://github.com/edgelesssys/constellation/actions/runs/12825033842)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
