### PR TITLE
dependencies: bump Go to v1.23.5

### DIFF
--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.5"
           cache: false
 
       - name: Install Crane

--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.5"
           cache: false
 
       - name: Determine version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.5"
           cache: false
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.5"
           cache: true
 
       - name: Build generateMeasurements tool

--- a/.github/workflows/test-operator-codegen.yml
+++ b/.github/workflows/test-operator-codegen.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.23.2"
+          go-version: "1.23.5"
           cache: true
 
       - name: Run code generation

--- a/3rdparty/gcp-guest-agent/Dockerfile
+++ b/3rdparty/gcp-guest-agent/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
     git
 
 # Install Go
-ARG GO_VER=1.22.3
+ARG GO_VER=1.23.5
 RUN wget -q https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go${GO_VER}.linux-amd64.tar.gz && \
     rm go${GO_VER}.linux-amd64.tar.gz

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_sdk",
     patches = ["//3rdparty/bazel/org_golang:go_tls_max_handshake_size.patch"],
-    version = "1.23.2",
+    version = "1.23.5",
 )
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/dev-docs/workflows/bump-go-version.md
+++ b/dev-docs/workflows/bump-go-version.md
@@ -17,7 +17,7 @@ go_sdk.download(
 
 ```
 
-Replace `go-version: "1.xx.x"` with the new version in all GitHub actions and workflows.
+Replace `go-version: "1.xx.x"` with the new version in all GitHub actions/workflows, our go.mod files and Containerfiles.
 You can use the following command to find replace all instances of `go-version: "1.xx.x"` in the `.github` directory:
 
 ```bash
@@ -25,7 +25,9 @@ OLD_VERSION="1.xx.x"
 NEW_VERSION="1.xx.y"
 find .github -type f -exec sed -i "s/go-version: \"${OLD_VERSION}\"/go-version: \"${NEW_VERSION}\"/g" {} \;
 sed -i "s/go ${OLD_VERSION}/go ${NEW_VERSION}/g" go.mod
+sed -i "s/go ${OLD_VERSION}/go ${NEW_VERSION}/g" hack/tools/go.mod
 sed -i "s/${OLD_VERSION}/${NEW_VERSION}/g" go.work
+sed -i "s/GO_VER=${OLD_VERSION}/GO_VER=${NEW_VERSION}/g" 3rdparty/gcp-guest-agent/Dockerfile
 ```
 
 Or manually:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelesssys/constellation/v2
 
-go 1.23.2
+go 1.23.5
 
 replace github.com/google/go-sev-guest => github.com/katexochen/go-sev-guest v0.0.0-20241216075901-ccd51e9e7b6e
 

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.23.2
+go 1.23.5
 
-toolchain go1.23.2
+toolchain go1.23.5
 
 use (
 	.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelesssys/constellation/v2/hack/tools
 
-go 1.23.2
+go 1.23.5
 
 require (
 	github.com/google/go-licenses v1.6.0


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Go v1.23.5 was released to address `CVE-2024-45341` and `CVE-2024-45336`.
As far as I can tell, these do not affect Constellation in any way, but newer versions of our dependencies are already requiring the new release as the minimum supported Go version.
Soft requirement for https://github.com/edgelesssys/constellation/pull/3586

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Bump Go to `v1.23.5`
- Update the "How to update Go version" guide to include the `go.mod` file in `hack/tools/` and the `gcpguestagent` Dockerfile in `3rdparty/gcp-guest-agent/`

