### PR TITLE
e2e: downgrade vale version to 3.9.3

### DIFF
--- a/.github/workflows/docs-vale.yml
+++ b/.github/workflows/docs-vale.yml
@@ -29,3 +29,4 @@ jobs:
         with:
           files: docs/docs
           fail_on_error: true
+          version: 3.9.3


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Vale version 3.9.4 [fails on autogenerated documentation](https://github.com/edgelesssys/constellation/actions/runs/13008630352/job/36281061170?pr=3568#step:4:1217).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Downgrade the vale version to 3.9.3

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
