### PR TITLE
helm: grant configmap watch permission to constellation-operator-cont…

### DIFF
--- a/internal/constellation/helm/charts/edgeless/operators/charts/constellation-operator/templates/manager-rbac.yaml
+++ b/internal/constellation/helm/charts/edgeless/operators/charts/constellation-operator/templates/manager-rbac.yaml
@@ -13,6 +13,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/constellation/helm/testdata/AWS/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
+++ b/internal/constellation/helm/testdata/AWS/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
@@ -16,6 +16,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/constellation/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
+++ b/internal/constellation/helm/testdata/Azure/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
@@ -16,6 +16,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/constellation/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
+++ b/internal/constellation/helm/testdata/GCP/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
@@ -16,6 +16,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/constellation/helm/testdata/OpenStack/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
+++ b/internal/constellation/helm/testdata/OpenStack/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
@@ -16,6 +16,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/constellation/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
+++ b/internal/constellation/helm/testdata/QEMU/constellation-operators/charts/constellation-operator/templates/manager-rbac.yaml
@@ -16,6 +16,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - ""
   resources:

--- a/operators/constellation-node-operator/controllers/nodeversion_controller.go
+++ b/operators/constellation-node-operator/controllers/nodeversion_controller.go
@@ -83,7 +83,7 @@ func NewNodeVersionReconciler(nodeReplacer nodeReplacer, etcdRemover etcdRemover
 //+kubebuilder:rbac:groups=nodemaintenance.medik8s.io,resources=nodemaintenances,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=nodes/status,verbs=get
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=list;get
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=list;get;watch
 
 // Reconcile replaces outdated nodes with new nodes as specified in the NodeVersion spec.
 func (r *NodeVersionReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {


### PR DESCRIPTION
…roller-manager

<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We have an annoying warning in the `constellation-operator-controller-manager` pod, indicating that it isn't allowed to watch configmaps:
```
E0203 09:59:44.215148       1 reflector.go:166] "Unhandled Error" err="external/gazelle~~go_deps~io_k8s_client_go/tools/cache/reflector.go:251: Failed to watch
 *v1.ConfigMap: configmaps is forbidden: User \"system:serviceaccount:kube-system:constellation-operator-controller-manager\" cannot watch resource \"configmap
s\" in API group \"\" at the cluster scope" logger="UnhandledError"
```
### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Grant the configmap watch permission to the pod.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [ ] Run the E2E tests that are relevant to this PR's changes
- [ ] Update [docs](https://github.com/edgelesssys/constellation/tree/main/docs)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
