### PR TITLE
deps: bump Go to v1.23.6

### DIFF
--- a/.github/workflows/build-ccm-gcp.yml
+++ b/.github/workflows/build-ccm-gcp.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23.5"
+          go-version: "1.23.6"
           cache: false
 
       - name: Install Crane

--- a/.github/workflows/build-os-image-scheduled.yml
+++ b/.github/workflows/build-os-image-scheduled.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23.5"
+          go-version: "1.23.6"
           cache: false
 
       - name: Determine version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
         if: matrix.language == 'go'
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23.5"
+          go-version: "1.23.6"
           cache: false
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23.5"
+          go-version: "1.23.6"
           cache: true
 
       - name: Build generateMeasurements tool

--- a/.github/workflows/test-operator-codegen.yml
+++ b/.github/workflows/test-operator-codegen.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go environment
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: "1.23.5"
+          go-version: "1.23.6"
           cache: true
 
       - name: Run code generation

--- a/3rdparty/gcp-guest-agent/Dockerfile
+++ b/3rdparty/gcp-guest-agent/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
     git
 
 # Install Go
-ARG GO_VER=1.23.5
+ARG GO_VER=1.23.6
 RUN wget -q https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go${GO_VER}.linux-amd64.tar.gz && \
     rm go${GO_VER}.linux-amd64.tar.gz

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_sdk",
     patches = ["//3rdparty/bazel/org_golang:go_tls_max_handshake_size.patch"],
-    version = "1.23.5",
+    version = "1.23.6",
 )
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelesssys/constellation/v2
 
-go 1.23.5
+go 1.23.6
 
 // TODO(daniel-weisse): revert after merging https://github.com/martinjungblut/go-cryptsetup/pull/16.
 replace github.com/martinjungblut/go-cryptsetup => github.com/daniel-weisse/go-cryptsetup v0.0.0-20230705150314-d8c07bd1723c

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.23.5
+go 1.23.6
 
-toolchain go1.23.5
+toolchain go1.23.6
 
 use (
 	.

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelesssys/constellation/v2/hack/tools
 
-go 1.23.5
+go 1.23.6
 
 require (
 	github.com/google/go-licenses v1.6.0


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Go `v1.23.6` contains a fix for [GO-2025-3447](https://pkg.go.dev/vuln/GO-2025-3447).
This vulnerability does not affect us, since we don't support ppc64le, but it was either updating the Go version or adding an exception for this vulnerability.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Bump Go version to `v1.23.6`
