### PR TITLE
ci: supply STACKIT credentials to cleanup job

### DIFF
--- a/.github/actions/e2e_cleanup_timeframe/action.yml
+++ b/.github/actions/e2e_cleanup_timeframe/action.yml
@@ -11,6 +11,12 @@ inputs:
   azure_credentials:
     description: "Credentials authorized to create Constellation on Azure."
     required: true
+  openStackCloudsYaml:
+    description: "The contents of ~/.config/openstack/clouds.yaml"
+    required: false
+  stackitUat:
+    description: "The UAT for STACKIT"
+    required: false
 
 runs:
   using: "composite"
@@ -30,6 +36,16 @@ runs:
       uses: ./.github/actions/login_gcp
       with:
         service_account: "destroy-e2e@constellation-e2e.iam.gserviceaccount.com"
+
+    - name: Login to OpenStack
+      uses: ./.github/actions/login_openstack
+      with:
+        clouds_yaml: ${{ inputs.openStackCloudsYaml }}
+
+    - name: Login to STACKIT
+      uses: ./.github/actions/login_stackit
+      with:
+        serviceAccountToken: ${{ inputs.stackitUat }}
 
     - name: Install tools
       uses: ./.github/actions/setup_bazel_nix

--- a/.github/workflows/e2e-cleanup-weekly.yml
+++ b/.github/workflows/e2e-cleanup-weekly.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 0 * * 0" # At 00:00 every Sunday UTC
   workflow_dispatch:
-    
+
 
 jobs:
   cleanup:
@@ -22,3 +22,5 @@ jobs:
           ghToken: ${{ secrets.GITHUB_TOKEN }}
           encryptionSecret: ${{ secrets.ARTIFACT_ENCRYPT_PASSWD }}
           azure_credentials: ${{ secrets.AZURE_E2E_DESTROY_CREDENTIALS }}
+          openStackCloudsYaml: ${{ secrets.STACKIT_CI_CLOUDS_YAML }}
+          stackitUat: ${{ secrets.STACKIT_CI_UAT }}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The cleanup job failed previously due to the missing `clouds.yaml` file for OpenStack / STACKIT.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Login to OpenStack in the cleanup job.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [AB#5280](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/5280)
- [Workflow run](https://github.com/edgelesssys/constellation/actions/runs/13372168786)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
