### PR TITLE
cli: re-introduce iam upgrade check

### DIFF
--- a/cli/internal/cmd/apply.go
+++ b/cli/internal/cmd/apply.go
@@ -368,7 +368,7 @@ func (a *applyCmd) apply(
 	// Check current Terraform state, if it exists and infrastructure upgrades are not skipped,
 	// and apply migrations if necessary.
 	if !a.flags.skipPhases.contains(skipInfrastructurePhase) {
-		if err := a.runTerraformApply(cmd, conf, stateFile, upgradeDir); err != nil {
+		if err := a.runTerraformApply(cmd, conf, stateFile, upgradeDir, a.flags.yes); err != nil {
 			return fmt.Errorf("applying Terraform configuration: %w", err)
 		}
 	}


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
We still maintain the function in which we manually add the CSP if we did changes that require an `constellation iam upgrade`, though the function wasn't used for some time. Either we drop this safety check completely (as it also only applies to the cli and not the terraform) and is one less manual step when changing code and releasing, or we use it. 

I'm currently of the opinion to drop this, but wanted to show what the full feature looked like.


### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- re-introduce iam upgrade check


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)

upgrade to this branch: (gcp-snp, 1:1) https://github.com/edgelesssys/constellation/actions/runs/13679706679
nop e2e gcp-snp: https://github.com/edgelesssys/constellation/actions/runs/13679730897

