### PR TITLE
ci: replace tenv linter with usetesting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,7 +31,7 @@ linters:
     - misspell
     - noctx
     - revive
-    - tenv
+    - usetesting
     - unconvert
     - unparam
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The `tenv` linter has been replaced with the `usetesting` linter, as can be seen [here](https://github.com/edgelesssys/constellation/actions/runs/13584440815/job/38152319087?pr=3670#step:12:285).

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Replace the `tenv` linter with `usetesting`  in the golangci-lint config.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
