### PR TITLE
ci: add k8s v1.31 and remove v1.28 from stackit e2e test

### DIFF
--- a/.github/workflows/e2e-test-stackit.yml
+++ b/.github/workflows/e2e-test-stackit.yml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        kubernetesVersion: [ "1.28", "1.29", "1.30" ]
+        kubernetesVersion: [ "1.29", "1.30", "1.31" ]
         clusterCreation: [ "cli", "terraform" ]
         test: [ "sonobuoy quick" ]
     runs-on: ubuntu-24.04


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
This was forgotten when upgrading the Kubernetes versions, and we didn't notice because the e2e tests weren't running

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove Kubernetes v1.28 from stackit e2e tests
- Add Kubernetes v1.31 to stackit e2e tests

### Related issue
- Closes https://github.com/edgelesssys/issues/issues/1449
- Closes https://github.com/edgelesssys/issues/issues/1450

