### PR TITLE
ci: bump slsa verifier

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -323,7 +323,7 @@ jobs:
   provenance-verify:
     runs-on: ubuntu-24.04
     env:
-      SLSA_VERIFIER_VERSION: "2.5.1"
+      SLSA_VERIFIER_VERSION: "2.7.0"
     needs:
       - build-cli
       - provenance

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload CLI as artifact (unix)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if : ${{ matrix.os != 'windows' }}
+        if: ${{ matrix.os != 'windows' }}
         with:
           name: constellation-${{ matrix.os }}-${{ matrix.arch }}
           path: |
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload CLI as artifact (windows)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if : ${{ matrix.os == 'windows' }}
+        if: ${{ matrix.os == 'windows' }}
         with:
           name: constellation-${{ matrix.os }}-${{ matrix.arch }}
           path: |
@@ -150,7 +150,7 @@ jobs:
 
       - name: Upload Terraform Provider Binary as artifact (unix)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if : ${{ matrix.os != 'windows' }}
+        if: ${{ matrix.os != 'windows' }}
         with:
           name: terraform-provider-constellation-${{ matrix.os }}-${{ matrix.arch }}
           path: |
@@ -158,7 +158,7 @@ jobs:
 
       - name: Upload Terraform Provider Binary as artifact (windows)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        if : ${{ matrix.os == 'windows' }}
+        if: ${{ matrix.os == 'windows' }}
         with:
           name: terraform-provider-constellation-${{ matrix.os }}-${{ matrix.arch }}
           path: |


### PR DESCRIPTION
The old version throws the following error in the release pipeline:
```
euler@work:/tmp/tmp.JU0IjLCB1T$ ./slsa-verifier-linux-amd64 verify-artifact constellation-darwin-amd64/constellation-darwin-amd64 --provenance-path multiple.intoto.jsonl/multiple.intoto.jsonl --source-uri github.com/edgelesssys/constellation
No certificate provided, trying Redis search index to find entries by subject digest
Verifying artifact constellation-darwin-amd64/constellation-darwin-amd64: FAILED: could not find a matching valid signature entry: got unexpected errors unexpected tlog entry type: extracting certificate from 108e9186e8c5677ade5ca56cc9a3b5df4ccda2a39b94d698a9d2f5d570822f672379566c34238d3a, unexpected tlog entry type: extracting certificate from 108e9186e8c5677ae1a41d2024bca58d90697a5e1c6e3acfb2ec50b6fb167880158d392bfb0179cb, invalid signature: no signature found, invalid signature: no signature found

FAILED: SLSA verification failed: could not find a matching valid signature entry: got unexpected errors unexpected tlog entry type: extracting certificate from 108e9186e8c5677ade5ca56cc9a3b5df4ccda2a39b94d698a9d2f5d570822f672379566c34238d3a, unexpected tlog entry type: extracting certificate from 108e9186e8c5677ae1a41d2024bca58d90697a5e1c6e3acfb2ec50b6fb167880158d392bfb0179cb, invalid signature: no signature found, invalid signature: no signature found
```
