### PR TITLE
ci: rename nixpkgs input

### DIFF
--- a/.github/actions/setup_bazel_nix/action.yml
+++ b/.github/actions/setup_bazel_nix/action.yml
@@ -221,7 +221,7 @@ runs:
         { tools, repository, rev }:
         let
           repoFlake = builtins.getFlake ("github:" + repository + "/" + rev);
-          nixpkgs = repoFlake.inputs.nixpkgsUnstable;
+          nixpkgs = repoFlake.inputs.nixpkgs;
           pkgs = import nixpkgs { system = builtins.currentSystem; };
           toolPkgs = map (p: pkgs.${p}) tools;
         in


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Forgot to rename a reference to the `nixpkgsUnstable` input in the CI in #3740, causing the [libvirtd build workflow](https://github.com/edgelesssys/constellation/actions/runs/14261151544/job/39972852647) to fail.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Refer to the correct input.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Additional info
<!-- Remove items that do not apply -->
- [Workflow run after the fix](https://github.com/edgelesssys/constellation/actions/runs/14261846784)

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
