### PR TITLE
deps: update Go to v1.24.2

### DIFF
--- a/3rdparty/gcp-guest-agent/Dockerfile
+++ b/3rdparty/gcp-guest-agent/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y \
     git
 
 # Install Go
-ARG GO_VER=1.23.6
+ARG GO_VER=1.24.2
 RUN wget -q https://go.dev/dl/go${GO_VER}.linux-amd64.tar.gz && \
     tar -C /usr/local -xzf go${GO_VER}.linux-amd64.tar.gz && \
     rm go${GO_VER}.linux-amd64.tar.gz

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
 go_sdk.download(
     name = "go_sdk",
     patches = ["//3rdparty/bazel/org_golang:go_tls_max_handshake_size.patch"],
-    version = "1.23.6",
+    version = "1.24.2",
 )
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")

--- a/bootstrapper/internal/initserver/initserver_test.go
+++ b/bootstrapper/internal/initserver/initserver_test.go
@@ -67,7 +67,7 @@ func TestNew(t *testing.T) {
 			assert := assert.New(t)
 
 			server, err := New(
-				context.TODO(), newFakeLock(), &stubClusterInitializer{}, atls.NewFakeIssuer(variant.Dummy{}),
+				t.Context(), newFakeLock(), &stubClusterInitializer{}, atls.NewFakeIssuer(variant.Dummy{}),
 				&stubDisk{}, fh, &tc.metadata, logger.NewTest(t),
 			)
 			if tc.wantErr {
@@ -352,9 +352,9 @@ func TestSetupDisk(t *testing.T) {
 
 			masterSecret := uri.MasterSecret{Key: tc.masterKey, Salt: tc.salt}
 
-			cloudKms, err := kmssetup.KMS(context.Background(), uri.NoStoreURI, masterSecret.EncodeToURI())
+			cloudKms, err := kmssetup.KMS(t.Context(), uri.NoStoreURI, masterSecret.EncodeToURI())
 			require.NoError(err)
-			assert.NoError(server.setupDisk(context.Background(), cloudKms))
+			assert.NoError(server.setupDisk(t.Context(), cloudKms))
 		})
 	}
 }

--- a/bootstrapper/internal/kubernetes/kubernetes_test.go
+++ b/bootstrapper/internal/kubernetes/kubernetes_test.go
@@ -201,7 +201,7 @@ func TestInitCluster(t *testing.T) {
 			}
 
 			_, err := kube.InitCluster(
-				context.Background(), string(tc.k8sVersion), "kubernetes",
+				t.Context(), string(tc.k8sVersion), "kubernetes",
 				false, nil, nil, "",
 			)
 
@@ -384,7 +384,7 @@ func TestJoinCluster(t *testing.T) {
 				log:               logger.NewTest(t),
 			}
 
-			err := kube.JoinCluster(context.Background(), joinCommand, tc.role, tc.k8sComponents)
+			err := kube.JoinCluster(t.Context(), joinCommand, tc.role, tc.k8sComponents)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/bootstrapper/internal/kubernetes/kubewaiter/kubewaiter_test.go
+++ b/bootstrapper/internal/kubernetes/kubewaiter/kubewaiter_test.go
@@ -39,7 +39,7 @@ func TestCloudKubeAPIWaiter(t *testing.T) {
 			require := require.New(t)
 
 			waiter := &CloudKubeAPIWaiter{}
-			ctx, cancel := context.WithTimeout(context.Background(), 0)
+			ctx, cancel := context.WithTimeout(t.Context(), 0)
 			defer cancel()
 			err := waiter.Wait(ctx, tc.kubeClient)
 			if tc.wantErr {

--- a/cli/internal/cloudcmd/apply_test.go
+++ b/cli/internal/cloudcmd/apply_test.go
@@ -185,14 +185,14 @@ func TestApplier(t *testing.T) {
 				out:           &bytes.Buffer{},
 			}
 
-			diff, err := applier.Plan(context.Background(), tc.config)
+			diff, err := applier.Plan(t.Context(), tc.config)
 			if err != nil {
 				assert.True(tc.wantErr, "unexpected error: %s", err)
 				return
 			}
 			assert.False(diff)
 
-			idFile, err := applier.Apply(context.Background(), tc.provider, tc.config.GetAttestationConfig().GetVariant(), true)
+			idFile, err := applier.Apply(t.Context(), tc.provider, tc.config.GetAttestationConfig().GetVariant(), true)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -303,7 +303,7 @@ func TestPlan(t *testing.T) {
 			cfg := config.Default()
 			cfg.RemoveProviderAndAttestationExcept(cloudprovider.Azure)
 
-			diff, err := u.Plan(context.Background(), cfg)
+			diff, err := u.Plan(t.Context(), cfg)
 			if tc.wantErr {
 				require.Error(err)
 			} else {
@@ -352,7 +352,7 @@ func TestApply(t *testing.T) {
 				out:             io.Discard,
 			}
 
-			_, err := u.Apply(context.Background(), cloudprovider.QEMU, variant.QEMUVTPM{}, WithoutRollbackOnError)
+			_, err := u.Apply(t.Context(), cloudprovider.QEMU, variant.QEMUVTPM{}, WithoutRollbackOnError)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/cli/internal/cloudcmd/iam_test.go
+++ b/cli/internal/cloudcmd/iam_test.go
@@ -128,7 +128,7 @@ func TestIAMCreator(t *testing.T) {
 				},
 			}
 
-			idFile, err := creator.Create(context.Background(), tc.provider, tc.config)
+			idFile, err := creator.Create(t.Context(), tc.provider, tc.config)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -184,7 +184,7 @@ func TestDestroyIAMConfiguration(t *testing.T) {
 				return tc.tfClient, nil
 			}}
 
-			err := destroyer.DestroyIAMConfiguration(context.Background(), "", terraform.LogLevelNone)
+			err := destroyer.DestroyIAMConfiguration(t.Context(), "", terraform.LogLevelNone)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -278,7 +278,7 @@ func TestGetTfstateServiceAccountKey(t *testing.T) {
 				return tc.cl, nil
 			}}
 
-			saKey, err := destroyer.GetTfStateServiceAccountKey(context.Background(), "")
+			saKey, err := destroyer.GetTfStateServiceAccountKey(t.Context(), "")
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cloudcmd/rollback_test.go
+++ b/cli/internal/cloudcmd/rollback_test.go
@@ -8,7 +8,6 @@ package cloudcmd
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"testing"
 
@@ -46,7 +45,7 @@ func TestRollbackTerraform(t *testing.T) {
 			}
 
 			destroyClusterErrOutput := &bytes.Buffer{}
-			err := rollbacker.rollback(context.Background(), destroyClusterErrOutput, terraform.LogLevelNone)
+			err := rollbacker.rollback(t.Context(), destroyClusterErrOutput, terraform.LogLevelNone)
 			if tc.wantCleanupErr {
 				assert.Error(err)
 				if tc.tfClient.cleanUpWorkspaceErr == nil {
@@ -107,7 +106,7 @@ func TestRollbackQEMU(t *testing.T) {
 
 			destroyClusterErrOutput := &bytes.Buffer{}
 
-			err := rollbacker.rollback(context.Background(), destroyClusterErrOutput, terraform.LogLevelNone)
+			err := rollbacker.rollback(t.Context(), destroyClusterErrOutput, terraform.LogLevelNone)
 			if tc.wantErr {
 				assert.Error(err)
 				if tc.tfClient.cleanUpWorkspaceErr == nil {

--- a/cli/internal/cloudcmd/terminate_test.go
+++ b/cli/internal/cloudcmd/terminate_test.go
@@ -63,7 +63,7 @@ func TestTerminator(t *testing.T) {
 				},
 			}
 
-			err := terminator.Terminate(context.Background(), "", terraform.LogLevelNone)
+			err := terminator.Terminate(t.Context(), "", terraform.LogLevelNone)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/cloudcmd/tfplan_test.go
+++ b/cli/internal/cloudcmd/tfplan_test.go
@@ -101,7 +101,7 @@ func TestTFPlan(t *testing.T) {
 			fs := tc.prepareFs(require.New(t))
 
 			hasDiff, planErr := plan(
-				context.Background(), tc.tf, fs, io.Discard, terraform.LogLevelDebug,
+				t.Context(), tc.tf, fs, io.Discard, terraform.LogLevelDebug,
 				&terraform.QEMUVariables{},
 				templateDir, existingWorkspace, backupDir,
 			)

--- a/cli/internal/cmd/apply_test.go
+++ b/cli/internal/cmd/apply_test.go
@@ -199,7 +199,7 @@ func TestBackupHelmCharts(t *testing.T) {
 				log: logger.NewTest(t),
 			}
 
-			err := a.backupHelmCharts(context.Background(), tc.helmApplier, tc.includesUpgrades, "")
+			err := a.backupHelmCharts(t.Context(), tc.helmApplier, tc.includesUpgrades, "")
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/cli/internal/cmd/init_test.go
+++ b/cli/internal/cmd/init_test.go
@@ -217,7 +217,7 @@ func TestInitialize(t *testing.T) {
 				require.NoError(fileHandler.WriteJSON(serviceAccPath, tc.serviceAccKey, file.OptNone))
 			}
 
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
 			defer cancel()
 			cmd.SetContext(ctx)

--- a/cli/internal/cmd/recover_test.go
+++ b/cli/internal/cmd/recover_test.go
@@ -138,7 +138,7 @@ func TestRecover(t *testing.T) {
 			require := require.New(t)
 
 			cmd := NewRecoverCmd()
-			cmd.SetContext(context.Background())
+			cmd.SetContext(t.Context())
 			out := &bytes.Buffer{}
 			cmd.SetOut(out)
 			cmd.SetErr(out)
@@ -225,7 +225,7 @@ func TestDoRecovery(t *testing.T) {
 				log:      r.log,
 			}
 
-			err := recoverDoer.Do(context.Background())
+			err := recoverDoer.Do(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/cli/internal/cmd/upgradecheck_test.go
+++ b/cli/internal/cmd/upgradecheck_test.go
@@ -139,7 +139,7 @@ func TestGetCompatibleImageMeasurements(t *testing.T) {
 		}
 	})
 
-	upgrades, err := getCompatibleImageMeasurements(context.Background(), &bytes.Buffer{}, client, &stubCosignVerifier{}, singleUUIDVerifier(), csp, attestationVariant, versionZero, logger.NewTest(t))
+	upgrades, err := getCompatibleImageMeasurements(t.Context(), &bytes.Buffer{}, client, &stubCosignVerifier{}, singleUUIDVerifier(), csp, attestationVariant, versionZero, logger.NewTest(t))
 	assert.NoError(err)
 
 	for _, measurement := range upgrades {
@@ -344,7 +344,7 @@ func TestNewCLIVersions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 
-			_, err := tc.verCollector.newCLIVersions(context.Background())
+			_, err := tc.verCollector.newCLIVersions(t.Context())
 			if tc.wantErr {
 				require.Error(err)
 				return
@@ -385,7 +385,7 @@ func TestFilterCompatibleCLIVersions(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 
-			_, err := tc.verCollector.filterCompatibleCLIVersions(context.Background(), tc.cliPatchVersions, consemver.NewFromInt(1, 24, 5, ""))
+			_, err := tc.verCollector.filterCompatibleCLIVersions(t.Context(), tc.cliPatchVersions, consemver.NewFromInt(1, 24, 5, ""))
 			if tc.wantErr {
 				require.Error(err)
 				return

--- a/cli/internal/cmd/verify_test.go
+++ b/cli/internal/cmd/verify_test.go
@@ -235,7 +235,7 @@ func TestFormatDefault(t *testing.T) {
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			_, err := formatDefault(context.Background(), tc.doc, tc.attCfg, logger.NewTest(t))
+			_, err := formatDefault(t.Context(), tc.doc, tc.attCfg, logger.NewTest(t))
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -313,7 +313,7 @@ func TestVerifyClient(t *testing.T) {
 				Nonce: tc.nonce,
 			}
 
-			_, err = verifier.Verify(context.Background(), addr, request, atls.NewFakeValidator(variant.Dummy{}))
+			_, err = verifier.Verify(t.Context(), addr, request, atls.NewFakeValidator(variant.Dummy{}))
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/cli/internal/terraform/terraform_test.go
+++ b/cli/internal/terraform/terraform_test.go
@@ -483,7 +483,7 @@ func TestCreateCluster(t *testing.T) {
 
 			path := path.Join(tc.pathBase, strings.ToLower(tc.provider.String()))
 			require.NoError(c.PrepareWorkspace(path, tc.vars))
-			infraState, err := c.ApplyCluster(context.Background(), tc.provider, LogLevelDebug)
+			infraState, err := c.ApplyCluster(t.Context(), tc.provider, LogLevelDebug)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -799,7 +799,7 @@ func TestCreateIAM(t *testing.T) {
 
 			path := path.Join(tc.pathBase, strings.ToLower(tc.provider.String()))
 			require.NoError(c.PrepareWorkspace(path, tc.vars))
-			IAMoutput, err := c.ApplyIAM(context.Background(), tc.provider, LogLevelDebug)
+			IAMoutput, err := c.ApplyIAM(t.Context(), tc.provider, LogLevelDebug)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -841,7 +841,7 @@ func TestDestroyInstances(t *testing.T) {
 				tf: tc.tf,
 			}
 
-			err := c.Destroy(context.Background(), LogLevelDebug)
+			err := c.Destroy(t.Context(), LogLevelDebug)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -1073,7 +1073,7 @@ func TestPlan(t *testing.T) {
 				workingDir: tc.pathBase,
 			}
 
-			_, err := c.Plan(context.Background(), LogLevelDebug)
+			_, err := c.Plan(t.Context(), LogLevelDebug)
 			if tc.wantErr {
 				require.Error(err)
 			} else {
@@ -1132,7 +1132,7 @@ func TestShowPlan(t *testing.T) {
 				workingDir: tc.pathBase,
 			}
 
-			err := c.ShowPlan(context.Background(), LogLevelDebug, bytes.NewBuffer(nil))
+			err := c.ShowPlan(t.Context(), LogLevelDebug, bytes.NewBuffer(nil))
 			if tc.wantErr {
 				require.Error(err)
 			} else {
@@ -1320,7 +1320,7 @@ func TestShowIAM(t *testing.T) {
 				tf: tc.tf,
 			}
 
-			_, err := c.ShowIAM(context.Background(), tc.csp)
+			_, err := c.ShowIAM(t.Context(), tc.csp)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/csi/cryptmapper/cryptmapper_test.go
+++ b/csi/cryptmapper/cryptmapper_test.go
@@ -202,7 +202,7 @@ func TestOpenCryptDevice(t *testing.T) {
 				getDiskFormat: tc.diskInfo,
 			}
 
-			out, err := mapper.OpenCryptDevice(context.Background(), tc.source, tc.volumeID, tc.integrity)
+			out, err := mapper.OpenCryptDevice(t.Context(), tc.source, tc.volumeID, tc.integrity)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {
@@ -223,7 +223,7 @@ func TestOpenCryptDevice(t *testing.T) {
 		kms:           &fakeKMS{},
 		getDiskFormat: getDiskFormat,
 	}
-	_, err := mapper.OpenCryptDevice(context.Background(), "/dev/some-device", "volume01", false)
+	_, err := mapper.OpenCryptDevice(t.Context(), "/dev/some-device", "volume01", false)
 	assert.NoError(t, err)
 }
 
@@ -270,7 +270,7 @@ func TestResizeCryptDevice(t *testing.T) {
 				mapper: testMapper(tc.device),
 			}
 
-			res, err := mapper.ResizeCryptDevice(context.Background(), tc.volumeID)
+			res, err := mapper.ResizeCryptDevice(t.Context(), tc.volumeID)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/csi/kms/constellation_test.go
+++ b/csi/kms/constellation_test.go
@@ -57,7 +57,7 @@ func TestConstellationKMS(t *testing.T) {
 				endpoint: listener.Addr().String(),
 				kms:      tc.kms,
 			}
-			res, err := kms.GetDEK(context.Background(), "data-key", 64)
+			res, err := kms.GetDEK(t.Context(), "data-key", 64)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/csi/test/mount_integration_test.go
+++ b/csi/test/mount_integration_test.go
@@ -105,7 +105,7 @@ func TestOpenAndClose(t *testing.T) {
 
 	mapper := cryptmapper.New(&fakeKMS{})
 
-	newPath, err := mapper.OpenCryptDevice(context.Background(), devicePath, deviceName, false)
+	newPath, err := mapper.OpenCryptDevice(t.Context(), devicePath, deviceName, false)
 	require.NoError(err)
 	defer func() {
 		_ = mapper.CloseCryptDevice(deviceName)
@@ -119,14 +119,14 @@ func TestOpenAndClose(t *testing.T) {
 	assert.True(os.IsNotExist(err))
 
 	// Opening the same device should return the same path and not error
-	newPath2, err := mapper.OpenCryptDevice(context.Background(), devicePath, deviceName, false)
+	newPath2, err := mapper.OpenCryptDevice(t.Context(), devicePath, deviceName, false)
 	require.NoError(err)
 	assert.Equal(newPath, newPath2)
 
 	// Resize the device
 	resize(devicePath)
 
-	resizedPath, err := mapper.ResizeCryptDevice(context.Background(), deviceName)
+	resizedPath, err := mapper.ResizeCryptDevice(t.Context(), deviceName)
 	require.NoError(err)
 	assert.Equal("/dev/mapper/"+deviceName, resizedPath)
 
@@ -137,7 +137,7 @@ func TestOpenAndClose(t *testing.T) {
 	assert.True(os.IsNotExist(err))
 
 	// check if we can reopen the device
-	_, err = mapper.OpenCryptDevice(context.Background(), devicePath, deviceName, true)
+	_, err = mapper.OpenCryptDevice(t.Context(), devicePath, deviceName, true)
 	assert.NoError(err)
 	assert.NoError(mapper.CloseCryptDevice(deviceName))
 }
@@ -150,7 +150,7 @@ func TestOpenAndCloseIntegrity(t *testing.T) {
 
 	mapper := cryptmapper.New(&fakeKMS{})
 
-	newPath, err := mapper.OpenCryptDevice(context.Background(), devicePath, deviceName, true)
+	newPath, err := mapper.OpenCryptDevice(t.Context(), devicePath, deviceName, true)
 	require.NoError(err)
 	assert.Equal("/dev/mapper/"+deviceName, newPath)
 
@@ -162,13 +162,13 @@ func TestOpenAndCloseIntegrity(t *testing.T) {
 	assert.NoError(err)
 
 	// Opening the same device should return the same path and not error
-	newPath2, err := mapper.OpenCryptDevice(context.Background(), devicePath, deviceName, true)
+	newPath2, err := mapper.OpenCryptDevice(t.Context(), devicePath, deviceName, true)
 	require.NoError(err)
 	assert.Equal(newPath, newPath2)
 
 	// integrity devices do not support resizing
 	resize(devicePath)
-	_, err = mapper.ResizeCryptDevice(context.Background(), deviceName)
+	_, err = mapper.ResizeCryptDevice(t.Context(), deviceName)
 	assert.Error(err)
 
 	assert.NoError(mapper.CloseCryptDevice(deviceName))
@@ -181,7 +181,7 @@ func TestOpenAndCloseIntegrity(t *testing.T) {
 	assert.True(os.IsNotExist(err))
 
 	// check if we can reopen the device
-	_, err = mapper.OpenCryptDevice(context.Background(), devicePath, deviceName, true)
+	_, err = mapper.OpenCryptDevice(t.Context(), devicePath, deviceName, true)
 	assert.NoError(err)
 	assert.NoError(mapper.CloseCryptDevice(deviceName))
 }
@@ -194,13 +194,13 @@ func TestDeviceCloning(t *testing.T) {
 
 	mapper := cryptmapper.New(&dynamicKMS{})
 
-	_, err := mapper.OpenCryptDevice(context.Background(), devicePath, deviceName, false)
+	_, err := mapper.OpenCryptDevice(t.Context(), devicePath, deviceName, false)
 	assert.NoError(err)
 
 	require.NoError(cp(devicePath, devicePath+"-copy"))
 	defer teardown(devicePath + "-copy")
 
-	_, err = mapper.OpenCryptDevice(context.Background(), devicePath+"-copy", deviceName+"-copy", false)
+	_, err = mapper.OpenCryptDevice(t.Context(), devicePath+"-copy", deviceName+"-copy", false)
 	assert.NoError(err)
 
 	assert.NoError(mapper.CloseCryptDevice(deviceName))
@@ -220,7 +220,7 @@ func TestConcurrency(t *testing.T) {
 
 	wg := sync.WaitGroup{}
 	runTest := func(path, name string) {
-		newPath, err := mapper.OpenCryptDevice(context.Background(), path, name, false)
+		newPath, err := mapper.OpenCryptDevice(t.Context(), path, name, false)
 		assert.NoError(err)
 		defer func() {
 			_ = mapper.CloseCryptDevice(name)

--- a/debugd/internal/debugd/deploy/download_test.go
+++ b/debugd/internal/debugd/deploy/download_test.go
@@ -123,7 +123,7 @@ func TestDownloadDeployment(t *testing.T) {
 				serviceManager: serviceMgr,
 			}
 
-			err := download.DownloadDeployment(context.Background(), ip)
+			err := download.DownloadDeployment(t.Context(), ip)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -194,7 +194,7 @@ func TestDownloadInfo(t *testing.T) {
 				info:   &tc.infoSetter,
 			}
 
-			err := download.DownloadInfo(context.Background(), ip)
+			err := download.DownloadInfo(t.Context(), ip)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/debugd/internal/debugd/deploy/service_test.go
+++ b/debugd/internal/debugd/deploy/service_test.go
@@ -108,7 +108,7 @@ func TestSystemdAction(t *testing.T) {
 				fs:                       fs,
 				systemdUnitFilewriteLock: sync.Mutex{},
 			}
-			err := manager.SystemdAction(context.Background(), ServiceManagerRequest{
+			err := manager.SystemdAction(t.Context(), ServiceManagerRequest{
 				Unit:   unitName,
 				Action: tc.action,
 			})
@@ -188,7 +188,7 @@ func TestWriteSystemdUnitFile(t *testing.T) {
 				fs:                       fs,
 				systemdUnitFilewriteLock: sync.Mutex{},
 			}
-			err := manager.WriteSystemdUnitFile(context.Background(), tc.unit)
+			err := manager.WriteSystemdUnitFile(t.Context(), tc.unit)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -302,7 +302,7 @@ func TestOverrideServiceUnitExecStart(t *testing.T) {
 				fs:                       fs,
 				systemdUnitFilewriteLock: sync.Mutex{},
 			}
-			err := manager.OverrideServiceUnitExecStart(context.Background(), tc.unitName, tc.execStart)
+			err := manager.OverrideServiceUnitExecStart(t.Context(), tc.unitName, tc.execStart)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/debugd/internal/debugd/logcollector/credentials_test.go
+++ b/debugd/internal/debugd/logcollector/credentials_test.go
@@ -67,7 +67,7 @@ func TestGetOpensearchCredentialsGCP(t *testing.T) {
 
 			g := &gcpCloudCredentialGetter{secretsAPI: tc.gcpAPI}
 
-			gotCreds, err := g.GetOpensearchCredentials(context.Background())
+			gotCreds, err := g.GetOpensearchCredentials(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -127,7 +127,7 @@ func TestGetOpensearchCredentialsAzure(t *testing.T) {
 
 			a := &azureCloudCredentialGetter{secretsAPI: tc.azureAPI}
 
-			gotCreds, err := a.GetOpensearchCredentials(context.Background())
+			gotCreds, err := a.GetOpensearchCredentials(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -184,7 +184,7 @@ func TestGetOpensearchCredentialsAWS(t *testing.T) {
 
 			a := &awsCloudCredentialGetter{secretmanager: tc.awsAPI}
 
-			gotCreds, err := a.GetOpensearchCredentials(context.Background())
+			gotCreds, err := a.GetOpensearchCredentials(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/debugd/internal/debugd/metadata/cloudprovider/cloudprovider_test.go
+++ b/debugd/internal/debugd/metadata/cloudprovider/cloudprovider_test.go
@@ -56,7 +56,7 @@ func TestRole(t *testing.T) {
 
 			fetcher := Fetcher{tc.meta}
 
-			role, err := fetcher.Role(context.Background())
+			role, err := fetcher.Role(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -110,7 +110,7 @@ func TestDiscoverDebugIPs(t *testing.T) {
 			fetcher := Fetcher{
 				metaAPI: &tc.meta,
 			}
-			ips, err := fetcher.DiscoverDebugdIPs(context.Background())
+			ips, err := fetcher.DiscoverDebugdIPs(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -149,7 +149,7 @@ func TestDiscoverLoadBalancerIP(t *testing.T) {
 				metaAPI: tc.metaAPI,
 			}
 
-			ip, err := fetcher.DiscoverLoadBalancerIP(context.Background())
+			ip, err := fetcher.DiscoverLoadBalancerIP(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/debugd/internal/debugd/metadata/fallback/fallback_test.go
+++ b/debugd/internal/debugd/metadata/fallback/fallback_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package fallback
 
 import (
-	"context"
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/internal/role"
@@ -23,19 +22,19 @@ func TestDiscoverDebugdIPs(t *testing.T) {
 	assert := assert.New(t)
 
 	fetcher := NewFallbackFetcher()
-	ips, err := fetcher.DiscoverDebugdIPs(context.Background())
+	ips, err := fetcher.DiscoverDebugdIPs(t.Context())
 	assert.NoError(err)
 	assert.Empty(ips)
 
-	rol, err := fetcher.Role(context.Background())
+	rol, err := fetcher.Role(t.Context())
 	assert.NoError(err)
 	assert.Equal(rol, role.Unknown)
 
-	uid, err := fetcher.UID(context.Background())
+	uid, err := fetcher.UID(t.Context())
 	assert.NoError(err)
 	assert.Empty(uid)
 
-	self, err := fetcher.Self(context.Background())
+	self, err := fetcher.Self(t.Context())
 	assert.NoError(err)
 	assert.Empty(self)
 }

--- a/debugd/internal/debugd/metadata/scheduler_test.go
+++ b/debugd/internal/debugd/metadata/scheduler_test.go
@@ -91,7 +91,7 @@ func TestSchedulerStart(t *testing.T) {
 			}
 
 			wg := &sync.WaitGroup{}
-			scheduler.Start(context.Background(), wg)
+			scheduler.Start(t.Context(), wg)
 			wg.Wait()
 
 			assert.Equal(tc.wantDeploymentDownloads, tc.downloader.downloadDeploymentIPs)

--- a/debugd/internal/debugd/server/server_test.go
+++ b/debugd/internal/debugd/server/server_test.go
@@ -79,7 +79,7 @@ func TestSetInfo(t *testing.T) {
 			defer conn.Close()
 			client := pb.NewDebugdClient(conn)
 
-			setInfoStatus, err := client.SetInfo(context.Background(), &pb.SetInfoRequest{Info: tc.setInfo})
+			setInfoStatus, err := client.SetInfo(t.Context(), &pb.SetInfoRequest{Info: tc.setInfo})
 			grpcServ.GracefulStop()
 
 			assert.NoError(err)
@@ -137,7 +137,7 @@ func TestGetInfo(t *testing.T) {
 			defer conn.Close()
 			client := pb.NewDebugdClient(conn)
 
-			resp, err := client.GetInfo(context.Background(), &pb.GetInfoRequest{})
+			resp, err := client.GetInfo(t.Context(), &pb.GetInfoRequest{})
 			grpcServ.GracefulStop()
 
 			if tc.wantErr {
@@ -201,7 +201,7 @@ func TestUploadFiles(t *testing.T) {
 			require.NoError(err)
 			defer conn.Close()
 			client := pb.NewDebugdClient(conn)
-			stream, err := client.UploadFiles(context.Background())
+			stream, err := client.UploadFiles(t.Context())
 			require.NoError(err)
 			resp, err := stream.CloseAndRecv()
 
@@ -245,7 +245,7 @@ func TestDownloadFiles(t *testing.T) {
 			require.NoError(err)
 			defer conn.Close()
 			client := pb.NewDebugdClient(conn)
-			stream, err := client.DownloadFiles(context.Background(), tc.request)
+			stream, err := client.DownloadFiles(t.Context(), tc.request)
 			require.NoError(err)
 			_, recvErr := stream.Recv()
 			if tc.wantRecvErr {
@@ -324,7 +324,7 @@ func TestUploadSystemServiceUnits(t *testing.T) {
 			require.NoError(err)
 			defer conn.Close()
 			client := pb.NewDebugdClient(conn)
-			resp, err := client.UploadSystemServiceUnits(context.Background(), tc.request)
+			resp, err := client.UploadSystemServiceUnits(t.Context(), tc.request)
 
 			grpcServ.GracefulStop()
 

--- a/disk-mapper/internal/recoveryserver/recoveryserver_test.go
+++ b/disk-mapper/internal/recoveryserver/recoveryserver_test.go
@@ -40,7 +40,7 @@ func TestServe(t *testing.T) {
 	server := New(atls.NewFakeIssuer(variant.Dummy{}), newStubKMS(nil, nil), log)
 	dialer := testdialer.NewBufconnDialer()
 	listener := dialer.GetListener("192.0.2.1:1234")
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	var wg sync.WaitGroup
 
 	// Serve method returns when context is canceled
@@ -62,7 +62,7 @@ func TestServe(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		_, _, err := server.Serve(context.Background(), listener, uuid)
+		_, _, err := server.Serve(t.Context(), listener, uuid)
 		assert.NoError(err)
 	}()
 	time.Sleep(100 * time.Millisecond)
@@ -70,7 +70,7 @@ func TestServe(t *testing.T) {
 	wg.Wait()
 
 	// Serve method returns an error when serving is unsuccessful
-	_, _, err := server.Serve(context.Background(), listener, uuid)
+	_, _, err := server.Serve(t.Context(), listener, uuid)
 	assert.Error(err)
 }
 
@@ -104,7 +104,7 @@ func TestRecover(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			ctx := context.Background()
+			ctx := t.Context()
 			serverUUID := "uuid"
 			server := New(atls.NewFakeIssuer(variant.Dummy{}), tc.factory, logger.NewTest(t))
 			netDialer := testdialer.NewBufconnDialer()

--- a/disk-mapper/internal/rejoinclient/rejoinclient_test.go
+++ b/disk-mapper/internal/rejoinclient/rejoinclient_test.go
@@ -71,7 +71,7 @@ func TestStartCancel(t *testing.T) {
 	go rejoinServer.Serve(listener)
 	defer rejoinServer.GracefulStop()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	var wg sync.WaitGroup
 	wg.Add(1)
 
@@ -294,7 +294,7 @@ func TestStart(t *testing.T) {
 
 			client := New(dialer, tc.nodeInfo, meta, logger.NewTest(t))
 
-			passphrase, secret := client.Start(context.Background(), "uuid")
+			passphrase, secret := client.Start(t.Context(), "uuid")
 			assert.Equal(diskKey, passphrase)
 			assert.Equal(measurementSecret, secret)
 		})

--- a/e2e/internal/upgrade/upgrade.go
+++ b/e2e/internal/upgrade/upgrade.go
@@ -90,7 +90,7 @@ func testStatusEventuallyWorks(t *testing.T, cli string, timeout time.Duration) 
 		// Show versions set in cluster.
 		// The string after "Cluster status:" in the output might not be updated yet.
 		// This is only updated after the operator finishes one reconcile loop.
-		cmd := exec.CommandContext(context.Background(), cli, "status")
+		cmd := exec.CommandContext(t.Context(), cli, "status")
 		stdout, stderr, err := runCommandWithSeparateOutputs(cmd)
 		if err != nil {
 			log.Printf("Stdout: %s\nStderr: %s", string(stdout), string(stderr))
@@ -121,7 +121,7 @@ func testMicroservicesEventuallyHaveVersion(t *testing.T, wantMicroserviceVersio
 
 func testNodesEventuallyHaveVersion(t *testing.T, k *kubernetes.Clientset, targetVersions VersionContainer, totalNodeCount int, timeout time.Duration) {
 	require.Eventually(t, func() bool {
-		nodes, err := k.CoreV1().Nodes().List(context.Background(), metaV1.ListOptions{})
+		nodes, err := k.CoreV1().Nodes().List(t.Context(), metaV1.ListOptions{})
 		if err != nil {
 			log.Println(err)
 			return false

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelesssys/constellation/v2
 
-go 1.23.6
+go 1.24.2
 
 // TODO(daniel-weisse): revert after merging https://github.com/martinjungblut/go-cryptsetup/pull/16.
 replace github.com/martinjungblut/go-cryptsetup => github.com/daniel-weisse/go-cryptsetup v0.0.0-20230705150314-d8c07bd1723c

--- a/go.work
+++ b/go.work
@@ -1,6 +1,6 @@
-go 1.23.6
+go 1.24.2
 
-toolchain go1.23.6
+toolchain go1.24.2
 
 use (
 	.

--- a/hack/bazel-deps-mirror/internal/mirror/mirror_test.go
+++ b/hack/bazel-deps-mirror/internal/mirror/mirror_test.go
@@ -137,7 +137,7 @@ func TestMirror(t *testing.T) {
 				unauthenticated: tc.unauthenticated,
 				log:             logger.NewTest(t),
 			}
-			err := m.Mirror(context.Background(), tc.hash, []string{tc.upstreamURL})
+			err := m.Mirror(t.Context(), tc.hash, []string{tc.upstreamURL})
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -180,7 +180,7 @@ func TestLearn(t *testing.T) {
 				},
 				log: logger.NewTest(t),
 			}
-			gotHash, err := m.Learn(context.Background(), []string{"https://example.com/foo"})
+			gotHash, err := m.Learn(t.Context(), []string{"https://example.com/foo"})
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -274,7 +274,7 @@ func TestCheck(t *testing.T) {
 				},
 				log: logger.NewTest(t),
 			}
-			err := m.Check(context.Background(), tc.hash)
+			err := m.Check(t.Context(), tc.hash)
 			if tc.wantErr {
 				assert.Error(t, err)
 			} else {

--- a/hack/qemu-metadata-api/server/server_test.go
+++ b/hack/qemu-metadata-api/server/server_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -127,7 +126,7 @@ func TestListSelf(t *testing.T) {
 
 			server := New(logger.NewTest(t), "test", "initSecretHash", tc.stubLeaseGetter)
 
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://192.0.0.1/self", nil)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://192.0.0.1/self", nil)
 			require.NoError(err)
 			req.RemoteAddr = tc.remoteAddr
 
@@ -187,7 +186,7 @@ func TestListPeers(t *testing.T) {
 
 			server := New(logger.NewTest(t), "test", "initSecretHash", tc.stubNetworkGetter)
 
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://192.0.0.1/peers", nil)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "http://192.0.0.1/peers", nil)
 			require.NoError(err)
 			req.RemoteAddr = tc.remoteAddr
 
@@ -243,7 +242,7 @@ func TestInitSecretHash(t *testing.T) {
 
 			server := New(logger.NewTest(t), "test", tc.wantHash, defaultConnect)
 
-			req, err := http.NewRequestWithContext(context.Background(), tc.method, "http://192.0.0.1/initsecrethash", nil)
+			req, err := http.NewRequestWithContext(t.Context(), tc.method, "http://192.0.0.1/initsecrethash", nil)
 			require.NoError(err)
 
 			w := httptest.NewRecorder()

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/edgelesssys/constellation/v2/hack/tools
 
-go 1.23.6
+go 1.24.2
 
 require (
 	github.com/google/go-licenses v1.6.0

--- a/internal/api/attestationconfigapi/fetcher_test.go
+++ b/internal/api/attestationconfigapi/fetcher_test.go
@@ -7,7 +7,6 @@ package attestationconfigapi
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -103,7 +102,7 @@ func TestFetchLatestSEVSNPVersion(t *testing.T) {
 				},
 			}
 			fetcher := newFetcherWithClientAndVerifier(client, stubVerifier{}, constants.CDNRepositoryURL)
-			res, err := fetcher.FetchLatestVersion(context.Background(), tc.attestation)
+			res, err := fetcher.FetchLatestVersion(t.Context(), tc.attestation)
 			assert := assert.New(t)
 			if tc.wantErr {
 				assert.Error(err)

--- a/internal/api/versionsapi/fetcher_test.go
+++ b/internal/api/versionsapi/fetcher_test.go
@@ -8,7 +8,6 @@ package versionsapi
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -192,7 +191,7 @@ func TestFetchVersionList(t *testing.T) {
 
 			fetcher := Fetcher{client, constants.CDNRepositoryURL}
 
-			list, err := fetcher.FetchVersionList(context.Background(), tc.list)
+			list, err := fetcher.FetchVersionList(t.Context(), tc.list)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/internal/atls/atls_test.go
+++ b/internal/atls/atls_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package atls
 
 import (
-	"context"
 	"encoding/asn1"
 	"errors"
 	"io"
@@ -162,7 +161,7 @@ func TestTLSConfig(t *testing.T) {
 			server.StartTLS()
 			defer server.Close()
 
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, server.URL, http.NoBody)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, http.NoBody)
 			require.NoError(err)
 			resp, err := client.Do(req)
 			if tc.wantErr {
@@ -221,7 +220,7 @@ func TestClientConnectionConcurrency(t *testing.T) {
 
 	var reqs []*http.Request
 	for _, url := range urls {
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, http.NoBody)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
 		require.NoError(err)
 		reqs = append(reqs, req)
 	}
@@ -295,7 +294,7 @@ func TestServerConnectionConcurrency(t *testing.T) {
 
 	var reqs []*http.Request
 	for _, url := range urls {
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, http.NoBody)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, url, http.NoBody)
 		require.NoError(err)
 		reqs = append(reqs, req)
 	}

--- a/internal/attestation/aws/nitrotpm/issuer_test.go
+++ b/internal/attestation/aws/nitrotpm/issuer_test.go
@@ -100,7 +100,7 @@ func TestGetInstanceInfo(t *testing.T) {
 			instanceInfoFunc := getInstanceInfo(&tc.client)
 			assert.NotNil(instanceInfoFunc)
 
-			info, err := instanceInfoFunc(context.Background(), tpm, nil)
+			info, err := instanceInfoFunc(t.Context(), tpm, nil)
 			if tc.wantErr {
 				assert.Error(err)
 				assert.Nil(info)

--- a/internal/attestation/aws/nitrotpm/validator_test.go
+++ b/internal/attestation/aws/nitrotpm/validator_test.go
@@ -42,7 +42,7 @@ func TestGeTrustedKey(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 			out, err := getTrustedKey(
-				context.Background(),
+				t.Context(),
 				vtpm.AttestationDocument{
 					Attestation: &attest.Attestation{
 						AkPub: tc.akPub,

--- a/internal/attestation/aws/snp/validator_test.go
+++ b/internal/attestation/aws/snp/validator_test.go
@@ -8,7 +8,6 @@ package snp
 
 import (
 	"bytes"
-	"context"
 	"crypto"
 	"crypto/x509"
 	"encoding/base64"
@@ -67,7 +66,7 @@ func TestGetTrustedKey(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 			out, err := validator().getTrustedKey(
-				context.Background(),
+				t.Context(),
 				vtpm.AttestationDocument{
 					Attestation: &attest.Attestation{
 						AkPub: tc.akPub,

--- a/internal/attestation/azure/snp/issuer_test.go
+++ b/internal/attestation/azure/snp/issuer_test.go
@@ -82,7 +82,7 @@ func TestGetSNPAttestation(t *testing.T) {
 
 			data := []byte("data")
 
-			attestationJSON, err := issuer.getInstanceInfo(context.Background(), nil, data)
+			attestationJSON, err := issuer.getInstanceInfo(t.Context(), nil, data)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/internal/attestation/azure/snp/validator_test.go
+++ b/internal/attestation/azure/snp/validator_test.go
@@ -182,7 +182,7 @@ func TestCheckIDKeyDigest(t *testing.T) {
 			report := reportWithIDKeyDigest(tc.idKeyDigest)
 			validator := newTestValidator(cfg, tc.validateMaaTokenErr)
 
-			err := validator.checkIDKeyDigest(context.Background(), report, "", nil)
+			err := validator.checkIDKeyDigest(t.Context(), report, "", nil)
 			if tc.wantErr {
 				require.Error(err)
 			} else {
@@ -650,7 +650,7 @@ func TestTrustedKeyFromSNP(t *testing.T) {
 				attestationValidator: tc.validator,
 			}
 
-			key, err := validator.getTrustedKey(context.Background(), attDoc, nil)
+			key, err := validator.getTrustedKey(t.Context(), attDoc, nil)
 			if tc.wantErr {
 				assert.Error(err)
 				if tc.assertion != nil {

--- a/internal/attestation/azure/tdx/issuer_test.go
+++ b/internal/attestation/azure/tdx/issuer_test.go
@@ -8,7 +8,6 @@ package tdx
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"encoding/json"
 	"io"
@@ -135,7 +134,7 @@ func TestIMDSGetQuote(t *testing.T) {
 				client: tc.client,
 			}
 
-			_, err := quoteGetter.getQuote(context.Background(), []byte("test"))
+			_, err := quoteGetter.getQuote(t.Context(), []byte("test"))
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/internal/attestation/azure/trustedlaunch/trustedlaunch_test.go
+++ b/internal/attestation/azure/trustedlaunch/trustedlaunch_test.go
@@ -8,7 +8,6 @@ package trustedlaunch
 
 import (
 	"bytes"
-	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
@@ -192,7 +191,7 @@ func TestGetAttestationCert(t *testing.T) {
 			issuer := NewIssuer(logger.NewTest(t))
 			issuer.hClient = newTestClient(tc.crlServer)
 
-			certs, err := issuer.getAttestationCert(context.Background(), tpm, nil)
+			certs, err := issuer.getAttestationCert(t.Context(), tpm, nil)
 			if tc.wantIssueErr {
 				assert.Error(err)
 				return
@@ -213,7 +212,7 @@ func TestGetAttestationCert(t *testing.T) {
 			roots.AddCert(cert)
 			validator.roots = roots
 
-			key, err := validator.verifyAttestationKey(context.Background(), attDoc, nil)
+			key, err := validator.verifyAttestationKey(t.Context(), attDoc, nil)
 			if tc.wantValidateErr {
 				assert.Error(err)
 				return

--- a/internal/attestation/gcp/es/issuer_test.go
+++ b/internal/attestation/gcp/es/issuer_test.go
@@ -67,7 +67,7 @@ func TestGetGCEInstanceInfo(t *testing.T) {
 			require := require.New(t)
 			var tpm io.ReadWriteCloser
 
-			out, err := gcp.GCEInstanceInfo(tc.client)(context.Background(), tpm, nil)
+			out, err := gcp.GCEInstanceInfo(tc.client)(t.Context(), tpm, nil)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/internal/attestation/gcp/es/validator_test.go
+++ b/internal/attestation/gcp/es/validator_test.go
@@ -153,7 +153,7 @@ Y+t5OxL3kL15VzY1Ob0d5cMCAwEAAQ==
 			getTrustedKey, err := gcp.TrustedKeyGetter(variant.GCPSEVES{}, tc.getClient)
 			require.NoError(t, err)
 
-			out, err := getTrustedKey(context.Background(), attDoc, nil)
+			out, err := getTrustedKey(t.Context(), attDoc, nil)
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/internal/attestation/measurements/fetchmeasurements_test.go
+++ b/internal/attestation/measurements/fetchmeasurements_test.go
@@ -141,7 +141,7 @@ func TestFetchMeasurements(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 			sut := NewVerifyFetcher(tc.cosign, tc.rekor, client)
-			m, err := sut.FetchAndVerifyMeasurements(context.Background(), "v999.999.999", cloudprovider.GCP, variant.GCPSEVES{}, tc.noVerify)
+			m, err := sut.FetchAndVerifyMeasurements(t.Context(), "v999.999.999", cloudprovider.GCP, variant.GCPSEVES{}, tc.noVerify)
 			if tc.wantErr {
 				assert.Error(err)
 				if tc.asRekorErr {

--- a/internal/attestation/measurements/measurements_test.go
+++ b/internal/attestation/measurements/measurements_test.go
@@ -8,7 +8,6 @@ package measurements
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -458,7 +457,7 @@ func TestMeasurementsFetchAndVerify(t *testing.T) {
 			require.NoError(err)
 
 			hash, err := m.fetchAndVerify(
-				context.Background(), client, verifier,
+				t.Context(), client, verifier,
 				measurementsURL, signatureURL,
 				tc.imageVersion,
 				tc.csp,

--- a/internal/attestation/vtpm/attestation_test.go
+++ b/internal/attestation/vtpm/attestation_test.go
@@ -90,7 +90,7 @@ func TestValidate(t *testing.T) {
 	nonce := []byte{1, 2, 3, 4}
 	challenge := []byte("Constellation")
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	attDocRaw, err := issuer.Issue(ctx, challenge, nonce)
 	require.NoError(err)
@@ -347,7 +347,7 @@ func TestFailIssuer(t *testing.T) {
 
 			tc.issuer.log = logger.NewTest(t)
 
-			_, err := tc.issuer.Issue(context.Background(), tc.userData, tc.nonce)
+			_, err := tc.issuer.Issue(t.Context(), tc.userData, tc.nonce)
 			assert.Error(err)
 		})
 	}

--- a/internal/cloud/aws/aws_test.go
+++ b/internal/cloud/aws/aws_test.go
@@ -185,7 +185,7 @@ func TestSelf(t *testing.T) {
 				ec2:  tc.ec2API,
 			}
 
-			self, err := m.Self(context.Background())
+			self, err := m.Self(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -431,7 +431,7 @@ func TestList(t *testing.T) {
 				ec2:  tc.ec2,
 			}
 
-			list, err := m.List(context.Background())
+			list, err := m.List(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -694,7 +694,7 @@ func TestGetLoadBalancerEndpoint(t *testing.T) {
 				ec2:               successfulEC2,
 			}
 
-			gotHost, gotPort, err := m.GetLoadBalancerEndpoint(context.Background())
+			gotHost, gotPort, err := m.GetLoadBalancerEndpoint(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/internal/cloud/azure/azure_test.go
+++ b/internal/cloud/azure/azure_test.go
@@ -150,7 +150,7 @@ func TestGetInstance(t *testing.T) {
 				scaleSetsVMAPI: tc.scaleSetsVMAPI,
 				netIfacAPI:     tc.networkInterfacesAPI,
 			}
-			instance, err := metadata.getInstance(context.Background(), tc.providerID)
+			instance, err := metadata.getInstance(t.Context(), tc.providerID)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -186,7 +186,7 @@ func TestUID(t *testing.T) {
 			cloud := &Cloud{
 				imds: tc.imdsAPI,
 			}
-			uid, err := cloud.UID(context.Background())
+			uid, err := cloud.UID(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -222,7 +222,7 @@ func TestInitSecretHash(t *testing.T) {
 			cloud := &Cloud{
 				imds: tc.imdsAPI,
 			}
-			initSecretHash, err := cloud.InitSecretHash(context.Background())
+			initSecretHash, err := cloud.InitSecretHash(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -410,7 +410,7 @@ func TestList(t *testing.T) {
 				scaleSetsAPI:   tc.scaleSetsAPI,
 				scaleSetsVMAPI: tc.scaleSetsVMAPI,
 			}
-			instances, err := azureMetadata.List(context.Background())
+			instances, err := azureMetadata.List(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -473,7 +473,7 @@ func TestGetNetworkSecurityGroupName(t *testing.T) {
 			metadata := Cloud{
 				secGroupAPI: tc.securityGroupsAPI,
 			}
-			name, err := metadata.getNetworkSecurityGroupName(context.Background(), "resource-group", "uid")
+			name, err := metadata.getNetworkSecurityGroupName(t.Context(), "resource-group", "uid")
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -547,7 +547,7 @@ func TestGetSubnetworkCIDR(t *testing.T) {
 				imds:       tc.imdsAPI,
 				virtNetAPI: tc.virtualNetworksAPI,
 			}
-			subnetworkCIDR, err := metadata.getSubnetworkCIDR(context.Background())
+			subnetworkCIDR, err := metadata.getSubnetworkCIDR(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -708,7 +708,7 @@ func TestGetLoadBalancerEndpoint(t *testing.T) {
 				loadBalancerAPI: tc.loadBalancerAPI,
 				pubIPAPI:        tc.publicIPAddressesAPI,
 			}
-			gotHost, gotPort, err := metadata.GetLoadBalancerEndpoint(context.Background())
+			gotHost, gotPort, err := metadata.GetLoadBalancerEndpoint(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/internal/cloud/azure/imds_test.go
+++ b/internal/cloud/azure/imds_test.go
@@ -214,7 +214,7 @@ func TestIMDSClient(t *testing.T) {
 			}
 			iClient := IMDSClient{client: &hClient}
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			id, err := iClient.providerID(ctx)
 			if tc.wantProviderIDErr {

--- a/internal/cloud/gcp/gcp_test.go
+++ b/internal/cloud/gcp/gcp_test.go
@@ -172,7 +172,7 @@ func TestGetInstance(t *testing.T) {
 				instanceAPI: &tc.instanceAPI,
 				subnetAPI:   &tc.subnetAPI,
 			}
-			instance, err := cloud.getInstance(context.Background(), tc.projectID, tc.zone, tc.instanceName)
+			instance, err := cloud.getInstance(t.Context(), tc.projectID, tc.zone, tc.instanceName)
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -474,7 +474,7 @@ func TestGetLoadbalancerEndpoint(t *testing.T) {
 				regionalForwardingRulesAPI: &tc.regionalForwardingRulesAPI,
 			}
 
-			gotHost, gotPort, err := cloud.GetLoadBalancerEndpoint(context.Background())
+			gotHost, gotPort, err := cloud.GetLoadBalancerEndpoint(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -810,7 +810,7 @@ func TestList(t *testing.T) {
 				zoneAPI:     &tc.zoneAPI,
 			}
 
-			instances, err := cloud.List(context.Background())
+			instances, err := cloud.List(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -915,7 +915,7 @@ func TestZones(t *testing.T) {
 
 			assert.Empty(cloud.zoneCache)
 
-			gotZones, err := cloud.zones(context.Background(), "someProject", "someregion-west3")
+			gotZones, err := cloud.zones(t.Context(), "someProject", "someregion-west3")
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -1066,7 +1066,7 @@ func TestUID(t *testing.T) {
 				instanceAPI: &tc.instanceAPI,
 			}
 
-			uid, err := cloud.UID(context.Background())
+			uid, err := cloud.UID(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -1170,7 +1170,7 @@ func TestInitSecretHash(t *testing.T) {
 				instanceAPI: &tc.instanceAPI,
 			}
 
-			initSecretHash, err := cloud.InitSecretHash(context.Background())
+			initSecretHash, err := cloud.InitSecretHash(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/internal/cloud/openstack/imds_test.go
+++ b/internal/cloud/openstack/imds_test.go
@@ -176,7 +176,7 @@ func TestProviderID(t *testing.T) {
 						cacheTime:     tc.cacheTime,
 					}
 
-					result, err := tu.method(imds, context.Background())
+					result, err := tu.method(imds, t.Context())
 
 					if tc.wantErr {
 						assert.Error(err)
@@ -264,7 +264,7 @@ func TestRole(t *testing.T) {
 				cacheTime: tc.cacheTime,
 			}
 
-			result, err := imds.role(context.Background())
+			result, err := imds.role(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -336,7 +336,7 @@ func TestVPCIP(t *testing.T) {
 				vpcIPCacheTime: tc.cacheTime,
 			}
 
-			result, err := imds.vpcIP(context.Background())
+			result, err := imds.vpcIP(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/internal/cloud/openstack/openstack_test.go
+++ b/internal/cloud/openstack/openstack_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package openstack
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -88,7 +87,7 @@ func TestSelf(t *testing.T) {
 
 			c := &MetadataClient{imds: tc.imds}
 
-			got, err := c.Self(context.Background())
+			got, err := c.Self(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -384,7 +383,7 @@ func TestList(t *testing.T) {
 
 			c := &MetadataClient{imds: tc.imds, api: tc.api}
 
-			got, err := c.List(context.Background())
+			got, err := c.List(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -418,7 +417,7 @@ func TestUID(t *testing.T) {
 
 			c := &MetadataClient{imds: tc.imds}
 
-			got, err := c.UID(context.Background())
+			got, err := c.UID(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -452,7 +451,7 @@ func TestInitSecretHash(t *testing.T) {
 
 			c := &MetadataClient{imds: tc.imds}
 
-			got, err := c.InitSecretHash(context.Background())
+			got, err := c.InitSecretHash(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)
@@ -486,7 +485,7 @@ func TestGetLoadBalancerEndpoint(t *testing.T) {
 
 			c := &MetadataClient{imds: tc.imds}
 
-			got, _, err := c.GetLoadBalancerEndpoint(context.Background())
+			got, _, err := c.GetLoadBalancerEndpoint(t.Context())
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/internal/constellation/apply_test.go
+++ b/internal/constellation/apply_test.go
@@ -38,7 +38,7 @@ func TestCheckLicense(t *testing.T) {
 			require := require.New(t)
 
 			a := &Applier{licenseChecker: tc.licenseChecker, log: logger.NewTest(t)}
-			_, err := a.CheckLicense(context.Background(), cloudprovider.Unknown, true, license.CommunityLicense)
+			_, err := a.CheckLicense(t.Context(), cloudprovider.Unknown, true, license.CommunityLicense)
 			if tc.wantErr {
 				require.Error(err)
 			} else {

--- a/internal/constellation/applyinit_test.go
+++ b/internal/constellation/applyinit_test.go
@@ -214,7 +214,7 @@ func TestInit(t *testing.T) {
 			}
 
 			clusterLogs := &bytes.Buffer{}
-			ctx, cancel := context.WithTimeout(context.Background(), time.Second*4)
+			ctx, cancel := context.WithTimeout(t.Context(), time.Second*4)
 			defer cancel()
 			_, err := a.Init(ctx, nil, tc.state, clusterLogs, InitPayload{
 				MasterSecret:    uri.MasterSecret{},
@@ -280,7 +280,7 @@ func TestAttestation(t *testing.T) {
 	}
 	state := &state.State{Version: state.Version1, Infrastructure: state.Infrastructure{ClusterEndpoint: "192.0.2.4"}}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx, cancel := context.WithTimeout(ctx, 4*time.Second)
 	defer cancel()
 

--- a/internal/constellation/helm/retryaction_test.go
+++ b/internal/constellation/helm/retryaction_test.go
@@ -64,7 +64,7 @@ func TestRetryApply(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			err := retryApply(context.Background(), tc.applier, time.Millisecond, logger.NewTest(t))
+			err := retryApply(t.Context(), tc.applier, time.Millisecond, logger.NewTest(t))
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/internal/constellation/kubecmd/backup_test.go
+++ b/internal/constellation/kubecmd/backup_test.go
@@ -57,7 +57,7 @@ func TestBackupCRDs(t *testing.T) {
 				log:     stubLog{},
 			}
 
-			_, err = client.BackupCRDs(context.Background(), file.NewHandler(memFs), tc.upgradeID)
+			_, err = client.BackupCRDs(t.Context(), file.NewHandler(memFs), tc.upgradeID)
 			if tc.wantError {
 				assert.Error(err)
 				return
@@ -146,7 +146,7 @@ func TestBackupCRs(t *testing.T) {
 				log:     stubLog{},
 			}
 
-			err := client.BackupCRs(context.Background(), file.NewHandler(memFs), []apiextensionsv1.CustomResourceDefinition{tc.crd}, tc.upgradeID)
+			err := client.BackupCRs(t.Context(), file.NewHandler(memFs), []apiextensionsv1.CustomResourceDefinition{tc.crd}, tc.upgradeID)
 			if tc.wantError {
 				assert.Error(err)
 				return

--- a/internal/constellation/kubecmd/kubecmd_test.go
+++ b/internal/constellation/kubecmd/kubecmd_test.go
@@ -180,7 +180,7 @@ func TestUpgradeNodeImage(t *testing.T) {
 				log:           logger.NewTest(t),
 			}
 
-			err = upgrader.UpgradeNodeImage(context.Background(), tc.newImageVersion, fmt.Sprintf("/path/to/image:%s", tc.newImageVersion.String()), tc.force)
+			err = upgrader.UpgradeNodeImage(t.Context(), tc.newImageVersion, fmt.Sprintf("/path/to/image:%s", tc.newImageVersion.String()), tc.force)
 			// Check upgrades first because if we checked err first, UpgradeImage may error due to other reasons and still trigger an upgrade.
 			if tc.wantUpdate {
 				assert.NotNil(unstructuredClient.updatedObject)
@@ -296,7 +296,7 @@ func TestUpgradeKubernetesVersion(t *testing.T) {
 				log:           logger.NewTest(t),
 			}
 
-			err = upgrader.UpgradeKubernetesVersion(context.Background(), tc.newKubernetesVersion, tc.force)
+			err = upgrader.UpgradeKubernetesVersion(t.Context(), tc.newKubernetesVersion, tc.force)
 			// Check upgrades first because if we checked err first, UpgradeImage may error due to other reasons and still trigger an upgrade.
 			if tc.wantUpdate {
 				assert.NotNil(unstructuredClient.updatedObject)
@@ -603,7 +603,7 @@ func TestApplyJoinConfig(t *testing.T) {
 				maxAttempts:   5,
 			}
 
-			err := cmd.ApplyJoinConfig(context.Background(), tc.newAttestationCfg, []byte{0x11})
+			err := cmd.ApplyJoinConfig(t.Context(), tc.newAttestationCfg, []byte{0x11})
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -667,7 +667,7 @@ func TestRetryAction(t *testing.T) {
 				return errs[failureCtr]
 			}
 
-			err := k.retryAction(context.Background(), action)
+			err := k.retryAction(t.Context(), action)
 			if tc.wantErr {
 				assert.Error(err)
 				assert.Equal(min(tc.failures, maxAttempts), failureCtr)
@@ -680,7 +680,7 @@ func TestRetryAction(t *testing.T) {
 }
 
 func TestExtendClusterConfigCertSANs(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	testCases := map[string]struct {
 		clusterConfig string

--- a/internal/grpc/atlscredentials/atlscredentials_test.go
+++ b/internal/grpc/atlscredentials/atlscredentials_test.go
@@ -73,7 +73,7 @@ func TestATLSCredentials(t *testing.T) {
 			defer conn.Close()
 
 			client := initproto.NewAPIClient(conn)
-			_, err = client.Init(context.Background(), &initproto.InitRequest{})
+			_, err = client.Init(t.Context(), &initproto.InitRequest{})
 		}()
 	}
 

--- a/internal/grpc/dialer/dialer_test.go
+++ b/internal/grpc/dialer/dialer_test.go
@@ -86,7 +86,7 @@ func TestDial(t *testing.T) {
 			defer conn.Close()
 
 			client := grpc_testing.NewTestServiceClient(conn)
-			_, err = client.EmptyCall(context.Background(), &grpc_testing.Empty{})
+			_, err = client.EmptyCall(t.Context(), &grpc_testing.Empty{})
 
 			if tc.wantErr {
 				assert.Error(err)

--- a/internal/grpc/grpclog/grpclog_test.go
+++ b/internal/grpc/grpclog/grpclog_test.go
@@ -76,7 +76,7 @@ func TestLogStateChanges(t *testing.T) {
 
 			var wg sync.WaitGroup
 			isReadyCallbackCalled := false
-			LogStateChangesUntilReady(context.Background(), tc.conn, logger, &wg, func() { isReadyCallbackCalled = true })
+			LogStateChangesUntilReady(t.Context(), tc.conn, logger, &wg, func() { isReadyCallbackCalled = true })
 			wg.Wait()
 			tc.assert(t, logger, isReadyCallbackCalled)
 		})

--- a/internal/imagefetcher/imagefetcher_test.go
+++ b/internal/imagefetcher/imagefetcher_test.go
@@ -256,7 +256,7 @@ func TestFetchReference(t *testing.T) {
 				fs:      af,
 			}
 
-			reference, err := fetcher.FetchReference(context.Background(), tc.provider, variant.Dummy{},
+			reference, err := fetcher.FetchReference(t.Context(), tc.provider, variant.Dummy{},
 				tc.image, "someRegion", false)
 
 			if tc.wantErr {

--- a/internal/imagefetcher/raw_test.go
+++ b/internal/imagefetcher/raw_test.go
@@ -8,7 +8,6 @@ package imagefetcher
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	"os"
@@ -91,7 +90,7 @@ func TestDownloadWithProgress(t *testing.T) {
 				fs:    fs,
 			}
 			var outBuffer bytes.Buffer
-			err := downloader.downloadWithProgress(context.Background(), &outBuffer, false, tc.source, "someVersion.raw")
+			err := downloader.downloadWithProgress(t.Context(), &outBuffer, false, tc.source, "someVersion.raw")
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -167,7 +166,7 @@ func TestDownload(t *testing.T) {
 				fs:    fs,
 			}
 			var outBuffer bytes.Buffer
-			gotDestination, err := downloader.Download(context.Background(), &outBuffer, false, tc.source, "someVersion")
+			gotDestination, err := downloader.Download(t.Context(), &outBuffer, false, tc.source, "someVersion")
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/internal/installer/installer_test.go
+++ b/internal/installer/installer_test.go
@@ -132,7 +132,7 @@ func TestInstall(t *testing.T) {
 				retriable: func(_ error) bool { return false },
 			}
 
-			err := inst.Install(context.Background(), tc.component)
+			err := inst.Install(t.Context(), tc.component)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -340,7 +340,7 @@ func TestRetryDownloadToTempDir(t *testing.T) {
 			}
 
 			// abort retryDownloadToTempDir in some test cases by using the context
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			wg := sync.WaitGroup{}
@@ -429,7 +429,7 @@ func TestDownloadToTempDir(t *testing.T) {
 				fs:      &afero.Afero{Fs: afs},
 				hClient: &hClient,
 			}
-			path, err := inst.downloadToTempDir(context.Background(), "http://server/path")
+			path, err := inst.downloadToTempDir(t.Context(), "http://server/path")
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/internal/kms/kms/cluster/cluster_test.go
+++ b/internal/kms/kms/cluster/cluster_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package cluster
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -29,7 +28,7 @@ func TestClusterKMS(t *testing.T) {
 	require.NoError(err)
 
 	keyLower, err := kms.GetDEK(
-		context.Background(),
+		t.Context(),
 		strings.ToLower(testVector.InfoPrefix+testVector.Info),
 		int(testVector.Length),
 	)
@@ -38,7 +37,7 @@ func TestClusterKMS(t *testing.T) {
 
 	// output of the KMS should be case sensitive
 	keyUpper, err := kms.GetDEK(
-		context.Background(),
+		t.Context(),
 		strings.ToUpper(testVector.InfoPrefix+testVector.Info),
 		int(testVector.Length),
 	)
@@ -105,7 +104,7 @@ func TestVectorsHKDF(t *testing.T) {
 			}
 			require.NoError(err)
 
-			out, err := kms.GetDEK(context.Background(), tc.dekID, int(tc.dekSize))
+			out, err := kms.GetDEK(t.Context(), tc.dekID, int(tc.dekSize))
 			require.NoError(err)
 			assert.Equal(tc.wantKey, out)
 		})

--- a/internal/kms/kms/internal/internal_test.go
+++ b/internal/kms/kms/internal/internal_test.go
@@ -135,7 +135,7 @@ func TestGetDEK(t *testing.T) {
 				Storage: tc.storage,
 			}
 
-			dek, err := client.GetDEK(context.Background(), "volume-01", 32)
+			dek, err := client.GetDEK(t.Context(), "volume-01", 32)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/internal/kms/setup/setup_test.go
+++ b/internal/kms/setup/setup_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package setup
 
 import (
-	"context"
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/internal/kms/uri"
@@ -26,12 +25,12 @@ func TestMain(m *testing.M) {
 func TestSetUpKMS(t *testing.T) {
 	assert := assert.New(t)
 
-	kms, err := KMS(context.Background(), "storage://unknown", "kms://unknown")
+	kms, err := KMS(t.Context(), "storage://unknown", "kms://unknown")
 	assert.Error(err)
 	assert.Nil(kms)
 
 	masterSecret := uri.MasterSecret{Key: []byte("key"), Salt: []byte("salt")}
-	kms, err = KMS(context.Background(), "storage://no-store", masterSecret.EncodeToURI())
+	kms, err = KMS(t.Context(), "storage://no-store", masterSecret.EncodeToURI())
 	assert.NoError(err)
 	assert.NotNil(kms)
 }

--- a/internal/kms/storage/awss3/awss3_test.go
+++ b/internal/kms/storage/awss3/awss3_test.go
@@ -80,7 +80,7 @@ func TestAWSS3Get(t *testing.T) {
 				client: tc.client,
 			}
 
-			out, err := store.Get(context.Background(), "test-key")
+			out, err := store.Get(t.Context(), "test-key")
 			if tc.wantErr {
 				assert.Error(err)
 
@@ -122,7 +122,7 @@ func TestAWSS3Put(t *testing.T) {
 
 			testData := []byte{0x1, 0x2, 0x3}
 
-			err := store.Put(context.Background(), "test-key", testData)
+			err := store.Put(t.Context(), "test-key", testData)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {
@@ -163,7 +163,7 @@ func TestAWSS3CreateBucket(t *testing.T) {
 				client: tc.client,
 			}
 
-			err := store.createBucket(context.Background(), "test-bucket", "test-region")
+			err := store.createBucket(t.Context(), "test-bucket", "test-region")
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/internal/kms/storage/azureblob/azureblob_test.go
+++ b/internal/kms/storage/azureblob/azureblob_test.go
@@ -51,7 +51,7 @@ func TestAzureGet(t *testing.T) {
 				container: "test",
 			}
 
-			out, err := client.Get(context.Background(), "test-key")
+			out, err := client.Get(t.Context(), "test-key")
 			if tc.wantErr {
 				assert.Error(err)
 
@@ -93,7 +93,7 @@ func TestAzurePut(t *testing.T) {
 				container: "test",
 			}
 
-			err := client.Put(context.Background(), "test-key", testData)
+			err := client.Put(t.Context(), "test-key", testData)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -130,7 +130,7 @@ func TestCreateContainerOrContinue(t *testing.T) {
 				container: "test",
 			}
 
-			err := client.createContainerOrContinue(context.Background())
+			err := client.createContainerOrContinue(t.Context())
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/internal/kms/storage/gcs/gcs_test.go
+++ b/internal/kms/storage/gcs/gcs_test.go
@@ -103,7 +103,7 @@ func TestGCPGet(t *testing.T) {
 				bucketName: "test",
 			}
 
-			out, err := client.Get(context.Background(), "test-key")
+			out, err := client.Get(t.Context(), "test-key")
 			if tc.wantErr {
 				assert.Error(err)
 
@@ -160,7 +160,7 @@ func TestGCPPut(t *testing.T) {
 			}
 			testData := []byte{0x1, 0x2, 0x3}
 
-			err := client.Put(context.Background(), "test-key", testData)
+			err := client.Put(t.Context(), "test-key", testData)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {
@@ -211,7 +211,7 @@ func TestGCPCreateContainerOrContinue(t *testing.T) {
 				bucketName: "test",
 			}
 
-			err := client.createContainerOrContinue(context.Background(), "project")
+			err := client.createContainerOrContinue(t.Context(), "project")
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/internal/kms/storage/memfs/memfs_test.go
+++ b/internal/kms/storage/memfs/memfs_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package memfs
 
 import (
-	"context"
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/internal/kms/storage"
@@ -30,7 +29,7 @@ func TestMemMapStorage(t *testing.T) {
 
 	testDEK1 := []byte("test DEK")
 	testDEK2 := []byte("more test DEK")
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// request unset value
 	_, err := store.Get(ctx, "test:input")

--- a/internal/kms/test/aws_test.go
+++ b/internal/kms/test/aws_test.go
@@ -34,7 +34,7 @@ func TestAwsStorage(t *testing.T) {
 	}
 	require := require.New(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 	defer cancel()
 
 	// create bucket
@@ -105,7 +105,7 @@ func TestAwsKms(t *testing.T) {
 	require := require.New(t)
 
 	store := memfs.New()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 	defer cancel()
 
 	cfg := uri.AWSConfig{

--- a/internal/kms/test/azure_test.go
+++ b/internal/kms/test/azure_test.go
@@ -31,7 +31,7 @@ func TestAzureStorage(t *testing.T) {
 	}
 	require := require.New(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 	defer cancel()
 
 	cfg := uri.AzureBlobConfig{
@@ -59,7 +59,7 @@ func TestAzureKeyKMS(t *testing.T) {
 	require := require.New(t)
 
 	store := memfs.New()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 	defer cancel()
 
 	cfg := uri.AzureConfig{
@@ -88,7 +88,7 @@ func TestAzureKeyHSM(t *testing.T) {
 	require := require.New(t)
 
 	store := memfs.New()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 	defer cancel()
 
 	cfg := uri.AzureConfig{

--- a/internal/kms/test/gcp_test.go
+++ b/internal/kms/test/gcp_test.go
@@ -32,7 +32,7 @@ func TestGCPKMS(t *testing.T) {
 	require := require.New(t)
 
 	store := memfs.New()
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 	defer cancel()
 
 	cfg := uri.GCPConfig{
@@ -59,7 +59,7 @@ func TestGcpStorage(t *testing.T) {
 	}
 	require := require.New(t)
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 	defer cancel()
 
 	cfg := uri.GoogleCloudStorageConfig{

--- a/internal/kms/test/integration_test.go
+++ b/internal/kms/test/integration_test.go
@@ -64,7 +64,7 @@ func runKMSTest(t *testing.T, kms kms.CloudKMS) {
 
 	dekName := "test-dek"
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 	defer cancel()
 
 	res, err := kms.GetDEK(ctx, dekName, config.SymmetricKeyLength)
@@ -90,7 +90,7 @@ func runStorageTest(t *testing.T, store kms.Storage) {
 	testData := []byte("Constellation test data")
 	testName := "constellation-test"
 
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*30)
 	defer cancel()
 
 	err := store.Put(ctx, testName, testData)

--- a/internal/license/checker_enterprise_test.go
+++ b/internal/license/checker_enterprise_test.go
@@ -10,7 +10,6 @@ package license
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"net/http"
 	"testing"
@@ -83,7 +82,7 @@ func TestQuotaCheck(t *testing.T) {
 				}),
 			}
 
-			quota, err := client.CheckLicense(context.Background(), cloudprovider.Unknown, Init, tc.license)
+			quota, err := client.CheckLicense(t.Context(), cloudprovider.Unknown, Init, tc.license)
 
 			if tc.wantError {
 				assert.Error(err)

--- a/internal/license/integration/license_integration_test.go
+++ b/internal/license/integration/license_integration_test.go
@@ -9,7 +9,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package integration
 
 import (
-	"context"
 	"testing"
 
 	"github.com/edgelesssys/constellation/v2/internal/cloud/cloudprovider"
@@ -39,7 +38,7 @@ func TestQuotaCheckIntegration(t *testing.T) {
 
 			client := license.NewChecker()
 
-			quota, err := client.CheckLicense(context.Background(), cloudprovider.Unknown, "test", tc.license)
+			quota, err := client.CheckLicense(t.Context(), cloudprovider.Unknown, "test", tc.license)
 
 			if tc.wantError {
 				assert.Error(err)

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -71,7 +71,7 @@ func TestDo(t *testing.T) {
 				retriable: isRetriable,
 			}
 			retrierResult := make(chan error, 1)
-			ctx, cancel := context.WithCancel(context.Background())
+			ctx, cancel := context.WithCancel(t.Context())
 			defer cancel()
 
 			go func() { retrierResult <- retrier.Do(ctx) }()

--- a/internal/sigstore/rekor_integration_test.go
+++ b/internal/sigstore/rekor_integration_test.go
@@ -9,7 +9,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package sigstore
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,7 +42,7 @@ func TestRekorSearchByHash(t *testing.T) {
 			rekor, err := NewRekor()
 			require.NoError(err)
 
-			uuids, err := rekor.SearchByHash(context.Background(), tc.hash)
+			uuids, err := rekor.SearchByHash(t.Context(), tc.hash)
 			assert.NoError(err)
 
 			if tc.wantEmpty {
@@ -85,7 +84,7 @@ func TestVerifyEntry(t *testing.T) {
 			rekor, err := NewRekor()
 			require.NoError(err)
 
-			err = rekor.VerifyEntry(context.Background(), tc.uuid, tc.pubKey)
+			err = rekor.VerifyEntry(t.Context(), tc.uuid, tc.pubKey)
 			if tc.wantError {
 				assert.Error(err)
 				return

--- a/internal/staticupload/staticupload_test.go
+++ b/internal/staticupload/staticupload_test.go
@@ -108,7 +108,7 @@ func TestUpload(t *testing.T) {
 				cacheInvalidationWaitTimeout: tc.cacheInvalidationWaitTimeout,
 				logger:                       logger.NewTest(t),
 			}
-			_, err := client.Upload(context.Background(), tc.in)
+			_, err := client.Upload(t.Context(), tc.in)
 
 			var invalidationErr *InvalidationError
 			if tc.wantCacheInvalidationErr {
@@ -220,7 +220,7 @@ func TestDeleteObject(t *testing.T) {
 				cacheInvalidationWaitTimeout: tc.cacheInvalidationWaitTimeout,
 				logger:                       logger.NewTest(t),
 			}
-			_, err := client.DeleteObject(context.Background(), newObjectInput(tc.nilInput, tc.nilKey))
+			_, err := client.DeleteObject(t.Context(), newObjectInput(tc.nilInput, tc.nilKey))
 
 			var invalidationErr *InvalidationError
 			if tc.wantCacheInvalidationErr {
@@ -259,7 +259,7 @@ func TestDeleteObject(t *testing.T) {
 				cacheInvalidationWaitTimeout: tc.cacheInvalidationWaitTimeout,
 				logger:                       logger.NewTest(t),
 			}
-			_, err := client.DeleteObjects(context.Background(), newObjectsInput(tc.nilInput, tc.nilKey))
+			_, err := client.DeleteObjects(t.Context(), newObjectsInput(tc.nilInput, tc.nilKey))
 
 			var invalidationErr *InvalidationError
 			if tc.wantCacheInvalidationErr {
@@ -401,7 +401,7 @@ func TestFlush(t *testing.T) {
 				invalidationIDs:              tc.invalidationIDs,
 				logger:                       logger.NewTest(t),
 			}
-			err := client.Flush(context.Background())
+			err := client.Flush(t.Context())
 
 			if tc.wantCacheInvalidationErr {
 				var invalidationErr *InvalidationError
@@ -444,18 +444,18 @@ func TestConcurrency(t *testing.T) {
 
 	upload := func() {
 		defer wg.Done()
-		_, _ = client.Upload(context.Background(), newInput())
+		_, _ = client.Upload(t.Context(), newInput())
 	}
 	deleteObject := func() {
 		defer wg.Done()
-		_, _ = client.DeleteObject(context.Background(), &s3.DeleteObjectInput{
+		_, _ = client.DeleteObject(t.Context(), &s3.DeleteObjectInput{
 			Bucket: ptr("test-bucket"),
 			Key:    ptr("test-key"),
 		})
 	}
 	deleteObjects := func() {
 		defer wg.Done()
-		_, _ = client.DeleteObjects(context.Background(), &s3.DeleteObjectsInput{
+		_, _ = client.DeleteObjects(t.Context(), &s3.DeleteObjectsInput{
 			Bucket: ptr("test-bucket"),
 			Delete: &s3types.Delete{
 				Objects: []s3types.ObjectIdentifier{
@@ -466,7 +466,7 @@ func TestConcurrency(t *testing.T) {
 	}
 	flushClient := func() {
 		defer wg.Done()
-		_ = client.Flush(context.Background())
+		_ = client.Flush(t.Context())
 	}
 
 	for i := 0; i < 100; i++ {

--- a/joinservice/internal/certcache/certcache_test.go
+++ b/joinservice/internal/certcache/certcache_test.go
@@ -116,7 +116,7 @@ func TestCreateCertChainCache(t *testing.T) {
 			assert := assert.New(t)
 			require := require.New(t)
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			c := &Client{
 				attVariant: variant.Dummy{},
@@ -204,7 +204,7 @@ func TestGetCertChainCache(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert := assert.New(t)
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			c := NewClient(logger.NewTest(t), tc.kubeClient, variant.Dummy{})
 

--- a/joinservice/internal/kms/kms_test.go
+++ b/joinservice/internal/kms/kms_test.go
@@ -60,7 +60,7 @@ func TestGetDataKey(t *testing.T) {
 
 			client.grpc = tc.client
 
-			res, err := client.GetDataKey(context.Background(), "disk-uuid", 32)
+			res, err := client.GetDataKey(t.Context(), "disk-uuid", 32)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/joinservice/internal/server/server_test.go
+++ b/joinservice/internal/server/server_test.go
@@ -201,7 +201,7 @@ func TestIssueJoinTicket(t *testing.T) {
 				DiskUuid:       "uuid",
 				IsControlPlane: tc.isControlPlane,
 			}
-			resp, err := api.IssueJoinTicket(context.Background(), req)
+			resp, err := api.IssueJoinTicket(t.Context(), req)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -265,7 +265,7 @@ func TestIssueRejoinTicker(t *testing.T) {
 			req := &joinproto.IssueRejoinTicketRequest{
 				DiskUuid: uuid,
 			}
-			resp, err := api.IssueRejoinTicket(context.Background(), req)
+			resp, err := api.IssueRejoinTicket(t.Context(), req)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/joinservice/internal/watcher/validator_test.go
+++ b/joinservice/internal/watcher/validator_test.go
@@ -147,7 +147,7 @@ func TestUpdate(t *testing.T) {
 
 	// test connection to server
 	clientOID := variant.Dummy{}
-	resp, err := testConnection(require, server.URL, clientOID)
+	resp, err := testConnection(t.Context(), require, server.URL, clientOID)
 	require.NoError(err)
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
@@ -159,7 +159,7 @@ func TestUpdate(t *testing.T) {
 	require.NoError(validator.Update())
 
 	// client connection should fail now, since the server's validator expects a different OID from the client
-	resp, err = testConnection(require, server.URL, clientOID)
+	resp, err = testConnection(t.Context(), require, server.URL, clientOID)
 	if err == nil {
 		defer resp.Body.Close()
 	}
@@ -230,12 +230,12 @@ func TestUpdateConcurrency(t *testing.T) {
 	wg.Wait()
 }
 
-func testConnection(require *require.Assertions, url string, oid variant.Getter) (*http.Response, error) {
+func testConnection(ctx context.Context, require *require.Assertions, url string, oid variant.Getter) (*http.Response, error) {
 	clientConfig, err := atls.CreateAttestationClientTLSConfig(fakeIssuer{oid}, nil)
 	require.NoError(err)
 	client := http.Client{Transport: &http.Transport{TLSClientConfig: clientConfig}}
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, http.NoBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	require.NoError(err)
 	return client.Do(req)
 }

--- a/keyservice/internal/server/server_test.go
+++ b/keyservice/internal/server/server_test.go
@@ -32,23 +32,23 @@ func TestGetDataKey(t *testing.T) {
 	kms := &stubKMS{derivedKey: []byte{0x0, 0x1, 0x2, 0x3, 0x4, 0x5}}
 	api := New(log, kms)
 
-	res, err := api.GetDataKey(context.Background(), &keyserviceproto.GetDataKeyRequest{DataKeyId: "1", Length: 32})
+	res, err := api.GetDataKey(t.Context(), &keyserviceproto.GetDataKeyRequest{DataKeyId: "1", Length: 32})
 	require.NoError(err)
 	assert.Equal(kms.derivedKey, res.DataKey)
 
 	// Test no data key id
-	res, err = api.GetDataKey(context.Background(), &keyserviceproto.GetDataKeyRequest{Length: 32})
+	res, err = api.GetDataKey(t.Context(), &keyserviceproto.GetDataKeyRequest{Length: 32})
 	require.Error(err)
 	assert.Nil(res)
 
 	// Test no / zero key length
-	res, err = api.GetDataKey(context.Background(), &keyserviceproto.GetDataKeyRequest{DataKeyId: "1"})
+	res, err = api.GetDataKey(t.Context(), &keyserviceproto.GetDataKeyRequest{DataKeyId: "1"})
 	require.Error(err)
 	assert.Nil(res)
 
 	// Test derive key error
 	api = New(log, &stubKMS{deriveKeyErr: errors.New("error")})
-	res, err = api.GetDataKey(context.Background(), &keyserviceproto.GetDataKeyRequest{DataKeyId: "1", Length: 32})
+	res, err = api.GetDataKey(t.Context(), &keyserviceproto.GetDataKeyRequest{DataKeyId: "1", Length: 32})
 	assert.Error(err)
 	assert.Nil(res)
 }

--- a/operators/constellation-node-operator/controllers/nodeversion_controller_test.go
+++ b/operators/constellation-node-operator/controllers/nodeversion_controller_test.go
@@ -123,7 +123,7 @@ func TestAnnotateNodes(t *testing.T) {
 					},
 				},
 			}
-			annotated, invalid := reconciler.annotateNodes(context.Background(), []corev1.Node{tc.node})
+			annotated, invalid := reconciler.annotateNodes(t.Context(), []corev1.Node{tc.node})
 			if tc.wantAnnotated == nil {
 				assert.Len(annotated, 0)
 				assert.Len(invalid, 1)
@@ -226,7 +226,7 @@ func TestPairDonorsAndHeirs(t *testing.T) {
 				},
 			}
 			nodeImage := updatev1alpha1.NodeVersion{}
-			pairs := reconciler.pairDonorsAndHeirs(context.Background(), &nodeImage, []corev1.Node{tc.outdatedNode}, []mintNode{tc.mintNode})
+			pairs := reconciler.pairDonorsAndHeirs(t.Context(), &nodeImage, []corev1.Node{tc.outdatedNode}, []mintNode{tc.mintNode})
 			if tc.wantPair == nil {
 				assert.Len(pairs, 0)
 				return
@@ -315,7 +315,7 @@ func TestMatchDonorsAndHeirs(t *testing.T) {
 					stubReaderClient: *newStubReaderClient(t, []runtime.Object{&tc.donor, &tc.heir}, nil, nil),
 				},
 			}
-			pairs := reconciler.matchDonorsAndHeirs(context.Background(), nil, []corev1.Node{tc.donor}, []corev1.Node{tc.heir})
+			pairs := reconciler.matchDonorsAndHeirs(t.Context(), nil, []corev1.Node{tc.donor}, []corev1.Node{tc.heir})
 			if tc.wantPair == nil {
 				assert.Len(pairs, 0)
 				return
@@ -693,7 +693,7 @@ func TestCreateNewNodes(t *testing.T) {
 				Scheme: getScheme(t),
 			}
 			newNodeConfig := newNodeConfig{desiredNodeImage, tc.outdatedNodes, tc.donors, tc.pendingNodes, tc.scalingGroupByID, tc.budget}
-			err := reconciler.createNewNodes(context.Background(), newNodeConfig)
+			err := reconciler.createNewNodes(t.Context(), newNodeConfig)
 			require.NoError(err)
 			assert.Equal(tc.wantCreateCalls, reconciler.nodeReplacer.(*stubNodeReplacerWriter).createCalls)
 		})

--- a/operators/constellation-node-operator/controllers/nodeversion_watches_test.go
+++ b/operators/constellation-node-operator/controllers/nodeversion_watches_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package controllers
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -250,7 +249,7 @@ func TestFindObjectsForScalingGroup(t *testing.T) {
 	}
 	assert := assert.New(t)
 	reconciler := NodeVersionReconciler{}
-	requests := reconciler.findObjectsForScalingGroup(context.TODO(), &scalingGroup)
+	requests := reconciler.findObjectsForScalingGroup(t.Context(), &scalingGroup)
 	assert.ElementsMatch(wantRequests, requests)
 }
 
@@ -284,7 +283,7 @@ func TestFindAllNodeVersions(t *testing.T) {
 			reconciler := NodeVersionReconciler{
 				Client: newStubReaderClient(t, []runtime.Object{tc.nodeVersion}, nil, tc.listNodeVersionsErr),
 			}
-			requests := reconciler.findAllNodeVersions(context.TODO(), nil)
+			requests := reconciler.findAllNodeVersions(t.Context(), nil)
 			assert.ElementsMatch(tc.wantRequests, requests)
 		})
 	}

--- a/operators/constellation-node-operator/controllers/pendingnode_controller_test.go
+++ b/operators/constellation-node-operator/controllers/pendingnode_controller_test.go
@@ -137,7 +137,7 @@ func TestFindObjectsForNode(t *testing.T) {
 			reconciler := PendingNodeReconciler{
 				Client: newStubReaderClient(t, []runtime.Object{tc.pendingNode}, nil, tc.listPendingNodesErr),
 			}
-			requests := reconciler.findObjectsForNode(context.TODO(), &corev1.Node{
+			requests := reconciler.findObjectsForNode(t.Context(), &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "pending-node",
 				},
@@ -218,7 +218,7 @@ func TestReachedGoal(t *testing.T) {
 			reconciler := PendingNodeReconciler{
 				Client: newStubReaderClient(t, []runtime.Object{&tc.pendingNode}, tc.getPendingNodeErr, nil),
 			}
-			reachedGoal, err := reconciler.reachedGoal(context.Background(), tc.pendingNode, tc.nodeState)
+			reachedGoal, err := reconciler.reachedGoal(t.Context(), tc.pendingNode, tc.nodeState)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/operators/constellation-node-operator/internal/cloud/aws/client/nodeimage_test.go
+++ b/operators/constellation-node-operator/internal/cloud/aws/client/nodeimage_test.go
@@ -91,7 +91,7 @@ func TestGetNodeImage(t *testing.T) {
 					describeInstancesErr: tc.describeInstancesErr,
 				},
 			}
-			gotImage, err := client.GetNodeImage(context.Background(), tc.providerID)
+			gotImage, err := client.GetNodeImage(t.Context(), tc.providerID)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -199,7 +199,7 @@ func TestGetScalingGroupID(t *testing.T) {
 					describeInstancesErr: tc.describeInstancesErr,
 				},
 			}
-			gotScalingID, err := client.GetScalingGroupID(context.Background(), tc.providerID)
+			gotScalingID, err := client.GetScalingGroupID(t.Context(), tc.providerID)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -357,7 +357,7 @@ func TestCreateNode(t *testing.T) {
 					setDesiredCapacityErr: tc.setDesiredCapacityErr,
 				},
 			}
-			nodeName, providerID, err := client.CreateNode(context.Background(), tc.providerID)
+			nodeName, providerID, err := client.CreateNode(t.Context(), tc.providerID)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -398,7 +398,7 @@ func TestDeleteNode(t *testing.T) {
 					terminateInstanceErr: tc.terminateInstanceErr,
 				},
 			}
-			err := client.DeleteNode(context.Background(), tc.providerID)
+			err := client.DeleteNode(t.Context(), tc.providerID)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/operators/constellation-node-operator/internal/cloud/aws/client/pendingnode_test.go
+++ b/operators/constellation-node-operator/internal/cloud/aws/client/pendingnode_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package client
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -161,7 +160,7 @@ func TestGetNodeState(t *testing.T) {
 					describeInstanceStatusErr: tc.describeInstanceStatusErr,
 				},
 			}
-			nodeState, err := client.GetNodeState(context.Background(), tc.providerID)
+			nodeState, err := client.GetNodeState(t.Context(), tc.providerID)
 			assert.Equal(tc.wantState, nodeState)
 			if tc.wantErr {
 				assert.Error(err)

--- a/operators/constellation-node-operator/internal/cloud/aws/client/scalinggroup_test.go
+++ b/operators/constellation-node-operator/internal/cloud/aws/client/scalinggroup_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package client
 
 import (
-	"context"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
@@ -91,7 +90,7 @@ func TestGetScalingGroupImage(t *testing.T) {
 					},
 				},
 			}
-			scalingGroupImage, err := client.GetScalingGroupImage(context.Background(), tc.providerID)
+			scalingGroupImage, err := client.GetScalingGroupImage(t.Context(), tc.providerID)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -216,7 +215,7 @@ func TestSetScalingGroupImage(t *testing.T) {
 					},
 				},
 			}
-			err := client.SetScalingGroupImage(context.Background(), tc.providerID, tc.imageURI)
+			err := client.SetScalingGroupImage(t.Context(), tc.providerID, tc.imageURI)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -319,7 +318,7 @@ func TestListScalingGroups(t *testing.T) {
 					describeAutoScalingGroupsErr: tc.describeAutoScalingGroupsErr,
 				},
 			}
-			gotGroups, err := client.ListScalingGroups(context.Background(), tc.providerID)
+			gotGroups, err := client.ListScalingGroups(t.Context(), tc.providerID)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/operators/constellation-node-operator/internal/cloud/azure/client/pendingnode_test.go
+++ b/operators/constellation-node-operator/internal/cloud/azure/client/pendingnode_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package client
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -67,7 +66,7 @@ func TestGetNodeState(t *testing.T) {
 					instanceViewErr: tc.getInstanceViewErr,
 				},
 			}
-			gotState, err := client.GetNodeState(context.Background(), tc.providerID)
+			gotState, err := client.GetNodeState(t.Context(), tc.providerID)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup_test.go
+++ b/operators/constellation-node-operator/internal/cloud/azure/client/scalinggroup_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package client
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -103,7 +102,7 @@ func TestGetScalingGroupImage(t *testing.T) {
 					getErr: tc.getScaleSetErr,
 				},
 			}
-			gotImage, err := client.GetScalingGroupImage(context.Background(), tc.scalingGroupID)
+			gotImage, err := client.GetScalingGroupImage(t.Context(), tc.scalingGroupID)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -155,7 +154,7 @@ func TestSetScalingGroupImage(t *testing.T) {
 					resultErr: tc.resultErr,
 				},
 			}
-			err := client.SetScalingGroupImage(context.Background(), tc.scalingGroupID, tc.imageURI)
+			err := client.SetScalingGroupImage(t.Context(), tc.scalingGroupID, tc.imageURI)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -291,7 +290,7 @@ func TestListScalingGroups(t *testing.T) {
 					},
 				},
 			}
-			gotGroups, err := client.ListScalingGroups(context.Background(), "uid")
+			gotGroups, err := client.ListScalingGroups(t.Context(), "uid")
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/operators/constellation-node-operator/internal/cloud/gcp/client/nodeimage_test.go
+++ b/operators/constellation-node-operator/internal/cloud/gcp/client/nodeimage_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package client
 
 import (
-	"context"
 	"errors"
 	"math/rand"
 	"testing"
@@ -101,7 +100,7 @@ func TestGetNodeImage(t *testing.T) {
 					disk:   tc.disk,
 				},
 			}
-			gotImage, err := client.GetNodeImage(context.Background(), tc.providerID)
+			gotImage, err := client.GetNodeImage(t.Context(), tc.providerID)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -162,7 +161,7 @@ func TestGetScalingGroupID(t *testing.T) {
 					instance: &instance,
 				},
 			}
-			gotScalingGroupID, err := client.GetScalingGroupID(context.Background(), tc.providerID)
+			gotScalingGroupID, err := client.GetScalingGroupID(t.Context(), tc.providerID)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -221,7 +220,7 @@ func TestCreateNode(t *testing.T) {
 				},
 				prng: rand.New(rand.NewSource(int64(time.Now().Nanosecond()))),
 			}
-			instanceName, providerID, err := client.CreateNode(context.Background(), tc.scalingGroupID)
+			instanceName, providerID, err := client.CreateNode(t.Context(), tc.scalingGroupID)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -287,7 +286,7 @@ func TestDeleteNode(t *testing.T) {
 					},
 				},
 			}
-			err := client.DeleteNode(context.Background(), tc.providerID)
+			err := client.DeleteNode(t.Context(), tc.providerID)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/operators/constellation-node-operator/internal/cloud/gcp/client/pendingnode_test.go
+++ b/operators/constellation-node-operator/internal/cloud/gcp/client/pendingnode_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package client
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -108,7 +107,7 @@ func TestGetNodeState(t *testing.T) {
 					},
 				},
 			}
-			nodeState, err := client.GetNodeState(context.Background(), tc.providerID)
+			nodeState, err := client.GetNodeState(t.Context(), tc.providerID)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/operators/constellation-node-operator/internal/cloud/gcp/client/project_test.go
+++ b/operators/constellation-node-operator/internal/cloud/gcp/client/project_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package client
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -57,7 +56,7 @@ func TestCanonicalProjectID(t *testing.T) {
 					getErr:  tc.getProjectErr,
 				},
 			}
-			gotID, err := client.canonicalProjectID(context.Background(), tc.projectID)
+			gotID, err := client.canonicalProjectID(t.Context(), tc.projectID)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/operators/constellation-node-operator/internal/cloud/gcp/client/scalinggroup_test.go
+++ b/operators/constellation-node-operator/internal/cloud/gcp/client/scalinggroup_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package client
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -96,7 +95,7 @@ func TestGetScalingGroupImage(t *testing.T) {
 					template: tc.instanceTemplate,
 				},
 			}
-			gotImage, err := client.GetScalingGroupImage(context.Background(), tc.scalingGroupID)
+			gotImage, err := client.GetScalingGroupImage(t.Context(), tc.scalingGroupID)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -281,7 +280,7 @@ func TestSetScalingGroupImage(t *testing.T) {
 					template:  tc.instanceTemplate,
 				},
 			}
-			err := client.SetScalingGroupImage(context.Background(), tc.scalingGroupID, tc.imageURI)
+			err := client.SetScalingGroupImage(t.Context(), tc.scalingGroupID, tc.imageURI)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -456,7 +455,7 @@ func TestListScalingGroups(t *testing.T) {
 					getErr: tc.templateGetErr,
 				},
 			}
-			gotGroups, err := client.ListScalingGroups(context.Background(), "uid")
+			gotGroups, err := client.ListScalingGroups(t.Context(), "uid")
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/operators/constellation-node-operator/internal/deploy/deploy_test.go
+++ b/operators/constellation-node-operator/internal/deploy/deploy_test.go
@@ -86,7 +86,7 @@ func TestInitialResources(t *testing.T) {
 				},
 			}
 			scalingGroupGetter := newScalingGroupGetter(tc.items, tc.imageErr, tc.nameErr, tc.listErr)
-			err := InitialResources(context.Background(), k8sClient, &stubImageInfo{}, scalingGroupGetter, "uid")
+			err := InitialResources(t.Context(), k8sClient, &stubImageInfo{}, scalingGroupGetter, "uid")
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -156,7 +156,7 @@ func TestCreateAutoscalingStrategy(t *testing.T) {
 			require := require.New(t)
 
 			k8sClient := &fakeK8sClient{createErr: tc.createErr}
-			err := createAutoscalingStrategy(context.Background(), k8sClient, "stub")
+			err := createAutoscalingStrategy(t.Context(), k8sClient, "stub")
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -246,7 +246,7 @@ func TestCreateNodeVersion(t *testing.T) {
 			if tc.existingNodeVersion != nil {
 				k8sClient.createdObjects = append(k8sClient.createdObjects, tc.existingNodeVersion)
 			}
-			err := createNodeVersion(context.Background(), k8sClient, "image-reference", "image-version")
+			err := createNodeVersion(t.Context(), k8sClient, "image-reference", "image-version")
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/operators/constellation-node-operator/internal/etcd/etcd_test.go
+++ b/operators/constellation-node-operator/internal/etcd/etcd_test.go
@@ -54,7 +54,7 @@ func TestRemoveEtcdMemberFromCluster(t *testing.T) {
 				},
 				listErr: tc.memberListErr,
 			}}
-			err := client.RemoveEtcdMemberFromCluster(context.Background(), tc.vpcIP)
+			err := client.RemoveEtcdMemberFromCluster(t.Context(), tc.vpcIP)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -98,7 +98,7 @@ func TestGetMemberID(t *testing.T) {
 				members: tc.members,
 				listErr: tc.memberListErr,
 			}}
-			gotMemberID, err := client.getMemberID(context.Background(), "192.0.2.1")
+			gotMemberID, err := client.getMemberID(t.Context(), "192.0.2.1")
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/operators/constellation-node-operator/internal/executor/executor_test.go
+++ b/operators/constellation-node-operator/internal/executor/executor_test.go
@@ -29,7 +29,7 @@ func TestStartTriggersImmediateReconciliation(t *testing.T) {
 	}
 	exec := New(ctrl, cfg)
 	// on start, the executor should trigger a reconciliation
-	stopAndWait := exec.Start(context.Background())
+	stopAndWait := exec.Start(t.Context())
 	<-ctrl.waitUntilReconciled // makes sure to wait until reconcile was called
 	ctrl.stop <- struct{}{}
 
@@ -48,10 +48,10 @@ func TestStartMultipleTimesIsCoalesced(t *testing.T) {
 	}
 	exec := New(ctrl, cfg)
 	// start once
-	stopAndWait := exec.Start(context.Background())
+	stopAndWait := exec.Start(t.Context())
 	// start again multiple times
 	for i := 0; i < 10; i++ {
-		_ = exec.Start(context.Background())
+		_ = exec.Start(t.Context())
 	}
 
 	<-ctrl.waitUntilReconciled // makes sure to wait until reconcile was called
@@ -72,7 +72,7 @@ func TestErrorTriggersImmediateReconciliation(t *testing.T) {
 		RateLimiter:      &stubRateLimiter{},   // no rate limiting
 	}
 	exec := New(ctrl, cfg)
-	stopAndWait := exec.Start(context.Background())
+	stopAndWait := exec.Start(t.Context())
 	for i := 0; i < 10; i++ {
 		<-ctrl.waitUntilReconciled // makes sure to wait until reconcile was called
 	}
@@ -96,7 +96,7 @@ func TestErrorTriggersRateLimiting(t *testing.T) {
 		},
 	}
 	exec := New(ctrl, cfg)
-	stopAndWait := exec.Start(context.Background())
+	stopAndWait := exec.Start(t.Context())
 	<-ctrl.waitUntilReconciled // makes sure to wait until reconcile was called once to trigger rate limiting
 	ctrl.stop <- struct{}{}
 
@@ -120,7 +120,7 @@ func TestRequeueAfterResultRequeueInterval(t *testing.T) {
 		},
 	}
 	exec := New(ctrl, cfg)
-	stopAndWait := exec.Start(context.Background())
+	stopAndWait := exec.Start(t.Context())
 	for i := 0; i < 10; i++ {
 		<-ctrl.waitUntilReconciled // makes sure to wait until reconcile was called
 	}
@@ -143,7 +143,7 @@ func TestExternalTrigger(t *testing.T) {
 		},
 	}
 	exec := New(ctrl, cfg)
-	stopAndWait := exec.Start(context.Background())
+	stopAndWait := exec.Start(t.Context())
 	<-ctrl.waitUntilReconciled // initial trigger
 	for i := 0; i < 10; i++ {
 		exec.Trigger()
@@ -167,7 +167,7 @@ func TestSimultaneousExternalTriggers(t *testing.T) {
 		},
 	}
 	exec := New(ctrl, cfg)
-	stopAndWait := exec.Start(context.Background())
+	stopAndWait := exec.Start(t.Context())
 	<-ctrl.waitUntilReconciled // initial trigger
 	for i := 0; i < 100; i++ {
 		exec.Trigger() // extra trigger calls are coalesced
@@ -184,7 +184,7 @@ func TestSimultaneousExternalTriggers(t *testing.T) {
 
 func TestContextCancel(t *testing.T) {
 	assert := assert.New(t)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	ctrl := newStubController(Result{}, nil)
 	cfg := Config{
 		PollingFrequency: time.Hour * 24 * 365, // 1 year. Should be high enough to not trigger the timer in the test.
@@ -219,7 +219,7 @@ func TestRequeueAfterPollingFrequency(t *testing.T) {
 		},
 	}
 	exec := New(ctrl, cfg)
-	stopAndWait := exec.Start(context.Background())
+	stopAndWait := exec.Start(t.Context())
 	for i := 0; i < 10; i++ {
 		<-ctrl.waitUntilReconciled // makes sure to wait until reconcile was called
 	}

--- a/operators/constellation-node-operator/internal/poller/poller_test.go
+++ b/operators/constellation-node-operator/internal/poller/poller_test.go
@@ -49,17 +49,17 @@ func TestResult(t *testing.T) {
 				pollErr:   tc.pollErr,
 				resultErr: tc.resultErr,
 			})
-			_, firstErr := poller.Result(context.Background())
+			_, firstErr := poller.Result(t.Context())
 			if tc.wantErr {
 				assert.Error(firstErr)
 				// calling Result again should return the same error
-				_, secondErr := poller.Result(context.Background())
+				_, secondErr := poller.Result(t.Context())
 				assert.Equal(firstErr, secondErr)
 				return
 			}
 			assert.NoError(firstErr)
 			// calling Result again should still not return an error
-			_, secondErr := poller.Result(context.Background())
+			_, secondErr := poller.Result(t.Context())
 			assert.NoError(secondErr)
 		})
 	}
@@ -136,7 +136,7 @@ func TestPollUntilDone(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				gotResult, gotErr = poller.PollUntilDone(context.Background(), &PollUntilDoneOptions{
+				gotResult, gotErr = poller.PollUntilDone(t.Context(), &PollUntilDoneOptions{
 					MaxBackoff: tc.maxBackoff,
 					Clock:      clock,
 				})

--- a/operators/constellation-node-operator/internal/upgrade/upgrade_test.go
+++ b/operators/constellation-node-operator/internal/upgrade/upgrade_test.go
@@ -40,7 +40,7 @@ func TestGRPCDialer(t *testing.T) {
 	require.Equal(os.ModeSocket, fileInfo.Mode()&os.ModeType)
 
 	upgradeClient := newClientWithAddress(sockAddr)
-	require.NoError(upgradeClient.Upgrade(context.Background(), []*components.Component{}, "v1.29.6"))
+	require.NoError(upgradeClient.Upgrade(t.Context(), []*components.Component{}, "v1.29.6"))
 }
 
 type fakeUpgradeAgent struct {

--- a/operators/constellation-node-operator/sgreconciler/scalinggroup_controller_test.go
+++ b/operators/constellation-node-operator/sgreconciler/scalinggroup_controller_test.go
@@ -88,7 +88,7 @@ func TestCreateScalingGroupIfNotExists(t *testing.T) {
 				autoscalingGroupName: "autoscaling-group-name",
 				role:                 updatev1alpha1.WorkerRole,
 			}
-			err := createScalingGroupIfNotExists(context.Background(), newScalingGroupConfig)
+			err := createScalingGroupIfNotExists(t.Context(), newScalingGroupConfig)
 			if tc.wantErr {
 				assert.Error(err)
 				return
@@ -184,7 +184,7 @@ func TestPatchNodeGroupName(t *testing.T) {
 				getErr:    tc.getErr,
 				updateErr: tc.updateErr,
 			}
-			gotExists, gotErr := patchNodeGroupName(context.Background(), k8sClient, "resource-name", "node-group-name")
+			gotExists, gotErr := patchNodeGroupName(t.Context(), k8sClient, "resource-name", "node-group-name")
 			if tc.wantErr {
 				assert.Error(gotErr)
 				return

--- a/s3proxy/internal/kms/kms_test.go
+++ b/s3proxy/internal/kms/kms_test.go
@@ -60,7 +60,7 @@ func TestGetDataKey(t *testing.T) {
 
 			client.grpc = tc.client
 
-			res, err := client.GetDataKey(context.Background(), "disk-uuid", 32)
+			res, err := client.GetDataKey(t.Context(), "disk-uuid", 32)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {

--- a/terraform-provider-constellation/internal/provider/cluster_resource_test.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: AGPL-3.0-only
 package provider
 
 import (
-	"context"
 	"fmt"
 	"regexp"
 	"testing"
@@ -96,14 +95,14 @@ func TestViolatedImageConstraint(t *testing.T) {
 				Version: tc.version,
 			}
 
-			input, diags := basetypes.NewObjectValueFrom(context.Background(), map[string]attr.Type{
+			input, diags := basetypes.NewObjectValueFrom(t.Context(), map[string]attr.Type{
 				"version":           basetypes.StringType{},
 				"reference":         basetypes.StringType{},
 				"short_path":        basetypes.StringType{},
 				"marketplace_image": basetypes.BoolType{},
 			}, img)
 			require.Equal(t, 0, diags.ErrorsCount())
-			_, _, diags2 := sut.getImageVersion(context.Background(), &ClusterResourceModel{
+			_, _, diags2 := sut.getImageVersion(t.Context(), &ClusterResourceModel{
 				Image: input,
 			})
 			require.Equal(t, tc.expectedErrorCount, diags2.ErrorsCount())

--- a/upgrade-agent/internal/server/server_test.go
+++ b/upgrade-agent/internal/server/server_test.go
@@ -125,7 +125,7 @@ func TestPrepareUpdate(t *testing.T) {
 			require := require.New(t)
 			assert := assert.New(t)
 
-			err := prepareUpdate(context.Background(), tc.installer, tc.updateRequest)
+			err := prepareUpdate(t.Context(), tc.installer, tc.updateRequest)
 			if tc.wantErr {
 				assert.Error(err)
 				return

--- a/verify/server/server_test.go
+++ b/verify/server/server_test.go
@@ -108,7 +108,7 @@ func TestGetAttestationGRPC(t *testing.T) {
 				issuer: tc.issuer,
 			}
 
-			resp, err := server.GetAttestation(context.Background(), tc.request)
+			resp, err := server.GetAttestation(t.Context(), tc.request)
 			if tc.wantErr {
 				assert.Error(err)
 			} else {
@@ -164,7 +164,7 @@ func TestGetAttestationHTTP(t *testing.T) {
 			httpServer := httptest.NewServer(http.HandlerFunc(server.getAttestationHTTP))
 			defer httpServer.Close()
 
-			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, httpServer.URL+tc.request, nil)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, httpServer.URL+tc.request, nil)
 			require.NoError(err)
 			resp, err := http.DefaultClient.Do(req)
 			require.NoError(err)


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Go 1.23.6 causes issues with Go vuln, due to unfixed problems with `net/http`.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Upgrade Go to [v1.24.2](https://go.dev/doc/devel/release#go1.24.0)
- Modernize tests to use `t.Context()` instead of `context.Background()`

