### PR TITLE
terraform: rename deprecated field for STACKIT

### DIFF
--- a/terraform/infrastructure/openstack/main.tf
+++ b/terraform/infrastructure/openstack/main.tf
@@ -22,7 +22,7 @@ provider "openstack" {
 }
 
 provider "stackit" {
-  region = "eu01"
+  default_region = "eu01"
 }
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
The STACKIT Terraform provider emits a warning when `region` is used, as it got replaced with `default_region`.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Update the option name.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
