### PR TITLE
mini-constellation: pin swtpm to v0.8.2

### DIFF
--- a/bazel/toolchains/container_images.bzl
+++ b/bazel/toolchains/container_images.bzl
@@ -16,6 +16,6 @@ def containter_image_deps():
     )
     oci_pull(
         name = "libvirtd_base",
-        digest = "sha256:10bc5281807d06e333f363dd27ccc8159884d706a6d738d6f54a925c483bdce3",
+        digest = "sha256:f23e0f587860c841adde25b1b4f0d99aa4fbce1c92b01b5b46ab5fa35980a135",
         image = "ghcr.io/edgelesssys/constellation/libvirtd-base",
     )

--- a/nix/container/libvirtd_base.nix
+++ b/nix/container/libvirtd_base.nix
@@ -62,12 +62,22 @@ let
   '';
   startScript = pkgsLinux.writeShellApplication {
     name = "start.sh";
-    runtimeInputs = with pkgsLinux; [
+    runtimeInputs = let nixpkgs24_11 = import "${pkgs.fetchFromGitHub {
+      # Pinned release which contains swtpm v0.8.2
+      # Newer versions of NixOS package swtpm v0.10.0 with https://github.com/stefanberger/swtpm/pull/896
+      # This release breaks MiniConstellation since either libvirt, or the Terraform libvirt provider
+      # tries to apply the TPM config twice, resulting in an error during the setup phase
+      owner = "NixOS";
+      repo = "nixpkgs";
+      tag = "24.11";
+      hash = "sha256-CqCX4JG7UiHvkrBTpYC3wcEurvbtTADLbo3Ns2CEoL8=";
+    }}"{system = "x86_64-linux";}; in
+    with pkgsLinux; [
       shadow
       coreutils
       libvirt
       qemu
-      swtpm
+      nixpkgs24_11.swtpm
     ];
     text = ''
       set -euo pipefail


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
https://github.com/edgelesssys/constellation/pull/3752 updated our libvirt base package to include swtpm at [v0.10.0](https://github.com/stefanberger/swtpm/releases/tag/v0.10.0). This in turn caused our e2e tests for [MiniConstellation to fail](https://github.com/edgelesssys/constellation/actions/runs/14394849916/job/40368623919).
I was able to track down the issue to https://github.com/stefanberger/swtpm/pull/896, but as far as I can tell, resolving this issue would require changes in either libvirt or the libvirt terraform provider.
Both solutions are a lot more effort than just keeping swtpm at v0.8.2 for MiniConstellation.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Pin swtpm to v0.8.2 in our libvirt base image used by MiniConstellation

### Related issue
- Fixes https://github.com/edgelesssys/issues/issues/1558

### Additional info
<!-- Remove items that do not apply -->
- [libvirt container build](https://github.com/edgelesssys/constellation/actions/runs/14401268948/job/40387380842)
- [MiniConstellation e2e test](https://github.com/edgelesssys/constellation/actions/runs/14401471694/job/40387997807)
