### PR TITLE
terraform: add missing GCP IAM permission to VM SA

### DIFF
--- a/terraform/infrastructure/iam/gcp/main.tf
+++ b/terraform/infrastructure/iam/gcp/main.tf
@@ -87,6 +87,7 @@ resource "google_project_iam_custom_role" "vm" {
     "compute.subnetworks.get",
     "compute.globalForwardingRules.list",
     "compute.zones.list",
+    "compute.forwardingRules.list",
   ]
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
Certain GCP projects don't have this permission in their SAs, see #3766.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add the `compute.forwardingRules.list` permission to the GCP VM SA.

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
