### PR TITLE
docs: change exemplary GCP zones to ones that provide SNP machines

### DIFF
--- a/docs/docs/getting-started/first-steps.md
+++ b/docs/docs/getting-started/first-steps.md
@@ -102,10 +102,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --prefix=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --prefix=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/docs/workflows/config.md
+++ b/docs/docs/workflows/config.md
@@ -210,10 +210,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --prefix=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --prefix=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -308,11 +308,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.0/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.0/getting-started/first-steps.md
@@ -137,11 +137,11 @@ The following steps guide you through the process of creating a cluster and depl
 
       You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-    * **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+    * **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
       You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-    * **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+    * **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
       You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.1/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.1/getting-started/first-steps.md
@@ -142,11 +142,11 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
 
       You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-    * **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+    * **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
       You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-    * **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+    * **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
       You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.10/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.10/getting-started/first-steps.md
@@ -67,10 +67,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.10/workflows/config.md
+++ b/docs/versioned_docs/version-2.10/workflows/config.md
@@ -160,10 +160,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -240,11 +240,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.11/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.11/getting-started/first-steps.md
@@ -67,10 +67,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.11/workflows/config.md
+++ b/docs/versioned_docs/version-2.11/workflows/config.md
@@ -160,10 +160,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -240,11 +240,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.12/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.12/getting-started/first-steps.md
@@ -67,10 +67,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.12/workflows/config.md
+++ b/docs/versioned_docs/version-2.12/workflows/config.md
@@ -160,10 +160,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -240,11 +240,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.13/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.13/getting-started/first-steps.md
@@ -67,10 +67,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.13/workflows/config.md
+++ b/docs/versioned_docs/version-2.13/workflows/config.md
@@ -160,10 +160,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -240,11 +240,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.13/workflows/terraform-module.md
+++ b/docs/versioned_docs/version-2.13/workflows/terraform-module.md
@@ -100,11 +100,11 @@ The files are deleted on `terraform destroy`.
     name    = "constell"
     project = "constell-proj" // replace with your project id
     service_account_id = "constid"
-    zone    = "europe-west2-a"
+    zone    = "europe-west3-a"
     node_groups = {
       control_plane_default = {
         role          = "control-plane"
-        zone          = "europe-west2-a"
+        zone          = "europe-west3-a"
         instance_type = "n2d-standard-4"
         disk_size     = 30
         disk_type     = "pd-ssd"
@@ -112,7 +112,7 @@ The files are deleted on `terraform destroy`.
       },
       worker_default = {
         role          = "worker"
-        zone          = "europe-west2-a"
+        zone          = "europe-west3-a"
         instance_type = "n2d-standard-4"
         disk_size     = 30
         disk_type     = "pd-ssd"

--- a/docs/versioned_docs/version-2.14/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.14/getting-started/first-steps.md
@@ -67,10 +67,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.14/workflows/config.md
+++ b/docs/versioned_docs/version-2.14/workflows/config.md
@@ -152,10 +152,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -232,11 +232,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.15/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.15/getting-started/first-steps.md
@@ -73,10 +73,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.15/workflows/config.md
+++ b/docs/versioned_docs/version-2.15/workflows/config.md
@@ -157,10 +157,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -244,11 +244,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.16/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.16/getting-started/first-steps.md
@@ -102,10 +102,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.16/workflows/config.md
+++ b/docs/versioned_docs/version-2.16/workflows/config.md
@@ -210,10 +210,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -308,11 +308,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.17/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.17/getting-started/first-steps.md
@@ -102,10 +102,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.17/workflows/config.md
+++ b/docs/versioned_docs/version-2.17/workflows/config.md
@@ -210,10 +210,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -308,11 +308,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.18/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.18/getting-started/first-steps.md
@@ -102,10 +102,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.18/workflows/config.md
+++ b/docs/versioned_docs/version-2.18/workflows/config.md
@@ -210,10 +210,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -308,11 +308,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.19/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.19/getting-started/first-steps.md
@@ -102,10 +102,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.19/workflows/config.md
+++ b/docs/versioned_docs/version-2.19/workflows/config.md
@@ -210,10 +210,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -308,11 +308,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.2/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.2/getting-started/first-steps.md
@@ -149,11 +149,11 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
 
       You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-    * **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+    * **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
       You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-    * **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+    * **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
       You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.20/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.20/getting-started/first-steps.md
@@ -102,10 +102,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.20/workflows/config.md
+++ b/docs/versioned_docs/version-2.20/workflows/config.md
@@ -210,10 +210,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -308,11 +308,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.21/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.21/getting-started/first-steps.md
@@ -102,10 +102,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.21/workflows/config.md
+++ b/docs/versioned_docs/version-2.21/workflows/config.md
@@ -210,10 +210,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -308,11 +308,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.22/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.22/getting-started/first-steps.md
@@ -102,10 +102,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --prefix=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --prefix=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.22/workflows/config.md
+++ b/docs/versioned_docs/version-2.22/workflows/config.md
@@ -210,10 +210,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --prefix=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --prefix=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -308,11 +308,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.3/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.3/getting-started/first-steps.md
@@ -62,10 +62,10 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
     Note that only regions offering CVMs of the `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 

--- a/docs/versioned_docs/version-2.3/workflows/config.md
+++ b/docs/versioned_docs/version-2.3/workflows/config.md
@@ -90,10 +90,10 @@ Since `clientSecretValue` is a sensitive value, you can leave it empty in the co
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session.
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -183,11 +183,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.4/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.4/getting-started/first-steps.md
@@ -62,10 +62,10 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
     Note that only regions offering CVMs of the `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 

--- a/docs/versioned_docs/version-2.4/workflows/config.md
+++ b/docs/versioned_docs/version-2.4/workflows/config.md
@@ -90,10 +90,10 @@ Since `clientSecretValue` is a sensitive value, you can leave it empty in the co
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session.
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -183,11 +183,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.5/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.5/getting-started/first-steps.md
@@ -34,10 +34,10 @@ If you don't have a cloud subscription, check out [MiniConstellation](first-step
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --generate-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --generate-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 

--- a/docs/versioned_docs/version-2.5/workflows/config.md
+++ b/docs/versioned_docs/version-2.5/workflows/config.md
@@ -96,10 +96,10 @@ Since `clientSecretValue` is a sensitive value, you can leave it empty in the co
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session.
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -189,11 +189,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.6/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.6/getting-started/first-steps.md
@@ -38,10 +38,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --generate-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --generate-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.6/workflows/config.md
+++ b/docs/versioned_docs/version-2.6/workflows/config.md
@@ -109,10 +109,10 @@ Since `clientSecretValue` is a sensitive value, you can leave it empty in the co
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session.
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -202,11 +202,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.7/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.7/getting-started/first-steps.md
@@ -38,10 +38,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --generate-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --generate-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.7/workflows/config.md
+++ b/docs/versioned_docs/version-2.7/workflows/config.md
@@ -109,10 +109,10 @@ Since `clientSecretValue` is a sensitive value, you can leave it empty in the co
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -204,11 +204,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.8/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.8/getting-started/first-steps.md
@@ -39,10 +39,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --generate-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --generate-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also creates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.8/workflows/config.md
+++ b/docs/versioned_docs/version-2.8/workflows/config.md
@@ -110,10 +110,10 @@ Since `clientSecretValue` is a sensitive value, you can leave it empty in the co
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -206,11 +206,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 

--- a/docs/versioned_docs/version-2.9/getting-started/first-steps.md
+++ b/docs/versioned_docs/version-2.9/getting-started/first-steps.md
@@ -67,10 +67,10 @@ If you encounter any problem with the following steps, make sure to use the [lat
     <TabItem value="gcp" label="GCP">
 
     ```bash
-    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test --update-config
+    constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test --update-config
     ```
 
-    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
+    This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`. It also updates the configuration file `constellation-conf.yaml` in your current directory with the IAM values filled in.
 
     Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `C2D` or `N2D`.
 

--- a/docs/versioned_docs/version-2.9/workflows/config.md
+++ b/docs/versioned_docs/version-2.9/workflows/config.md
@@ -117,10 +117,10 @@ Paste the output into the corresponding fields of the `constellation-conf.yaml` 
 You must be authenticated with the [GCP CLI](https://cloud.google.com/sdk/gcloud) in the shell session with a user that has the [required permissions for IAM creation](../getting-started/install.md#set-up-cloud-credentials).
 
 ```bash
-constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west2-a --serviceAccountID=constell-test
+constellation iam create gcp --projectID=yourproject-12345 --zone=europe-west3-a --serviceAccountID=constell-test
 ```
 
-This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west2-a` creating a new service account `constell-test`.
+This command creates IAM configuration in the GCP project `yourproject-12345` on the GCP zone `europe-west3-a` creating a new service account `constell-test`.
 
 Note that only regions offering CVMs of the `C2D` or `N2D` series are supported. You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available), which you can filter by machine type `N2D`.
 
@@ -197,11 +197,11 @@ The following describes the configuration fields and how you obtain the required
 
   You can find it on the [welcome screen of your GCP project](https://console.cloud.google.com/welcome). For more information refer to [Google's documentation](https://support.google.com/googleapi/answer/7014113).
 
-* **region**: The GCP region you want to deploy your cluster in, e.g., `us-west1`.
+* **region**: The GCP region you want to deploy your cluster in, e.g., `us-central1`.
 
   You can find a [list of all regions in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 
-* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-west1-a`.
+* **zone**: The GCP zone you want to deploy your cluster in, e.g., `us-central1-a`.
 
   You can find a [list of all zones in Google's documentation](https://cloud.google.com/compute/docs/regions-zones#available).
 


### PR DESCRIPTION
europe-west2 and us-west1 only have SEV-ES