### PR TITLE
terraform: make GCP SA id optional

### DIFF
--- a/terraform/infrastructure/iam/gcp/variables.tf
+++ b/terraform/infrastructure/iam/gcp/variables.tf
@@ -5,6 +5,7 @@ variable "project_id" {
 
 variable "service_account_id" {
   type        = string
+  default     = null
   description = "[DEPRECATED use var.name_prefix] ID for the service account being created. Must match ^[a-z](?:[-a-z0-9]{4,28}[a-z0-9])$."
 }
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
<!-- Please add background information on why this PR is opened. -->
#3656 missed to add a default value for the `service_account_id` when removing / deprecating it. This caused [a bug](https://github.com/edgelesssys/issues/issues/1584) in the E2E test. 

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Add a default value to the variable, which makes it optional.

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->

### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
