### PR TITLE
terraform-provider: pass ServiceCIDR from resource to chart loader

### DIFF
--- a/terraform-provider-constellation/internal/provider/cluster_resource.go
+++ b/terraform-provider-constellation/internal/provider/cluster_resource.go
@@ -1093,6 +1093,7 @@ func (r *ClusterResource) apply(ctx context.Context, data *ClusterResourceModel,
 		DeployCSIDriver:     microserviceCfg.CSIDriver,
 		masterSecret:        secrets.masterSecret,
 		serviceAccURI:       serviceAccURI,
+		serviceCIDR:         networkCfg.IPCidrService.ValueString(),
 	}
 	if csp == cloudprovider.OpenStack {
 		payload.openStackHelmValues = &helm.OpenStackValues{
@@ -1267,6 +1268,7 @@ type applyHelmChartsPayload struct {
 	masterSecret        uri.MasterSecret         // master secret of the cluster.
 	serviceAccURI       string                   // URI of the service account used within the cluster.
 	openStackHelmValues *helm.OpenStackValues    // OpenStack-specific Helm values.
+	serviceCIDR         string                   // CIDR used for k8s services - needed for CoreDNS chart.
 }
 
 // applyHelmCharts applies the Helm charts to the cluster.
@@ -1288,6 +1290,7 @@ func (r *ClusterResource) applyHelmCharts(ctx context.Context, applier *constell
 		// The user has previously been warned about this when planning a microservice version change.
 		AllowDestructive: helm.AllowDestructive,
 		OpenStackValues:  payload.openStackHelmValues,
+		ServiceCIDR:      payload.serviceCIDR,
 	}
 
 	if err := applier.AnnotateCoreDNSResources(ctx); err != nil {


### PR DESCRIPTION
### Context

The CoreDNS Helm chart needs to be configured with an explicit cluster IP address for the kube-dns service. This IP is derived from the service CIDR, thus the service CIDR is required as an input to the Helm chart loader. #3388 added the CIDR to the CLI code path, but forgot to update the Terraform codepath, preventing customisation of the service CIDR using the Terraform provider.

### Proposed change(s)

- Forward service CIDR from Terraform data to Helm chart loader.

### Additional info
<!-- Remove items that do not apply -->
- [AB#5594](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/5594)

### Checklist
- [ ] Run the E2E tests that are relevant to this PR's changes
  - [x] manually tested with custom service CIDR on GCP 
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
