### PR TITLE
renovate: exclude s3proxy pseudo-versions upgrades

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -30,7 +30,6 @@
   ignoreDeps: [
     'github.com/edgelesssys/constellation/v2',
     'github.com/daniel-weisse/go-cryptsetup',
-
     // Only update once they fixed dependency violations on their side.
     'github.com/google/go-tpm-tools',
   ],
@@ -252,6 +251,7 @@
       matchPackageNames: [
         'ghcr.io/edgelesssys/{/,}**',
         '!ghcr.io/edgelesssys/cloud-provider-gcp',
+        '!ghcr.io/edgelesssys/constellation/s3proxy',
       ],
       versioning: 'semver',
       // Allow packages of ghcr.io/edgelesssys to update to unstable prereleases.

--- a/s3proxy/deploy/deployment-s3proxy.yaml
+++ b/s3proxy/deploy/deployment-s3proxy.yaml
@@ -72,7 +72,7 @@ spec:
     spec:
       containers:
         - name: s3proxy
-          image: ghcr.io/edgelesssys/constellation/s3proxy:v2.13.0-pre
+          image: ghcr.io/edgelesssys/constellation/s3proxy:v2.23.0
           args:
             - "--level=-1"
           ports:

--- a/s3proxy/deploy/s3proxy/values.yaml
+++ b/s3proxy/deploy/s3proxy/values.yaml
@@ -3,7 +3,7 @@ awsAccessKeyID: "replaceme"
 awsSecretAccessKey: "replaceme"
 
 # Pod image to deploy.
-image: "ghcr.io/edgelesssys/constellation/s3proxy:v2.23.0-pre.0.20250409150110-8e6c93474149"
+image: "ghcr.io/edgelesssys/constellation/s3proxy:v2.23.0"
 
 # Control if multipart uploads are blocked.
 allowMultipart: false


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Renovate kept giving us updates for the s3proxy container image.
We don't need these updates for our tests, nor do we make any larger changes to the s3proxy that warrant frequent updates to said image.
Furthermore, a lot of unrelated changes trigger a rebuild of the container image, causing many unrelated PRs to trigger a dependency update

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Exclude s3proxy pseudo version updates from renovate
