### PR TITLE
ci: run e2e cleanup daily

### DIFF
--- a/.github/actions/e2e_cleanup_timeframe/e2e-cleanup.sh
+++ b/.github/actions/e2e_cleanup_timeframe/e2e-cleanup.sh
@@ -2,7 +2,7 @@
 
 # get_e2e_test_ids_on_date gets all workflow IDs of workflows that contain "e2e" on a specific date.
 function get_e2e_test_ids_on_date {
-  ids="$(gh run list --created "$1" --status failure --json createdAt,workflowName,databaseId --jq '.[] | select(.workflowName | contains("e2e") and (contains("MiniConstellation") | not)) | .databaseId' -L1000 -R edgelesssys/constellation || exit 1)"
+  ids="$(gh run list --created "$1" --status failure --json createdAt,workflowName,databaseId --jq '.[] | select(.workflowName | (contains("e2e") or contains("Release")) and (contains("MiniConstellation") | not)) | .databaseId' -L1000 -R edgelesssys/constellation || exit 1)"
   echo "${ids}"
 }
 

--- a/.github/actions/e2e_cleanup_timeframe/e2e-cleanup.sh
+++ b/.github/actions/e2e_cleanup_timeframe/e2e-cleanup.sh
@@ -33,7 +33,7 @@ artifact_pwd=${ENCRYPTION_SECRET}
 shopt -s nullglob
 
 start_date=$(date "+%Y-%m-%d")
-end_date=$(date --date "-14 day" "+%Y-%m-%d")
+end_date=$(date --date "-4 day" "+%Y-%m-%d")
 dates_to_clean=()
 
 # get all dates of the last week

--- a/.github/actions/e2e_cleanup_timeframe/e2e-cleanup.sh
+++ b/.github/actions/e2e_cleanup_timeframe/e2e-cleanup.sh
@@ -11,24 +11,15 @@ function download_tfstate_artifact {
   gh run download "$1" -p "terraform-state-*" -R edgelesssys/constellation > /dev/null
 }
 
-# delete_resources runs terraform destroy on the constellation-terraform subfolder of a given folder.
-function delete_resources {
-  if [[ -d "$1/constellation-terraform" ]]; then
-    cd "$1/constellation-terraform" || return 1
-    terraform init > /dev/null || return 1 # first, install plugins
-    terraform destroy -auto-approve || return 1
-    cd ../../ || return 1
+# delete_terraform_resources runs terraform destroy on the given folder.
+function delete_terraform_resources {
+  delete_err=0
+  if pushd "${1}/${2}"; then
+    terraform init > /dev/null || delete_err=1 # first, install plugins
+    terraform destroy -auto-approve || delete_err=1
+    popd || exit 1
   fi
-}
-
-# delete_iam_config runs terraform destroy on the constellation-iam-terraform subfolder of a given folder.
-function delete_iam_config {
-  if [[ -d "$1/constellation-iam-terraform" ]]; then
-    cd "$1/constellation-iam-terraform" || return 1
-    terraform init > /dev/null || return 1 # first, install plugins
-    terraform destroy -auto-approve || return 1
-    cd ../../ || return 1
-  fi
+  return "${delete_err}"
 }
 
 # check if the password for artifact decryption was given
@@ -88,9 +79,9 @@ echo "[*] deleting resources"
 error_occurred=0
 for directory in ./terraform-state-*; do
   echo "    deleting resources in ${directory}"
-  delete_resources "${directory}" || error_occurred=1
+  delete_terraform_resources "${directory}" "constellation-terraform" || echo "[!] deleting resources failed" && error_occurred=1
   echo "    deleting IAM configuration in ${directory}"
-  delete_iam_config "${directory}" || error_occurred=1
+  delete_terraform_resources "${directory}" "constellation-iam-terraform" || echo "[!] deleting IAM resources failed" && error_occurred=1
   echo "    deleting directory ${directory}"
   rm -rf "${directory}"
 done

--- a/.github/actions/e2e_cleanup_timeframe/e2e-cleanup.sh
+++ b/.github/actions/e2e_cleanup_timeframe/e2e-cleanup.sh
@@ -42,7 +42,7 @@ artifact_pwd=${ENCRYPTION_SECRET}
 shopt -s nullglob
 
 start_date=$(date "+%Y-%m-%d")
-end_date=$(date --date "-7 day" "+%Y-%m-%d")
+end_date=$(date --date "-14 day" "+%Y-%m-%d")
 dates_to_clean=()
 
 # get all dates of the last week

--- a/.github/workflows/e2e-cleanup.yml
+++ b/.github/workflows/e2e-cleanup.yml
@@ -1,8 +1,8 @@
-name: e2e weekly cleanup
+name: e2e cleanup
 
 on:
   schedule:
-    - cron: "0 0 * * 0" # At 00:00 every Sunday UTC
+    - cron: "0 0 * * *" # At 00:00 every day
   workflow_dispatch:
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
No reason to only run this once a week. Resources should be cleaned up as quick as possible

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Run clean up once a day
- Don't abort a clean up run if a step fails, instead continue to the end
- Clean up resources from release runs

<!-- (uncomment if applicable)
### Related issue
- link to the issue
-->
