### PR TITLE
helm: force app creds in GCP CCM

### DIFF
--- a/internal/constellation/helm/charts/edgeless/constellation-services/charts/ccm/templates/gcp-cm.yaml
+++ b/internal/constellation/helm/charts/edgeless/constellation-services/charts/ccm/templates/gcp-cm.yaml
@@ -5,5 +5,11 @@ metadata:
   name: gceconf
   namespace: {{ .Release.Namespace }}
 data:
-  gce.conf: "[global]\nproject-id = {{.Values.GCP.projectID }}\nuse-metadata-server = true\nnode-tags = constellation-{{ .Values.GCP.uid }}\nregional = true\n"
+  gce.conf: |
+    [global]
+    project-id = {{.Values.GCP.projectID }}
+    use-metadata-server = true
+    node-tags = constellation-{{ .Values.GCP.uid }}
+    regional = true
+    token-url = nil # This forces use of GOOGLE_APPLICATION_CREDENTIALS.
 {{- end -}}

--- a/internal/constellation/helm/testdata/GCP/constellation-services/charts/ccm/templates/gcp-cm.yaml
+++ b/internal/constellation/helm/testdata/GCP/constellation-services/charts/ccm/templates/gcp-cm.yaml
@@ -4,4 +4,4 @@ metadata:
   name: gceconf
   namespace: testNamespace
 data:
-  gce.conf: "[global]\nproject-id = 42424242424242\nuse-metadata-server = true\nnode-tags = constellation-242424242424\nregional = true\n"
+  gce.conf: "[global]\nproject-id = 42424242424242\nuse-metadata-server = true\nnode-tags = constellation-242424242424\nregional = true\ntoken-url = nil # This forces use of GOOGLE_APPLICATION_CREDENTIALS."


### PR DESCRIPTION
### Context

The GCP Cloud Controller Manager should be using the Constellation service account (`google_service_account.service_account`). However, with the current configuration we end up using the ambient service account attached to VMs (`google_service_account.vm`). This is due to its unintuitive token-choosing logic 

1. Default is the metadata server token source: https://github.com/kubernetes/cloud-provider-gcp/blob/ccm/v30.1.4/providers/gce/gce.go#L335.
2. If the config key `token-url` is set to the special string `"nil"`, the default is removed again: https://github.com/kubernetes/cloud-provider-gcp/blob/ccm/v30.1.4/providers/gce/gce.go#L350.
3. When there is no token source configured, a new `google.DefaultTokenSource` is created: https://github.com/kubernetes/cloud-provider-gcp/blob/ccm/v30.1.4/providers/gce/gce.go#L964. This one actually consumes the credentials file set with `GOOGLE_APPLICATION_CREDENTIALS`.

### Proposed change(s)

- Add the configuration that forces use of `GOOGLE_APPLICATION_CREDENTIALS`.

### Additional info

- [AB#5615](https://dev.azure.com/Edgeless/ae37573d-ccde-4af2-ab1e-001e587197d1/_workitems/edit/5615)

### Checklist

- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [LB test](https://github.com/edgelesssys/constellation/actions/runs/14923229263/) (broken on main)
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
