### PR TITLE
ci: dont fail if Azure resources were already deleted

### DIFF
--- a/.github/actions/e2e_cleanup_timeframe/e2e-cleanup.sh
+++ b/.github/actions/e2e_cleanup_timeframe/e2e-cleanup.sh
@@ -87,9 +87,15 @@ echo "[*] deleting resources"
 error_occurred=0
 for directory in ./terraform-state-*; do
   echo "    deleting resources in ${directory}"
-  delete_terraform_resources "${directory}" "constellation-terraform" || echo "[!] deleting resources failed" && error_occurred=1
+  if ! delete_terraform_resources "${directory}" "constellation-terraform"; then
+    echo "[!] deleting resources failed"
+    error_occurred=1
+  fi
   echo "    deleting IAM configuration in ${directory}"
-  delete_terraform_resources "${directory}" "constellation-iam-terraform" || echo "[!] deleting IAM resources failed" && error_occurred=1
+  if ! delete_terraform_resources "${directory}" "constellation-iam-terraform"; then
+    echo "[!] deleting IAM resources failed"
+    error_occurred=1
+  fi
   echo "    deleting directory ${directory}"
   rm -rf "${directory}"
 done


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Our daily cleanup jobs fail if they try to clean up resources on Azure that were already deleted through other means.
This is caused by us including a data source (`azurerm_user_assigned_identity.uaid`) which is only used to generate an output value.
Since Terraform evaluates the file and outputs before running a destroy operation, Terraform tries to evaluate the data source, fails, and then aborts the destroy operation.

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Remove the data source from the Terraform files before running `terraform destroy`
  - This data source is only required to generate an ouput value, it has no effect on our other resources, and can be safely ignored

### Additional info
<!-- Remove items that do not apply -->
- [test run](https://github.com/edgelesssys/constellation/actions/runs/14966809165/job/42038480420)
