### PR TITLE
dev-docs: add script for updating k8s versions in workflow files

### DIFF
--- a/.github/workflows/e2e-test-daily.yml
+++ b/.github/workflows/e2e-test-daily.yml
@@ -45,7 +45,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        kubernetesVersion: ["1.30"] # This should correspond to the current default k8s minor.
+        kubernetesVersion: ["v1.31"] # This should correspond to the current default k8s minor.
         attestationVariant: ["gcp-sev-es", "gcp-sev-snp", "azure-sev-snp", "azure-tdx", "aws-sev-snp"]
         refStream: ["ref/main/stream/debug/?", "ref/release/stream/stable/?"]
         test: ["sonobuoy quick"]

--- a/dev-docs/workflows/upgrade-kubernetes.md
+++ b/dev-docs/workflows/upgrade-kubernetes.md
@@ -27,7 +27,20 @@ curl -qL https://mcr.microsoft.com/v2/oss/kubernetes/azure-cloud-node-manager/ta
 
 Normally renovate will handle the upgrading of Kubernetes dependencies.
 
-Also, don't forget to update the Kubernetes versions tested in the CI. (e.g. release, weekly E2E tests)
+## Update e2e tests
+
+Run the following script to update the k8s versions used in the e2e workflows, adjusting the versions to what you're upgrading to.
+
+```sh
+next=v1.33
+current=v1.32
+old=v1.31
+oldold=v1.30
+sed -i -e "s/$current/$next/g" -e "s/$old/$current/g" -e "s/$oldold/$old/g" \
+  .github/workflows/e2e-test-daily.yml \
+  .github/workflows/e2e-test-weekly.yml \
+  .github/workflows/e2e-test-release.yml
+```
 
 ## Test the new Kubernetes version
 


### PR DESCRIPTION
### Context

We need to do a bunch of version replacements in e2e files when updating k8s. This is error prone and should be easier to do. 

### Proposed change(s)

- Suggest a script for updating the versions in the workflow yaml. 
- Fix the version in the daily workflow, which probably escaped grep due to the missing `v` prefix.


### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x], or check after submitting. -->
<!-- more information in dev-docs/workflows/pull-request.md -->
- [x] Run the E2E tests that are relevant to this PR's changes
  - [x] [e2e-daily](https://github.com/edgelesssys/constellation/actions/runs/16627150812) just to check that the version still works
- [x] Add labels (e.g., for changelog category)
- [x] Is PR title adequate for changelog?
- [x] Link to Milestone
