### PR TITLE
ci: extend aws credential lifetime during image build

### DIFF
--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -151,6 +151,8 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::795746500882:role/GitHubConstellationImagePipeline
           aws-region: eu-central-1
+          # extend token expiry to 3 hours to ensure long image builds don't fail because of expired credentials
+          role-duration-seconds: 10800
 
       - name: Login to Azure
         uses: ./.github/actions/login_azure
@@ -172,7 +174,7 @@ jobs:
         run: |
           sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_unconfined=0
           sudo sysctl --ignore --write kernel.apparmor_restrict_unprivileged_userns=0
-          
+
       - name: Build and upload
         id: build
         shell: bash


### PR DESCRIPTION
<!--
Thank you for your contribution!

For more information check our contributors guide CONTRIBUTING.md (link below text box).

NOTE: This template is a guideline to help you to provide meaningful information for reviewers.
Feel free to edit, complete or extend this list while the PR is open.
-->
### Context
Image builds keep failing due to expired AWS credentials when building the image takes longer than an hour

### Proposed change(s)
<!-- Please provide a description of the change(s) here. -->
- Extend AWS credential lifetime to 3 hours for image builds
